### PR TITLE
release: v0.4.1, declare and enforce MSRV 1.88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,23 @@ jobs:
     - name: Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
 
+  msrv:
+    name: MSRV (1.88)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust 1.88
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: "1.88"
+
+    - name: Cache
+      uses: Swatinem/rust-cache@v2
+
+    - name: Check all features on MSRV
+      run: cargo check --all-features
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,7 +3756,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stoolap"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "stoolap"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
+rust-version = "1.88"
 authors = ["Stoolap Contributors"]
 description = "High-performance embedded SQL database with MVCC, time-travel queries, and full ACID compliance"
 license = "Apache-2.0"

--- a/docs/_docs/development/building.md
+++ b/docs/_docs/development/building.md
@@ -11,7 +11,7 @@ This page covers how to build Stoolap from source, including prerequisites, feat
 
 ## Prerequisites
 
-- **Rust toolchain**: Latest stable (edition 2021, Rust 1.56+)
+- **Rust toolchain**: Rust 1.88 or later (edition 2021)
 - **Git**: For version embedding at build time
 
 Install Rust via [rustup](https://rustup.rs/):

--- a/docs/_docs/getting-started/installation.md
+++ b/docs/_docs/getting-started/installation.md
@@ -11,7 +11,7 @@ This guide walks you through the process of installing Stoolap on different plat
 
 ## Prerequisites
 
-- Rust 1.70 or later (with Cargo)
+- Rust 1.88 or later (with Cargo)
 - Git (for installation from source)
 - Basic familiarity with command line tools
 
@@ -143,7 +143,7 @@ After installing Stoolap, you can:
 
 If you encounter issues during installation:
 
-- Ensure Rust is installed: `rustc --version` (should be 1.70+)
+- Ensure Rust is installed: `rustc --version` (should be 1.88+)
 - Ensure Cargo is available: `cargo --version`
 - For permission issues on Linux/macOS, use `sudo` as needed
 

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -5039,10 +5039,7 @@ impl Executor {
         let mut has_value = false;
 
         // Unroll loop by 4 for better CPU pipelining.
-        // as_chunks needs Rust 1.88; the documented MSRV is 1.70.
-        #[allow(clippy::chunks_exact_to_as_chunks)]
-        let chunks = rows.chunks_exact(4);
-        let remainder = chunks.remainder();
+        let (chunks, remainder) = rows.as_chunks::<4>();
 
         for chunk in chunks {
             for (_, row) in chunk {


### PR DESCRIPTION
Release prep for v0.4.1. After merge, tag `v0.4.1` on main and paste the release notes below into the GitHub release.

## Changes

- Version bump `0.4.0` -> `0.4.1`
- `rust-version = "1.88"` in Cargo.toml plus a CI job checking `--all-features` on 1.88
- Installation docs corrected: they claimed Rust 1.70+, which has been false for a while

## Why MSRV 1.88 and not 1.70

Determined empirically with the committed lockfile:

- `Cargo.lock` is v4 format: cargo older than 1.78 cannot parse the repo at all
- `home@0.5.12` (pulled in via rustyline) declares `rust-version = 1.88`, and 1.85 refuses to build it
- `cargo check --all-features` passes cleanly on exactly 1.88

Lowering the floor would require pinning older dependency versions. If you want that instead, say so and I will do the pinning; otherwise 1.88 is the honest number.

Follow-up candidate (not in this PR): #33 reverted `as_chunks` to protect the assumed 1.70 MSRV. With 1.88 declared, that revert can be undone and the `chunks_exact_to_as_chunks` allow dropped.

## Verification

- `cargo +1.88 check --all-features` passes; 1.77 and 1.85 fail as expected
- fmt, clippy `--all-targets --all-features -D warnings` clean
- Both suites green: 4890/4890 (default) and 4890/4890 (`test-filedb`)

## Release notes draft for the v0.4.1 GitHub release

---

## What's New in v0.4.1

This is a correctness, durability, and performance release. Every fix below was verified with a regression test that fails on v0.4.0, and the storage changes went through independent adversarial review.

### Wrong-Results Fixes

**Semantic query cache** (#31):
- String `IN` lists no longer return an identical empty result from an unrelated cached query
- `>` vs `>=` and `<` vs `<=` predicates no longer reuse each other's cached boundary results
- `NOT IN` no longer incorrectly subsumed by a cached `IN` result; duplicate values inside `IN` lists normalize to the same cache identity

**Joins** (#31):
- Merge join no longer treats `NULL = NULL` as a match
- FULL and RIGHT OUTER merge joins emit unmatched right-side rows correctly

**Aggregates** (#31):
- `COUNT(col)` no longer counts NULLs in the inline HAVING fast path (new dedicated accumulator)
- `HAVING COUNT(*)` binds to the correct aggregate slot when `COUNT(col)` is also present
- `COUNT(DISTINCT col)` deduplicates in the index-streaming path

**Compiled expression caches** (#36):
- Program caches are now keyed by two independent 64-bit hashes instead of one, and `IN`-list and `VALUES` contents are fully hashed (previously only the element count). A hash collision can no longer return the wrong compiled filter program.

**Cold volumes fail closed** (#35):
- A cold volume that cannot be reloaded (I/O error, corruption) now fails the query with an error instead of silently dropping that volume's rows from results. This covers scans, point lookups, index population, window functions, and backups (about 60 call sites made fallible).
- UPDATE and DELETE capture a statement-scoped snapshot of the cold segment set (segment ordering, mappings, and tombstones together) before the first mutation. Concurrent compaction or eviction can no longer change what a running statement sees, and unique-constraint checks run against the same snapshot.

### Durability and Crash Safety

**WAL hardening** (#34):
- A WAL write or fsync failure now poisons the WAL and truncates the file back to the last durable position. A commit that was never acknowledged can no longer resurrect at recovery from a partially flushed suffix.
- DDL commit markers are now fsynced in `sync_mode=normal` too. Previously an acknowledged CREATE/ALTER/DROP could be lost on power failure.
- WAL rotation and truncation share the same locking and durable-floor invariants as the write path.

**Fail loud instead of silent loss** (#32):
- `RENAME TABLE` failures during legacy tombstone migration now error and fully revert instead of silently dropping tombstones
- DELETE of a cold row now also cleans the hot PK index (stale index entries could resurrect deleted rows in point lookups)
- An unreadable or unsupported table manifest is now a hard error. Previously the volume reaper could interpret it as "no volumes" and delete data files. This also protects v0.4.1 databases from accidental opens by future versions.

### WAL Performance

`sync_mode=full` now fsyncs at transaction commit and DDL boundaries instead of once per row (#34). Durable multi-row transactions are up to 374x faster in our insert benchmark. Single-row autocommit behavior is unchanged.

### New Features

- **COPY FROM**: CSV and JSON bulk import, plus a fix for `--` comment parsing
- **Named parameters** for prepared statements in the Rust API and the C FFI
- **SHOW INDEXES** now displays HNSW index parameters
- **CREATE TABLE** accepts non-reserved keywords as table names

### Upgrading from v0.4.0 (read this)

Opening an existing database with v0.4.1 in writable mode upgrades the on-disk format immediately and permanently (manifest v6 to v7, WAL entries v2 to v3). Data is fully preserved, no manual steps are needed, and we verified round-trip migration with live cross-version tests.

**The upgrade is one-way.** v0.4.0 binaries cannot read the upgraded files. Worse, v0.4.0's manifest loader treats an unreadable manifest as "no volumes" and its reaper then deletes the volume files. Running a v0.4.0 binary against an upgraded database directory can destroy the database.

Before first open with v0.4.1:
1. Stop all processes using the database
2. Take a file-level backup of the database directory
3. Make sure no v0.4.0 binary (old CLI, old driver, cron job) will touch the directory afterwards

v0.4.1 itself refuses to open unknown manifest versions, so this hazard class is fixed going forward.

### Toolchain

The minimum supported Rust version is now declared and enforced in CI: **Rust 1.88**. Earlier docs said 1.70, but the dependency tree already required newer; 1.88 is the verified floor.

**Full Changelog**: https://github.com/stoolap/stoolap/compare/v0.4.0...v0.4.1