### PR TITLE
Add simple alternative SVG logo shape concepts

### DIFF
--- a/docs/assets/img/logo-options/logo-kite.svg
+++ b/docs/assets/img/logo-options/logo-kite.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Stoolap kite logo">
+  <rect width="512" height="512" rx="112" fill="#f6faef"/>
+  <path d="M256 72 416 256 256 440 96 256Z" fill="#95b746"/>
+  <path d="M256 72 416 256 256 256Z" fill="#0b4328" opacity=".92"/>
+  <path d="M96 256h320" stroke="#0b4328" stroke-width="24" stroke-linecap="round"/>
+  <circle cx="256" cy="256" r="34" fill="#f6faef" stroke="#0b4328" stroke-width="18"/>
+</svg>

--- a/docs/assets/img/logo-options/logo-orbit.svg
+++ b/docs/assets/img/logo-options/logo-orbit.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Stoolap orbit logo">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#95b746"/>
+      <stop offset="1" stop-color="#0b4328"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="#f6faef"/>
+  <circle cx="256" cy="256" r="128" fill="none" stroke="url(#g)" stroke-width="40"/>
+  <circle cx="332" cy="180" r="36" fill="#95b746"/>
+  <path d="M168 336c24 30 55 44 94 44 44 0 76-15 103-52" fill="none" stroke="#0b4328" stroke-width="28" stroke-linecap="round"/>
+</svg>

--- a/docs/assets/img/logo-options/logo-petal.svg
+++ b/docs/assets/img/logo-options/logo-petal.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Stoolap petal logo">
+  <rect width="512" height="512" rx="112" fill="#f6faef"/>
+  <g transform="translate(256 256)">
+    <path d="M0-162c46 0 82 35 82 82 0 42-31 73-82 126-51-53-82-84-82-126 0-47 36-82 82-82Z" fill="#95b746"/>
+    <path d="M162 0c0 46-35 82-82 82-42 0-73-31-126-82 53-51 84-82 126-82 47 0 82 36 82 82Z" fill="#207e53"/>
+    <path d="M0 162c-46 0-82-35-82-82 0-42 31-73 82-126 51 53 82 84 82 126 0 47-36 82-82 82Z" fill="#0b4328"/>
+    <circle r="42" fill="#f6faef" stroke="#0b4328" stroke-width="16"/>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Replace the current highly detailed rectangular logo artwork with several simpler, unique mark shapes that keep the existing green palette and scale better for mobile and small icons.

### Description
- Add three new lightweight SVG logo options under `docs/assets/img/logo-options/`: `logo-orbit.svg`, `logo-kite.svg`, and `logo-petal.svg`.
- Each SVG uses simple geometry and the existing green color palette (`#95b746`, `#0b4328`, etc.) so they can be previewed without replacing the current logo.
- Assets are additive so the existing `logo.svg` and site usage remain unchanged.

### Testing
- Verified files were created and listed with `wc -l docs/assets/img/logo-options/*.svg` which succeeded and reported line counts for each new SVG.
- Confirmed repository state with `git status --short` and committed the new files with `git commit` which succeeded.
- Opened and inspected the new SVGs with `nl`/file output to ensure the expected contents were written.
- Created a PR record (title/body) to propose these options for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d934e8708c832997aa566ca2ee00ee)