### PR TITLE
Fix MVCC issues with write-write conflicts and deletion visibility

### DIFF
--- a/internal/common/version.go
+++ b/internal/common/version.go
@@ -23,7 +23,7 @@ const (
 	// VersionPatch is the patch version of the driver
 	VersionPatch = "7"
 	// VersionSuffix is the suffix of the driver version
-	VersionSuffix = "38827d80" // git commit hash
+	VersionSuffix = "20188f95" // git commit hash
 
 	// VersionString is the version string of the driver
 	VersionString = "Stoolap v" + VersionMajor + "." + VersionMinor + "." + VersionPatch + "-" + VersionSuffix

--- a/internal/common/version.go
+++ b/internal/common/version.go
@@ -23,7 +23,7 @@ const (
 	// VersionPatch is the patch version of the driver
 	VersionPatch = "7"
 	// VersionSuffix is the suffix of the driver version
-	VersionSuffix = "bbdd608d" // git commit hash
+	VersionSuffix = "38827d80" // git commit hash
 
 	// VersionString is the version string of the driver
 	VersionString = "Stoolap v" + VersionMajor + "." + VersionMinor + "." + VersionPatch + "-" + VersionSuffix

--- a/internal/common/version.go
+++ b/internal/common/version.go
@@ -23,7 +23,7 @@ const (
 	// VersionPatch is the patch version of the driver
 	VersionPatch = "7"
 	// VersionSuffix is the suffix of the driver version
-	VersionSuffix = "177f469a" // git commit hash
+	VersionSuffix = "bbdd608d" // git commit hash
 
 	// VersionString is the version string of the driver
 	VersionString = "Stoolap v" + VersionMajor + "." + VersionMinor + "." + VersionPatch + "-" + VersionSuffix

--- a/internal/storage/mvcc/registry.go
+++ b/internal/storage/mvcc/registry.go
@@ -199,6 +199,11 @@ func (r *TransactionRegistry) GetTransactionBeginSeq(txnID int64) int64 {
 	return 0
 }
 
+// GetCurrentSequence returns the current sequence number
+func (r *TransactionRegistry) GetCurrentSequence() int64 {
+	return r.nextSequence.Load()
+}
+
 // IsDirectlyVisible is an optimized version that only checks common cases
 // for better performance in bulk operations. It only returns true for
 // already committed transactions (in ReadCommitted mode).

--- a/internal/storage/mvcc/transaction.go
+++ b/internal/storage/mvcc/transaction.go
@@ -143,7 +143,10 @@ func (t *MVCCTransaction) Commit() error {
 
 	if effectiveIsolationLevel == storage.SnapshotIsolation && !isReadOnly {
 		// Commit each table with conflict checking
-		for _, table := range t.tables {
+		for tableName, table := range t.tables {
+			t.engine.AcquireTableLock(tableName)
+			defer t.engine.ReleaseTableLock(tableName)
+
 			if table.txnVersions != nil {
 				if err := table.Commit(); err != nil {
 					t.engine.registry.AbortTransaction(t.id)

--- a/internal/storage/mvcc/transaction.go
+++ b/internal/storage/mvcc/transaction.go
@@ -141,65 +141,18 @@ func (t *MVCCTransaction) Commit() error {
 		effectiveIsolationLevel = t.specificIsolationLevel
 	}
 
-	// For SNAPSHOT isolation, serialize commit operations to prevent race conditions
 	if effectiveIsolationLevel == storage.SnapshotIsolation && !isReadOnly {
-		// Get the transaction's begin timestamp
-		beginSeq := t.engine.registry.GetTransactionBeginSeq(t.id)
-		// Lock the engine's commit mutex to serialize SNAPSHOT commits
-		t.engine.commitMu.Lock()
-		defer t.engine.commitMu.Unlock()
-
-		// Collect all written rows for conflict detection and sequence assignment
-		writtenRowsByTable := make(map[string][]int64)
-
-		// Check each table that has been modified
-		for tableName, table := range t.tables {
-			if table.txnVersions != nil && table.txnVersions.localVersions.Len() > 0 {
-				// Get the version store for conflict detection
-				versionStore := t.engine.versionStores[tableName]
-				if versionStore != nil {
-					// Collect all row IDs that were written by this transaction
-					var writtenRows []int64
-					table.txnVersions.localVersions.ForEach(func(rowID int64, version RowVersion) bool {
-						writtenRows = append(writtenRows, rowID)
-						return true
-					})
-
-					// Save for later sequence assignment (after table.Commit clears txnVersions)
-					writtenRowsByTable[tableName] = writtenRows
-
-					// Check for write-write conflicts
-					if versionStore.CheckWriteConflict(writtenRows, beginSeq) {
-						// Conflict detected - abort the transaction
-						t.engine.registry.AbortTransaction(t.id)
-						return errors.New("transaction aborted due to write-write conflict")
-					}
+		// Commit each table with conflict checking
+		for _, table := range t.tables {
+			if table.txnVersions != nil {
+				if err := table.Commit(); err != nil {
+					t.engine.registry.AbortTransaction(t.id)
+					return err
 				}
 			}
 		}
 
-		// Generate a single commit sequence for all writes in this transaction
-		// This must happen BEFORE committing tables to avoid races
-		commitSeq := t.engine.registry.nextSequence.Add(1)
-
-		// Commit all MVCC tables to merge their changes to the global version stores
-		for _, table := range t.tables {
-			if err := table.Commit(); err != nil {
-				// If commit fails, abort the transaction
-				t.engine.registry.AbortTransaction(t.id)
-				return err
-			}
-		}
-
-		// Set write sequences for all written rows atomically
-		// This must happen AFTER data is written but BEFORE releasing the commit mutex
-		for tableName, writtenRows := range writtenRowsByTable {
-			if versionStore := t.engine.versionStores[tableName]; versionStore != nil {
-				versionStore.SetWriteSequences(writtenRows, commitSeq)
-			}
-		}
-
-		// Only after data is written, mark transaction as committed in registry
+		// Only after all data is written, mark transaction as committed in registry
 		t.engine.registry.CommitTransaction(t.id)
 	} else {
 		// For READ COMMITTED or read-only transactions, no serialization needed
@@ -224,27 +177,12 @@ func (t *MVCCTransaction) Commit() error {
 			}
 		}
 
-		// Generate commit sequence if we have writes
-		var commitSeq int64
-		if !isReadOnly {
-			commitSeq = t.engine.registry.nextSequence.Add(1)
-		}
-
 		// First commit all MVCC tables to merge their changes to the global version stores
 		for _, table := range t.tables {
 			if err := table.Commit(); err != nil {
 				// If commit fails, abort the transaction
 				t.engine.registry.AbortTransaction(t.id)
 				return err
-			}
-		}
-
-		// Set write sequences for conflict detection by other transactions
-		if !isReadOnly {
-			for tableName, writtenRows := range writtenRowsByTable {
-				if versionStore := t.engine.versionStores[tableName]; versionStore != nil {
-					versionStore.SetWriteSequences(writtenRows, commitSeq)
-				}
 			}
 		}
 

--- a/stoolap.go
+++ b/stoolap.go
@@ -450,8 +450,15 @@ func (db *DB) Begin() (Tx, error) {
 
 // BeginTx starts a new transaction with options
 func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (Tx, error) {
+	// Default to the engine's current isolation level
 	isolationLevel := sql.LevelReadCommitted
-	if opts != nil {
+	engineLevel := db.engine.GetIsolationLevel()
+	if engineLevel == storage.SnapshotIsolation {
+		isolationLevel = sql.LevelSnapshot
+	}
+
+	// Override with options if provided
+	if opts != nil && opts.Isolation != sql.LevelDefault {
 		isolationLevel = opts.Isolation
 	}
 

--- a/test/dirty_read_write_concurrent_stress_test.go
+++ b/test/dirty_read_write_concurrent_stress_test.go
@@ -1,0 +1,570 @@
+package test
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stoolap/stoolap"
+	"github.com/stoolap/stoolap/internal/storage"
+)
+
+// TestHighConcurrencyDirtyWrite tests dirty write prevention under extreme concurrency
+func TestHighConcurrencyDirtyWrite(t *testing.T) {
+	testCases := []struct {
+		name         string
+		isolation    storage.IsolationLevel
+		numWriters   int
+		numRows      int
+		numOpsPerTxn int
+	}{
+		{"READ_COMMITTED_100_WRITERS", storage.ReadCommitted, 100, 50, 10},
+		{"SNAPSHOT_100_WRITERS", storage.SnapshotIsolation, 100, 50, 10},
+		{"READ_COMMITTED_EXTREME", storage.ReadCommitted, 200, 100, 20},
+		{"SNAPSHOT_EXTREME", storage.SnapshotIsolation, 200, 100, 20},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := stoolap.Open("memory://")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+
+			ctx := context.Background()
+			err = db.Engine().SetIsolationLevel(tc.isolation)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create table
+			_, err = db.Exec(ctx, "CREATE TABLE stress_test (id INTEGER PRIMARY KEY, value INTEGER, version INTEGER)")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Insert initial rows
+			for i := 1; i <= tc.numRows; i++ {
+				_, err = db.Exec(ctx, fmt.Sprintf("INSERT INTO stress_test (id, value, version) VALUES (%d, %d, 0)", i, i*100))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Tracking variables
+			var dirtyWriteAttempts atomic.Int64
+			var successfulWrites atomic.Int64
+			var dirtyWritesPrevented atomic.Int64
+			var otherErrors atomic.Int64
+
+			// Run concurrent writers
+			var wg sync.WaitGroup
+			start := time.Now()
+
+			for w := 0; w < tc.numWriters; w++ {
+				wg.Add(1)
+				go func(workerID int) {
+					defer wg.Done()
+
+					// Each worker performs multiple operations
+					for op := 0; op < tc.numOpsPerTxn; op++ {
+						tx, err := db.Begin()
+						if err != nil {
+							otherErrors.Add(1)
+							continue
+						}
+
+						// Randomly select rows to update
+						rowsToUpdate := make([]int, 0, 3)
+						for i := 0; i < 3; i++ {
+							rowID := rand.Intn(tc.numRows) + 1
+							rowsToUpdate = append(rowsToUpdate, rowID)
+						}
+
+						// Try to update multiple rows in a transaction
+						updateSuccess := true
+						for _, rowID := range rowsToUpdate {
+							dirtyWriteAttempts.Add(1)
+
+							// Read current value
+							var currentValue, currentVersion int
+							rows, err := tx.QueryContext(ctx, fmt.Sprintf("SELECT value, version FROM stress_test WHERE id = %d", rowID))
+							if err != nil {
+								updateSuccess = false
+								break
+							}
+							if rows.Next() {
+								rows.Scan(&currentValue, &currentVersion)
+								rows.Close()
+							} else {
+								rows.Close()
+								updateSuccess = false
+								break
+							}
+
+							// Try to update
+							_, err = tx.ExecContext(ctx,
+								"UPDATE stress_test SET value = ?, version = ? WHERE id = ?",
+								driver.NamedValue{Ordinal: 1, Value: currentValue + workerID},
+								driver.NamedValue{Ordinal: 2, Value: currentVersion + 1},
+								driver.NamedValue{Ordinal: 3, Value: rowID})
+
+							if err != nil {
+								if err.Error() == "error executing UPDATE: row is being modified by another transaction" {
+									dirtyWritesPrevented.Add(1)
+								} else {
+									otherErrors.Add(1)
+								}
+								updateSuccess = false
+								break
+							}
+						}
+
+						// Try to commit
+						if updateSuccess {
+							err = tx.Commit()
+							if err != nil {
+								if err.Error() == "error executing UPDATE: row is being modified by another transaction" {
+									dirtyWritesPrevented.Add(1)
+								} else {
+									otherErrors.Add(1)
+								}
+							} else {
+								successfulWrites.Add(1)
+							}
+						} else {
+							tx.Rollback()
+						}
+					}
+				}(w)
+			}
+
+			wg.Wait()
+			duration := time.Since(start)
+
+			// Verify data consistency
+			rows, err := db.Query(ctx, "SELECT id, value, version FROM stress_test ORDER BY id")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rows.Close()
+
+			maxVersion := 0
+			inconsistencies := 0
+			for rows.Next() {
+				var id, value, version int
+				rows.Scan(&id, &value, &version)
+				if version > maxVersion {
+					maxVersion = version
+				}
+				// Check if value and version are consistent
+				// Value should have been incremented by various amounts
+				// Version should match the number of successful updates
+				if version < 0 || value < id*100 {
+					inconsistencies++
+					t.Logf("Inconsistent row %d: value=%d, version=%d", id, value, version)
+				}
+			}
+
+			// Report results
+			fmt.Printf("\n[%s] Results:\n", tc.name)
+			fmt.Printf("  Duration: %v\n", duration)
+			fmt.Printf("  Total write attempts: %d\n", dirtyWriteAttempts.Load())
+			fmt.Printf("  Successful writes: %d\n", successfulWrites.Load())
+			fmt.Printf("  Dirty writes prevented: %d\n", dirtyWritesPrevented.Load())
+			fmt.Printf("  Other errors: %d\n", otherErrors.Load())
+			fmt.Printf("  Max version seen: %d\n", maxVersion)
+			fmt.Printf("  Data inconsistencies: %d\n", inconsistencies)
+			fmt.Printf("  Prevention rate: %.2f%%\n",
+				float64(dirtyWritesPrevented.Load())/float64(dirtyWriteAttempts.Load())*100)
+
+			// Verify no data corruption
+			if inconsistencies > 0 {
+				t.Errorf("Data corruption detected: %d inconsistent rows", inconsistencies)
+			}
+		})
+	}
+}
+
+// TestHighConcurrencyDirtyRead tests dirty read prevention under extreme concurrency
+func TestHighConcurrencyDirtyRead(t *testing.T) {
+	testCases := []struct {
+		name       string
+		isolation  storage.IsolationLevel
+		numReaders int
+		numWriters int
+	}{
+		{"READ_COMMITTED_HEAVY_READ", storage.ReadCommitted, 100, 20},
+		{"SNAPSHOT_HEAVY_READ", storage.SnapshotIsolation, 100, 20},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := stoolap.Open("memory://")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+
+			ctx := context.Background()
+			err = db.Engine().SetIsolationLevel(tc.isolation)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create table with a flag column
+			_, err = db.Exec(ctx, "CREATE TABLE read_test (id INTEGER PRIMARY KEY, value INTEGER, is_committed INTEGER)")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Insert initial rows (1 = committed, 0 = uncommitted)
+			for i := 1; i <= 10; i++ {
+				_, err = db.Exec(ctx, fmt.Sprintf("INSERT INTO read_test (id, value, is_committed) VALUES (%d, %d, 1)", i, i*1000))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Tracking variables
+			var dirtyReadsDetected atomic.Int64
+			var cleanReads atomic.Int64
+			var totalReads atomic.Int64
+
+			// Channel to coordinate
+			stopCh := make(chan struct{})
+			var wg sync.WaitGroup
+
+			// Start writers that create uncommitted changes
+			for w := 0; w < tc.numWriters; w++ {
+				wg.Add(1)
+				go func(writerID int) {
+					defer wg.Done()
+
+					for {
+						select {
+						case <-stopCh:
+							return
+						default:
+							tx, err := db.Begin()
+							if err != nil {
+								continue
+							}
+
+							// Update a random row with uncommitted marker
+							rowID := rand.Intn(10) + 1
+							newValue := writerID*10000 + rowID
+
+							_, err = tx.ExecContext(ctx,
+								"UPDATE read_test SET value = ?, is_committed = ? WHERE id = ?",
+								driver.NamedValue{Ordinal: 1, Value: newValue},
+								driver.NamedValue{Ordinal: 2, Value: 0}, // Mark as uncommitted (0)
+								driver.NamedValue{Ordinal: 3, Value: rowID})
+
+							if err != nil {
+								tx.Rollback()
+								continue
+							}
+
+							// Hold transaction open for a bit
+							time.Sleep(time.Millisecond * time.Duration(rand.Intn(10)))
+
+							// Randomly commit or rollback
+							if rand.Float32() < 0.5 {
+								// Before commit, mark as committed
+								_, err = tx.ExecContext(ctx,
+									"UPDATE read_test SET is_committed = ? WHERE id = ?",
+									driver.NamedValue{Ordinal: 1, Value: 1}, // Mark as committed (1)
+									driver.NamedValue{Ordinal: 2, Value: rowID})
+								tx.Commit()
+							} else {
+								tx.Rollback()
+							}
+						}
+					}
+				}(w)
+			}
+
+			// Start readers
+			for r := 0; r < tc.numReaders; r++ {
+				wg.Add(1)
+				go func(readerID int) {
+					defer wg.Done()
+
+					for {
+						select {
+						case <-stopCh:
+							return
+						default:
+							totalReads.Add(1)
+
+							tx, err := db.Begin()
+							if err != nil {
+								continue
+							}
+
+							// Read all rows
+							rows, err := tx.QueryContext(ctx, "SELECT id, value, is_committed FROM read_test ORDER BY id")
+							if err != nil {
+								tx.Rollback()
+								continue
+							}
+
+							dirtyReadFound := false
+							for rows.Next() {
+								var id, value, isCommitted int
+								rows.Scan(&id, &value, &isCommitted)
+
+								// If we see is_committed=0, it means we read uncommitted data
+								if isCommitted == 0 {
+									dirtyReadFound = true
+									dirtyReadsDetected.Add(1)
+									t.Logf("DIRTY READ: Reader %d saw uncommitted value %d for row %d",
+										readerID, value, id)
+									break
+								}
+							}
+							rows.Close()
+
+							if !dirtyReadFound {
+								cleanReads.Add(1)
+							}
+
+							tx.Rollback()
+						}
+					}
+				}(r)
+			}
+
+			// Run for a fixed duration
+			time.Sleep(5 * time.Second)
+			close(stopCh)
+			wg.Wait()
+
+			// Report results
+			fmt.Printf("\n[%s] Dirty Read Test Results:\n", tc.name)
+			fmt.Printf("  Total reads: %d\n", totalReads.Load())
+			fmt.Printf("  Clean reads: %d\n", cleanReads.Load())
+			fmt.Printf("  Dirty reads detected: %d\n", dirtyReadsDetected.Load())
+			fmt.Printf("  Dirty read rate: %.4f%%\n",
+				float64(dirtyReadsDetected.Load())/float64(totalReads.Load())*100)
+
+			// Verify no dirty reads
+			if dirtyReadsDetected.Load() > 0 {
+				t.Errorf("Dirty reads detected: %d out of %d reads",
+					dirtyReadsDetected.Load(), totalReads.Load())
+			}
+		})
+	}
+}
+
+// TestMixedWorkloadStress tests both reads and writes under extreme concurrency
+func TestMixedWorkloadStress(t *testing.T) {
+	db, err := stoolap.Open("memory://")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	err = db.Engine().SetIsolationLevel(storage.SnapshotIsolation)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create table
+	_, err = db.Exec(ctx, "CREATE TABLE mixed_test (id INTEGER PRIMARY KEY, balance INTEGER, txn_count INTEGER)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert initial rows - simulate bank accounts
+	const numAccounts = 100
+	const initialBalance = 1000
+	for i := 1; i <= numAccounts; i++ {
+		_, err = db.Exec(ctx, fmt.Sprintf("INSERT INTO mixed_test (id, balance, txn_count) VALUES (%d, %d, 0)", i, initialBalance))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Tracking
+	var totalTransfers atomic.Int64
+	var successfulTransfers atomic.Int64
+	var dirtyWritesPrevented atomic.Int64
+	var balanceErrors atomic.Int64
+
+	// Run mixed workload
+	var wg sync.WaitGroup
+	stopCh := make(chan struct{})
+	start := time.Now()
+
+	// Transfer workers - simulate money transfers
+	for w := 0; w < 50; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+
+			for {
+				select {
+				case <-stopCh:
+					return
+				default:
+					totalTransfers.Add(1)
+
+					// Random transfer between accounts
+					fromAccount := rand.Intn(numAccounts) + 1
+					toAccount := rand.Intn(numAccounts) + 1
+					if fromAccount == toAccount {
+						continue
+					}
+					amount := rand.Intn(100) + 1
+
+					tx, err := db.Begin()
+					if err != nil {
+						continue
+					}
+
+					success := true
+
+					// Read balances
+					var fromBalance, toBalance int
+					rows, err := tx.QueryContext(ctx,
+						fmt.Sprintf("SELECT balance FROM mixed_test WHERE id = %d", fromAccount))
+					if err != nil {
+						success = false
+					} else if rows.Next() {
+						rows.Scan(&fromBalance)
+						rows.Close()
+					} else {
+						rows.Close()
+						success = false
+					}
+
+					if success {
+						rows, err = tx.QueryContext(ctx,
+							fmt.Sprintf("SELECT balance FROM mixed_test WHERE id = %d", toAccount))
+						if err != nil {
+							success = false
+						} else if rows.Next() {
+							rows.Scan(&toBalance)
+							rows.Close()
+						} else {
+							rows.Close()
+							success = false
+						}
+					}
+
+					// Check sufficient balance
+					if success && fromBalance < amount {
+						success = false
+						balanceErrors.Add(1)
+					}
+
+					// Perform transfer
+					if success {
+						// Deduct from source
+						_, err = tx.ExecContext(ctx,
+							"UPDATE mixed_test SET balance = balance - ?, txn_count = txn_count + 1 WHERE id = ?",
+							driver.NamedValue{Ordinal: 1, Value: amount},
+							driver.NamedValue{Ordinal: 2, Value: fromAccount})
+						if err != nil {
+							if err.Error() == "error executing UPDATE: row is being modified by another transaction" {
+								dirtyWritesPrevented.Add(1)
+							}
+							success = false
+						}
+					}
+
+					if success {
+						// Add to destination
+						_, err = tx.ExecContext(ctx,
+							"UPDATE mixed_test SET balance = balance + ?, txn_count = txn_count + 1 WHERE id = ?",
+							driver.NamedValue{Ordinal: 1, Value: amount},
+							driver.NamedValue{Ordinal: 2, Value: toAccount})
+						if err != nil {
+							if err.Error() == "error executing UPDATE: row is being modified by another transaction" {
+								dirtyWritesPrevented.Add(1)
+							}
+							success = false
+						}
+					}
+
+					// Commit or rollback
+					if success {
+						err = tx.Commit()
+						if err == nil {
+							successfulTransfers.Add(1)
+						}
+					} else {
+						tx.Rollback()
+					}
+				}
+			}
+		}(w)
+	}
+
+	// Balance checker - continuously verify total balance
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				// Calculate total balance
+				var totalBalance int
+				rows, err := db.Query(ctx, "SELECT SUM(balance) FROM mixed_test")
+				if err == nil && rows.Next() {
+					rows.Scan(&totalBalance)
+					rows.Close()
+
+					expectedTotal := numAccounts * initialBalance
+					if totalBalance != expectedTotal {
+						t.Errorf("Balance inconsistency detected! Expected %d, got %d",
+							expectedTotal, totalBalance)
+					}
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	}()
+
+	// Run for fixed duration
+	time.Sleep(10 * time.Second)
+	close(stopCh)
+	wg.Wait()
+	duration := time.Since(start)
+
+	// Final verification
+	var totalBalance, totalTxnCount int
+	rows, _ := db.Query(ctx, "SELECT SUM(balance), SUM(txn_count) FROM mixed_test")
+	if rows.Next() {
+		rows.Scan(&totalBalance, &totalTxnCount)
+		rows.Close()
+	}
+
+	// Report results
+	fmt.Printf("\nMixed Workload Stress Test Results:\n")
+	fmt.Printf("  Duration: %v\n", duration)
+	fmt.Printf("  Total transfer attempts: %d\n", totalTransfers.Load())
+	fmt.Printf("  Successful transfers: %d\n", successfulTransfers.Load())
+	fmt.Printf("  Dirty writes prevented: %d\n", dirtyWritesPrevented.Load())
+	fmt.Printf("  Insufficient balance errors: %d\n", balanceErrors.Load())
+	fmt.Printf("  Total transactions recorded: %d\n", totalTxnCount/2) // Divided by 2 as each transfer touches 2 accounts
+	fmt.Printf("  Throughput: %.2f transfers/sec\n", float64(successfulTransfers.Load())/duration.Seconds())
+
+	// Verify conservation of money
+	expectedTotal := numAccounts * initialBalance
+	if totalBalance != expectedTotal {
+		t.Errorf("Money not conserved! Expected %d, got %d", expectedTotal, totalBalance)
+	}
+}

--- a/test/dirty_read_write_test.go
+++ b/test/dirty_read_write_test.go
@@ -1,0 +1,316 @@
+package test
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stoolap/stoolap"
+	"github.com/stoolap/stoolap/internal/storage"
+)
+
+// TestDirtyWritePrevention tests that dirty writes are not possible
+func TestDirtyWritePrevention(t *testing.T) {
+	testCases := []struct {
+		name      string
+		isolation storage.IsolationLevel
+	}{
+		{"READ_COMMITTED", storage.ReadCommitted},
+		{"SNAPSHOT", storage.SnapshotIsolation},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := stoolap.Open("memory://")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+
+			ctx := context.Background()
+			err = db.Engine().SetIsolationLevel(tc.isolation)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create table and insert initial value
+			_, err = db.Exec(ctx, "CREATE TABLE test (id INTEGER PRIMARY KEY, value INTEGER)")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = db.Exec(ctx, "INSERT INTO test (id, value) VALUES (1, 100)")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Start two transactions
+			tx1, err := db.Begin()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			tx2, err := db.Begin()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Tx1 updates the value but doesn't commit
+			_, err = tx1.ExecContext(ctx, "UPDATE test SET value = ? WHERE id = 1",
+				driver.NamedValue{Ordinal: 1, Value: 200})
+			if err != nil {
+				t.Fatal(err)
+			}
+			fmt.Printf("[%s] Tx1 updated value to 200 (not committed)\n", tc.name)
+
+			// Tx2 tries to update the same row (should block or fail, not overwrite)
+			done := make(chan error, 1)
+			go func() {
+				_, err := tx2.ExecContext(ctx, "UPDATE test SET value = ? WHERE id = 1",
+					driver.NamedValue{Ordinal: 1, Value: 300})
+				done <- err
+			}()
+
+			// Wait a bit to see if tx2 proceeds (it shouldn't for dirty write)
+			select {
+			case err := <-done:
+				if err == nil {
+					t.Errorf("[%s] DIRTY WRITE: Tx2 was able to update uncommitted data!", tc.name)
+				} else {
+					fmt.Printf("[%s] Tx2 update blocked/failed as expected: %v\n", tc.name, err)
+				}
+			case <-time.After(100 * time.Millisecond):
+				fmt.Printf("[%s] Tx2 update blocked (timeout) - correct behavior\n", tc.name)
+			}
+
+			// Clean up
+			tx1.Rollback()
+			tx2.Rollback()
+		})
+	}
+}
+
+// TestDirtyReadPrevention tests that dirty reads are not possible
+func TestDirtyReadPrevention(t *testing.T) {
+	testCases := []struct {
+		name      string
+		isolation storage.IsolationLevel
+	}{
+		{"READ_COMMITTED", storage.ReadCommitted},
+		{"SNAPSHOT", storage.SnapshotIsolation},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := stoolap.Open("memory://")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+
+			ctx := context.Background()
+			err = db.Engine().SetIsolationLevel(tc.isolation)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create table and insert initial value
+			_, err = db.Exec(ctx, "CREATE TABLE test (id INTEGER PRIMARY KEY, value INTEGER)")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = db.Exec(ctx, "INSERT INTO test (id, value) VALUES (1, 100)")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Coordination channels
+			updateDone := make(chan bool)
+			readDone := make(chan int)
+
+			// Start transaction 1 that will update but not commit
+			go func() {
+				tx1, err := db.Begin()
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				defer tx1.Rollback()
+
+				// Update value to 200
+				_, err = tx1.ExecContext(ctx, "UPDATE test SET value = ? WHERE id = 1",
+					driver.NamedValue{Ordinal: 1, Value: 200})
+				if err != nil {
+					t.Error(err)
+					return
+				}
+
+				fmt.Printf("[%s] Tx1 updated value to 200 (not committed)\n", tc.name)
+				updateDone <- true
+
+				// Hold the transaction open for a while
+				time.Sleep(200 * time.Millisecond)
+				fmt.Printf("[%s] Tx1 rolling back\n", tc.name)
+			}()
+
+			// Wait for update to complete
+			<-updateDone
+
+			// Start transaction 2 that tries to read
+			go func() {
+				tx2, err := db.Begin()
+				if err != nil {
+					t.Error(err)
+					readDone <- -1
+					return
+				}
+				defer tx2.Rollback()
+
+				// Try to read the value
+				var value int
+				rows, err := tx2.QueryContext(ctx, "SELECT value FROM test WHERE id = 1")
+				if err != nil {
+					t.Error(err)
+					readDone <- -1
+					return
+				}
+
+				if rows.Next() {
+					err = rows.Scan(&value)
+					rows.Close()
+					if err != nil {
+						t.Error(err)
+						readDone <- -1
+						return
+					}
+				}
+
+				fmt.Printf("[%s] Tx2 read value: %d\n", tc.name, value)
+				readDone <- value
+			}()
+
+			// Get the read value
+			readValue := <-readDone
+
+			// Check if dirty read occurred
+			if readValue == 200 {
+				t.Errorf("[%s] DIRTY READ: Tx2 read uncommitted value 200!", tc.name)
+			} else if readValue == 100 {
+				fmt.Printf("[%s] Correct: Tx2 read committed value 100\n", tc.name)
+			} else {
+				t.Errorf("[%s] Unexpected value read: %d", tc.name, readValue)
+			}
+		})
+	}
+}
+
+// TestConcurrentDirtyWritePrevention tests dirty write prevention under concurrent load
+func TestConcurrentDirtyWritePrevention(t *testing.T) {
+	testCases := []struct {
+		name      string
+		isolation storage.IsolationLevel
+	}{
+		{"READ_COMMITTED", storage.ReadCommitted},
+		{"SNAPSHOT", storage.SnapshotIsolation},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := stoolap.Open("memory://")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+
+			ctx := context.Background()
+			err = db.Engine().SetIsolationLevel(tc.isolation)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create table with multiple rows
+			_, err = db.Exec(ctx, "CREATE TABLE test (id INTEGER PRIMARY KEY, value INTEGER)")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Insert multiple rows
+			for i := 1; i <= 5; i++ {
+				_, err = db.Exec(ctx, fmt.Sprintf("INSERT INTO test (id, value) VALUES (%d, %d)", i, i*100))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Run multiple concurrent transactions
+			const numGoroutines = 10
+			var wg sync.WaitGroup
+			errors := make(chan error, numGoroutines)
+
+			for i := 0; i < numGoroutines; i++ {
+				wg.Add(1)
+				go func(id int) {
+					defer wg.Done()
+
+					tx, err := db.Begin()
+					if err != nil {
+						errors <- err
+						return
+					}
+					defer tx.Rollback()
+
+					// Each transaction tries to update all rows
+					for rowID := 1; rowID <= 5; rowID++ {
+						_, err = tx.ExecContext(ctx, "UPDATE test SET value = ? WHERE id = ?",
+							driver.NamedValue{Ordinal: 1, Value: (id+1)*1000 + rowID},
+							driver.NamedValue{Ordinal: 2, Value: rowID})
+						if err != nil {
+							// Update might fail due to conflicts, which is expected
+							continue
+						}
+					}
+
+					// Try to commit
+					err = tx.Commit()
+					if err != nil {
+						errors <- err
+					}
+				}(i)
+			}
+
+			wg.Wait()
+			close(errors)
+
+			// Count errors (some conflicts are expected)
+			errorCount := 0
+			for err := range errors {
+				if err != nil {
+					errorCount++
+					fmt.Printf("[%s] Transaction error (expected): %v\n", tc.name, err)
+				}
+			}
+
+			fmt.Printf("[%s] %d/%d transactions failed (conflicts expected)\n", tc.name, errorCount, numGoroutines)
+
+			// Verify final state is consistent
+			rows, err := db.Query(ctx, "SELECT id, value FROM test ORDER BY id")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rows.Close()
+
+			fmt.Printf("[%s] Final values:\n", tc.name)
+			for rows.Next() {
+				var id, value int
+				if err := rows.Scan(&id, &value); err != nil {
+					t.Fatal(err)
+				}
+				fmt.Printf("  Row %d: value=%d\n", id, value)
+			}
+		})
+	}
+}

--- a/test/dirty_write_batch_test.go
+++ b/test/dirty_write_batch_test.go
@@ -1,0 +1,301 @@
+package test
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stoolap/stoolap"
+	"github.com/stoolap/stoolap/internal/storage"
+)
+
+func TestDirtyWriteBatchPrevention(t *testing.T) {
+	testCases := []struct {
+		name      string
+		isolation storage.IsolationLevel
+	}{
+		{"READ_COMMITTED", storage.ReadCommitted},
+		{"SNAPSHOT", storage.SnapshotIsolation},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := stoolap.Open("memory://")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+
+			ctx := context.Background()
+			err = db.Engine().SetIsolationLevel(tc.isolation)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create table
+			_, err = db.Exec(ctx, "CREATE TABLE test (id INTEGER PRIMARY KEY, value INTEGER)")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Insert initial rows
+			_, err = db.Exec(ctx, "INSERT INTO test (id, value) VALUES (1, 100), (2, 200), (3, 300)")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Start two transactions
+			tx1, err := db.Begin()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			tx2, err := db.Begin()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Tx1 updates row 2 but doesn't commit
+			_, err = tx1.ExecContext(ctx, "UPDATE test SET value = 250 WHERE id = 2")
+			if err != nil {
+				t.Fatal(err)
+			}
+			fmt.Printf("[%s] Tx1 updated row 2 to 250 (not committed)\n", tc.name)
+
+			// Tx2 tries to insert multiple rows, including one that would update row 2
+			_, err = tx2.ExecContext(ctx, "INSERT INTO test (id, value) VALUES (2, 999), (4, 400), (5, 500)")
+			if err != nil {
+				fmt.Printf("[%s] Tx2 batch insert blocked/failed as expected: %v\n", tc.name, err)
+			} else {
+				t.Errorf("[%s] DIRTY WRITE: Tx2 was able to insert over uncommitted data!", tc.name)
+			}
+
+			// Clean up
+			tx1.Rollback()
+			tx2.Rollback()
+		})
+	}
+}
+
+func TestDirtyWriteBatchUpdate(t *testing.T) {
+	db, err := stoolap.Open("memory://")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	err = db.Engine().SetIsolationLevel(storage.SnapshotIsolation)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create table
+	_, err = db.Exec(ctx, "CREATE TABLE test (id INTEGER PRIMARY KEY, value INTEGER)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert initial rows
+	_, err = db.Exec(ctx, "INSERT INTO test (id, value) VALUES (1, 100), (2, 200), (3, 300), (4, 400), (5, 500)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start two transactions
+	tx1, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx2, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tx1 updates rows 2 and 3 but doesn't commit
+	_, err = tx1.ExecContext(ctx, "UPDATE test SET value = value + 1000 WHERE id IN (2, 3)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println("Tx1 updated rows 2,3 (not committed)")
+
+	// Tx2 tries to update rows 3,4,5 (row 3 conflicts)
+	_, err = tx2.ExecContext(ctx, "UPDATE test SET value = value + 2000 WHERE id IN (3, 4, 5)")
+	if err != nil {
+		fmt.Printf("Tx2 batch update failed as expected: %v\n", err)
+	} else {
+		// Check what values Tx2 sees
+		rows, _ := tx2.QueryContext(ctx, "SELECT id, value FROM test WHERE id IN (3, 4, 5) ORDER BY id")
+		defer rows.Close()
+
+		fmt.Println("Tx2 sees:")
+		for rows.Next() {
+			var id, value int
+			rows.Scan(&id, &value)
+			fmt.Printf("  Row %d: value=%d\n", id, value)
+		}
+
+		t.Error("DIRTY WRITE: Tx2 was able to update rows with uncommitted changes!")
+	}
+
+	// Clean up
+	tx1.Rollback()
+	tx2.Rollback()
+}
+
+// TestDirtyWriteBatchTransfer tests a simple two-account transfer scenario
+func TestDirtyWriteBatchTransfer(t *testing.T) {
+	testCases := []struct {
+		name      string
+		isolation storage.IsolationLevel
+	}{
+		{"READ_COMMITTED", storage.ReadCommitted},
+		{"SNAPSHOT", storage.SnapshotIsolation},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := stoolap.Open("memory://")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+
+			ctx := context.Background()
+			err = db.Engine().SetIsolationLevel(tc.isolation)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create table with two accounts
+			_, err = db.Exec(ctx, "CREATE TABLE accounts (id INTEGER PRIMARY KEY, balance INTEGER)")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Insert two accounts with 1000 each
+			_, err = db.Exec(ctx, "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 1000)")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Verify initial state
+			var totalBalance int
+			rows, _ := db.Query(ctx, "SELECT SUM(balance) FROM accounts")
+			if rows.Next() {
+				rows.Scan(&totalBalance)
+				rows.Close()
+			}
+			if totalBalance != 2000 {
+				t.Fatalf("Initial balance incorrect: %d", totalBalance)
+			}
+
+			// Run concurrent transfers
+			var wg sync.WaitGroup
+			successCount := 0
+			failCount := 0
+			var mu sync.Mutex
+
+			for i := 0; i < 10; i++ {
+				wg.Add(1)
+				go func(id int) {
+					defer wg.Done()
+
+					// Start transaction
+					tx, err := db.Begin()
+					if err != nil {
+						mu.Lock()
+						failCount++
+						mu.Unlock()
+						return
+					}
+
+					// Try to transfer 100 from account 1 to account 2
+					success := true
+
+					// Deduct from account 1
+					_, err = tx.ExecContext(ctx,
+						"UPDATE accounts SET balance = balance - ? WHERE id = ?",
+						driver.NamedValue{Ordinal: 1, Value: 100},
+						driver.NamedValue{Ordinal: 2, Value: 1})
+					if err != nil {
+						success = false
+						t.Logf("Worker %d: Failed to deduct: %v", id, err)
+					}
+
+					// Add delay to increase chance of conflicts
+					time.Sleep(10 * time.Millisecond)
+
+					// Add to account 2
+					if success {
+						_, err = tx.ExecContext(ctx,
+							"UPDATE accounts SET balance = balance + ? WHERE id = ?",
+							driver.NamedValue{Ordinal: 1, Value: 100},
+							driver.NamedValue{Ordinal: 2, Value: 2})
+						if err != nil {
+							success = false
+							t.Logf("Worker %d: Failed to credit: %v", id, err)
+						}
+					}
+
+					// Commit or rollback
+					if success {
+						err = tx.Commit()
+						if err != nil {
+							t.Logf("Worker %d: Commit failed: %v", id, err)
+							mu.Lock()
+							failCount++
+							mu.Unlock()
+						} else {
+							mu.Lock()
+							successCount++
+							mu.Unlock()
+						}
+					} else {
+						tx.Rollback()
+						mu.Lock()
+						failCount++
+						mu.Unlock()
+					}
+				}(i)
+			}
+
+			wg.Wait()
+
+			// Check final balance
+			rows, _ = db.Query(ctx, "SELECT SUM(balance) FROM accounts")
+			if rows.Next() {
+				rows.Scan(&totalBalance)
+				rows.Close()
+			}
+
+			// Check individual balances
+			var bal1, bal2 int
+			rows, _ = db.Query(ctx, "SELECT balance FROM accounts WHERE id = 1")
+			if rows.Next() {
+				rows.Scan(&bal1)
+				rows.Close()
+			}
+			rows, _ = db.Query(ctx, "SELECT balance FROM accounts WHERE id = 2")
+			if rows.Next() {
+				rows.Scan(&bal2)
+				rows.Close()
+			}
+
+			fmt.Printf("[%s] Results:\n", tc.name)
+			fmt.Printf("  Successful transfers: %d\n", successCount)
+			fmt.Printf("  Failed transfers: %d\n", failCount)
+			fmt.Printf("  Account 1 balance: %d\n", bal1)
+			fmt.Printf("  Account 2 balance: %d\n", bal2)
+			fmt.Printf("  Total balance: %d (expected: 2000)\n", totalBalance)
+
+			if totalBalance != 2000 {
+				t.Errorf("Money not conserved! Total balance: %d, expected: 2000", totalBalance)
+			}
+		})
+	}
+}

--- a/test/dirty_write_simple_test.go
+++ b/test/dirty_write_simple_test.go
@@ -1,0 +1,351 @@
+package test
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stoolap/stoolap"
+	"github.com/stoolap/stoolap/internal/storage"
+)
+
+func TestDirtyWriteSimple(t *testing.T) {
+	db, err := stoolap.Open("memory://")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	err = db.Engine().SetIsolationLevel(storage.ReadCommitted)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create table and insert initial value
+	_, err = db.Exec(ctx, "CREATE TABLE test (id INTEGER PRIMARY KEY, value INTEGER)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.Exec(ctx, "INSERT INTO test (id, value) VALUES (1, 100)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start Tx1
+	tx1, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tx1 reads the value
+	var value1 int
+	rows1, err := tx1.QueryContext(ctx, "SELECT value FROM test WHERE id = 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows1.Next() {
+		rows1.Scan(&value1)
+		rows1.Close()
+	}
+	fmt.Printf("Tx1 read value: %d\n", value1)
+
+	// Tx1 updates but doesn't commit
+	_, err = tx1.ExecContext(ctx, "UPDATE test SET value = ? WHERE id = 1",
+		driver.NamedValue{Ordinal: 1, Value: 200})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println("Tx1 updated to 200 (not committed)")
+
+	// Start Tx2
+	tx2, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tx2 reads the value (should see 100, not 200)
+	var value2 int
+	rows2, err := tx2.QueryContext(ctx, "SELECT value FROM test WHERE id = 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows2.Next() {
+		rows2.Scan(&value2)
+		rows2.Close()
+	}
+	fmt.Printf("Tx2 read value: %d (correct, sees committed value)\n", value2)
+
+	// Tx2 tries to update the same row
+	// This should fail or block because Tx1 has uncommitted changes to this row
+	_, err = tx2.ExecContext(ctx, "UPDATE test SET value = ? WHERE id = 1",
+		driver.NamedValue{Ordinal: 1, Value: 300})
+	if err != nil {
+		fmt.Printf("Tx2 update failed (correct): %v\n", err)
+	} else {
+		fmt.Println("Tx2 update succeeded (WRONG! This is a dirty write)")
+
+		// Let's see what each transaction thinks the value is
+		var checkValue1, checkValue2 int
+
+		// Tx1 checks
+		rows, _ := tx1.QueryContext(ctx, "SELECT value FROM test WHERE id = 1")
+		if rows.Next() {
+			rows.Scan(&checkValue1)
+			rows.Close()
+		}
+		fmt.Printf("Tx1 now sees value: %d\n", checkValue1)
+
+		// Tx2 checks
+		rows, _ = tx2.QueryContext(ctx, "SELECT value FROM test WHERE id = 1")
+		if rows.Next() {
+			rows.Scan(&checkValue2)
+			rows.Close()
+		}
+		fmt.Printf("Tx2 now sees value: %d\n", checkValue2)
+	}
+
+	// Commit both
+	err1 := tx1.Commit()
+	err2 := tx2.Commit()
+
+	fmt.Printf("Tx1 commit: %v\n", err1)
+	fmt.Printf("Tx2 commit: %v\n", err2)
+
+	// Check final value
+	var finalValue int
+	err = db.QueryRow(ctx, "SELECT value FROM test WHERE id = 1").Scan(&finalValue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("Final value: %d\n", finalValue)
+}
+
+// TestSimpleMoneyTransfer tests money transfer scenario with proper balance conservation
+func TestSimpleMoneyTransfer(t *testing.T) {
+	db, err := stoolap.Open("memory://")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	err = db.Engine().SetIsolationLevel(storage.SnapshotIsolation)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create accounts table
+	_, err = db.Exec(ctx, "CREATE TABLE accounts (id INTEGER PRIMARY KEY, balance INTEGER)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create 10 accounts with 1000 each
+	for i := 1; i <= 10; i++ {
+		_, err = db.Exec(ctx, fmt.Sprintf("INSERT INTO accounts (id, balance) VALUES (%d, 1000)", i))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Verify initial total
+	var initialTotal int
+	rows, _ := db.Query(ctx, "SELECT SUM(balance) FROM accounts")
+	if rows.Next() {
+		rows.Scan(&initialTotal)
+		rows.Close()
+	}
+	fmt.Printf("Initial total balance: %d\n", initialTotal)
+
+	// Run transfers
+	var successfulTransfers atomic.Int32
+	var failedTransfers atomic.Int32
+	var wg sync.WaitGroup
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(txID int) {
+			defer wg.Done()
+
+			// Add some delay to reduce contention
+			time.Sleep(time.Duration(txID) * time.Millisecond)
+
+			// Random transfer
+			fromID := (txID % 10) + 1
+			toID := ((txID + 3) % 10) + 1
+			if fromID == toID {
+				toID = (toID % 10) + 1
+			}
+			amount := 50
+
+			// Start transaction
+			tx, err := db.Begin()
+			if err != nil {
+				failedTransfers.Add(1)
+				return
+			}
+
+			success := true
+
+			// Check source balance
+			var sourceBalance int
+			rows, err := tx.QueryContext(ctx,
+				"SELECT balance FROM accounts WHERE id = ?",
+				driver.NamedValue{Ordinal: 1, Value: fromID})
+			if err != nil {
+				success = false
+			} else if rows.Next() {
+				rows.Scan(&sourceBalance)
+				rows.Close()
+				if sourceBalance < amount {
+					success = false // Insufficient funds
+				}
+			} else {
+				rows.Close()
+				success = false
+			}
+
+			// Perform transfer
+			if success {
+				// Deduct from source
+				_, err = tx.ExecContext(ctx,
+					"UPDATE accounts SET balance = balance - ? WHERE id = ?",
+					driver.NamedValue{Ordinal: 1, Value: amount},
+					driver.NamedValue{Ordinal: 2, Value: fromID})
+				if err != nil {
+					t.Logf("Tx %d: Failed to deduct from account %d: %v", txID, fromID, err)
+					success = false
+				}
+			}
+
+			// Small delay to increase contention
+			time.Sleep(5 * time.Millisecond)
+
+			if success {
+				// Add to destination
+				_, err = tx.ExecContext(ctx,
+					"UPDATE accounts SET balance = balance + ? WHERE id = ?",
+					driver.NamedValue{Ordinal: 1, Value: amount},
+					driver.NamedValue{Ordinal: 2, Value: toID})
+				if err != nil {
+					t.Logf("Tx %d: Failed to credit account %d: %v", txID, toID, err)
+					success = false
+				} else {
+					t.Logf("Tx %d: Successfully transferred %d from account %d to %d", txID, amount, fromID, toID)
+				}
+			}
+
+			// Commit or rollback
+			if success {
+				err = tx.Commit()
+				if err == nil {
+					successfulTransfers.Add(1)
+					t.Logf("Tx %d: Committed successfully", txID)
+				} else {
+					t.Logf("Tx %d: Commit failed: %v", txID, err)
+					failedTransfers.Add(1)
+				}
+			} else {
+				err = tx.Rollback()
+				t.Logf("Tx %d: Rolled back due to failure", txID)
+				failedTransfers.Add(1)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Check final total
+	var finalTotal int
+	rows, _ = db.Query(ctx, "SELECT SUM(balance) FROM accounts")
+	if rows.Next() {
+		rows.Scan(&finalTotal)
+		rows.Close()
+	}
+
+	// Check individual account balances
+	fmt.Printf("\nFinal account balances:\n")
+	rows, _ = db.Query(ctx, "SELECT id, balance FROM accounts ORDER BY id")
+	for rows.Next() {
+		var id, balance int
+		rows.Scan(&id, &balance)
+		fmt.Printf("  Account %d: %d\n", id, balance)
+	}
+	rows.Close()
+
+	fmt.Printf("\nTransfer Results:\n")
+	fmt.Printf("  Successful transfers: %d\n", successfulTransfers.Load())
+	fmt.Printf("  Failed transfers: %d\n", failedTransfers.Load())
+	fmt.Printf("  Initial total: %d\n", initialTotal)
+	fmt.Printf("  Final total: %d\n", finalTotal)
+
+	if initialTotal != finalTotal {
+		t.Errorf("Money not conserved! Initial: %d, Final: %d", initialTotal, finalTotal)
+	}
+}
+
+// TestArithmeticUpdate tests that arithmetic updates work correctly
+func TestArithmeticUpdate(t *testing.T) {
+	db, err := stoolap.Open("memory://")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+
+	// Create table
+	_, err = db.Exec(ctx, "CREATE TABLE counter (id INTEGER PRIMARY KEY, value INTEGER)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert initial value
+	_, err = db.Exec(ctx, "INSERT INTO counter (id, value) VALUES (1, 100)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test arithmetic update
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Update with arithmetic
+	_, err = tx.ExecContext(ctx, "UPDATE counter SET value = value + 50 WHERE id = 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check value within transaction
+	var valueInTx int
+	rows, _ := tx.QueryContext(ctx, "SELECT value FROM counter WHERE id = 1")
+	if rows.Next() {
+		rows.Scan(&valueInTx)
+		rows.Close()
+	}
+	fmt.Printf("Value in transaction after update: %d\n", valueInTx)
+
+	// Rollback
+	tx.Rollback()
+
+	// Check value after rollback
+	var valueAfterRollback int
+	rows, _ = db.Query(ctx, "SELECT value FROM counter WHERE id = 1")
+	if rows.Next() {
+		rows.Scan(&valueAfterRollback)
+		rows.Close()
+	}
+	fmt.Printf("Value after rollback: %d\n", valueAfterRollback)
+
+	if valueAfterRollback != 100 {
+		t.Errorf("Rollback didn't restore original value! Expected 100, got %d", valueAfterRollback)
+	}
+}

--- a/test/integration_sql_test.go
+++ b/test/integration_sql_test.go
@@ -61,10 +61,6 @@ func TestIntegrationSQL(t *testing.T) {
 		testTransactionSupport(t, db)
 	})
 
-	t.Run("WindowFunctions", func(t *testing.T) {
-		testWindowFunctions(t, db)
-	})
-
 	t.Run("SimpleJoins", func(t *testing.T) {
 		testSimpleJoins(t, db)
 	})
@@ -575,12 +571,6 @@ func testTransactionSupport(t *testing.T, db *sql.DB) {
 
 	// Clean up
 	_, _ = db.Exec("DROP TABLE tx_test")
-}
-
-func testWindowFunctions(t *testing.T, db *sql.DB) {
-	// Window functions with OVER clause are not yet fully supported
-	// Skip this test for now
-	t.Skip("Window functions with OVER clause not yet supported")
 }
 
 func testSimpleJoins(t *testing.T, db *sql.DB) {

--- a/test/isolation_level_test.go
+++ b/test/isolation_level_test.go
@@ -18,6 +18,7 @@ package test
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	_ "github.com/stoolap/stoolap/pkg/driver"
@@ -335,7 +336,7 @@ func TestConnectionIsolation(t *testing.T) {
 		} else {
 			t.Errorf("Expected write-write conflict for SNAPSHOT isolation, but commit succeeded. Final value: %d", finalValue)
 		}
-	} else if err.Error() != "transaction aborted due to write-write conflict" {
+	} else if !strings.Contains(err.Error(), "write-write conflict") {
 		t.Errorf("Expected write-write conflict error, got: %v", err)
 	}
 }
@@ -414,7 +415,7 @@ func TestTransactionLevelOverride(t *testing.T) {
 	err = tx2.Commit()
 	if err == nil {
 		t.Error("Expected write-write conflict, but commit succeeded")
-	} else if err.Error() != "transaction aborted due to write-write conflict" {
+	} else if !strings.Contains(err.Error(), "write-write conflict") {
 		t.Errorf("Expected write-write conflict error, got: %v", err)
 	}
 }

--- a/test/mvcc_deletion_isolation_test.go
+++ b/test/mvcc_deletion_isolation_test.go
@@ -629,7 +629,6 @@ func TestMVCCDeletionRollback(t *testing.T) {
 
 // TestMVCCDeletionWithUpdate tests deletion visibility when combined with updates
 func TestMVCCDeletionWithUpdate(t *testing.T) {
-	t.Skip("Skipping test for now, the MVCC only keep the single version of the row")
 	db, err := sql.Open("stoolap", "memory://")
 	if err != nil {
 		t.Fatalf("Failed to open database: %v", err)

--- a/test/mvcc_deletion_pk_test.go
+++ b/test/mvcc_deletion_pk_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2025 Stoolap Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/stoolap/stoolap/pkg/driver"
+)
+
+// TestMVCCDeletionByPrimaryKey specifically tests the bug where deleted rows
+// were not visible when queried by primary key in SNAPSHOT isolation
+func TestMVCCDeletionByPrimaryKey(t *testing.T) {
+	db, err := sql.Open("stoolap", "memory://")
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create and populate table
+	_, err = db.Exec("CREATE TABLE test_pk_deletion (id INTEGER PRIMARY KEY, name TEXT)")
+	if err != nil {
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	_, err = db.Exec("INSERT INTO test_pk_deletion VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie')")
+	if err != nil {
+		t.Fatalf("Failed to insert data: %v", err)
+	}
+
+	// Start T1 with SNAPSHOT isolation
+	tx1, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSnapshot})
+	if err != nil {
+		t.Fatalf("Failed to begin tx1: %v", err)
+	}
+	defer tx1.Rollback()
+
+	// T1: Verify initial state
+	var count int
+	err = tx1.QueryRow("SELECT COUNT(*) FROM test_pk_deletion").Scan(&count)
+	if err != nil {
+		t.Fatalf("Failed to count rows: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("Expected 3 rows initially, got %d", count)
+	}
+
+	// Delete Bob in a separate transaction
+	tx2, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSnapshot})
+	if err != nil {
+		t.Fatalf("Failed to begin tx2: %v", err)
+	}
+
+	_, err = tx2.Exec("DELETE FROM test_pk_deletion WHERE id = 2")
+	if err != nil {
+		t.Fatalf("Failed to delete: %v", err)
+	}
+
+	err = tx2.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit deletion: %v", err)
+	}
+
+	// T1: Should still see all 3 rows
+	err = tx1.QueryRow("SELECT COUNT(*) FROM test_pk_deletion").Scan(&count)
+	if err != nil {
+		t.Fatalf("Failed to count after deletion: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("SNAPSHOT: Expected 3 rows, got %d", count)
+	}
+
+	// T1: Query by primary key - this was the failing case
+	var name string
+	err = tx1.QueryRow("SELECT name FROM test_pk_deletion WHERE id = 2").Scan(&name)
+	if err == sql.ErrNoRows {
+		t.Error("SNAPSHOT: Should be able to see deleted row when querying by primary key")
+	} else if err != nil {
+		t.Fatalf("Failed to query by primary key: %v", err)
+	} else if name != "Bob" {
+		t.Errorf("Expected name 'Bob', got '%s'", name)
+	} else {
+		t.Log("SUCCESS: Can see deleted row 'Bob' when querying by primary key")
+	}
+
+	// T1: Also verify with other query patterns
+	rows, err := tx1.Query("SELECT id, name FROM test_pk_deletion ORDER BY id")
+	if err != nil {
+		t.Fatalf("Failed to query all rows: %v", err)
+	}
+	defer rows.Close()
+
+	expectedRows := []struct {
+		id   int
+		name string
+	}{
+		{1, "Alice"},
+		{2, "Bob"},
+		{3, "Charlie"},
+	}
+
+	i := 0
+	for rows.Next() {
+		var id int
+		var name string
+		err = rows.Scan(&id, &name)
+		if err != nil {
+			t.Fatalf("Failed to scan row: %v", err)
+		}
+
+		if i >= len(expectedRows) {
+			t.Error("Too many rows returned")
+			break
+		}
+
+		if id != expectedRows[i].id || name != expectedRows[i].name {
+			t.Errorf("Row %d: expected (%d, %s), got (%d, %s)",
+				i, expectedRows[i].id, expectedRows[i].name, id, name)
+		}
+		i++
+	}
+
+	if i != len(expectedRows) {
+		t.Errorf("Expected %d rows, got %d", len(expectedRows), i)
+	}
+
+	tx1.Commit()
+
+	// New transaction should NOT see Bob
+	tx3, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSnapshot})
+	if err != nil {
+		t.Fatalf("Failed to begin tx3: %v", err)
+	}
+	defer tx3.Rollback()
+
+	err = tx3.QueryRow("SELECT name FROM test_pk_deletion WHERE id = 2").Scan(&name)
+	if err != sql.ErrNoRows {
+		t.Error("New transaction should NOT see deleted row")
+	}
+
+	var count3 int
+	err = tx3.QueryRow("SELECT COUNT(*) FROM test_pk_deletion").Scan(&count3)
+	if err != nil {
+		t.Fatalf("Failed to count in new transaction: %v", err)
+	}
+	if count3 != 2 {
+		t.Errorf("New transaction should see 2 rows, got %d", count3)
+	}
+}

--- a/test/snapshot_lost_update_test.go
+++ b/test/snapshot_lost_update_test.go
@@ -1,0 +1,228 @@
+package test
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stoolap/stoolap"
+	"github.com/stoolap/stoolap/internal/storage"
+)
+
+// TestSnapshotLostUpdatePrevention tests that SNAPSHOT isolation prevents lost updates
+func TestSnapshotLostUpdatePrevention(t *testing.T) {
+	db, err := stoolap.Open("memory://")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	err = db.Engine().SetIsolationLevel(storage.SnapshotIsolation)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create table
+	_, err = db.Exec(ctx, "CREATE TABLE accounts (id INTEGER PRIMARY KEY, balance INTEGER)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert initial data
+	_, err = db.Exec(ctx, "INSERT INTO accounts (id, balance) VALUES (1, 1000)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start two transactions
+	tx1, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx1.Rollback()
+
+	tx2, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx2.Rollback()
+
+	// Both transactions read the same account
+	var balance1, balance2 int
+	rows1, err := tx1.QueryContext(ctx, "SELECT balance FROM accounts WHERE id = 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows1.Next() {
+		rows1.Scan(&balance1)
+		rows1.Close()
+	}
+	t.Logf("Tx1 read balance: %d", balance1)
+
+	rows2, err := tx2.QueryContext(ctx, "SELECT balance FROM accounts WHERE id = 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows2.Next() {
+		rows2.Scan(&balance2)
+		rows2.Close()
+	}
+	t.Logf("Tx2 read balance: %d", balance2)
+
+	// Both try to update based on what they read
+	// Tx1 adds 100
+	_, err = tx1.ExecContext(ctx,
+		"UPDATE accounts SET balance = ? WHERE id = 1",
+		driver.NamedValue{Ordinal: 1, Value: balance1 + 100})
+	if err != nil {
+		t.Fatalf("Tx1 update failed: %v", err)
+	}
+	t.Log("Tx1 updated balance to", balance1+100)
+
+	// Tx1 commits first
+	err = tx1.Commit()
+	if err != nil {
+		t.Fatalf("Tx1 commit failed: %v", err)
+	}
+	t.Log("Tx1 committed successfully")
+
+	// Tx2 also tries to add 200 based on its read
+	_, err = tx2.ExecContext(ctx,
+		"UPDATE accounts SET balance = ? WHERE id = 1",
+		driver.NamedValue{Ordinal: 1, Value: balance2 + 200})
+	if err != nil {
+		t.Fatalf("Tx2 update failed: %v", err)
+	}
+	t.Log("Tx2 updated balance to", balance2+200)
+
+	// Tx2 commit should fail due to write-write conflict
+	err = tx2.Commit()
+	if err == nil {
+		t.Error("Expected write-write conflict, but tx2 commit succeeded - LOST UPDATE!")
+	} else {
+		t.Logf("Tx2 commit correctly failed with: %v", err)
+	}
+
+	// Verify final balance
+	var finalBalance int
+	rows, _ := db.Query(ctx, "SELECT balance FROM accounts WHERE id = 1")
+	if rows.Next() {
+		rows.Scan(&finalBalance)
+		rows.Close()
+	}
+	t.Logf("Final balance: %d (should be 1100, not 1200)", finalBalance)
+
+	if finalBalance != 1100 {
+		t.Errorf("Lost update detected! Final balance is %d, expected 1100", finalBalance)
+	}
+}
+
+// TestConcurrentSnapshotUpdates tests multiple concurrent updates under SNAPSHOT isolation
+func TestConcurrentSnapshotUpdates(t *testing.T) {
+	db, err := stoolap.Open("memory://")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	err = db.Engine().SetIsolationLevel(storage.SnapshotIsolation)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create table
+	_, err = db.Exec(ctx, "CREATE TABLE counters (id INTEGER PRIMARY KEY, value INTEGER)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert initial data
+	_, err = db.Exec(ctx, "INSERT INTO counters (id, value) VALUES (1, 0)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run concurrent increments
+	const numWorkers = 10
+	const incrementsPerWorker = 10
+
+	var wg sync.WaitGroup
+	successCount := 0
+	conflictCount := 0
+	var mu sync.Mutex
+
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+
+			for i := 0; i < incrementsPerWorker; i++ {
+				tx, err := db.Begin()
+				if err != nil {
+					continue
+				}
+
+				// Read current value
+				var currentValue int
+				rows, err := tx.QueryContext(ctx, "SELECT value FROM counters WHERE id = 1")
+				if err != nil {
+					tx.Rollback()
+					continue
+				}
+				if rows.Next() {
+					rows.Scan(&currentValue)
+					rows.Close()
+				} else {
+					rows.Close()
+					tx.Rollback()
+					continue
+				}
+
+				// Update with increment
+				_, err = tx.ExecContext(ctx,
+					"UPDATE counters SET value = ? WHERE id = 1",
+					driver.NamedValue{Ordinal: 1, Value: currentValue + 1})
+				if err != nil {
+					tx.Rollback()
+					continue
+				}
+
+				// Try to commit
+				err = tx.Commit()
+				mu.Lock()
+				if err == nil {
+					successCount++
+				} else {
+					conflictCount++
+				}
+				mu.Unlock()
+			}
+		}(w)
+	}
+
+	wg.Wait()
+
+	// Check final value
+	var finalValue int
+	rows, _ := db.Query(ctx, "SELECT value FROM counters WHERE id = 1")
+	if rows.Next() {
+		rows.Scan(&finalValue)
+		rows.Close()
+	}
+
+	fmt.Printf("\nConcurrent SNAPSHOT Update Results:\n")
+	fmt.Printf("  Successful commits: %d\n", successCount)
+	fmt.Printf("  Conflicts detected: %d\n", conflictCount)
+	fmt.Printf("  Total attempts: %d\n", successCount+conflictCount)
+	fmt.Printf("  Final counter value: %d\n", finalValue)
+
+	// The final value should equal the number of successful commits
+	if finalValue != successCount {
+		t.Errorf("Lost updates detected! Final value %d != successful commits %d",
+			finalValue, successCount)
+	}
+}

--- a/test/stress_lost_update_test.go
+++ b/test/stress_lost_update_test.go
@@ -1,0 +1,114 @@
+package test
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stoolap/stoolap"
+	"github.com/stoolap/stoolap/internal/storage"
+)
+
+// TestStressLostUpdate aggressively tests for lost updates
+func TestStressLostUpdate(t *testing.T) {
+	for round := 0; round < 10; round++ {
+		db, err := stoolap.Open("memory://")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := context.Background()
+		err = db.Engine().SetIsolationLevel(storage.SnapshotIsolation)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create table
+		_, err = db.Exec(ctx, "CREATE TABLE test (id INTEGER PRIMARY KEY, value INTEGER)")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Insert initial data
+		_, err = db.Exec(ctx, "INSERT INTO test (id, value) VALUES (1, 0)")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Run 100 concurrent increments
+		const numWorkers = 100
+		var wg sync.WaitGroup
+		successCount := 0
+		var mu sync.Mutex
+
+		for i := 0; i < numWorkers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				tx, err := db.Begin()
+				if err != nil {
+					return
+				}
+
+				// Read current value
+				var currentValue int
+				rows, err := tx.QueryContext(ctx, "SELECT value FROM test WHERE id = 1")
+				if err != nil {
+					tx.Rollback()
+					return
+				}
+				if rows.Next() {
+					rows.Scan(&currentValue)
+					rows.Close()
+				} else {
+					rows.Close()
+					tx.Rollback()
+					return
+				}
+
+				// Update with increment
+				_, err = tx.ExecContext(ctx,
+					"UPDATE test SET value = ? WHERE id = 1",
+					driver.NamedValue{Ordinal: 1, Value: currentValue + 1})
+				if err != nil {
+					tx.Rollback()
+					return
+				}
+
+				// Try to commit
+				err = tx.Commit()
+				if err == nil {
+					mu.Lock()
+					successCount++
+					mu.Unlock()
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		// Check final value
+		var finalValue int
+		rows, _ := db.Query(ctx, "SELECT value FROM test WHERE id = 1")
+		if rows.Next() {
+			rows.Scan(&finalValue)
+			rows.Close()
+		}
+
+		fmt.Printf("Round %d: %d successful commits, final value = %d",
+			round+1, successCount, finalValue)
+
+		if finalValue != successCount {
+			fmt.Printf(" - LOST %d UPDATES!\n", successCount-finalValue)
+			t.Errorf("Round %d: Lost updates detected! Final value %d != successful commits %d",
+				round+1, finalValue, successCount)
+		} else {
+			fmt.Printf(" - OK\n")
+		}
+
+		db.Close()
+	}
+}

--- a/test/uncommitted_writes_test.go
+++ b/test/uncommitted_writes_test.go
@@ -1,0 +1,214 @@
+package test
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	_ "github.com/stoolap/stoolap/pkg/driver"
+)
+
+// TestUncommittedWritesTracking tests the issue where committed rows still appear
+// to be "being modified by another transaction"
+func TestUncommittedWritesTracking(t *testing.T) {
+	// Create a temporary database in memory
+	dbPath := "memory://"
+	db, err := sql.Open("stoolap", dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create a table
+	_, err = db.Exec("CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT)")
+	if err != nil {
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	// Insert a row in a transaction
+	tx1, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
+	_, err = tx1.Exec("INSERT INTO test_table (id, value) VALUES (1, 'initial value')")
+	if err != nil {
+		t.Fatalf("Failed to insert row: %v", err)
+	}
+
+	// Commit the transaction
+	err = tx1.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit transaction 1: %v", err)
+	}
+
+	t.Log("Transaction 1 committed successfully with row id=1")
+
+	// Now start a new transaction and try to update the same row
+	tx2, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 2: %v", err)
+	}
+
+	_, err = tx2.Exec("UPDATE test_table SET value = 'updated value' WHERE id = 1")
+	if err != nil {
+		t.Errorf("Failed to update row in transaction 2: %v", err)
+		if err.Error() == "row is being modified by another transaction" {
+			t.Error("BUG: The row should not be claimed by any transaction since tx1 was committed!")
+		}
+	} else {
+		t.Log("Successfully updated row in transaction 2")
+	}
+
+	// Try to commit tx2
+	err = tx2.Commit()
+	if err != nil {
+		t.Errorf("Failed to commit transaction 2: %v", err)
+	}
+
+	// Try a third transaction to see if the issue persists
+	tx3, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 3: %v", err)
+	}
+
+	_, err = tx3.Exec("UPDATE test_table SET value = 'third update' WHERE id = 1")
+	if err != nil {
+		t.Errorf("Failed to update row in transaction 3: %v", err)
+		if err.Error() == "row is being modified by another transaction" {
+			t.Error("BUG: The uncommittedWrites map is not being cleaned up properly!")
+		}
+	}
+
+	tx3.Rollback()
+
+	// Verify the final value
+	var value string
+	err = db.QueryRow("SELECT value FROM test_table WHERE id = 1").Scan(&value)
+	if err != nil {
+		t.Fatalf("Failed to query final value: %v", err)
+	}
+	t.Logf("Final value in database: %s", value)
+}
+
+// TestUncommittedWritesCleanupOnCommit verifies that uncommitted writes are properly cleaned up after commit
+func TestUncommittedWritesCleanupOnCommit(t *testing.T) {
+	// Create a temporary database in memory
+	dbPath := "memory://"
+	db, err := sql.Open("stoolap", dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create table
+	_, err = db.Exec("CREATE TABLE cleanup_test (id INTEGER PRIMARY KEY, value TEXT)")
+	if err != nil {
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	// Insert multiple rows
+	for i := 1; i <= 5; i++ {
+		_, err = db.Exec("INSERT INTO cleanup_test (id, value) VALUES (?, ?)", i, fmt.Sprintf("value %d", i))
+		if err != nil {
+			t.Fatalf("Failed to insert row %d: %v", i, err)
+		}
+	}
+
+	// Now update multiple rows in a transaction
+	tx2, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 2: %v", err)
+	}
+
+	// Update rows 1, 3, and 5
+	for _, id := range []int{1, 3, 5} {
+		_, err = tx2.Exec("UPDATE cleanup_test SET value = ? WHERE id = ?", fmt.Sprintf("updated value %d", id), id)
+		if err != nil {
+			t.Fatalf("Failed to update row %d: %v", id, err)
+		}
+	}
+
+	// Commit transaction 2
+	err = tx2.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit transaction 2: %v", err)
+	}
+
+	// Now try to update the same rows in a new transaction
+	tx3, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 3: %v", err)
+	}
+
+	// Try to update the same rows that were updated in tx2
+	for _, id := range []int{1, 3, 5} {
+		_, err = tx3.Exec("UPDATE cleanup_test SET value = ? WHERE id = ?", fmt.Sprintf("re-updated value %d", id), id)
+		if err != nil {
+			t.Errorf("Failed to update row %d in tx3: %v", id, err)
+			if err.Error() == "row is being modified by another transaction" {
+				t.Errorf("BUG: Row %d should not be locked after tx2 committed!", id)
+			}
+		}
+	}
+
+	tx3.Rollback()
+}
+
+// TestUncommittedWritesCleanupOnRollback verifies that uncommitted writes are properly cleaned up after rollback
+func TestUncommittedWritesCleanupOnRollback(t *testing.T) {
+	// Create a temporary database in memory
+	dbPath := "memory://"
+	db, err := sql.Open("stoolap", dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create table with data
+	_, err = db.Exec("CREATE TABLE rollback_test (id INTEGER PRIMARY KEY, value TEXT)")
+	if err != nil {
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	// Insert a row
+	_, err = db.Exec("INSERT INTO rollback_test (id, value) VALUES (1, 'initial value')")
+	if err != nil {
+		t.Fatalf("Failed to insert row: %v", err)
+	}
+
+	// Start a transaction that will be rolled back
+	tx2, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 2: %v", err)
+	}
+
+	// Update the row
+	_, err = tx2.Exec("UPDATE rollback_test SET value = 'updated in tx2' WHERE id = 1")
+	if err != nil {
+		t.Fatalf("Failed to update row in tx2: %v", err)
+	}
+
+	// Rollback instead of commit
+	err = tx2.Rollback()
+	if err != nil {
+		t.Fatalf("Failed to rollback transaction 2: %v", err)
+	}
+
+	// Now try to update the same row in a new transaction
+	tx3, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 3: %v", err)
+	}
+
+	// This should succeed since tx2 was rolled back
+	_, err = tx3.Exec("UPDATE rollback_test SET value = 'updated in tx3' WHERE id = 1")
+	if err != nil {
+		t.Errorf("Failed to update row in tx3 after tx2 rollback: %v", err)
+		if err.Error() == "row is being modified by another transaction" {
+			t.Error("BUG: Row should not be locked after tx2 was rolled back!")
+		}
+	}
+
+	tx3.Commit()
+}


### PR DESCRIPTION
## Summary
- Implemented write-write conflict detection for SNAPSHOT isolation
- Fixed deletion visibility in primary key queries  
- Fixed row claiming to only claim existing rows during updates/deletes

## Test plan
- Added comprehensive test coverage for MVCC conflicts
- Added deletion visibility tests
- Fixed failing concurrent tests