### PR TITLE
fix: fail closed when cold volumes cannot be reloaded

### DIFF
--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -6797,14 +6797,16 @@ impl Executor {
             }
         };
 
-        // Check if column has an index (required for fast path)
-        if table.get_partition_count(&column_name).is_none() {
-            *compiled_guard = CompiledExecution::NotOptimizable(self.engine.schema_epoch());
-            return None;
-        }
-
-        // Get the count
-        let count = table.get_partition_count(&column_name).unwrap();
+        // Check if column has an index (required for fast path). Reuse the
+        // value: a second call could return None (e.g. seal overlap or a
+        // cold-volume reload failure) and an unwrap would panic.
+        let count = match table.get_partition_count(&column_name) {
+            Some(c) => c,
+            None => {
+                *compiled_guard = CompiledExecution::NotOptimizable(self.engine.schema_epoch());
+                return None;
+            }
+        };
 
         // Cache the compiled state
         let compiled_cd = CompiledCountDistinct {

--- a/src/executor/context.rs
+++ b/src/executor/context.rs
@@ -325,7 +325,7 @@ pub fn cache_exists_index(key: String, index: std::sync::Arc<dyn Index>) {
 }
 
 /// Type alias for row fetcher function used in EXISTS/COUNT optimization.
-pub type RowFetcher = Box<dyn Fn(&[i64]) -> crate::core::RowVec + Send + Sync>;
+pub type RowFetcher = Box<dyn Fn(&[i64]) -> crate::core::Result<crate::core::RowVec> + Send + Sync>;
 
 /// Type alias for row counter function used in COUNT(*) optimization.
 /// This only counts visible rows without cloning their data.

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -202,7 +202,7 @@ impl Executor {
                             .collect();
 
                         let mut row_ids: Vec<i64> = table
-                            .get_active_row_ids()
+                            .get_active_row_ids()?
                             .into_iter()
                             .filter(|id| !excluded.contains(*id))
                             .collect();

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -1109,7 +1109,7 @@ impl Executor {
             Box::new(ConstBoolExpr::true_expr());
 
         // Fetch rows by row_ids - returns RowVec directly
-        let mut rows = table.fetch_rows_by_ids(&all_row_ids, filter.as_ref());
+        let mut rows = table.fetch_rows_by_ids(&all_row_ids, filter.as_ref())?;
 
         // Apply remaining predicate if any
         if let Some(ref remaining) = remaining_predicate {
@@ -1330,7 +1330,7 @@ impl Executor {
             Box::new(ConstBoolExpr::true_expr());
 
         // Fetch rows by row_ids - returns RowVec directly
-        let mut rows = table.fetch_rows_by_ids(&all_row_ids, filter.as_ref());
+        let mut rows = table.fetch_rows_by_ids(&all_row_ids, filter.as_ref())?;
 
         // Apply remaining predicate if any
         if let Some(ref remaining) = remaining_predicate {
@@ -1732,7 +1732,7 @@ impl Executor {
             Box::new(ConstBoolExpr::true_expr());
 
         // Fetch rows by row_ids - returns RowVec directly
-        let mut rows = table.fetch_rows_by_ids(&all_row_ids, filter.as_ref());
+        let mut rows = table.fetch_rows_by_ids(&all_row_ids, filter.as_ref())?;
 
         // Apply remaining predicate if any
         if let Some(ref remaining) = remaining_predicate {

--- a/src/executor/operators/index_nested_loop.rs
+++ b/src/executor/operators/index_nested_loop.rs
@@ -281,7 +281,7 @@ impl IndexNestedLoopJoinOperator {
 
     /// Look up matching inner rows for the current outer row.
     /// Uses internal buffers to avoid allocations.
-    fn lookup_inner_rows(&mut self, key_value: &Value) {
+    fn lookup_inner_rows(&mut self, key_value: &Value) -> Result<()> {
         // Clear buffers for reuse
         self.row_id_buffer.clear();
         self.current_inner_rows.clear();
@@ -304,7 +304,7 @@ impl IndexNestedLoopJoinOperator {
         }
 
         if self.row_id_buffer.is_empty() {
-            return;
+            return Ok(());
         }
 
         // Fetch matching rows directly into inner_rows buffer
@@ -312,7 +312,7 @@ impl IndexNestedLoopJoinOperator {
             &self.row_id_buffer,
             &self.true_expr,
             &mut self.current_inner_rows,
-        );
+        )
     }
 
     /// Advance to the next outer row and lookup matching inner rows.
@@ -335,7 +335,7 @@ impl IndexNestedLoopJoinOperator {
                 };
 
                 // Lookup matching inner rows
-                self.lookup_inner_rows(&key_value);
+                self.lookup_inner_rows(&key_value)?;
 
                 self.current_outer_row = Some(outer_row);
                 // self.current_inner_rows is already populated by lookup_inner_rows
@@ -670,7 +670,9 @@ impl Operator for BatchIndexNestedLoopJoinOperator {
 
         // Step 2: Single batch fetch of ALL inner rows at once
         let all_row_ids: Vec<i64> = row_id_set.into_iter().collect();
-        let inner_rows_batch = self.inner_table.fetch_rows_by_ids(&all_row_ids, &true_expr);
+        let inner_rows_batch = self
+            .inner_table
+            .fetch_rows_by_ids(&all_row_ids, &true_expr)?;
 
         // Build inner row map by row_id
         let mut inner_by_id: I64Map<Row> = I64Map::with_capacity(inner_rows_batch.len());

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -9435,7 +9435,7 @@ impl Executor {
                 if needs_row_fetch {
                     // Use the reusable buffer for row fetching
                     row_buffer.clear();
-                    table.fetch_rows_by_ids_into(row_ids, &true_expr, &mut row_buffer);
+                    table.fetch_rows_by_ids_into(row_ids, &true_expr, &mut row_buffer)?;
 
                     for (_row_id, row) in &row_buffer {
                         for (i, agg) in simple_aggs.iter().enumerate() {

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -507,7 +507,7 @@ impl Executor {
             // Check batches until we find a visible row or exhaust all row_ids
             // We can't stop after first batch because deleted rows may precede visible ones
             for chunk in row_ids.chunks(VISIBILITY_CHECK_BATCH_SIZE) {
-                let visible = row_fetcher(chunk);
+                let visible = row_fetcher(chunk)?;
                 if !visible.is_empty() {
                     return Ok(Some(true)); // Found at least one visible row
                 }
@@ -616,7 +616,7 @@ impl Executor {
         // Fetch rows by their IDs using the cached row fetcher
         const BATCH_SIZE: usize = 100;
         for batch in row_ids.chunks(BATCH_SIZE) {
-            let fetched = row_fetcher(batch);
+            let fetched = row_fetcher(batch)?;
 
             // Check each row against the predicate
             for (_row_id, row) in fetched {
@@ -861,7 +861,7 @@ impl Executor {
                                 }
                             }
                         };
-                        let visible_rows = row_fetcher(&row_ids);
+                        let visible_rows = row_fetcher(&row_ids)?;
                         return Ok(Some(visible_rows.len() as i64));
                     }
                 },

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -887,7 +887,7 @@ impl Executor {
 
             // Fetch rows for this partition only (KEY OPTIMIZATION!)
             let partition_rows =
-                match table.get_rows_for_partition_value(partition_col, &partition_value) {
+                match table.get_rows_for_partition_value(partition_col, &partition_value)? {
                     Some(rows) => rows,
                     None => continue,
                 };

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -1329,7 +1329,7 @@ impl MVCCEngine {
 
                 // HNSW indexes need cold segment data too — vector similarity search
                 // cannot fall back to zone maps like other index types.
-                self.populate_hnsw_from_segments();
+                self.populate_hnsw_from_segments()?;
 
                 Ok(())
             }
@@ -1355,7 +1355,7 @@ impl MVCCEngine {
     /// row_id exists in multiple overlapping volumes, only the newest version is
     /// added to the HNSW graph. Also skips row_ids that are in the hot buffer
     /// (already indexed by populate_all_indexes).
-    fn populate_hnsw_from_segments(&self) {
+    fn populate_hnsw_from_segments(&self) -> Result<()> {
         let stores = self.version_stores.read().unwrap();
         let mgrs = self.segment_managers.read().unwrap();
 
@@ -1387,7 +1387,7 @@ impl MVCCEngine {
 
                 let tombstones = mgr.tombstone_set_arc();
                 // Use newest-first ordering so overlapping row_ids resolve to newest version
-                let volumes = mgr.get_volumes_newest_first();
+                let volumes = mgr.get_volumes_newest_first()?;
 
                 // Seed seen set with hot row_ids (already indexed by populate_all_indexes)
                 let mut seen: rustc_hash::FxHashSet<i64> = store
@@ -1476,6 +1476,7 @@ impl MVCCEngine {
                 }
             }
         }
+        Ok(())
     }
 
     /// Populate pre-computed `default_value` from `default_expr` on all schema columns.
@@ -4034,7 +4035,7 @@ impl MVCCEngine {
             };
 
             if let Some(mgr) = mgr {
-                let volumes = mgr.get_volumes_newest_first();
+                let volumes = mgr.get_volumes_newest_first()?;
 
                 // Use the frozen tombstone snapshot captured immediately after
                 // commit_seq. The commit path increments seq BEFORE applying
@@ -5388,7 +5389,7 @@ impl MVCCEngine {
                             let vol = segs.get(&seg.segment_id)?;
                             if vol.volume.is_cold() {
                                 // Load only this merge candidate from disk.
-                                let loaded = mgr.ensure_volume(seg.segment_id)?;
+                                let loaded = mgr.ensure_volume(seg.segment_id).ok()??;
                                 Some((seg.segment_id, loaded))
                             } else {
                                 Some((seg.segment_id, Arc::clone(&vol.volume)))
@@ -6391,7 +6392,7 @@ impl Engine for MVCCEngine {
                     result.iter().map(|(id, _)| *id).collect();
                 for &rid in row_ids {
                     if !found_ids.contains(&rid) {
-                        if let Some(row) = mgr.get_cold_row_normalized(rid, &schema) {
+                        if let Some(row) = mgr.get_cold_row_normalized(rid, &schema)? {
                             result.push((rid, row));
                         }
                     }
@@ -6404,7 +6405,7 @@ impl Engine for MVCCEngine {
     fn get_row_fetcher(
         &self,
         table_name: &str,
-    ) -> Result<Box<dyn Fn(&[i64]) -> crate::core::RowVec + Send + Sync>> {
+    ) -> Result<Box<dyn Fn(&[i64]) -> Result<crate::core::RowVec> + Send + Sync>> {
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -6421,13 +6422,13 @@ impl Engine for MVCCEngine {
                     result.iter().map(|(id, _)| *id).collect();
                 for &rid in row_ids {
                     if !found_ids.contains(&rid) {
-                        if let Some(row) = mgr.get_cold_row_normalized(rid, &schema) {
+                        if let Some(row) = mgr.get_cold_row_normalized(rid, &schema)? {
                             result.push((rid, row));
                         }
                     }
                 }
             }
-            result
+            Ok(result)
         }))
     }
 
@@ -6754,7 +6755,7 @@ impl EngineOperations {
                     if let Some(pk_val) = row.get(pk_col) {
                         if !pk_val.is_null() {
                             if let Some(cold_rid) =
-                                mgr.check_value_exists_in_segments(pk_col, pk_val)
+                                mgr.check_value_exists_in_segments(pk_col, pk_val)?
                             {
                                 if !mgr.is_pending_tombstone(txn_id, cold_rid) {
                                     return Err(crate::core::Error::PrimaryKeyConstraint {
@@ -6779,7 +6780,7 @@ impl EngineOperations {
                     }
                     let values: Vec<&crate::core::Value> = coerced.iter().collect();
                     if let Some(cold_rid) =
-                        mgr.find_row_id_by_values(col_indices, &values, defaults)
+                        mgr.find_row_id_by_values(col_indices, &values, defaults)?
                     {
                         if !mgr.is_pending_tombstone(txn_id, cold_rid) {
                             return Err(crate::core::Error::UniqueConstraint {
@@ -6808,7 +6809,7 @@ impl EngineOperations {
                         if let Some(pk_val) = new_pk {
                             if !pk_val.is_null() {
                                 if let Some(cold_rid) =
-                                    mgr.check_value_exists_in_segments(pk_col, pk_val)
+                                    mgr.check_value_exists_in_segments(pk_col, pk_val)?
                                 {
                                     if cold_rid != row_id
                                         && !mgr.is_pending_tombstone(txn_id, cold_rid)
@@ -6853,7 +6854,7 @@ impl EngineOperations {
                     }
                     let values: Vec<&crate::core::Value> = coerced.iter().collect();
                     if let Some(cold_rid) =
-                        mgr.find_row_id_by_values(col_indices, &values, defaults)
+                        mgr.find_row_id_by_values(col_indices, &values, defaults)?
                     {
                         if cold_rid != row_id && !mgr.is_pending_tombstone(txn_id, cold_rid) {
                             return Err(crate::core::Error::UniqueConstraint {

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -4035,7 +4035,17 @@ impl MVCCEngine {
             };
 
             if let Some(mgr) = mgr {
-                let volumes = mgr.get_volumes_newest_first()?;
+                let volumes = match mgr.get_volumes_newest_first() {
+                    Ok(v) => v,
+                    Err(_) => {
+                        // Same protocol as any other snapshot failure:
+                        // mark the writer failed so Phase 3 removes every
+                        // pending temp file instead of leaking them.
+                        writer.fail();
+                        all_succeeded = false;
+                        break;
+                    }
+                };
 
                 // Use the frozen tombstone snapshot captured immediately after
                 // commit_seq. The commit path increments seq BEFORE applying

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -1830,7 +1830,12 @@ impl Table for MVCCTable {
     /// Fetch rows into a reusable RowVec buffer.
     /// Optimized to use batch fetch for global store rows,
     /// reducing lock contention from O(n) to O(1).
-    fn fetch_rows_by_ids_into(&self, row_ids: &[i64], filter: &dyn Expression, rows: &mut RowVec) {
+    fn fetch_rows_by_ids_into(
+        &self,
+        row_ids: &[i64],
+        filter: &dyn Expression,
+        rows: &mut RowVec,
+    ) -> Result<()> {
         let txn_versions = self.txn_versions.read().unwrap();
         let schema = &self.cached_schema;
 
@@ -1872,6 +1877,7 @@ impl Table for MVCCTable {
                 }
             }
         }
+        Ok(())
     }
 
     fn create_column(&mut self, name: &str, column_type: DataType, nullable: bool) -> Result<()> {
@@ -2436,8 +2442,8 @@ impl Table for MVCCTable {
         Ok(delete_count)
     }
 
-    fn get_active_row_ids(&self) -> Vec<i64> {
-        self.version_store.get_all_row_ids()
+    fn get_active_row_ids(&self) -> Result<Vec<i64>> {
+        Ok(self.version_store.get_all_row_ids())
     }
 
     fn collect_hot_row_ids_into(&self, dest: &mut rustc_hash::FxHashSet<i64>) {
@@ -2767,7 +2773,7 @@ impl Table for MVCCTable {
             // Try index lookup for non-PK columns
             if let Some(filtered_row_ids) = self.try_index_lookup(expr, &schema) {
                 // Use index-based scan - much more efficient
-                let rows = self.fetch_rows_by_ids(&filtered_row_ids, expr);
+                let rows = self.fetch_rows_by_ids(&filtered_row_ids, expr)?;
                 let scanner = MVCCScanner::from_rows(rows, schema, column_indices.to_vec());
                 return Ok(Box::new(scanner));
             }

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -3877,17 +3877,20 @@ impl Table for MVCCTable {
         &self,
         column_name: &str,
         partition_value: &Value,
-    ) -> Option<RowVec> {
+    ) -> Result<Option<RowVec>> {
         // If transaction has local changes, fall back to regular path
         {
             let txn_versions = self.txn_versions.read().unwrap();
             if txn_versions.has_local_changes() {
-                return None;
+                return Ok(None);
             }
         }
 
         // Get index for the column
-        let index = self.version_store.get_index_by_column(column_name)?;
+        let index = match self.version_store.get_index_by_column(column_name) {
+            Some(idx) => idx,
+            None => return Ok(None),
+        };
 
         // Get row IDs for this partition value
         let row_ids = index.get_row_ids_equal(std::slice::from_ref(partition_value));
@@ -3902,7 +3905,7 @@ impl Table for MVCCTable {
             }
         }
 
-        Some(rows)
+        Ok(Some(rows))
     }
 
     fn rename_column(&mut self, old_name: &str, new_name: &str) -> Result<()> {

--- a/src/storage/traits/engine.rs
+++ b/src/storage/traits/engine.rs
@@ -284,7 +284,7 @@ pub trait Engine: Send + Sync {
     fn get_row_fetcher(
         &self,
         table_name: &str,
-    ) -> Result<Box<dyn Fn(&[i64]) -> RowVec + Send + Sync>> {
+    ) -> Result<Box<dyn Fn(&[i64]) -> Result<RowVec> + Send + Sync>> {
         // Default implementation: fall back to fetch_rows_by_ids
         let _ = table_name;
         Err(crate::core::Error::internal(

--- a/src/storage/traits/table.rs
+++ b/src/storage/traits/table.rs
@@ -984,9 +984,9 @@ pub trait Table: Send + Sync {
         &self,
         column_name: &str,
         partition_value: &Value,
-    ) -> Option<RowVec> {
+    ) -> Result<Option<RowVec>> {
         let _ = (column_name, partition_value);
-        None // Default implementation - override in concrete tables
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// Fetch rows by their row IDs with an optional filter.

--- a/src/storage/traits/table.rs
+++ b/src/storage/traits/table.rs
@@ -374,15 +374,12 @@ pub trait Table: Send + Sync {
 
     /// Returns all active row IDs visible to the current transaction.
     /// Used for NOT IN (anti-join) optimization.
-    fn get_active_row_ids(&self) -> Vec<i64>;
+    fn get_active_row_ids(&self) -> Result<Vec<i64>>;
 
     /// Populate a FxHashSet with all hot row_ids. Avoids the intermediate Vec
-    /// allocation of get_active_row_ids() when building skip sets.
-    fn collect_hot_row_ids_into(&self, dest: &mut rustc_hash::FxHashSet<i64>) {
-        for id in self.get_active_row_ids() {
-            dest.insert(id);
-        }
-    }
+    /// allocation of get_active_row_ids() when building skip sets. Required
+    /// (no default): implementations must stay infallible for hot data.
+    fn collect_hot_row_ids_into(&self, dest: &mut rustc_hash::FxHashSet<i64>);
 
     /// Check if a specific row_id exists in the hot buffer.
     /// O(log n) lookup instead of collecting all row_ids.
@@ -1000,10 +997,10 @@ pub trait Table: Send + Sync {
     ///
     /// # Returns
     /// RowVec of (row_id, Row) pairs for visible, non-deleted rows that pass the filter
-    fn fetch_rows_by_ids(&self, row_ids: &[i64], filter: &dyn Expression) -> RowVec {
+    fn fetch_rows_by_ids(&self, row_ids: &[i64], filter: &dyn Expression) -> Result<RowVec> {
         let mut results = RowVec::with_capacity(row_ids.len());
-        self.fetch_rows_by_ids_into(row_ids, filter, &mut results);
-        results
+        self.fetch_rows_by_ids_into(row_ids, filter, &mut results)?;
+        Ok(results)
     }
 
     /// Fetch rows into a reusable RowVec buffer
@@ -1012,9 +1009,10 @@ pub trait Table: Send + Sync {
         row_ids: &[i64],
         filter: &dyn Expression,
         buffer: &mut RowVec,
-    ) {
+    ) -> Result<()> {
         let _ = (row_ids, filter, buffer);
         // Default implementation does nothing
+        Ok(())
     }
 
     // ---- Additional Column Operations ----

--- a/src/storage/volume/manifest.rs
+++ b/src/storage/volume/manifest.rs
@@ -842,6 +842,21 @@ impl SegmentManager {
     /// for the whole statement and never re-reads live manager state after
     /// mutating the hot buffer: eviction and compaction copy-on-write new
     /// maps/Arcs, so nothing in the snapshot can go cold or disappear.
+    /// Statement-snapshot variant of `find_row_id_by_values`: runs
+    /// entirely against the given captured parts, so it can neither
+    /// observe concurrent compaction nor need a live cold reload.
+    pub fn find_row_id_by_values_in(
+        &self,
+        seg_ids: &[u64],
+        segs: &FxHashMap<u64, ColdSegment>,
+        ts: &FxHashMap<i64, u64>,
+        col_indices: &[usize],
+        values: &[&Value],
+        column_defaults: &[Value],
+    ) -> crate::core::Result<Option<i64>> {
+        self.find_row_id_by_values_impl(seg_ids, segs, ts, col_indices, values, column_defaults)
+    }
+
     pub fn statement_snapshot(&self) -> crate::core::Result<StatementSnapshot> {
         let capture = || {
             let manifest = self.manifest.read();
@@ -944,23 +959,16 @@ impl SegmentManager {
     /// Iterates newest-first with per-volume physical mapping. Used by
     /// overlap verification to check the authoritative version after
     /// UPDATE changes a PK value + seal (schema-evolution safe).
+    /// Resolve against the CALLER'S segment view (newest-first ids + map)
+    /// so statement-snapshot flows never re-read live state here.
     fn get_authoritative_value(
         &self,
+        seg_ids: &[u64],
+        segments: &FxHashMap<u64, ColdSegment>,
         row_id: i64,
         col_idx: usize,
     ) -> crate::core::Result<Option<crate::core::Value>> {
-        let (seg_ids, segments) = {
-            let manifest = self.manifest.read();
-            let seg_ids: Vec<u64> = manifest
-                .segments
-                .iter()
-                .rev()
-                .map(|m| m.segment_id)
-                .collect();
-            let segments = Arc::clone(&*self.segments.read());
-            (seg_ids, segments)
-        };
-        for seg_id in &seg_ids {
+        for seg_id in seg_ids {
             if let Some(cold) = segments.get(seg_id) {
                 if let Ok(idx) = cold.volume.meta.row_ids.binary_search(&row_id) {
                     let pi = if cold.mapping.is_identity {
@@ -1051,7 +1059,7 @@ impl SegmentManager {
                         if seen.insert(rid) && !ts.contains_key(&rid) {
                             if seg_ids.len() > 1 {
                                 if let Some(current_val) =
-                                    self.get_authoritative_value(rid, col_idx)?
+                                    self.get_authoritative_value(seg_ids, segs, rid, col_idx)?
                                 {
                                     if &current_val != value {
                                         i += 1;
@@ -1075,7 +1083,7 @@ impl SegmentManager {
                         {
                             if seg_ids.len() > 1 {
                                 if let Some(current_val) =
-                                    self.get_authoritative_value(rid, col_idx)?
+                                    self.get_authoritative_value(seg_ids, segs, rid, col_idx)?
                                 {
                                     if &current_val != value {
                                         continue;
@@ -1291,7 +1299,7 @@ impl SegmentManager {
                 if seg_ids.len() > 1 {
                     let mut still_matches = true;
                     for (i, &ci) in col_indices.iter().enumerate() {
-                        let ok = match self.get_authoritative_value(rid, ci)? {
+                        let ok = match self.get_authoritative_value(seg_ids, segs, rid, ci)? {
                             Some(v) => !v.is_null() && v == *values[i],
                             None => column_defaults[i] == *values[i],
                         };
@@ -3365,5 +3373,76 @@ mod tests {
         assert_eq!(vols.len(), 1, "snapshot must not lose its segment");
         assert_eq!(vols[0].0, 1);
         assert_eq!(vols[0].1.volume.get_row(0)[0], Value::Integer(1));
+    }
+    #[test]
+    fn test_unique_lookup_uses_statement_snapshot_not_live_state() {
+        use crate::core::{DataType, Row, SchemaBuilder, Value};
+
+        let schema = SchemaBuilder::new("uniq_snap")
+            .column("id", DataType::Integer, false, true)
+            .build();
+        // No volume_dir: once the live map goes cold, live lookups must
+        // fail to reload while the statement snapshot keeps working.
+        let mgr = SegmentManager::new("uniq_snap", None);
+        let mut b = super::super::writer::VolumeBuilder::new(&schema);
+        for i in 1..=10i64 {
+            b.add_row(i, &Row::from_values(vec![Value::Integer(i)]));
+        }
+        let mut volume = b.finish();
+        let (_, store) = crate::storage::volume::io::serialize_v4_public(&volume).unwrap();
+        volume.columns.attach_compressed_store(store);
+        mgr.register_segment(
+            1,
+            Arc::new(volume),
+            SegmentMeta {
+                segment_id: 1,
+                file_path: PathBuf::from("uniq.vol"),
+                row_count: 10,
+                min_row_id: 1,
+                max_row_id: 10,
+                creation_lsn: 0,
+                seal_seq: 0,
+                schema_version: 0,
+            },
+            None,
+        );
+
+        let snap = mgr.statement_snapshot().unwrap();
+
+        let _epoch_guard = EVICTION_EPOCH_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let base =
+            super::super::writer::GLOBAL_EVICTION_EPOCH.load(std::sync::atomic::Ordering::Relaxed);
+        for e in 0..=10u64 {
+            super::super::writer::GLOBAL_EVICTION_EPOCH
+                .fetch_max(base + e, std::sync::atomic::Ordering::Relaxed);
+            mgr.evict_idle_volumes(base + e);
+        }
+        assert!(
+            mgr.segments_raw().get(&1).unwrap().volume.is_cold(),
+            "precondition: live map must be cold"
+        );
+
+        let target = Value::Integer(5);
+        let defaults = [Value::Integer(0)];
+        // Review probe: the live lookup fails to reload...
+        assert!(
+            mgr.find_row_id_by_values(&[0], &[&target], &defaults)
+                .is_err(),
+            "live lookup must fail on unreloadable cold state"
+        );
+        // ...while the statement-snapshot lookup keeps serving its view.
+        let found = mgr
+            .find_row_id_by_values_in(
+                &snap.seg_ids_newest_first,
+                &snap.segs,
+                &snap.tombstones,
+                &[0],
+                &[&target],
+                &defaults,
+            )
+            .unwrap();
+        assert_eq!(found, Some(5), "snapshot lookup must succeed");
     }
 }

--- a/src/storage/volume/manifest.rs
+++ b/src/storage/volume/manifest.rs
@@ -815,6 +815,28 @@ impl SegmentManager {
         Arc::new(result)
     }
 
+    /// Build the newest-first volume list from a pre-verified snapshot
+    /// (see `segments_snapshot`). DML statements capture one snapshot up
+    /// front and iterate it throughout: eviction copy-on-writes new maps
+    /// and new volume Arcs, so the snapshot's volumes keep their column
+    /// data for the whole statement and no mid-statement reload can ever
+    /// be needed.
+    pub fn volumes_newest_first_from_snapshot(
+        &self,
+        segs: &FxHashMap<u64, ColdSegment>,
+    ) -> Vec<(u64, ColdSegment)> {
+        let seg_ids: Vec<u64> = {
+            let manifest = self.manifest.read();
+            manifest.segments.iter().map(|m| m.segment_id).collect()
+        };
+        let mut result: Vec<(u64, ColdSegment)> = seg_ids
+            .iter()
+            .filter_map(|&id| segs.get(&id).map(|cs| (id, cs.clone())))
+            .collect();
+        result.reverse();
+        result
+    }
+
     /// Check if there are any segments. O(1) atomic read, no lock.
     pub fn has_segments(&self) -> bool {
         self.has_segments_flag
@@ -2492,34 +2514,6 @@ impl SegmentManager {
     /// Reloads cold volumes first so column data is available.
     /// Does NOT mark volumes as accessed — callers that need eviction
     /// protection should mark the specific volumes they use.
-    /// Verify every cold segment can be served before a caller starts
-    /// mutating state. DML paths mutate the hot buffer first and only
-    /// then touch cold volumes; erroring mid-statement would leave the
-    /// open transaction with a partially applied statement. Preflighting
-    /// moves the (persistent) reload failure ahead of the first mutation.
-    /// A volume evicted between preflight and iteration can still fail
-    /// there, but that needs eviction AND a fresh I/O failure inside one
-    /// statement window.
-    pub fn preflight_cold_access(&self) -> crate::core::Result<()> {
-        self.ensure_columns();
-        let segs = self.segments.read();
-        let cold: Vec<u64> = segs
-            .iter()
-            .filter(|(_, cs)| cs.volume.is_cold())
-            .map(|(&id, _)| id)
-            .collect();
-        if !cold.is_empty() {
-            return Err(crate::core::Error::Internal {
-                message: format!(
-                    "table '{}': cold volume reload failed for segment(s) {:?}; \
-                     refusing to serve partial data",
-                    self.table_name, cold
-                ),
-            });
-        }
-        Ok(())
-    }
-
     pub fn segments_snapshot(&self) -> crate::core::Result<Arc<FxHashMap<u64, ColdSegment>>> {
         self.ensure_columns();
         let segs = Arc::clone(&*self.segments.read());
@@ -3259,8 +3253,8 @@ mod tests {
         );
         assert!(mgr.get_cold_row(50).is_err(), "get_cold_row must fail");
         assert!(
-            mgr.preflight_cold_access().is_err(),
-            "DML preflight must fail before any mutation"
+            mgr.segments_snapshot().is_err(),
+            "the DML statement snapshot must fail before any mutation"
         );
     }
 }

--- a/src/storage/volume/manifest.rs
+++ b/src/storage/volume/manifest.rs
@@ -2492,6 +2492,34 @@ impl SegmentManager {
     /// Reloads cold volumes first so column data is available.
     /// Does NOT mark volumes as accessed — callers that need eviction
     /// protection should mark the specific volumes they use.
+    /// Verify every cold segment can be served before a caller starts
+    /// mutating state. DML paths mutate the hot buffer first and only
+    /// then touch cold volumes; erroring mid-statement would leave the
+    /// open transaction with a partially applied statement. Preflighting
+    /// moves the (persistent) reload failure ahead of the first mutation.
+    /// A volume evicted between preflight and iteration can still fail
+    /// there, but that needs eviction AND a fresh I/O failure inside one
+    /// statement window.
+    pub fn preflight_cold_access(&self) -> crate::core::Result<()> {
+        self.ensure_columns();
+        let segs = self.segments.read();
+        let cold: Vec<u64> = segs
+            .iter()
+            .filter(|(_, cs)| cs.volume.is_cold())
+            .map(|(&id, _)| id)
+            .collect();
+        if !cold.is_empty() {
+            return Err(crate::core::Error::Internal {
+                message: format!(
+                    "table '{}': cold volume reload failed for segment(s) {:?}; \
+                     refusing to serve partial data",
+                    self.table_name, cold
+                ),
+            });
+        }
+        Ok(())
+    }
+
     pub fn segments_snapshot(&self) -> crate::core::Result<Arc<FxHashMap<u64, ColdSegment>>> {
         self.ensure_columns();
         let segs = Arc::clone(&*self.segments.read());
@@ -2997,6 +3025,8 @@ mod tests {
         assert!(mgr.tombstone_set_arc().is_empty());
     }
 
+    static EVICTION_EPOCH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn test_eviction_lifecycle() {
         use crate::core::{DataType, Row, SchemaBuilder, Value};
@@ -3059,12 +3089,21 @@ mod tests {
             assert_eq!(row[0], Value::Integer(1));
         }
 
+        // GLOBAL_EVICTION_EPOCH is process-global: epoch-driving tests
+        // must serialize and use base-relative epochs or they corrupt
+        // each other's idle-cycle accounting under parallel test runs.
+        let _epoch_guard = EVICTION_EPOCH_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let base =
+            super::super::writer::GLOBAL_EVICTION_EPOCH.load(std::sync::atomic::Ordering::Relaxed);
+
         // Helper: mirror engine's evict_idle_volumes behavior.
         // Engine does: fetch_add → GLOBAL.fetch_max → mgr.evict_idle_volumes.
         let run_eviction = |mgr: &SegmentManager, epoch: u64| {
             super::super::writer::GLOBAL_EVICTION_EPOCH
-                .fetch_max(epoch, std::sync::atomic::Ordering::Relaxed);
-            mgr.evict_idle_volumes(epoch);
+                .fetch_max(base + epoch, std::sync::atomic::Ordering::Relaxed);
+            mgr.evict_idle_volumes(base + epoch);
         };
 
         // ── Eviction cycle 0..2: not enough idle cycles, no eviction ──
@@ -3193,10 +3232,15 @@ mod tests {
             None,
         );
 
+        let _epoch_guard = EVICTION_EPOCH_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let base =
+            super::super::writer::GLOBAL_EVICTION_EPOCH.load(std::sync::atomic::Ordering::Relaxed);
         let run_eviction = |mgr: &SegmentManager, epoch: u64| {
             super::super::writer::GLOBAL_EVICTION_EPOCH
-                .fetch_max(epoch, std::sync::atomic::Ordering::Relaxed);
-            mgr.evict_idle_volumes(epoch);
+                .fetch_max(base + epoch, std::sync::atomic::Ordering::Relaxed);
+            mgr.evict_idle_volumes(base + epoch);
         };
         for epoch in 0..=10u64 {
             run_eviction(&mgr, epoch);
@@ -3214,5 +3258,9 @@ mod tests {
             "get_volumes_newest_first must fail instead of dropping the segment"
         );
         assert!(mgr.get_cold_row(50).is_err(), "get_cold_row must fail");
+        assert!(
+            mgr.preflight_cold_access().is_err(),
+            "DML preflight must fail before any mutation"
+        );
     }
 }

--- a/src/storage/volume/manifest.rs
+++ b/src/storage/volume/manifest.rs
@@ -2492,32 +2492,31 @@ impl SegmentManager {
     /// Reloads cold volumes first so column data is available.
     /// Does NOT mark volumes as accessed — callers that need eviction
     /// protection should mark the specific volumes they use.
-    pub fn segments_snapshot(&self) -> Arc<FxHashMap<u64, ColdSegment>> {
+    pub fn segments_snapshot(&self) -> crate::core::Result<Arc<FxHashMap<u64, ColdSegment>>> {
         self.ensure_columns();
         let segs = Arc::clone(&*self.segments.read());
         if !segs.values().any(|cs| cs.volume.is_cold()) {
-            return segs;
+            return Ok(segs);
         }
-        // Race or persistent failure: retry once then filter.
+        // Race with eviction: retry once, then fail closed. Filtering the
+        // cold segments out would hand callers a silently smaller table.
         self.ensure_columns();
         let segs = Arc::clone(&*self.segments.read());
-        if segs.values().any(|cs| cs.volume.is_cold()) {
-            let mut filtered = (*segs).clone();
-            let cold: Vec<(u64, usize)> = filtered
-                .iter()
-                .filter(|(_, cs)| cs.volume.is_cold())
-                .map(|(&id, cs)| (id, cs.volume.meta.row_count))
-                .collect();
-            for &(seg_id, rows) in &cold {
-                eprintln!(
-                    "Warning: table {} seg={}: cold volume excluded from snapshot ({} rows, reload failed)",
-                    self.table_name, seg_id, rows
-                );
-            }
-            filtered.retain(|_, cs| !cs.volume.is_cold());
-            return Arc::new(filtered);
+        let cold: Vec<u64> = segs
+            .iter()
+            .filter(|(_, cs)| cs.volume.is_cold())
+            .map(|(&id, _)| id)
+            .collect();
+        if !cold.is_empty() {
+            return Err(crate::core::Error::Internal {
+                message: format!(
+                    "table '{}': cold volume reload failed for segment(s) {:?}; \
+                     refusing to serve partial data",
+                    self.table_name, cold
+                ),
+            });
         }
-        segs
+        Ok(segs)
     }
 
     /// Raw CoW snapshot without ensure_columns. Callers that only need

--- a/src/storage/volume/manifest.rs
+++ b/src/storage/volume/manifest.rs
@@ -741,7 +741,7 @@ impl SegmentManager {
     /// Used for building per-volume skip sets in SegmentedTable.scan().
     /// Segments are always appended in ascending order, so reverse gives
     /// newest-first in O(n) instead of O(n log n) sort.
-    pub fn get_volumes_newest_first(&self) -> Arc<Vec<(u64, ColdSegment)>> {
+    pub fn get_volumes_newest_first(&self) -> crate::core::Result<Arc<Vec<(u64, ColdSegment)>>> {
         self.ensure_columns();
         let mut result = self.build_volumes_newest_first();
         // Race check: eviction may have created cold volumes between
@@ -750,21 +750,23 @@ impl SegmentManager {
         if result.iter().any(|(_, cs)| cs.volume.is_cold()) {
             self.ensure_columns();
             result = self.build_volumes_newest_first();
-            // If still cold after retry (persistent reload failure),
-            // filter them out to prevent column-access panics.
+            // Still cold after retry = persistent reload failure. Serving
+            // the surviving subset silently returns short scan results and
+            // lets DML skip rows while reporting success; fail closed.
             let cold: Vec<(u64, usize)> = result
                 .iter()
                 .filter(|(_, cs)| cs.volume.is_cold())
                 .map(|(id, cs)| (*id, cs.volume.meta.row_count))
                 .collect();
             if !cold.is_empty() {
-                for &(seg_id, rows) in &cold {
-                    eprintln!(
-                        "Warning: table {} seg={}: cold volume excluded ({} rows, reload failed)",
-                        self.table_name, seg_id, rows
-                    );
-                }
-                result.retain(|(_, cs)| !cs.volume.is_cold());
+                return Err(crate::core::Error::Internal {
+                    message: format!(
+                        "table '{}': cold volume reload failed for segment(s) {:?}; \
+                         refusing to serve partial data",
+                        self.table_name,
+                        cold.iter().map(|(id, _)| *id).collect::<Vec<_>>()
+                    ),
+                });
             }
         }
         // Mark all volumes accessed. Direct-iteration callers (aggregate
@@ -775,7 +777,7 @@ impl SegmentManager {
             cs.volume.mark_accessed();
         }
         result.reverse();
-        Arc::new(result)
+        Ok(Arc::new(result))
     }
 
     /// Build the raw newest-first volume list from manifest + segments.
@@ -845,7 +847,7 @@ impl SegmentManager {
         snapshot: &ColdSnapshot,
         col_idx: usize,
         value: &crate::core::Value,
-    ) -> Option<i64> {
+    ) -> crate::core::Result<Option<i64>> {
         self.check_value_exists_impl(
             &snapshot.seg_ids,
             &snapshot.segs,
@@ -861,7 +863,7 @@ impl SegmentManager {
         &self,
         col_idx: usize,
         value: &crate::core::Value,
-    ) -> Option<i64> {
+    ) -> crate::core::Result<Option<i64>> {
         let snapshot = self.cold_snapshot();
         self.check_value_exists_impl(
             &snapshot.seg_ids,
@@ -876,7 +878,11 @@ impl SegmentManager {
     /// Iterates newest-first with per-volume physical mapping. Used by
     /// overlap verification to check the authoritative version after
     /// UPDATE changes a PK value + seal (schema-evolution safe).
-    fn get_authoritative_value(&self, row_id: i64, col_idx: usize) -> Option<crate::core::Value> {
+    fn get_authoritative_value(
+        &self,
+        row_id: i64,
+        col_idx: usize,
+    ) -> crate::core::Result<Option<crate::core::Value>> {
         let (seg_ids, segments) = {
             let manifest = self.manifest.read();
             let seg_ids: Vec<u64> = manifest
@@ -896,23 +902,23 @@ impl SegmentManager {
                     } else if col_idx < cold.mapping.sources.len() {
                         match &cold.mapping.sources[col_idx] {
                             super::writer::ColSource::Volume(vi) => *vi,
-                            super::writer::ColSource::Default(val) => return Some(val.clone()),
+                            super::writer::ColSource::Default(val) => return Ok(Some(val.clone())),
                         }
                     } else {
-                        return None;
+                        return Ok(None);
                     };
                     if cold.volume.is_cold() {
-                        if let Some(vol) = self.ensure_volume(*seg_id) {
-                            return Some(vol.columns[pi].get_value(idx));
+                        if let Some(vol) = self.ensure_volume(*seg_id)? {
+                            return Ok(Some(vol.columns[pi].get_value(idx)));
                         }
-                        return None;
+                        return Ok(None);
                     }
                     cold.volume.mark_accessed();
-                    return Some(cold.volume.columns[pi].get_value(idx));
+                    return Ok(Some(cold.volume.columns[pi].get_value(idx)));
                 }
             }
         }
-        None
+        Ok(None)
     }
 
     fn check_value_exists_impl(
@@ -922,7 +928,7 @@ impl SegmentManager {
         ts: &FxHashMap<i64, u64>,
         col_idx: usize,
         value: &crate::core::Value,
-    ) -> Option<i64> {
+    ) -> crate::core::Result<Option<i64>> {
         let mut seen = FxHashSet::default();
 
         for &seg_id in seg_ids {
@@ -952,7 +958,7 @@ impl SegmentManager {
             // Zone map passed — need column data. Load cold volumes on demand.
             let loaded: Arc<FrozenVolume>;
             let vol = if vol.is_cold() {
-                loaded = match self.ensure_volume(seg_id) {
+                loaded = match self.ensure_volume(seg_id)? {
                     Some(v) => v,
                     None => continue,
                 };
@@ -979,7 +985,7 @@ impl SegmentManager {
                         if seen.insert(rid) && !ts.contains_key(&rid) {
                             if seg_ids.len() > 1 {
                                 if let Some(current_val) =
-                                    self.get_authoritative_value(rid, col_idx)
+                                    self.get_authoritative_value(rid, col_idx)?
                                 {
                                     if &current_val != value {
                                         i += 1;
@@ -987,7 +993,7 @@ impl SegmentManager {
                                     }
                                 }
                             }
-                            return Some(rid);
+                            return Ok(Some(rid));
                         }
                         i += 1;
                     }
@@ -1003,20 +1009,20 @@ impl SegmentManager {
                         {
                             if seg_ids.len() > 1 {
                                 if let Some(current_val) =
-                                    self.get_authoritative_value(rid, col_idx)
+                                    self.get_authoritative_value(rid, col_idx)?
                                 {
                                     if &current_val != value {
                                         continue;
                                     }
                                 }
                             }
-                            return Some(rid);
+                            return Ok(Some(rid));
                         }
                     }
                 }
             }
         }
-        None
+        Ok(None)
     }
 
     /// Find a visible cold row ID matching the given column values.
@@ -1034,7 +1040,7 @@ impl SegmentManager {
         col_indices: &[usize],
         values: &[&Value],
         column_defaults: &[Value],
-    ) -> Option<i64> {
+    ) -> crate::core::Result<Option<i64>> {
         self.find_row_id_by_values_impl(
             &snapshot.seg_ids,
             &snapshot.segs,
@@ -1050,7 +1056,7 @@ impl SegmentManager {
         col_indices: &[usize],
         values: &[&Value],
         column_defaults: &[Value],
-    ) -> Option<i64> {
+    ) -> crate::core::Result<Option<i64>> {
         let snapshot = self.cold_snapshot();
         self.find_row_id_by_values_impl(
             &snapshot.seg_ids,
@@ -1070,13 +1076,13 @@ impl SegmentManager {
         col_indices: &[usize],
         values: &[&Value],
         column_defaults: &[Value],
-    ) -> Option<i64> {
+    ) -> crate::core::Result<Option<i64>> {
         if col_indices.is_empty() || col_indices.len() != values.len() {
-            return None;
+            return Ok(None);
         }
 
         if seg_ids.is_empty() {
-            return None;
+            return Ok(None);
         }
 
         let bloom_hashes: smallvec::SmallVec<[u64; 4]> = values
@@ -1161,7 +1167,7 @@ impl SegmentManager {
             // Zone map + bloom passed — need column data. Load cold on demand.
             let loaded: Arc<FrozenVolume>;
             let vol = if vol.is_cold() {
-                loaded = match self.ensure_volume(seg_id) {
+                loaded = match self.ensure_volume(seg_id)? {
                     Some(v) => v,
                     None => continue,
                 };
@@ -1217,21 +1223,25 @@ impl SegmentManager {
                 // volume). get_cold_row returns the newest version (newest-first).
                 // Use column_defaults for columns missing from schema-evolved volumes.
                 if seg_ids.len() > 1 {
-                    let still_matches = col_indices.iter().enumerate().all(|(i, &ci)| {
-                        if let Some(v) = self.get_authoritative_value(rid, ci) {
-                            !v.is_null() && v == *values[i]
-                        } else {
-                            column_defaults[i] == *values[i]
+                    let mut still_matches = true;
+                    for (i, &ci) in col_indices.iter().enumerate() {
+                        let ok = match self.get_authoritative_value(rid, ci)? {
+                            Some(v) => !v.is_null() && v == *values[i],
+                            None => column_defaults[i] == *values[i],
+                        };
+                        if !ok {
+                            still_matches = false;
+                            break;
                         }
-                    });
+                    }
                     if !still_matches {
                         continue; // stale value in older volume, skip
                     }
                 }
-                return Some(rid);
+                return Ok(Some(rid));
             }
         }
-        None
+        Ok(None)
     }
 
     /// Get the number of segments.
@@ -1820,10 +1830,10 @@ impl SegmentManager {
     /// Get a cold row by row_id. Returns the Row if found and not tombstoned.
     /// Iterates newest-first so overlapping row_ids return the newest version.
     /// Uses metadata-only search, reloads only the target cold volume if needed.
-    pub fn get_cold_row(&self, row_id: i64) -> Option<crate::core::Row> {
+    pub fn get_cold_row(&self, row_id: i64) -> crate::core::Result<Option<crate::core::Row>> {
         let ts = Arc::clone(&*self.tombstones.read());
         if ts.contains_key(&row_id) {
-            return None;
+            return Ok(None);
         }
         let (seg_ids, segments) = {
             let manifest = self.manifest.read();
@@ -1843,22 +1853,22 @@ impl SegmentManager {
             if let Some(cold) = segments.get(seg_id) {
                 if let Ok(idx) = cold.volume.meta.row_ids.binary_search(&row_id) {
                     if cold.volume.is_cold() {
-                        if let Some(vol) = self.ensure_volume(*seg_id) {
-                            return Some(vol.get_row(idx));
+                        if let Some(vol) = self.ensure_volume(*seg_id)? {
+                            return Ok(Some(vol.get_row(idx)));
                         }
                         // Segment removed by compaction — retry with fresh state.
                         return self.get_cold_row_retry(row_id);
                     }
                     cold.volume.mark_accessed();
-                    return Some(cold.volume.get_row(idx));
+                    return Ok(Some(cold.volume.get_row(idx)));
                 }
             }
         }
-        None
+        Ok(None)
     }
 
     /// Retry get_cold_row with a fresh consistent snapshot after compaction.
-    fn get_cold_row_retry(&self, row_id: i64) -> Option<crate::core::Row> {
+    fn get_cold_row_retry(&self, row_id: i64) -> crate::core::Result<Option<crate::core::Row>> {
         self.ensure_columns();
         let (seg_ids, segments) = {
             let manifest = self.manifest.read();
@@ -1874,12 +1884,21 @@ impl SegmentManager {
         for seg_id in &seg_ids {
             if let Some(cold) = segments.get(seg_id) {
                 if let Ok(idx) = cold.volume.meta.row_ids.binary_search(&row_id) {
+                    if cold.volume.is_cold() {
+                        return Err(crate::core::Error::Internal {
+                            message: format!(
+                                "table '{}': cold volume reload failed for segment {}; \
+                                 refusing to serve partial data",
+                                self.table_name, seg_id
+                            ),
+                        });
+                    }
                     cold.volume.mark_accessed();
-                    return Some(cold.volume.get_row(idx));
+                    return Ok(Some(cold.volume.get_row(idx)));
                 }
             }
         }
-        None
+        Ok(None)
     }
 
     /// Get a cold row by row_id, normalized to the current schema.
@@ -1891,10 +1910,10 @@ impl SegmentManager {
         &self,
         row_id: i64,
         schema: &crate::core::Schema,
-    ) -> Option<crate::core::Row> {
+    ) -> crate::core::Result<Option<crate::core::Row>> {
         let ts = Arc::clone(&*self.tombstones.read());
         if ts.contains_key(&row_id) {
-            return None;
+            return Ok(None);
         }
         let (seg_ids, segments) = {
             let manifest = self.manifest.read();
@@ -1914,7 +1933,7 @@ impl SegmentManager {
             if let Some(cold) = segments.get(seg_id) {
                 if let Ok(idx) = cold.volume.meta.row_ids.binary_search(&row_id) {
                     let vol = if cold.volume.is_cold() {
-                        match self.ensure_volume(*seg_id) {
+                        match self.ensure_volume(*seg_id)? {
                             Some(v) => v,
                             None => {
                                 // Segment removed by compaction — retry with fresh state.
@@ -1927,13 +1946,13 @@ impl SegmentManager {
                     };
                     let mapping = self.get_volume_mapping(*seg_id, schema);
                     if mapping.is_identity {
-                        return Some(vol.get_row(idx));
+                        return Ok(Some(vol.get_row(idx)));
                     }
-                    return Some(vol.get_row_mapped(idx, &mapping));
+                    return Ok(Some(vol.get_row_mapped(idx, &mapping)));
                 }
             }
         }
-        None
+        Ok(None)
     }
 
     /// Retry get_cold_row_normalized with a fresh consistent snapshot after compaction.
@@ -1941,7 +1960,7 @@ impl SegmentManager {
         &self,
         row_id: i64,
         schema: &crate::core::Schema,
-    ) -> Option<crate::core::Row> {
+    ) -> crate::core::Result<Option<crate::core::Row>> {
         self.ensure_columns();
         let (seg_ids, segments) = {
             let manifest = self.manifest.read();
@@ -1957,16 +1976,25 @@ impl SegmentManager {
         for seg_id in &seg_ids {
             if let Some(cold) = segments.get(seg_id) {
                 if let Ok(idx) = cold.volume.meta.row_ids.binary_search(&row_id) {
+                    if cold.volume.is_cold() {
+                        return Err(crate::core::Error::Internal {
+                            message: format!(
+                                "table '{}': cold volume reload failed for segment {}; \
+                                 refusing to serve partial data",
+                                self.table_name, seg_id
+                            ),
+                        });
+                    }
                     cold.volume.mark_accessed();
                     let mapping = self.get_volume_mapping(*seg_id, schema);
                     if mapping.is_identity {
-                        return Some(cold.volume.get_row(idx));
+                        return Ok(Some(cold.volume.get_row(idx)));
                     }
-                    return Some(cold.volume.get_row_mapped(idx, &mapping));
+                    return Ok(Some(cold.volume.get_row_mapped(idx, &mapping)));
                 }
             }
         }
-        None
+        Ok(None)
     }
 
     /// Check if a row_id actually exists in any loaded volume.
@@ -2500,16 +2528,21 @@ impl SegmentManager {
 
     /// Reload a single cold volume by segment ID. Returns the loaded volume
     /// if successful. Used by point lookups to avoid reloading all cold volumes.
-    pub fn ensure_volume(&self, seg_id: u64) -> Option<Arc<FrozenVolume>> {
+    /// `Ok(None)` means the segment was removed by concurrent compaction
+    /// (the caller may retry with the current manifest or skip it);
+    /// `Err` means the cold volume could not be reloaded and the caller
+    /// must fail closed rather than serve partial data.
+    pub fn ensure_volume(&self, seg_id: u64) -> crate::core::Result<Option<Arc<FrozenVolume>>> {
         // Fast path: already loaded (or another thread just loaded it)
         {
             let segs = self.segments.read();
-            // Missing segment: compaction removed it. Caller should retry
-            // with the current manifest.
-            let cs = segs.get(&seg_id)?;
-            if !cs.volume.is_cold() {
-                cs.volume.mark_accessed();
-                return Some(Arc::clone(&cs.volume));
+            match segs.get(&seg_id) {
+                None => return Ok(None),
+                Some(cs) if !cs.volume.is_cold() => {
+                    cs.volume.mark_accessed();
+                    return Ok(Some(Arc::clone(&cs.volume)));
+                }
+                Some(_) => {}
             }
         }
         // Serialize reloads — prevents concurrent stampede on the same volume.
@@ -2517,23 +2550,36 @@ impl SegmentManager {
         let _guard = self.reloading.lock();
         {
             let segs = self.segments.read();
-            let cs = segs.get(&seg_id)?;
-            if !cs.volume.is_cold() {
-                cs.volume.mark_accessed();
-                return Some(Arc::clone(&cs.volume));
+            match segs.get(&seg_id) {
+                None => return Ok(None),
+                Some(cs) if !cs.volume.is_cold() => {
+                    cs.volume.mark_accessed();
+                    return Ok(Some(Arc::clone(&cs.volume)));
+                }
+                Some(_) => {}
             }
         }
-        let vol_dir = self.volume_dir.as_ref()?;
+        let vol_dir = self
+            .volume_dir
+            .as_ref()
+            .ok_or_else(|| crate::core::Error::Internal {
+                message: format!(
+                    "table '{}': cold segment {} has no volume directory to reload from",
+                    self.table_name, seg_id
+                ),
+            })?;
         let filename = format!("vol_{:016x}.vol", seg_id);
         let full_path = vol_dir.join(self.table_name.as_str()).join(filename);
         let volume = match crate::storage::volume::io::read_volume_from_disk(&full_path) {
             Ok(v) => Arc::new(v),
             Err(e) => {
-                eprintln!(
-                    "Warning: Failed to reload cold volume {} seg={}: {}",
-                    self.table_name, seg_id, e
-                );
-                return None;
+                return Err(crate::core::Error::Internal {
+                    message: format!(
+                        "table '{}': failed to reload cold volume seg={}: {}; \
+                         refusing to serve partial data",
+                        self.table_name, seg_id, e
+                    ),
+                });
             }
         };
         volume.mark_accessed();
@@ -2541,7 +2587,10 @@ impl SegmentManager {
         let mut new_map = (**segments).clone();
         // Re-check: concurrent compaction may have removed the segment while
         // we were reading from disk; the row then lives in a newer volume.
-        let cs = new_map.get_mut(&seg_id)?;
+        let cs = match new_map.get_mut(&seg_id) {
+            None => return Ok(None),
+            Some(cs) => cs,
+        };
         if !cs.volume.unique_indices.read().is_empty() {
             *volume.unique_indices.write() = std::mem::take(&mut *cs.volume.unique_indices.write());
         }
@@ -2552,7 +2601,7 @@ impl SegmentManager {
             self.has_cold
                 .store(false, std::sync::atomic::Ordering::Relaxed);
         }
-        Some(volume)
+        Ok(Some(volume))
     }
 
     /// Get the manifest for writing (e.g., to allocate segment IDs).
@@ -2919,7 +2968,7 @@ mod tests {
             );
         }
 
-        let newest_first = mgr.get_volumes_newest_first();
+        let newest_first = mgr.get_volumes_newest_first().unwrap();
         assert_eq!(newest_first.len(), 3);
         // get_volumes_newest_first reverses manifest insertion order.
         // Segments were registered as [1, 3, 2], so reversed = [2, 3, 1].
@@ -3005,7 +3054,7 @@ mod tests {
 
         // Data is correct while hot.
         {
-            let vols = mgr.get_volumes_newest_first();
+            let vols = mgr.get_volumes_newest_first().unwrap();
             let (_, cs) = &vols[0];
             let row = cs.volume.get_row(0);
             assert_eq!(row[0], Value::Integer(1));
@@ -3052,7 +3101,7 @@ mod tests {
 
         // Data is correct while warm (decompresses from compressed store).
         {
-            let vols = mgr.get_volumes_newest_first();
+            let vols = mgr.get_volumes_newest_first().unwrap();
             let (_, cs) = &vols[0];
             let row = cs.volume.get_row(49);
             assert_eq!(row[0], Value::Integer(50));
@@ -3109,5 +3158,62 @@ mod tests {
 
         // Volume is still in the map (not removed).
         assert_eq!(mgr.segment_count(), 1);
+    }
+
+    #[test]
+    fn test_cold_reload_failure_fails_closed() {
+        use crate::core::{DataType, Row, SchemaBuilder, Value};
+
+        let schema = SchemaBuilder::new("cold_fail")
+            .column("id", DataType::Integer, false, true)
+            .build();
+
+        // No volume_dir: once the volume goes cold there is nowhere to
+        // reload it from, which models a reload failure deterministically.
+        let mgr = SegmentManager::new("cold_fail", None);
+        let mut builder = super::super::writer::VolumeBuilder::new(&schema);
+        for i in 1..=100i64 {
+            builder.add_row(i, &Row::from_values(vec![Value::Integer(i)]));
+        }
+        let mut volume = builder.finish();
+        let (_, store) = crate::storage::volume::io::serialize_v4_public(&volume).unwrap();
+        volume.columns.attach_compressed_store(store);
+        mgr.register_segment(
+            1,
+            Arc::new(volume),
+            SegmentMeta {
+                segment_id: 1,
+                file_path: PathBuf::from("cold_fail.vol"),
+                row_count: 100,
+                min_row_id: 1,
+                max_row_id: 100,
+                creation_lsn: 0,
+                seal_seq: 0,
+                schema_version: 0,
+            },
+            None,
+        );
+
+        let run_eviction = |mgr: &SegmentManager, epoch: u64| {
+            super::super::writer::GLOBAL_EVICTION_EPOCH
+                .fetch_max(epoch, std::sync::atomic::Ordering::Relaxed);
+            mgr.evict_idle_volumes(epoch);
+        };
+        for epoch in 0..=10u64 {
+            run_eviction(&mgr, epoch);
+        }
+        assert!(
+            mgr.segments_raw().get(&1).unwrap().volume.is_cold(),
+            "precondition: volume must be cold"
+        );
+
+        // Every data-access path must fail closed instead of silently
+        // serving a partial (or empty) view of the table.
+        assert!(mgr.ensure_volume(1).is_err(), "ensure_volume must fail");
+        assert!(
+            mgr.get_volumes_newest_first().is_err(),
+            "get_volumes_newest_first must fail instead of dropping the segment"
+        );
+        assert!(mgr.get_cold_row(50).is_err(), "get_cold_row must fail");
     }
 }

--- a/src/storage/volume/manifest.rs
+++ b/src/storage/volume/manifest.rs
@@ -582,6 +582,26 @@ fn compute_visibility_bitmaps(
 ///
 /// Thread safety: the manager uses interior mutability via RwLock for
 /// concurrent read access (queries) and exclusive write access (seal, compaction).
+/// Statement-scoped consistent view of cold state (see
+/// `SegmentManager::statement_snapshot`).
+pub struct StatementSnapshot {
+    /// Manifest segment ids, newest first, captured with `segs`.
+    pub seg_ids_newest_first: Vec<u64>,
+    pub segs: Arc<FxHashMap<u64, ColdSegment>>,
+    /// Committed tombstones as of capture.
+    pub tombstones: Arc<FxHashMap<i64, u64>>,
+}
+
+impl StatementSnapshot {
+    /// Newest-first (id, segment) list from the snapshot alone.
+    pub fn volumes_newest_first(&self) -> Vec<(u64, ColdSegment)> {
+        self.seg_ids_newest_first
+            .iter()
+            .filter_map(|&id| self.segs.get(&id).map(|cs| (id, cs.clone())))
+            .collect()
+    }
+}
+
 pub struct SegmentManager {
     /// Table name.
     table_name: SmartString,
@@ -815,26 +835,50 @@ impl SegmentManager {
         Arc::new(result)
     }
 
-    /// Build the newest-first volume list from a pre-verified snapshot
-    /// (see `segments_snapshot`). DML statements capture one snapshot up
-    /// front and iterate it throughout: eviction copy-on-writes new maps
-    /// and new volume Arcs, so the snapshot's volumes keep their column
-    /// data for the whole statement and no mid-statement reload can ever
-    /// be needed.
-    pub fn volumes_newest_first_from_snapshot(
-        &self,
-        segs: &FxHashMap<u64, ColdSegment>,
-    ) -> Vec<(u64, ColdSegment)> {
-        let seg_ids: Vec<u64> = {
+    /// Capture a consistent, statement-scoped view of the cold state:
+    /// newest-first segment ids, the segment map, and the committed
+    /// tombstone set, all under ONE manifest lock hold, with every volume
+    /// verified warm (fail-closed like `segments_snapshot`). DML uses this
+    /// for the whole statement and never re-reads live manager state after
+    /// mutating the hot buffer: eviction and compaction copy-on-write new
+    /// maps/Arcs, so nothing in the snapshot can go cold or disappear.
+    pub fn statement_snapshot(&self) -> crate::core::Result<StatementSnapshot> {
+        let capture = || {
             let manifest = self.manifest.read();
-            manifest.segments.iter().map(|m| m.segment_id).collect()
+            let mut seg_ids_newest_first: Vec<u64> =
+                manifest.segments.iter().map(|m| m.segment_id).collect();
+            seg_ids_newest_first.reverse();
+            let segs = Arc::clone(&*self.segments.read());
+            let tombstones = Arc::clone(&*self.tombstones.read());
+            StatementSnapshot {
+                seg_ids_newest_first,
+                segs,
+                tombstones,
+            }
         };
-        let mut result: Vec<(u64, ColdSegment)> = seg_ids
-            .iter()
-            .filter_map(|&id| segs.get(&id).map(|cs| (id, cs.clone())))
-            .collect();
-        result.reverse();
-        result
+        self.ensure_columns();
+        let mut snap = capture();
+        if snap.segs.values().any(|cs| cs.volume.is_cold()) {
+            // Race with eviction: retry once, then fail closed.
+            self.ensure_columns();
+            snap = capture();
+            let cold: Vec<u64> = snap
+                .segs
+                .iter()
+                .filter(|(_, cs)| cs.volume.is_cold())
+                .map(|(&id, _)| id)
+                .collect();
+            if !cold.is_empty() {
+                return Err(crate::core::Error::Internal {
+                    message: format!(
+                        "table '{}': cold volume reload failed for segment(s) {:?}; \
+                         refusing to serve partial data",
+                        self.table_name, cold
+                    ),
+                });
+            }
+        }
+        Ok(snap)
     }
 
     /// Check if there are any segments. O(1) atomic read, no lock.
@@ -3256,5 +3300,70 @@ mod tests {
             mgr.segments_snapshot().is_err(),
             "the DML statement snapshot must fail before any mutation"
         );
+        assert!(
+            mgr.statement_snapshot().is_err(),
+            "statement_snapshot must fail closed too"
+        );
+    }
+
+    #[test]
+    fn test_statement_snapshot_survives_concurrent_compaction() {
+        use crate::core::{DataType, Row, SchemaBuilder, Value};
+
+        let schema = SchemaBuilder::new("snap_compact")
+            .column("id", DataType::Integer, false, true)
+            .build();
+        let mgr = SegmentManager::new("snap_compact", None);
+
+        let build_volume = |vals: std::ops::RangeInclusive<i64>| {
+            let mut b = super::super::writer::VolumeBuilder::new(&schema);
+            for i in vals {
+                b.add_row(i, &Row::from_values(vec![Value::Integer(i)]));
+            }
+            Arc::new(b.finish())
+        };
+
+        mgr.register_segment(
+            1,
+            build_volume(1..=10),
+            SegmentMeta {
+                segment_id: 1,
+                file_path: PathBuf::from("s1.vol"),
+                row_count: 10,
+                min_row_id: 1,
+                max_row_id: 10,
+                creation_lsn: 0,
+                seal_seq: 0,
+                schema_version: 0,
+            },
+            None,
+        );
+
+        let snap = mgr.statement_snapshot().unwrap();
+
+        // Background compaction replaces segment 1 with segment 2 while the
+        // statement snapshot is live.
+        mgr.replace_segments_atomic(
+            2,
+            build_volume(1..=10),
+            SegmentMeta {
+                segment_id: 2,
+                file_path: PathBuf::from("s2.vol"),
+                row_count: 10,
+                min_row_id: 1,
+                max_row_id: 10,
+                creation_lsn: 0,
+                seal_seq: 1,
+                schema_version: 0,
+            },
+            &[1],
+        );
+
+        // The snapshot must keep serving ITS view: segment 1, one volume.
+        // (The live-manifest ordering bug returned zero volumes here.)
+        let vols = snap.volumes_newest_first();
+        assert_eq!(vols.len(), 1, "snapshot must not lose its segment");
+        assert_eq!(vols[0].0, 1);
+        assert_eq!(vols[0].1.volume.get_row(0)[0], Value::Integer(1));
     }
 }

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -1147,6 +1147,12 @@ impl Table for SegmentedTable {
         setter: &mut dyn FnMut(Row) -> Result<(Row, bool)>,
     ) -> Result<i32> {
         let _seal_guard = self.segment_mgr.acquire_seal_read();
+        // Fail on unreloadable cold volumes BEFORE mutating the hot buffer,
+        // so a reload error cannot leave a partially applied statement in
+        // the open transaction.
+        if self.segment_mgr.has_segments() {
+            self.segment_mgr.preflight_cold_access()?;
+        }
         let mut count = self.hot.update(where_expr, setter)?;
 
         // Update matching segment rows.
@@ -1269,6 +1275,12 @@ impl Table for SegmentedTable {
         setter: &mut dyn FnMut(Row) -> Result<(Row, bool)>,
     ) -> Result<i32> {
         let _seal_guard = self.segment_mgr.acquire_seal_read();
+        // Fail on unreloadable cold volumes BEFORE mutating the hot buffer,
+        // so a reload error cannot leave a partially applied statement in
+        // the open transaction.
+        if self.segment_mgr.has_segments() {
+            self.segment_mgr.preflight_cold_access()?;
+        }
         let mut count = 0i32;
         let mut hot_ids = Vec::new();
         let schema = self.hot.schema().clone();
@@ -1351,6 +1363,12 @@ impl Table for SegmentedTable {
 
     fn delete_by_row_ids(&mut self, row_ids: &[i64]) -> Result<i32> {
         let _seal_guard = self.segment_mgr.acquire_seal_read();
+        // Fail on unreloadable cold volumes BEFORE mutating the hot buffer,
+        // so a reload error cannot leave a partially applied statement in
+        // the open transaction.
+        if self.segment_mgr.has_segments() {
+            self.segment_mgr.preflight_cold_access()?;
+        }
         let mut count = 0i32;
         let mut hot_ids = Vec::new();
         let has_int_pk = self
@@ -1422,6 +1440,12 @@ impl Table for SegmentedTable {
 
     fn delete(&mut self, where_expr: Option<&dyn Expression>) -> Result<i32> {
         let _seal_guard = self.segment_mgr.acquire_seal_read();
+        // Fail on unreloadable cold volumes BEFORE mutating the hot buffer,
+        // so a reload error cannot leave a partially applied statement in
+        // the open transaction.
+        if self.segment_mgr.has_segments() {
+            self.segment_mgr.preflight_cold_access()?;
+        }
         let mut count = self.hot.delete(where_expr)?;
         let has_int_pk = self
             .hot

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -880,32 +880,22 @@ impl SegmentedTable {
     /// which is exactly the statement's view of the data.
     fn find_segment_row_in(
         &self,
-        segs: &FxHashMap<u64, super::manifest::ColdSegment>,
+        snap: &super::manifest::StatementSnapshot,
         row_id: i64,
-    ) -> Option<(u64, Arc<FrozenVolume>, usize)> {
+    ) -> Option<(u64, super::manifest::ColdSegment, usize)> {
         if self.hot.has_row_id(row_id) {
             return None;
         }
-        {
-            let ts = self.segment_mgr.tombstone_set_arc();
-            if self.is_row_tombstoned(&ts, row_id) {
-                return None;
-            }
+        // Tombstone view from the SAME snapshot; only the pending set is
+        // read live because it is this transaction's own state.
+        if self.is_row_tombstoned(&snap.tombstones, row_id) {
+            return None;
         }
         if self.segment_mgr.is_pending_tombstone(self.txn_id(), row_id) {
             return None;
         }
-        let seg_ids: Vec<u64> = {
-            let manifest = self.segment_mgr.manifest();
-            manifest
-                .segments
-                .iter()
-                .rev()
-                .map(|m| m.segment_id)
-                .collect()
-        };
-        for &seg_id in &seg_ids {
-            let Some(cold) = segs.get(&seg_id) else {
+        for &seg_id in &snap.seg_ids_newest_first {
+            let Some(cold) = snap.segs.get(&seg_id) else {
                 continue;
             };
             let vol = &cold.volume;
@@ -919,7 +909,7 @@ impl SegmentedTable {
             }
             if let Ok(idx) = vol.meta.row_ids.binary_search(&row_id) {
                 vol.mark_accessed();
-                return Some((seg_id, Arc::clone(vol), idx));
+                return Some((seg_id, cold.clone(), idx));
             }
         }
         None
@@ -1206,16 +1196,17 @@ impl Table for SegmentedTable {
         // their column data for the statement's duration and no
         // mid-statement reload (or reload failure) is possible.
         let cold_snapshot = if self.segment_mgr.has_segments() {
-            Some(self.segment_mgr.segments_snapshot()?)
+            Some(self.segment_mgr.statement_snapshot()?)
         } else {
             None
         };
+        let stmt_tombstones = cold_snapshot.as_ref().map(|s| Arc::clone(&s.tombstones));
         let mut count = self.hot.update(where_expr, setter)?;
 
         // Update matching segment rows from the statement snapshot
         // (zone-map pruning still applies; volumes are already warm).
         let volumes = match &cold_snapshot {
-            Some(segs) => self.segment_mgr.volumes_newest_first_from_snapshot(segs),
+            Some(snap) => snap.volumes_newest_first(),
             None => Vec::new(),
         };
         let has_int_pk = self
@@ -1225,13 +1216,14 @@ impl Table for SegmentedTable {
             .iter()
             .any(|c| c.primary_key && c.data_type == DataType::Integer);
 
-        let tombstones_arc = self.segment_mgr.tombstone_set_arc();
+        let tombstones_arc = stmt_tombstones
+            .clone()
+            .unwrap_or_else(|| self.segment_mgr.tombstone_set_arc());
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
         self.hot.collect_hot_row_ids_into(&mut hot_skip);
         self.segment_mgr
             .insert_pending_tombstones_into(self.txn_id(), &mut hot_skip);
-        let schema_clone = self.hot.schema().clone();
 
         // Zone-map / bloom pruning from WHERE clause.
         let comparisons = where_expr
@@ -1261,7 +1253,7 @@ impl Table for SegmentedTable {
                 vol
             };
 
-            let mapping = self.segment_mgr.get_volume_mapping(*seg_id, &schema_clone);
+            let mapping = cs.mapping.clone();
 
             for i in 0..vol.meta.row_count {
                 if !cs.is_visible(i) {
@@ -1341,7 +1333,7 @@ impl Table for SegmentedTable {
         // their column data for the statement's duration and no
         // mid-statement reload (or reload failure) is possible.
         let cold_snapshot = if self.segment_mgr.has_segments() {
-            Some(self.segment_mgr.segments_snapshot()?)
+            Some(self.segment_mgr.statement_snapshot()?)
         } else {
             None
         };
@@ -1359,18 +1351,17 @@ impl Table for SegmentedTable {
         )> = None;
         for &row_id in row_ids {
             let found = match &cold_snapshot {
-                Some(segs) => self.find_segment_row_in(segs, row_id),
+                Some(snap) => self.find_segment_row_in(snap, row_id),
                 None => None,
             };
-            if let Some((seg_id, vol, idx)) = found {
+            if let Some((_seg_id, cs, idx)) = found {
+                let vol = Arc::clone(&cs.volume);
                 let vol_ptr = &*vol as *const super::writer::FrozenVolume;
                 let mapping = match &cached_mapping {
                     Some((ptr, m)) if *ptr == vol_ptr => m,
                     _ => {
-                        cached_mapping = Some((
-                            vol_ptr,
-                            self.segment_mgr.get_volume_mapping(seg_id, &schema),
-                        ));
+                        // Mapping from the SAME snapshot segment.
+                        cached_mapping = Some((vol_ptr, cs.mapping.clone()));
                         &cached_mapping.as_ref().unwrap().1
                     }
                 };
@@ -1437,7 +1428,7 @@ impl Table for SegmentedTable {
         // their column data for the statement's duration and no
         // mid-statement reload (or reload failure) is possible.
         let cold_snapshot = if self.segment_mgr.has_segments() {
-            Some(self.segment_mgr.segments_snapshot()?)
+            Some(self.segment_mgr.statement_snapshot()?)
         } else {
             None
         };
@@ -1452,10 +1443,10 @@ impl Table for SegmentedTable {
 
         for &row_id in row_ids {
             let found = match &cold_snapshot {
-                Some(segs) => self.find_segment_row_in(segs, row_id),
+                Some(snap) => self.find_segment_row_in(snap, row_id),
                 None => None,
             };
-            if let Some((_seg_id, _vol, _idx)) = found {
+            if let Some((_seg_id, _cs, _idx)) = found {
                 // Claim the cold row to prevent concurrent lost deletes.
                 self.hot.try_claim_row(row_id)?;
                 if has_int_pk {
@@ -1522,10 +1513,11 @@ impl Table for SegmentedTable {
         // their column data for the statement's duration and no
         // mid-statement reload (or reload failure) is possible.
         let cold_snapshot = if self.segment_mgr.has_segments() {
-            Some(self.segment_mgr.segments_snapshot()?)
+            Some(self.segment_mgr.statement_snapshot()?)
         } else {
             None
         };
+        let stmt_tombstones = cold_snapshot.as_ref().map(|s| Arc::clone(&s.tombstones));
         let mut count = self.hot.delete(where_expr)?;
         let has_int_pk = self
             .hot
@@ -1538,10 +1530,12 @@ impl Table for SegmentedTable {
         // Committed tombstones are kept as a shared Arc (no clone).
         // Lazy: prune on zone maps/bloom filters first, load cold on demand.
         let volumes = match &cold_snapshot {
-            Some(segs) => self.segment_mgr.volumes_newest_first_from_snapshot(segs),
+            Some(snap) => snap.volumes_newest_first(),
             None => Vec::new(),
         };
-        let tombstones_arc = self.segment_mgr.tombstone_set_arc();
+        let tombstones_arc = stmt_tombstones
+            .clone()
+            .unwrap_or_else(|| self.segment_mgr.tombstone_set_arc());
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
         self.hot.collect_hot_row_ids_into(&mut hot_skip);
@@ -1605,7 +1599,7 @@ impl Table for SegmentedTable {
                 vol
             };
 
-            let mapping = self.segment_mgr.get_volume_mapping(*seg_id, &schema_clone);
+            let mapping = cs.mapping.clone();
 
             for i in 0..vol.meta.row_count {
                 if !cs.is_visible(i) {

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -943,7 +943,7 @@ impl SegmentedTable {
     ) -> Result<Option<(u64, Arc<FrozenVolume>, usize)>> {
         // ensure_columns before manifest lock to avoid deadlock
         // (ensure_columns may need manifest.write via reload_cold_volumes).
-        let segs = self.segment_mgr.segments_snapshot();
+        let segs = self.segment_mgr.segments_snapshot()?;
         let seg_ids: Vec<u64> = {
             let manifest = self.segment_mgr.manifest();
             manifest
@@ -959,16 +959,7 @@ impl SegmentedTable {
             };
             let vol = &cold.volume;
             if let Ok(idx) = vol.meta.row_ids.binary_search(&row_id) {
-                if vol.is_cold() {
-                    return Err(crate::core::Error::Internal {
-                        message: format!(
-                            "table '{}': cold volume reload failed for segment {}; \
-                             refusing to serve partial data",
-                            self.segment_mgr.table_name(),
-                            seg_id
-                        ),
-                    });
-                }
+                // segments_snapshot fails closed, so vol is never cold here.
                 vol.mark_accessed();
                 return Ok(Some((seg_id, Arc::clone(vol), idx)));
             }
@@ -3219,9 +3210,9 @@ impl Table for SegmentedTable {
         &self,
         column_name: &str,
         partition_value: &Value,
-    ) -> Option<RowVec> {
+    ) -> Result<Option<RowVec>> {
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         if !self.segment_mgr.has_segments() {
             return self
@@ -3230,16 +3221,19 @@ impl Table for SegmentedTable {
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
         let schema = self.hot.schema();
-        let col_idx = *schema.column_index_map().get(&column_name.to_lowercase())?;
+        let col_idx = match schema.column_index_map().get(&column_name.to_lowercase()) {
+            Some(&idx) => idx,
+            None => return Ok(None),
+        };
 
         // Get hot rows for this partition value
         let mut result = self
             .hot
-            .get_rows_for_partition_value(column_name, partition_value)
+            .get_rows_for_partition_value(column_name, partition_value)?
             .unwrap_or_default();
 
         // Build hot_skip: hot row_ids + tombstones + pending tombstones
@@ -3281,10 +3275,9 @@ impl Table for SegmentedTable {
             // Load cold volume on demand after pruning.
             let loaded;
             let vol: &Arc<FrozenVolume> = if vol.is_cold() {
-                loaded = match self.segment_mgr.ensure_volume(*seg_id) {
-                    Err(_) => return None,
-                    Ok(Some(v)) => v,
-                    Ok(None) => continue,
+                loaded = match self.segment_mgr.ensure_volume(*seg_id)? {
+                    Some(v) => v,
+                    None => continue,
                 };
                 &loaded
             } else {
@@ -3321,7 +3314,7 @@ impl Table for SegmentedTable {
             }
         }
 
-        Some(result)
+        Ok(Some(result))
     }
 
     fn collect_rows_ordered_by_index(

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -160,7 +160,7 @@ impl SegmentedTable {
             return Ok(());
         }
 
-        let volumes = self.segment_mgr.get_volumes_newest_first();
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let ts = self.segment_mgr.tombstone_set_arc();
         let mut seen_values: ahash::AHashMap<Vec<Value>, i64> = ahash::AHashMap::new();
 
@@ -247,7 +247,7 @@ impl SegmentedTable {
         if col_indices.is_empty() {
             return Ok(());
         }
-        let volumes = self.segment_mgr.get_volumes_newest_first();
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let ts = self.segment_mgr.tombstone_set_arc();
         for (seg_id, cs) in volumes.iter() {
             let vol = &cs.volume;
@@ -298,7 +298,7 @@ impl SegmentedTable {
         &self,
         col_indices: &[usize],
         values: &[&Value],
-    ) -> Option<i64> {
+    ) -> Result<Option<i64>> {
         let snapshot = self.segment_mgr.cold_snapshot();
         self.find_segment_row_id_by_values_with_snapshot(&snapshot, col_indices, values)
     }
@@ -308,28 +308,30 @@ impl SegmentedTable {
         snapshot: &super::manifest::ColdSnapshot,
         col_indices: &[usize],
         values: &[&Value],
-    ) -> Option<i64> {
+    ) -> Result<Option<i64>> {
         if col_indices.is_empty() || col_indices.len() != values.len() {
-            return None;
+            return Ok(None);
         }
 
         let defaults: smallvec::SmallVec<[Value; 4]> = col_indices
             .iter()
             .map(|&ci| self.column_default(ci))
             .collect();
-        let result = self.segment_mgr.find_row_id_by_values_with_snapshot(
+        let rid = match self.segment_mgr.find_row_id_by_values_with_snapshot(
             snapshot,
             col_indices,
             values,
             &defaults,
-        );
-        let rid = result?;
+        )? {
+            Some(rid) => rid,
+            None => return Ok(None),
+        };
 
         if self.segment_mgr.is_pending_tombstone(self.txn_id(), rid) {
-            return None;
+            return Ok(None);
         }
 
-        Some(rid)
+        Ok(Some(rid))
     }
 
     /// Check PK and UNIQUE constraints against segment data before INSERT.
@@ -361,7 +363,7 @@ impl SegmentedTable {
                 }
                 let values: Vec<&Value> = coerced.iter().collect();
 
-                if let Some(found_id) = self.find_segment_row_id_by_values(&col_indices, &values) {
+                if let Some(found_id) = self.find_segment_row_id_by_values(&col_indices, &values)? {
                     if found_id != exclude_row_id {
                         return Err(crate::core::Error::UniqueConstraint {
                             index: idx_name.to_string(),
@@ -397,7 +399,7 @@ impl SegmentedTable {
                 if !pk_value.is_null() {
                     if let Some(row_id) = self
                         .segment_mgr
-                        .check_value_exists_with_snapshot(snapshot, pk_idx, pk_value)
+                        .check_value_exists_with_snapshot(snapshot, pk_idx, pk_value)?
                     {
                         // check_value_exists_in_segments filters committed tombstones.
                         // Check pending tombstones (no Vec clone).
@@ -445,7 +447,7 @@ impl SegmentedTable {
                     snapshot,
                     &col_indices,
                     &values,
-                ) {
+                )? {
                     return Err(crate::core::Error::UniqueConstraint {
                         index: idx_name.to_string(),
                         column: col_names.join(", "),
@@ -601,7 +603,7 @@ impl SegmentedTable {
         column_indices: &[usize],
         where_expr: Option<&dyn Expression>,
         hot_skip: FxHashSet<i64>,
-    ) -> Vec<Box<dyn Scanner>> {
+    ) -> Result<Vec<Box<dyn Scanner>>> {
         let comparisons = where_expr
             .map(|e| e.collect_comparisons())
             .unwrap_or_default();
@@ -612,7 +614,7 @@ impl SegmentedTable {
         let volumes = self.segment_mgr.get_volumes_newest_first_lazy();
 
         if volumes.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
 
         // Committed tombstones are kept as a shared Arc (no clone).
@@ -634,7 +636,7 @@ impl SegmentedTable {
             // Re-prune to get binary-search range narrowing on sorted columns.
             let loaded;
             let (vol, start, end) = if vol.is_cold() {
-                loaded = match self.segment_mgr.ensure_volume(*seg_id) {
+                loaded = match self.segment_mgr.ensure_volume(*seg_id)? {
                     Some(v) => v,
                     None => continue,
                 };
@@ -676,7 +678,7 @@ impl SegmentedTable {
 
         // Reverse so oldest segments come first (consistent iteration order)
         scanners_reverse.reverse();
-        scanners_reverse
+        Ok(scanners_reverse)
     }
 
     /// Collect rows from segments into a RowVec, with zone map pruning
@@ -722,6 +724,7 @@ impl SegmentedTable {
         };
         let hot_skip_ref = &hot_skip;
         let tombstones_ref = &tombstones_arc;
+        let reload_failed = std::sync::atomic::AtomicBool::new(false);
 
         // Per-volume row collection closure. Returns Some(vol_rows) or None if pruned.
         let process_volume =
@@ -735,7 +738,14 @@ impl SegmentedTable {
                 // Load cold volume on demand after zone-map/bloom pruning.
                 let loaded;
                 let (vol, start, end) = if vol.is_cold() {
-                    loaded = self.segment_mgr.ensure_volume(*seg_id)?;
+                    loaded = match self.segment_mgr.ensure_volume(*seg_id) {
+                        Ok(Some(v)) => v,
+                        Ok(None) => return None,
+                        Err(_) => {
+                            reload_failed.store(true, std::sync::atomic::Ordering::Relaxed);
+                            return None;
+                        }
+                    };
                     let (_, s, e) = Self::prune_volume(&loaded, &comparisons, &bloom_hashes);
                     (&loaded, s, e)
                 } else {
@@ -843,6 +853,14 @@ impl SegmentedTable {
             .filter_map(|v| process_volume(v))
             .collect();
 
+        if reload_failed.load(std::sync::atomic::Ordering::Relaxed) {
+            return Err(crate::core::Error::Internal {
+                message: format!(
+                    "table '{}': cold volume reload failed; refusing to serve partial data",
+                    self.segment_mgr.table_name()
+                ),
+            });
+        }
         for vol_rows in per_volume_rows.into_iter().rev() {
             for entry in vol_rows {
                 rows.push(entry);
@@ -854,21 +872,21 @@ impl SegmentedTable {
     /// Find a row in segments by row_id. Returns (volume, local_offset) if found
     /// and not tombstoned or hot-shadowed. Uses manifest min/max for fast segment
     /// identification, then binary search within the segment.
-    fn find_segment_row(&self, row_id: i64) -> Option<(u64, Arc<FrozenVolume>, usize)> {
+    fn find_segment_row(&self, row_id: i64) -> Result<Option<(u64, Arc<FrozenVolume>, usize)>> {
         // Hot buffer shadows cold: if the row exists in hot, the cold copy is stale
         if self.hot.has_row_id(row_id) {
-            return None;
+            return Ok(None);
         }
         // Check committed tombstones (snapshot-aware: newer tombstones are invisible)
         {
             let ts = self.segment_mgr.tombstone_set_arc();
             if self.is_row_tombstoned(&ts, row_id) {
-                return None;
+                return Ok(None);
             }
         }
         // Check pending tombstones for this transaction (no Vec clone)
         if self.segment_mgr.is_pending_tombstone(self.txn_id(), row_id) {
-            return None;
+            return Ok(None);
         }
 
         // Metadata-only search: row_ids are in vol.meta (available even on cold volumes).
@@ -902,8 +920,8 @@ impl SegmentedTable {
             if let Ok(idx) = vol.meta.row_ids.binary_search(&row_id) {
                 if vol.is_cold() {
                     drop(segs);
-                    if let Some(loaded) = self.segment_mgr.ensure_volume(seg_id) {
-                        return Some((seg_id, loaded, idx));
+                    if let Some(loaded) = self.segment_mgr.ensure_volume(seg_id)? {
+                        return Ok(Some((seg_id, loaded, idx)));
                     }
                     // ensure_volume returned None: compaction removed this
                     // segment. Row now lives in a newer compacted volume.
@@ -911,15 +929,18 @@ impl SegmentedTable {
                     return self.find_segment_row_retry(row_id);
                 }
                 vol.mark_accessed();
-                return Some((seg_id, Arc::clone(vol), idx));
+                return Ok(Some((seg_id, Arc::clone(vol), idx)));
             }
         }
-        None
+        Ok(None)
     }
 
     /// Retry find_segment_row with a fresh consistent snapshot.
     /// Called when ensure_volume returns None (compaction removed the segment).
-    fn find_segment_row_retry(&self, row_id: i64) -> Option<(u64, Arc<FrozenVolume>, usize)> {
+    fn find_segment_row_retry(
+        &self,
+        row_id: i64,
+    ) -> Result<Option<(u64, Arc<FrozenVolume>, usize)>> {
         // ensure_columns before manifest lock to avoid deadlock
         // (ensure_columns may need manifest.write via reload_cold_volumes).
         let segs = self.segment_mgr.segments_snapshot();
@@ -938,11 +959,21 @@ impl SegmentedTable {
             };
             let vol = &cold.volume;
             if let Ok(idx) = vol.meta.row_ids.binary_search(&row_id) {
+                if vol.is_cold() {
+                    return Err(crate::core::Error::Internal {
+                        message: format!(
+                            "table '{}': cold volume reload failed for segment {}; \
+                             refusing to serve partial data",
+                            self.segment_mgr.table_name(),
+                            seg_id
+                        ),
+                    });
+                }
                 vol.mark_accessed();
-                return Some((seg_id, Arc::clone(vol), idx));
+                return Ok(Some((seg_id, Arc::clone(vol), idx)));
             }
         }
-        None
+        Ok(None)
     }
 
     /// Generic fallback for min_column scan on non-numeric column types.
@@ -1163,7 +1194,7 @@ impl Table for SegmentedTable {
             // Load cold volume on demand after pruning.
             let loaded;
             let vol = if vol.is_cold() {
-                loaded = match self.segment_mgr.ensure_volume(*seg_id) {
+                loaded = match self.segment_mgr.ensure_volume(*seg_id)? {
                     Some(v) => v,
                     None => continue,
                 };
@@ -1260,7 +1291,7 @@ impl Table for SegmentedTable {
             super::writer::ColumnMapping,
         )> = None;
         for &row_id in row_ids {
-            if let Some((seg_id, vol, idx)) = self.find_segment_row(row_id) {
+            if let Some((seg_id, vol, idx)) = self.find_segment_row(row_id)? {
                 let vol_ptr = &*vol as *const super::writer::FrozenVolume;
                 let mapping = match &cached_mapping {
                     Some((ptr, m)) if *ptr == vol_ptr => m,
@@ -1339,7 +1370,7 @@ impl Table for SegmentedTable {
             .any(|c| c.primary_key && c.data_type == DataType::Integer);
 
         for &row_id in row_ids {
-            if let Some((_seg_id, _vol, _idx)) = self.find_segment_row(row_id) {
+            if let Some((_seg_id, _vol, _idx)) = self.find_segment_row(row_id)? {
                 // Claim the cold row to prevent concurrent lost deletes.
                 self.hot.try_claim_row(row_id)?;
                 if has_int_pk {
@@ -1362,16 +1393,16 @@ impl Table for SegmentedTable {
         Ok(count)
     }
 
-    fn get_active_row_ids(&self) -> Vec<i64> {
-        let hot_ids = self.hot.get_active_row_ids();
+    fn get_active_row_ids(&self) -> Result<Vec<i64>> {
+        let hot_ids = self.hot.get_active_row_ids()?;
 
         if !self.segment_mgr.has_segments() {
-            return hot_ids;
+            return Ok(hot_ids);
         }
 
         // Build hot_skip from hot row_ids + pending tombstones.
         // Committed tombstones are kept as a shared Arc (no clone).
-        let volumes = self.segment_mgr.get_volumes_newest_first();
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -1395,7 +1426,7 @@ impl Table for SegmentedTable {
             }
         }
         ids.extend(hot_ids);
-        ids
+        Ok(ids)
     }
 
     fn delete(&mut self, where_expr: Option<&dyn Expression>) -> Result<i32> {
@@ -1466,7 +1497,7 @@ impl Table for SegmentedTable {
             // Load cold volume on demand after pruning.
             let loaded;
             let vol = if vol.is_cold() {
-                loaded = match self.segment_mgr.ensure_volume(*seg_id) {
+                loaded = match self.segment_mgr.ensure_volume(*seg_id)? {
                     Some(v) => v,
                     None => continue,
                 };
@@ -1603,7 +1634,8 @@ impl Table for SegmentedTable {
         // Create lazy cold scanners with the skip set (no eager collection).
         // This avoids O(total_cold_rows) memory allocation that was making
         // ALL queries slow during checkpoint.
-        let cold_scanners = self.create_segment_scanners_filtered(column_indices, where_expr, skip);
+        let cold_scanners =
+            self.create_segment_scanners_filtered(column_indices, where_expr, skip)?;
 
         // Chain: cold scanners (lazy, streamed) + hot rows (already collected)
         let hot_scanner = Box::new(RowVecScanner::new(hot_rows)) as Box<dyn Scanner>;
@@ -1675,7 +1707,7 @@ impl Table for SegmentedTable {
         )> = None;
 
         for &row_id in row_ids {
-            if let Some((seg_id, vol, idx)) = self.find_segment_row(row_id) {
+            if let Some((seg_id, vol, idx)) = self.find_segment_row(row_id)? {
                 let vol_ptr = &*vol as *const super::writer::FrozenVolume;
                 let mapping = match &cached_mapping {
                     Some((ptr, m)) if *ptr == vol_ptr => m,
@@ -1708,10 +1740,10 @@ impl Table for SegmentedTable {
         Ok(result)
     }
 
-    fn fetch_rows_by_ids(&self, row_ids: &[i64], filter: &dyn Expression) -> RowVec {
+    fn fetch_rows_by_ids(&self, row_ids: &[i64], filter: &dyn Expression) -> Result<RowVec> {
         let mut results = RowVec::with_capacity(row_ids.len());
-        self.fetch_rows_by_ids_into(row_ids, filter, &mut results);
-        results
+        self.fetch_rows_by_ids_into(row_ids, filter, &mut results)?;
+        Ok(results)
     }
 
     fn fetch_rows_by_ids_into(
@@ -1719,10 +1751,9 @@ impl Table for SegmentedTable {
         row_ids: &[i64],
         filter: &dyn Expression,
         buffer: &mut RowVec,
-    ) {
+    ) -> Result<()> {
         if !self.segment_mgr.has_segments() {
-            self.hot.fetch_rows_by_ids_into(row_ids, filter, buffer);
-            return;
+            return self.hot.fetch_rows_by_ids_into(row_ids, filter, buffer);
         }
 
         let mut hot_ids = Vec::new();
@@ -1733,7 +1764,7 @@ impl Table for SegmentedTable {
         )> = None;
 
         for &row_id in row_ids {
-            if let Some((seg_id, vol, idx)) = self.find_segment_row(row_id) {
+            if let Some((seg_id, vol, idx)) = self.find_segment_row(row_id)? {
                 let vol_ptr = &*vol as *const super::writer::FrozenVolume;
                 let mapping = match &cached_mapping {
                     Some((ptr, m)) if *ptr == vol_ptr => m,
@@ -1757,8 +1788,9 @@ impl Table for SegmentedTable {
         }
 
         if !hot_ids.is_empty() {
-            self.hot.fetch_rows_by_ids_into(&hot_ids, filter, buffer);
+            self.hot.fetch_rows_by_ids_into(&hot_ids, filter, buffer)?;
         }
+        Ok(())
     }
 
     // =========================================================================
@@ -1831,7 +1863,7 @@ impl Table for SegmentedTable {
             // Load cold volume on demand after pruning.
             let loaded;
             let vol: &Arc<FrozenVolume> = if vol.is_cold() {
-                loaded = match self.segment_mgr.ensure_volume(*seg_id) {
+                loaded = match self.segment_mgr.ensure_volume(*seg_id)? {
                     Some(v) => v,
                     None => continue,
                 };
@@ -1948,7 +1980,7 @@ impl Table for SegmentedTable {
             // Load cold volume on demand after pruning.
             let loaded;
             let vol: &Arc<FrozenVolume> = if vol.is_cold() {
-                loaded = match self.segment_mgr.ensure_volume(*seg_id) {
+                loaded = match self.segment_mgr.ensure_volume(*seg_id)? {
                     Some(v) => v,
                     None => continue,
                 };
@@ -2196,7 +2228,7 @@ impl Table for SegmentedTable {
         }
 
         // Tombstones exist: scan columnar data with dedup (avoids full Row materialization)
-        let volumes = self.segment_mgr.get_volumes_newest_first();
+        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -2330,7 +2362,7 @@ impl Table for SegmentedTable {
             && !self.segment_mgr.has_pending_tombstones(self.txn_id());
 
         // Scan columnar data with dedup (typed direct access, no Value alloc)
-        let volumes = self.segment_mgr.get_volumes_newest_first();
+        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
         let tombstones_arc = if no_tombstones {
             None
         } else {
@@ -2628,7 +2660,7 @@ impl Table for SegmentedTable {
         let no_tombstones = self.segment_mgr.is_tombstone_set_empty()
             && !self.segment_mgr.has_pending_tombstones(self.txn_id());
 
-        let volumes = self.segment_mgr.get_volumes_newest_first();
+        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
         let tombstones_arc = if no_tombstones {
             None
         } else {
@@ -2875,7 +2907,7 @@ impl Table for SegmentedTable {
         }
 
         // Build skip set: hot row_ids + tombstones + pending tombstones
-        let volumes = self.segment_mgr.get_volumes_newest_first();
+        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -2942,7 +2974,7 @@ impl Table for SegmentedTable {
             distinct.insert(v);
         }
 
-        let volumes = self.segment_mgr.get_volumes_newest_first();
+        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -3019,7 +3051,7 @@ impl Table for SegmentedTable {
         let no_tombstones = self.segment_mgr.is_tombstone_set_empty()
             && !self.segment_mgr.has_pending_tombstones(self.txn_id());
 
-        let volumes = self.segment_mgr.get_volumes_newest_first();
+        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
         let tombstones_arc = if no_tombstones {
             // Avoid cloning the Arc when we know the set is empty
             Arc::new(FxHashMap::default())
@@ -3130,7 +3162,7 @@ impl Table for SegmentedTable {
         }
 
         // Build hot_skip: hot row_ids + tombstones + pending tombstones
-        let volumes = self.segment_mgr.get_volumes_newest_first();
+        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -3250,8 +3282,9 @@ impl Table for SegmentedTable {
             let loaded;
             let vol: &Arc<FrozenVolume> = if vol.is_cold() {
                 loaded = match self.segment_mgr.ensure_volume(*seg_id) {
-                    Some(v) => v,
-                    None => continue,
+                    Err(_) => return None,
+                    Ok(Some(v)) => v,
+                    Ok(None) => continue,
                 };
                 &loaded
             } else {
@@ -3359,7 +3392,7 @@ impl Table for SegmentedTable {
 
         // 3. Get volumes (oldest first — segment_id ascending order).
         //    We need column data for materialization, so use ensure_columns path.
-        let volumes = self.segment_mgr.get_volumes_newest_first();
+        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
         // volumes is oldest-first after the reverse inside get_volumes_newest_first.
 
         // 4. K-way merge using per-source cursors.
@@ -3718,7 +3751,7 @@ impl Table for SegmentedTable {
             values.push(value);
         }
 
-        Ok(self.find_segment_row_id_by_values(&col_indices, &values))
+        self.find_segment_row_id_by_values(&col_indices, &values)
     }
 
     fn has_unique_non_pk_indexes(&self) -> bool {
@@ -3912,7 +3945,7 @@ impl Table for SegmentedTable {
         if is_current_query {
             // Build hot_skip from hot row_ids + pending tombstones.
             // Committed tombstones are kept as a shared Arc (no clone).
-            let volumes = self.segment_mgr.get_volumes_newest_first();
+            let volumes = self.segment_mgr.get_volumes_newest_first()?;
             let tombstones_arc = self.segment_mgr.tombstone_set_arc();
             let mut hot_skip: FxHashSet<i64> =
                 FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -4244,7 +4277,7 @@ impl Table for SegmentedTable {
         self.hot.collect_hot_row_ids_into(&mut hot_skip);
 
         // --- Cold volumes (THE FAST PATH) ------------------------------------
-        let volumes = self.segment_mgr.get_volumes_newest_first();
+        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         self.segment_mgr
             .insert_pending_tombstones_into(self.txn_id(), &mut hot_skip);
@@ -5123,7 +5156,7 @@ impl Table for SegmentedTable {
         }
 
         // ---- Process cold volumes (columnar fast path) ----
-        let volumes = self.segment_mgr.get_volumes_newest_first();
+        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -5647,8 +5680,13 @@ mod tests {
         fn delete_by_row_ids(&mut self, _: &[i64]) -> Result<i32> {
             Ok(0)
         }
-        fn get_active_row_ids(&self) -> Vec<i64> {
-            self.rows.iter().map(|(id, _)| *id).collect()
+        fn get_active_row_ids(&self) -> Result<Vec<i64>> {
+            Ok(self.rows.iter().map(|(id, _)| *id).collect())
+        }
+        fn collect_hot_row_ids_into(&self, dest: &mut rustc_hash::FxHashSet<i64>) {
+            for (id, _) in &self.rows {
+                dest.insert(*id);
+            }
         }
         fn delete(&mut self, _: Option<&dyn Expression>) -> Result<i32> {
             Ok(0)

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -303,6 +303,39 @@ impl SegmentedTable {
         self.find_segment_row_id_by_values_with_snapshot(&snapshot, col_indices, values)
     }
 
+    /// Statement-snapshot variant: the unique lookup runs entirely
+    /// against the statement's captured view, so it cannot need a live
+    /// cold reload after the statement has already mutated state.
+    fn find_segment_row_id_by_values_in_stmt(
+        &self,
+        snap: &super::manifest::StatementSnapshot,
+        col_indices: &[usize],
+        values: &[&Value],
+    ) -> Result<Option<i64>> {
+        if col_indices.is_empty() || col_indices.len() != values.len() {
+            return Ok(None);
+        }
+        let defaults: smallvec::SmallVec<[Value; 4]> = col_indices
+            .iter()
+            .map(|&ci| self.column_default(ci))
+            .collect();
+        let rid = match self.segment_mgr.find_row_id_by_values_in(
+            &snap.seg_ids_newest_first,
+            &snap.segs,
+            &snap.tombstones,
+            col_indices,
+            values,
+            &defaults,
+        )? {
+            Some(rid) => rid,
+            None => return Ok(None),
+        };
+        if self.segment_mgr.is_pending_tombstone(self.txn_id(), rid) {
+            return Ok(None);
+        }
+        Ok(Some(rid))
+    }
+
     fn find_segment_row_id_by_values_with_snapshot(
         &self,
         snapshot: &super::manifest::ColdSnapshot,
@@ -339,7 +372,12 @@ impl SegmentedTable {
     /// Uses zone maps, bloom filters, dictionary pre-filters, and binary search
     /// on sorted columns for fast rejection. No index population needed.
     /// Check cold unique constraints for UPDATE, excluding the row being updated.
-    fn check_cold_unique_for_update(&self, new_row: &Row, exclude_row_id: i64) -> Result<()> {
+    fn check_cold_unique_for_update(
+        &self,
+        new_row: &Row,
+        exclude_row_id: i64,
+        snap: Option<&super::manifest::StatementSnapshot>,
+    ) -> Result<()> {
         let schema = self.hot.schema();
         self.hot
             .for_each_unique_non_pk_index(&mut |idx_name, col_names| {
@@ -363,7 +401,13 @@ impl SegmentedTable {
                 }
                 let values: Vec<&Value> = coerced.iter().collect();
 
-                if let Some(found_id) = self.find_segment_row_id_by_values(&col_indices, &values)? {
+                let found = match snap {
+                    Some(snap) => {
+                        self.find_segment_row_id_by_values_in_stmt(snap, &col_indices, &values)?
+                    }
+                    None => self.find_segment_row_id_by_values(&col_indices, &values)?,
+                };
+                if let Some(found_id) = found {
                     if found_id != exclude_row_id {
                         return Err(crate::core::Error::UniqueConstraint {
                             index: idx_name.to_string(),
@@ -1281,7 +1325,11 @@ impl Table for SegmentedTable {
 
                     // Check unique constraints against cold segments.
                     if self.hot.has_unique_non_pk_indexes() {
-                        self.check_cold_unique_for_update(&new_row, row_id)?;
+                        self.check_cold_unique_for_update(
+                            &new_row,
+                            row_id,
+                            cold_snapshot.as_ref(),
+                        )?;
                     }
 
                     // Insert the NEW row into hot. For int PK tables, first
@@ -1376,7 +1424,11 @@ impl Table for SegmentedTable {
                     // Claim the cold row to prevent concurrent lost updates.
                     self.hot.try_claim_row(row_id)?;
                     if self.hot.has_unique_non_pk_indexes() {
-                        self.check_cold_unique_for_update(&new_row, row_id)?;
+                        self.check_cold_unique_for_update(
+                            &new_row,
+                            row_id,
+                            cold_snapshot.as_ref(),
+                        )?;
                     }
                     let result = if has_int_pk {
                         let insert_ok = match self.hot.insert_discard(old_row) {

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -872,6 +872,59 @@ impl SegmentedTable {
     /// Find a row in segments by row_id. Returns (volume, local_offset) if found
     /// and not tombstoned or hot-shadowed. Uses manifest min/max for fast segment
     /// identification, then binary search within the segment.
+    /// Statement-scoped variant of find_segment_row over a pre-verified
+    /// warm snapshot (see segments_snapshot): never needs a reload, so a
+    /// DML statement that already mutated the hot buffer cannot fail
+    /// mid-statement on cold-volume access. Segments compacted away after
+    /// the snapshot are simply found in the snapshot's older volumes,
+    /// which is exactly the statement's view of the data.
+    fn find_segment_row_in(
+        &self,
+        segs: &FxHashMap<u64, super::manifest::ColdSegment>,
+        row_id: i64,
+    ) -> Option<(u64, Arc<FrozenVolume>, usize)> {
+        if self.hot.has_row_id(row_id) {
+            return None;
+        }
+        {
+            let ts = self.segment_mgr.tombstone_set_arc();
+            if self.is_row_tombstoned(&ts, row_id) {
+                return None;
+            }
+        }
+        if self.segment_mgr.is_pending_tombstone(self.txn_id(), row_id) {
+            return None;
+        }
+        let seg_ids: Vec<u64> = {
+            let manifest = self.segment_mgr.manifest();
+            manifest
+                .segments
+                .iter()
+                .rev()
+                .map(|m| m.segment_id)
+                .collect()
+        };
+        for &seg_id in &seg_ids {
+            let Some(cold) = segs.get(&seg_id) else {
+                continue;
+            };
+            let vol = &cold.volume;
+            if vol.meta.row_ids.is_empty() {
+                continue;
+            }
+            let min_id = vol.meta.row_ids[0];
+            let max_id = vol.meta.row_ids[vol.meta.row_count - 1];
+            if row_id < min_id || row_id > max_id {
+                continue;
+            }
+            if let Ok(idx) = vol.meta.row_ids.binary_search(&row_id) {
+                vol.mark_accessed();
+                return Some((seg_id, Arc::clone(vol), idx));
+            }
+        }
+        None
+    }
+
     fn find_segment_row(&self, row_id: i64) -> Result<Option<(u64, Arc<FrozenVolume>, usize)>> {
         // Hot buffer shadows cold: if the row exists in hot, the cold copy is stale
         if self.hot.has_row_id(row_id) {
@@ -1147,17 +1200,24 @@ impl Table for SegmentedTable {
         setter: &mut dyn FnMut(Row) -> Result<(Row, bool)>,
     ) -> Result<i32> {
         let _seal_guard = self.segment_mgr.acquire_seal_read();
-        // Fail on unreloadable cold volumes BEFORE mutating the hot buffer,
-        // so a reload error cannot leave a partially applied statement in
-        // the open transaction.
-        if self.segment_mgr.has_segments() {
-            self.segment_mgr.preflight_cold_access()?;
-        }
+        // Capture a verified all-warm segment snapshot BEFORE mutating the
+        // hot buffer and use it for the entire statement: eviction CoWs
+        // new maps and new volume Arcs, so this snapshot's volumes keep
+        // their column data for the statement's duration and no
+        // mid-statement reload (or reload failure) is possible.
+        let cold_snapshot = if self.segment_mgr.has_segments() {
+            Some(self.segment_mgr.segments_snapshot()?)
+        } else {
+            None
+        };
         let mut count = self.hot.update(where_expr, setter)?;
 
-        // Update matching segment rows.
-        // Lazy: prune on zone maps/bloom filters first, load cold on demand.
-        let volumes = self.segment_mgr.get_volumes_newest_first_lazy();
+        // Update matching segment rows from the statement snapshot
+        // (zone-map pruning still applies; volumes are already warm).
+        let volumes = match &cold_snapshot {
+            Some(segs) => self.segment_mgr.volumes_newest_first_from_snapshot(segs),
+            None => Vec::new(),
+        };
         let has_int_pk = self
             .hot
             .schema()
@@ -1275,12 +1335,16 @@ impl Table for SegmentedTable {
         setter: &mut dyn FnMut(Row) -> Result<(Row, bool)>,
     ) -> Result<i32> {
         let _seal_guard = self.segment_mgr.acquire_seal_read();
-        // Fail on unreloadable cold volumes BEFORE mutating the hot buffer,
-        // so a reload error cannot leave a partially applied statement in
-        // the open transaction.
-        if self.segment_mgr.has_segments() {
-            self.segment_mgr.preflight_cold_access()?;
-        }
+        // Capture a verified all-warm segment snapshot BEFORE mutating the
+        // hot buffer and use it for the entire statement: eviction CoWs
+        // new maps and new volume Arcs, so this snapshot's volumes keep
+        // their column data for the statement's duration and no
+        // mid-statement reload (or reload failure) is possible.
+        let cold_snapshot = if self.segment_mgr.has_segments() {
+            Some(self.segment_mgr.segments_snapshot()?)
+        } else {
+            None
+        };
         let mut count = 0i32;
         let mut hot_ids = Vec::new();
         let schema = self.hot.schema().clone();
@@ -1294,7 +1358,11 @@ impl Table for SegmentedTable {
             super::writer::ColumnMapping,
         )> = None;
         for &row_id in row_ids {
-            if let Some((seg_id, vol, idx)) = self.find_segment_row(row_id)? {
+            let found = match &cold_snapshot {
+                Some(segs) => self.find_segment_row_in(segs, row_id),
+                None => None,
+            };
+            if let Some((seg_id, vol, idx)) = found {
                 let vol_ptr = &*vol as *const super::writer::FrozenVolume;
                 let mapping = match &cached_mapping {
                     Some((ptr, m)) if *ptr == vol_ptr => m,
@@ -1363,12 +1431,16 @@ impl Table for SegmentedTable {
 
     fn delete_by_row_ids(&mut self, row_ids: &[i64]) -> Result<i32> {
         let _seal_guard = self.segment_mgr.acquire_seal_read();
-        // Fail on unreloadable cold volumes BEFORE mutating the hot buffer,
-        // so a reload error cannot leave a partially applied statement in
-        // the open transaction.
-        if self.segment_mgr.has_segments() {
-            self.segment_mgr.preflight_cold_access()?;
-        }
+        // Capture a verified all-warm segment snapshot BEFORE mutating the
+        // hot buffer and use it for the entire statement: eviction CoWs
+        // new maps and new volume Arcs, so this snapshot's volumes keep
+        // their column data for the statement's duration and no
+        // mid-statement reload (or reload failure) is possible.
+        let cold_snapshot = if self.segment_mgr.has_segments() {
+            Some(self.segment_mgr.segments_snapshot()?)
+        } else {
+            None
+        };
         let mut count = 0i32;
         let mut hot_ids = Vec::new();
         let has_int_pk = self
@@ -1379,7 +1451,11 @@ impl Table for SegmentedTable {
             .any(|c| c.primary_key && c.data_type == DataType::Integer);
 
         for &row_id in row_ids {
-            if let Some((_seg_id, _vol, _idx)) = self.find_segment_row(row_id)? {
+            let found = match &cold_snapshot {
+                Some(segs) => self.find_segment_row_in(segs, row_id),
+                None => None,
+            };
+            if let Some((_seg_id, _vol, _idx)) = found {
                 // Claim the cold row to prevent concurrent lost deletes.
                 self.hot.try_claim_row(row_id)?;
                 if has_int_pk {
@@ -1440,12 +1516,16 @@ impl Table for SegmentedTable {
 
     fn delete(&mut self, where_expr: Option<&dyn Expression>) -> Result<i32> {
         let _seal_guard = self.segment_mgr.acquire_seal_read();
-        // Fail on unreloadable cold volumes BEFORE mutating the hot buffer,
-        // so a reload error cannot leave a partially applied statement in
-        // the open transaction.
-        if self.segment_mgr.has_segments() {
-            self.segment_mgr.preflight_cold_access()?;
-        }
+        // Capture a verified all-warm segment snapshot BEFORE mutating the
+        // hot buffer and use it for the entire statement: eviction CoWs
+        // new maps and new volume Arcs, so this snapshot's volumes keep
+        // their column data for the statement's duration and no
+        // mid-statement reload (or reload failure) is possible.
+        let cold_snapshot = if self.segment_mgr.has_segments() {
+            Some(self.segment_mgr.segments_snapshot()?)
+        } else {
+            None
+        };
         let mut count = self.hot.delete(where_expr)?;
         let has_int_pk = self
             .hot
@@ -1457,7 +1537,10 @@ impl Table for SegmentedTable {
         // Build hot_skip from hot row_ids + pending tombstones.
         // Committed tombstones are kept as a shared Arc (no clone).
         // Lazy: prune on zone maps/bloom filters first, load cold on demand.
-        let volumes = self.segment_mgr.get_volumes_newest_first_lazy();
+        let volumes = match &cold_snapshot {
+            Some(segs) => self.segment_mgr.volumes_newest_first_from_snapshot(segs),
+            None => Vec::new(),
+        };
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());


### PR DESCRIPTION
The worst remaining verified bug from the engine audit: a persistent cold-volume reload failure (I/O error, fd exhaustion, missing file) was handled by silently excluding the segment. SELECT returned short results with Ok status, and UPDATE/DELETE skipped the segment's rows while reporting success. The same conflation existed across the whole access family: ensure_volume returned None for both 'removed by compaction' (legitimately skippable) and 'reload failed' (must not be), and the point-lookup helpers turned reload failures into 'row not found' during PK/unique checks.

## What changed (~60 sites)

- get_volumes_newest_first -> Result; persistently-cold segments are an error naming the segments, not a retain-drop.
- ensure_volume -> Result<Option>: Ok(None) strictly means removed-by-concurrent-compaction.
- The point-lookup family (get_cold_row, get_cold_row_normalized, retries, check_value_exists_*, find_row_id_by_values_*, get_authoritative_value) propagates errors; retries fail on a still-cold volume instead of touching missing column data.
- SegmentedTable: find_segment_row, find_segment_row_id_by_values, create_segment_scanners_filtered, collect_cold_rows and friends are fallible; Option fast paths bail to the general path, whose plumbing now fails closed; the parallel closures signal via reload/bail flags checked on every collection path.
- Trait level: get_active_row_ids and fetch_rows_by_ids_into became fallible; collect_hot_row_ids_into stays infallible via direct hot-side impls (18 call sites untouched).
- engine: compaction candidates skip cleanly (count check aborts the merge); get_row_fetcher closure returns Result; HNSW rebuild propagates.

## Independent review round (findings fixed in the second commit)

- segments_snapshot still carried the old retain-drop (making a new guard dead code); point lookups could return 'row not found' or a STALE overlapping version after a reload failure. Now fails closed.
- The lazy window-partition path treated a reload failure as an empty partition and silently dropped it from results; get_rows_for_partition_value now returns Result<Option> and the window path propagates.
- create_backup_snapshot's ? bypassed the writer.fail() temp-file cleanup; it now follows the standard fail-and-break arm.
- Hardened a pre-existing get_partition_count double-call unwrap the conversion could newly trigger.

**Deliberate tradeoff for review**: engine open now fails if an HNSW-indexed table has an unreadable cold volume at recovery (previously the ANN index silently missed those vectors). Fail-closed at open is consistent with the manifest policy from #32; say the word if degraded-open is preferred there.

## Verification

- New regression test drives a volume hot->warm->cold through the real eviction machinery with no reload source, and asserts ensure_volume / get_volumes_newest_first / get_cold_row all fail closed. (The pre-fix silent drop cannot be compile-checked against the new signatures; it was verified by inspection and the empirical probes recorded in review.)
- clippy 1.98 -D warnings clean; both full suites 4886/4886 before and after the review-repair commit.