### PR TITLE
perf(executor): cut per-statement fixed costs on the cached SELECT path

### DIFF
--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -6572,16 +6572,8 @@ impl Executor {
         stmt: &SelectStatement,
         compiled: &RwLock<CompiledExecution>,
     ) -> Option<Result<Box<dyn QueryResult>>> {
-        // Quick reject: must not be in an explicit transaction (for simplicity)
-        {
-            let active_tx = match self.active_transaction.try_lock() {
-                Ok(guard) => guard,
-                Err(_) => return None,
-            };
-            if active_tx.is_some() {
-                return None;
-            }
-        }
+        // Caller (try_compiled_fast_paths) guarantees no explicit transaction
+        // is active; this path reads committed state only.
 
         // Try read lock first - check if already compiled
         {
@@ -6850,16 +6842,8 @@ impl Executor {
         stmt: &SelectStatement,
         compiled: &RwLock<CompiledExecution>,
     ) -> Option<Result<Box<dyn QueryResult>>> {
-        // Quick reject: must not be in an explicit transaction (for simplicity)
-        {
-            let active_tx = match self.active_transaction.try_lock() {
-                Ok(guard) => guard,
-                Err(_) => return None,
-            };
-            if active_tx.is_some() {
-                return None;
-            }
-        }
+        // Caller (try_compiled_fast_paths) guarantees no explicit transaction
+        // is active; this path reads committed state only.
 
         // Try read lock first - check if already compiled
         {

--- a/src/executor/dml_fast_path.rs
+++ b/src/executor/dml_fast_path.rs
@@ -184,7 +184,9 @@ impl Executor {
         let (pk_value, pk_value_source) = match val_expr {
             Expression::IntegerLiteral(lit) => (lit.value, PkValueSource::Literal(lit.value)),
             Expression::FloatLiteral(lit) => {
-                let v = lit.value as i64;
+                // Only lossless float keys qualify: truncating 5.5 to 5
+                // would mutate row 5 where correct execution matches nothing.
+                let v = Self::lossless_float_key(lit.value)?;
                 (v, PkValueSource::Literal(v))
             }
             Expression::Parameter(param) => {
@@ -195,7 +197,7 @@ impl Executor {
                     let value = ctx.get_named_param(name)?;
                     let pk_value = match value {
                         Value::Integer(i) => *i,
-                        Value::Float(f) => *f as i64,
+                        Value::Float(f) => Self::lossless_float_key(*f)?,
                         _ => return None,
                     };
                     (
@@ -214,7 +216,7 @@ impl Executor {
                     }
                     let pk_value = match &params[param_idx] {
                         Value::Integer(i) => *i,
-                        Value::Float(f) => *f as i64,
+                        Value::Float(f) => Self::lossless_float_key(*f)?,
                         _ => return None,
                     };
                     (pk_value, PkValueSource::Parameter(param_idx))
@@ -235,7 +237,7 @@ impl Executor {
         match source {
             PkValueSource::NamedParameter(name) => match ctx.get_named_param(name)? {
                 Value::Integer(i) => Some(*i),
-                Value::Float(f) => Some(*f as i64),
+                Value::Float(f) => Self::lossless_float_key(*f),
                 _ => None,
             },
             _ => Self::extract_pk_value_from_params(source, ctx.params()),
@@ -253,7 +255,7 @@ impl Executor {
                 }
                 match &params[*idx] {
                     Value::Integer(i) => Some(*i),
-                    Value::Float(f) => Some(*f as i64),
+                    Value::Float(f) => Self::lossless_float_key(*f),
                     _ => None,
                 }
             }

--- a/src/executor/dml_fast_path.rs
+++ b/src/executor/dml_fast_path.rs
@@ -49,16 +49,8 @@ impl Executor {
         ctx: &ExecutionContext,
         compiled: &RwLock<CompiledExecution>,
     ) -> Option<Result<Box<dyn QueryResult>>> {
-        // Quick reject: explicit transaction (use try_lock for fast rejection)
-        {
-            let active_tx = match self.active_transaction.try_lock() {
-                Ok(guard) => guard,
-                Err(_) => return None, // Lock contention - fall back to normal path
-            };
-            if active_tx.is_some() {
-                return None;
-            }
-        }
+        // Caller (try_compiled_fast_paths) guarantees no explicit transaction
+        // is active; this path reads and writes committed state only.
 
         // Try read lock first - check if already compiled
         {
@@ -98,16 +90,8 @@ impl Executor {
         ctx: &ExecutionContext,
         compiled: &RwLock<CompiledExecution>,
     ) -> Option<Result<Box<dyn QueryResult>>> {
-        // Quick reject: explicit transaction (use try_lock for fast rejection)
-        {
-            let active_tx = match self.active_transaction.try_lock() {
-                Ok(guard) => guard,
-                Err(_) => return None, // Lock contention - fall back to normal path
-            };
-            if active_tx.is_some() {
-                return None;
-            }
-        }
+        // Caller (try_compiled_fast_paths) guarantees no explicit transaction
+        // is active; this path reads and writes committed state only.
 
         // Try read lock first - check if already compiled
         {

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -399,11 +399,6 @@ impl Executor {
     /// If found, it uses the cached AST. Otherwise, it parses the query
     /// and caches the result for future use.
     fn execute_cached(&self, sql: &str, ctx: &ExecutionContext) -> Result<Box<dyn QueryResult>> {
-        // Capture transaction state once for the whole statement: the probe
-        // battery and the ctx txn-id injection both need it, and repeated
-        // mutex acquisitions dominate the fixed cost of cached statements.
-        let active_txn_id = self.active_txn_id();
-
         // Try to get from cache
         if let Some(cached) = self.query_cache.get(sql) {
             // Validate parameter count if query has parameters
@@ -416,6 +411,19 @@ impl Executor {
                     )));
                 }
             }
+
+            // INSERT handles the active transaction itself; dispatch before
+            // the txn-state capture so the hot prepared-INSERT path takes
+            // the transaction mutex only once.
+            if let Statement::Insert(stmt) = cached.statement.as_ref() {
+                return self.execute_insert_with_compiled_cache(stmt, ctx, &cached.compiled);
+            }
+
+            // Capture transaction state once for the rest of the statement:
+            // the probe battery and the ctx txn-id injection both need it,
+            // and repeated mutex acquisitions dominate the fixed cost of
+            // cached statements.
+            let active_txn_id = self.active_txn_id();
 
             if let Some(result) = self.try_compiled_fast_paths(
                 cached.statement.as_ref(),
@@ -451,6 +459,12 @@ impl Executor {
                 .query_cache
                 .put(sql, stmt_arc.clone(), has_params, param_count);
 
+            if let Statement::Insert(stmt) = stmt_arc.as_ref() {
+                return self.execute_insert_with_compiled_cache(stmt, ctx, &cached_plan.compiled);
+            }
+
+            let active_txn_id = self.active_txn_id();
+
             if let Some(result) = self.try_compiled_fast_paths(
                 stmt_arc.as_ref(),
                 ctx,
@@ -483,11 +497,11 @@ impl Executor {
     }
 
     /// Run the compiled fast-path battery for a single cached statement.
+    /// Callers dispatch INSERT before calling this (its compiled path
+    /// handles the active transaction itself).
     ///
     /// `in_txn` gates the SELECT/UPDATE/DELETE probes: they read committed
     /// state only, so inside an explicit transaction they must not fire.
-    /// INSERT is exempt; its compiled path handles the active transaction
-    /// itself.
     #[inline]
     fn try_compiled_fast_paths(
         &self,
@@ -511,10 +525,6 @@ impl Executor {
             }
             Statement::Delete(stmt) if !in_txn => {
                 self.try_fast_pk_delete_compiled(stmt, ctx, compiled)
-            }
-            // INSERT: Use compiled cache to avoid recomputing schema metadata
-            Statement::Insert(stmt) => {
-                Some(self.execute_insert_with_compiled_cache(stmt, ctx, compiled))
             }
             _ => None,
         }
@@ -753,6 +763,12 @@ impl Executor {
                     plan.param_count, provided
                 )));
             }
+        }
+
+        // INSERT handles the active transaction itself; dispatch before the
+        // txn-state capture so prepared INSERT takes the mutex only once.
+        if let Statement::Insert(stmt) = plan.statement.as_ref() {
+            return self.execute_insert_with_compiled_cache(stmt, ctx, &plan.compiled);
         }
 
         let active_txn_id = self.active_txn_id();

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -399,6 +399,11 @@ impl Executor {
     /// If found, it uses the cached AST. Otherwise, it parses the query
     /// and caches the result for future use.
     fn execute_cached(&self, sql: &str, ctx: &ExecutionContext) -> Result<Box<dyn QueryResult>> {
+        // Capture transaction state once for the whole statement: the probe
+        // battery and the ctx txn-id injection both need it, and repeated
+        // mutex acquisitions dominate the fixed cost of cached statements.
+        let active_txn_id = self.active_txn_id();
+
         // Try to get from cache
         if let Some(cached) = self.query_cache.get(sql) {
             // Validate parameter count if query has parameters
@@ -412,50 +417,22 @@ impl Executor {
                 }
             }
 
-            // Try compiled fast paths based on statement type
-            match cached.statement.as_ref() {
-                Statement::Select(stmt) => {
-                    // Try PK lookup fast path first
-                    if let Some(result) =
-                        self.try_fast_pk_lookup_compiled(stmt, ctx, &cached.compiled)
-                    {
-                        return result;
-                    }
-                    // Try COUNT(DISTINCT col) fast path
-                    if let Some(result) =
-                        self.try_fast_count_distinct_compiled(stmt, &cached.compiled)
-                    {
-                        return result;
-                    }
-                    // Try COUNT(*) fast path
-                    if let Some(result) = self.try_fast_count_star_compiled(stmt, &cached.compiled)
-                    {
-                        return result;
-                    }
-                }
-                Statement::Update(stmt) => {
-                    if let Some(result) =
-                        self.try_fast_pk_update_compiled(stmt, ctx, &cached.compiled)
-                    {
-                        return result;
-                    }
-                }
-                Statement::Delete(stmt) => {
-                    if let Some(result) =
-                        self.try_fast_pk_delete_compiled(stmt, ctx, &cached.compiled)
-                    {
-                        return result;
-                    }
-                }
-                // INSERT: Use compiled cache to avoid recomputing schema metadata
-                Statement::Insert(stmt) => {
-                    return self.execute_insert_with_compiled_cache(stmt, ctx, &cached.compiled);
-                }
-                _ => {}
+            if let Some(result) = self.try_compiled_fast_paths(
+                cached.statement.as_ref(),
+                ctx,
+                &cached.compiled,
+                active_txn_id.is_some(),
+            ) {
+                return result;
             }
 
             // Execute the cached statement (standard path)
-            return self.execute_statement(&cached.statement, ctx);
+            return self.execute_statement_inner(
+                &cached.statement,
+                ctx,
+                active_txn_id,
+                Some(&cached.classification),
+            );
         }
 
         // Parse the query
@@ -474,58 +451,73 @@ impl Executor {
                 .query_cache
                 .put(sql, stmt_arc.clone(), has_params, param_count);
 
-            // Try compiled fast paths based on statement type
-            match stmt_arc.as_ref() {
-                Statement::Select(select) => {
-                    // Try PK lookup fast path first
-                    if let Some(result) =
-                        self.try_fast_pk_lookup_compiled(select, ctx, &cached_plan.compiled)
-                    {
-                        return result;
-                    }
-                    // Try COUNT(DISTINCT col) fast path
-                    if let Some(result) =
-                        self.try_fast_count_distinct_compiled(select, &cached_plan.compiled)
-                    {
-                        return result;
-                    }
-                    // Try COUNT(*) fast path
-                    if let Some(result) =
-                        self.try_fast_count_star_compiled(select, &cached_plan.compiled)
-                    {
-                        return result;
-                    }
-                }
-                Statement::Update(update) => {
-                    if let Some(result) =
-                        self.try_fast_pk_update_compiled(update, ctx, &cached_plan.compiled)
-                    {
-                        return result;
-                    }
-                }
-                Statement::Delete(delete) => {
-                    if let Some(result) =
-                        self.try_fast_pk_delete_compiled(delete, ctx, &cached_plan.compiled)
-                    {
-                        return result;
-                    }
-                }
-                // INSERT: Use compiled cache to avoid recomputing schema metadata
-                Statement::Insert(insert) => {
-                    return self.execute_insert_with_compiled_cache(
-                        insert,
-                        ctx,
-                        &cached_plan.compiled,
-                    );
-                }
-                _ => {}
+            if let Some(result) = self.try_compiled_fast_paths(
+                stmt_arc.as_ref(),
+                ctx,
+                &cached_plan.compiled,
+                active_txn_id.is_some(),
+            ) {
+                return result;
             }
 
             // Execute directly from the Arc (no clone needed)
-            return self.execute_statement(&stmt_arc, ctx);
+            return self.execute_statement_inner(
+                &stmt_arc,
+                ctx,
+                active_txn_id,
+                Some(&cached_plan.classification),
+            );
         }
 
         self.execute_program_with_context(&program, ctx)
+    }
+
+    /// Current explicit-transaction id, if one is active.
+    #[inline]
+    fn active_txn_id(&self) -> Option<i64> {
+        self.active_transaction
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|t| t.transaction.id())
+    }
+
+    /// Run the compiled fast-path battery for a single cached statement.
+    ///
+    /// `in_txn` gates the SELECT/UPDATE/DELETE probes: they read committed
+    /// state only, so inside an explicit transaction they must not fire.
+    /// INSERT is exempt; its compiled path handles the active transaction
+    /// itself.
+    #[inline]
+    fn try_compiled_fast_paths(
+        &self,
+        statement: &Statement,
+        ctx: &ExecutionContext,
+        compiled: &Arc<std::sync::RwLock<query_cache::CompiledExecution>>,
+        in_txn: bool,
+    ) -> Option<Result<Box<dyn QueryResult>>> {
+        match statement {
+            Statement::Select(stmt) if !in_txn => {
+                if let Some(result) = self.try_fast_pk_lookup_compiled(stmt, ctx, compiled) {
+                    return Some(result);
+                }
+                if let Some(result) = self.try_fast_count_distinct_compiled(stmt, compiled) {
+                    return Some(result);
+                }
+                self.try_fast_count_star_compiled(stmt, compiled)
+            }
+            Statement::Update(stmt) if !in_txn => {
+                self.try_fast_pk_update_compiled(stmt, ctx, compiled)
+            }
+            Statement::Delete(stmt) if !in_txn => {
+                self.try_fast_pk_delete_compiled(stmt, ctx, compiled)
+            }
+            // INSERT: Use compiled cache to avoid recomputing schema metadata
+            Statement::Insert(stmt) => {
+                Some(self.execute_insert_with_compiled_cache(stmt, ctx, compiled))
+            }
+            _ => None,
+        }
     }
 
     /// Get the query cache
@@ -596,65 +588,86 @@ impl Executor {
         statement: &Statement,
         ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        self.execute_statement_inner(statement, ctx, self.active_txn_id(), None)
+    }
+
+    /// Execute a single statement with pre-captured transaction state.
+    ///
+    /// `plan_slots` is Some for statements coming through the query cache:
+    /// it carries the plan's classification slot, and doubles as the
+    /// "compiled probe battery already ran" signal (the battery ran or was
+    /// skipped for an explicit transaction, where the uncompiled probe
+    /// would bail too).
+    fn execute_statement_inner(
+        &self,
+        statement: &Statement,
+        ctx: &ExecutionContext,
+        active_txn_id: Option<i64>,
+        plan_classification: Option<
+            &std::sync::OnceLock<Arc<query_classification::QueryClassification>>,
+        >,
+    ) -> Result<Box<dyn QueryResult>> {
         // If there's an active transaction, inject the transaction ID into the context
         // This enables CURRENT_TRANSACTION_ID() function to return the correct value
-        let ctx = {
-            let active_tx = self.active_transaction.lock().unwrap();
-            if let Some(ref tx_state) = *active_tx {
-                let txn_id = tx_state.transaction.id();
-                ctx.with_transaction_id(txn_id as u64)
-            } else {
-                ctx.clone()
+        let ctx_with_txn;
+        let ctx = match active_txn_id {
+            Some(txn_id) => {
+                ctx_with_txn = ctx.with_transaction_id(txn_id as u64);
+                &ctx_with_txn
             }
+            None => ctx,
         };
 
         match statement {
             // DDL statements
-            Statement::CreateTable(stmt) => self.execute_create_table(stmt, &ctx),
-            Statement::DropTable(stmt) => self.execute_drop_table(stmt, &ctx),
-            Statement::CreateIndex(stmt) => self.execute_create_index(stmt, &ctx),
-            Statement::DropIndex(stmt) => self.execute_drop_index(stmt, &ctx),
-            Statement::AlterTable(stmt) => self.execute_alter_table(stmt, &ctx),
-            Statement::CreateView(stmt) => self.execute_create_view(stmt, &ctx),
-            Statement::DropView(stmt) => self.execute_drop_view(stmt, &ctx),
+            Statement::CreateTable(stmt) => self.execute_create_table(stmt, ctx),
+            Statement::DropTable(stmt) => self.execute_drop_table(stmt, ctx),
+            Statement::CreateIndex(stmt) => self.execute_create_index(stmt, ctx),
+            Statement::DropIndex(stmt) => self.execute_drop_index(stmt, ctx),
+            Statement::AlterTable(stmt) => self.execute_alter_table(stmt, ctx),
+            Statement::CreateView(stmt) => self.execute_create_view(stmt, ctx),
+            Statement::DropView(stmt) => self.execute_drop_view(stmt, ctx),
 
             // DML statements
-            Statement::Insert(stmt) => self.execute_insert(stmt, &ctx),
-            Statement::Update(stmt) => self.execute_update(stmt, &ctx),
-            Statement::Delete(stmt) => self.execute_delete(stmt, &ctx),
-            Statement::Truncate(stmt) => self.execute_truncate(stmt, &ctx),
+            Statement::Insert(stmt) => self.execute_insert(stmt, ctx),
+            Statement::Update(stmt) => self.execute_update(stmt, ctx),
+            Statement::Delete(stmt) => self.execute_delete(stmt, ctx),
+            Statement::Truncate(stmt) => self.execute_truncate(stmt, ctx),
 
             // Query statements - try fast-path first for simple PK lookups
             Statement::Select(stmt) => {
-                // Fast-path for simple PK lookups (bypasses full planner)
-                if let Some(result) = self.try_fast_pk_lookup(stmt, &ctx) {
-                    return result;
+                // Fast-path for simple PK lookups (bypasses full planner);
+                // cached plans already ran the compiled probe battery.
+                if plan_classification.is_none() {
+                    if let Some(result) = self.try_fast_pk_lookup(stmt, ctx) {
+                        return result;
+                    }
                 }
                 // Fall back to full query execution
-                self.execute_select(stmt, &ctx)
+                self.execute_select_with_plan(stmt, ctx, plan_classification)
             }
 
             // Transaction control
-            Statement::Begin(stmt) => self.execute_begin(stmt, &ctx),
-            Statement::Commit(stmt) => self.execute_commit_stmt(stmt, &ctx),
-            Statement::Rollback(stmt) => self.execute_rollback_stmt(stmt, &ctx),
-            Statement::Savepoint(stmt) => self.execute_savepoint(stmt, &ctx),
-            Statement::ReleaseSavepoint(stmt) => self.execute_release_savepoint(stmt, &ctx),
+            Statement::Begin(stmt) => self.execute_begin(stmt, ctx),
+            Statement::Commit(stmt) => self.execute_commit_stmt(stmt, ctx),
+            Statement::Rollback(stmt) => self.execute_rollback_stmt(stmt, ctx),
+            Statement::Savepoint(stmt) => self.execute_savepoint(stmt, ctx),
+            Statement::ReleaseSavepoint(stmt) => self.execute_release_savepoint(stmt, ctx),
 
             // Utility statements
-            Statement::Set(stmt) => self.execute_set(stmt, &ctx),
-            Statement::ShowTables(stmt) => self.execute_show_tables(stmt, &ctx),
-            Statement::ShowViews(stmt) => self.execute_show_views(stmt, &ctx),
-            Statement::ShowCreateTable(stmt) => self.execute_show_create_table(stmt, &ctx),
-            Statement::ShowCreateView(stmt) => self.execute_show_create_view(stmt, &ctx),
-            Statement::ShowIndexes(stmt) => self.execute_show_indexes(stmt, &ctx),
-            Statement::Describe(stmt) => self.execute_describe(stmt, &ctx),
-            Statement::Pragma(stmt) => self.execute_pragma(stmt, &ctx),
-            Statement::Expression(stmt) => self.execute_expression_stmt(stmt, &ctx),
-            Statement::Explain(stmt) => self.execute_explain(stmt, &ctx),
-            Statement::Analyze(stmt) => self.execute_analyze(stmt, &ctx),
-            Statement::Vacuum(stmt) => self.execute_vacuum(stmt, &ctx),
-            Statement::Copy(stmt) => self.execute_copy(stmt, &ctx),
+            Statement::Set(stmt) => self.execute_set(stmt, ctx),
+            Statement::ShowTables(stmt) => self.execute_show_tables(stmt, ctx),
+            Statement::ShowViews(stmt) => self.execute_show_views(stmt, ctx),
+            Statement::ShowCreateTable(stmt) => self.execute_show_create_table(stmt, ctx),
+            Statement::ShowCreateView(stmt) => self.execute_show_create_view(stmt, ctx),
+            Statement::ShowIndexes(stmt) => self.execute_show_indexes(stmt, ctx),
+            Statement::Describe(stmt) => self.execute_describe(stmt, ctx),
+            Statement::Pragma(stmt) => self.execute_pragma(stmt, ctx),
+            Statement::Expression(stmt) => self.execute_expression_stmt(stmt, ctx),
+            Statement::Explain(stmt) => self.execute_explain(stmt, ctx),
+            Statement::Analyze(stmt) => self.execute_analyze(stmt, ctx),
+            Statement::Vacuum(stmt) => self.execute_vacuum(stmt, ctx),
+            Statement::Copy(stmt) => self.execute_copy(stmt, ctx),
         }
     }
 
@@ -742,36 +755,22 @@ impl Executor {
             }
         }
 
-        // Try compiled fast paths based on statement type
-        match plan.statement.as_ref() {
-            Statement::Select(stmt) => {
-                if let Some(result) = self.try_fast_pk_lookup_compiled(stmt, ctx, &plan.compiled) {
-                    return result;
-                }
-                if let Some(result) = self.try_fast_count_distinct_compiled(stmt, &plan.compiled) {
-                    return result;
-                }
-                if let Some(result) = self.try_fast_count_star_compiled(stmt, &plan.compiled) {
-                    return result;
-                }
-            }
-            Statement::Update(stmt) => {
-                if let Some(result) = self.try_fast_pk_update_compiled(stmt, ctx, &plan.compiled) {
-                    return result;
-                }
-            }
-            Statement::Delete(stmt) => {
-                if let Some(result) = self.try_fast_pk_delete_compiled(stmt, ctx, &plan.compiled) {
-                    return result;
-                }
-            }
-            Statement::Insert(stmt) => {
-                return self.execute_insert_with_compiled_cache(stmt, ctx, &plan.compiled);
-            }
-            _ => {}
+        let active_txn_id = self.active_txn_id();
+        if let Some(result) = self.try_compiled_fast_paths(
+            plan.statement.as_ref(),
+            ctx,
+            &plan.compiled,
+            active_txn_id.is_some(),
+        ) {
+            return result;
         }
 
-        self.execute_statement(&plan.statement, ctx)
+        self.execute_statement_inner(
+            &plan.statement,
+            ctx,
+            active_txn_id,
+            Some(&plan.classification),
+        )
     }
 }
 

--- a/src/executor/pk_fast_path.rs
+++ b/src/executor/pk_fast_path.rs
@@ -44,8 +44,6 @@ struct PkLookupInfo {
     table_name: String,
     /// PK value to look up
     pk_value: i64,
-    /// How to extract the PK value (for caching)
-    pk_value_source: PkValueSource,
     /// Cached schema to avoid second lookup
     schema: CompactArc<Schema>,
 }
@@ -95,6 +93,11 @@ impl Executor {
             return None;
         }
 
+        // Quick reject: LIMIT 0 or OFFSET would change the result
+        if !Self::pk_fast_path_limit_ok(stmt) {
+            return None;
+        }
+
         // Must be SELECT * (for now - column projection adds complexity)
         if stmt.columns.len() != 1 || !matches!(&stmt.columns[0], Expression::Star(_)) {
             return None;
@@ -121,6 +124,23 @@ impl Executor {
         where_clause: &Expression,
         ctx: &ExecutionContext,
     ) -> Option<PkLookupInfo> {
+        let (pk_value_source, schema) =
+            self.extract_pk_lookup_structure(table_name, where_clause)?;
+        let pk_value = self.extract_pk_value_fast(&pk_value_source, ctx)?;
+        Some(PkLookupInfo {
+            table_name: table_name.to_string(),
+            pk_value,
+            schema,
+        })
+    }
+
+    /// Structural half of PK-lookup detection: schema/PK/equality shape,
+    /// with parameter values left unresolved.
+    fn extract_pk_lookup_structure(
+        &self,
+        table_name: &str,
+        where_clause: &Expression,
+    ) -> Option<(PkValueSource, CompactArc<Schema>)> {
         // Get table schema to find PK column
         let schema = self.engine.get_table_schema(table_name).ok()?;
         let pk_indices = schema.primary_key_indices();
@@ -130,11 +150,9 @@ impl Executor {
             return None;
         }
         let pk_idx = pk_indices[0];
-        let pk_column = &schema.columns[pk_idx].name;
 
-        // Extract comparison info from WHERE clause
-        let (col_name, pk_value, pk_value_source) =
-            self.extract_pk_equality(where_clause, pk_column, ctx)?;
+        // Extract comparison structure from WHERE clause
+        let (col_name, pk_value_source) = Self::extract_pk_equality_source(where_clause)?;
 
         // Column must match PK (case-insensitive)
         // Use schema's pre-computed lowercase for pk_column
@@ -148,56 +166,49 @@ impl Executor {
             return None;
         }
 
-        Some(PkLookupInfo {
-            table_name: table_name.to_string(),
-            pk_value,
-            pk_value_source,
-            schema,
-        })
+        Some((pk_value_source, schema))
     }
 
-    /// Extract PK equality from WHERE clause
-    /// Returns (column_name, pk_value, pk_value_source) if WHERE is `pk_col = literal` or `pk_col = $param`
-    fn extract_pk_equality(
-        &self,
-        expr: &Expression,
-        _pk_column: &str,
-        ctx: &ExecutionContext,
-    ) -> Option<(String, i64, PkValueSource)> {
+    /// The PK fast path returns at most one row, so a literal LIMIT >= 1
+    /// with no OFFSET cannot change the result. Anything else (LIMIT 0,
+    /// any OFFSET, a parameter or expression limit) must take the full
+    /// execution path.
+    fn pk_fast_path_limit_ok(stmt: &SelectStatement) -> bool {
+        if stmt.offset.is_some() {
+            return false;
+        }
+        match stmt.limit.as_deref() {
+            None => true,
+            Some(Expression::IntegerLiteral(lit)) => lit.value >= 1,
+            Some(_) => false,
+        }
+    }
+
+    /// Extract PK equality structure from WHERE clause without resolving
+    /// parameter values. Returns (column_name, pk_value_source) if WHERE is
+    /// `pk_col = literal` or `pk_col = $param`.
+    fn extract_pk_equality_source(expr: &Expression) -> Option<(String, PkValueSource)> {
         match expr {
             Expression::Infix(infix) => {
                 // Must be equality operator
                 if infix.operator != "=" {
                     return None;
                 }
-
-                // Try column = value pattern
-                if let Some((col, val, source)) =
-                    self.extract_col_eq_val(&infix.left, &infix.right, ctx)
-                {
-                    return Some((col, val, source));
-                }
-
-                // Try value = column pattern
-                if let Some((col, val, source)) =
-                    self.extract_col_eq_val(&infix.right, &infix.left, ctx)
-                {
-                    return Some((col, val, source));
-                }
-
-                None
+                Self::extract_col_eq_source(&infix.left, &infix.right)
+                    .or_else(|| Self::extract_col_eq_source(&infix.right, &infix.left))
             }
             _ => None,
         }
     }
 
-    /// Extract column name, integer value, and value source from col = val pattern
-    fn extract_col_eq_val(
-        &self,
+    /// Extract column name and value source from a col = val pattern.
+    /// Purely structural: parameter values are resolved per execution by
+    /// `extract_pk_value_fast`, so a wrongly-typed parameter this time must
+    /// not make the statement look structurally non-optimizable.
+    fn extract_col_eq_source(
         col_expr: &Expression,
         val_expr: &Expression,
-        ctx: &ExecutionContext,
-    ) -> Option<(String, i64, PkValueSource)> {
+    ) -> Option<(String, PkValueSource)> {
         // Get column name
         let col_name = match col_expr {
             Expression::Identifier(id) => id.value.to_string(),
@@ -205,51 +216,33 @@ impl Executor {
             _ => return None,
         };
 
-        // Get integer value and source
-        let (pk_value, pk_value_source) = match val_expr {
-            Expression::IntegerLiteral(lit) => (lit.value, PkValueSource::Literal(lit.value)),
+        let source = match val_expr {
+            Expression::IntegerLiteral(lit) => PkValueSource::Literal(lit.value),
             Expression::FloatLiteral(lit) => {
+                // Only lossless float keys qualify: truncating 5.5 to 5
+                // would serve row 5 where correct execution matches nothing.
                 let v = lit.value as i64;
-                (v, PkValueSource::Literal(v))
+                if v as f64 == lit.value {
+                    PkValueSource::Literal(v)
+                } else {
+                    return None;
+                }
             }
             Expression::Parameter(param) => {
-                // Resolve parameter from context
-                // Named parameters (e.g., :name) use get_named_param()
-                // Positional parameters ($1, $2, ...) are 1-indexed, array is 0-indexed
+                // Named parameters (e.g., :name); positional ($1, $2, ...)
+                // are 1-indexed, the array is 0-indexed
                 if param.name.starts_with(':') {
-                    let name = &param.name[1..];
-                    let value = ctx.get_named_param(name)?;
-                    let pk_value = match value {
-                        Value::Integer(i) => *i,
-                        Value::Float(f) => *f as i64,
-                        _ => return None,
-                    };
-                    (
-                        pk_value,
-                        PkValueSource::NamedParameter(SmartString::new(name)),
-                    )
+                    PkValueSource::NamedParameter(SmartString::new(&param.name[1..]))
+                } else if param.index > 0 {
+                    PkValueSource::Parameter(param.index - 1)
                 } else {
-                    let params = ctx.params();
-                    let param_idx = if param.index > 0 {
-                        param.index - 1
-                    } else {
-                        return None;
-                    };
-                    if param_idx >= params.len() {
-                        return None;
-                    }
-                    let pk_value = match &params[param_idx] {
-                        Value::Integer(i) => *i,
-                        Value::Float(f) => *f as i64,
-                        _ => return None,
-                    };
-                    (pk_value, PkValueSource::Parameter(param_idx))
+                    return None;
                 }
             }
             _ => return None,
         };
 
-        Some((col_name, pk_value, pk_value_source))
+        Some((col_name, source))
     }
 
     /// Normalize a row to match the current schema
@@ -365,11 +358,20 @@ impl Executor {
         match source {
             PkValueSource::NamedParameter(name) => match ctx.get_named_param(name)? {
                 Value::Integer(i) => Some(*i),
-                Value::Float(f) => Some(*f as i64),
+                Value::Float(f) => Self::lossless_float_key(*f),
                 _ => None,
             },
             _ => Self::extract_pk_value_from_slice(source, ctx.params()),
         }
+    }
+
+    /// A float key qualifies only when it converts to i64 without loss:
+    /// truncating 5.5 to 5 would serve row 5 where correct execution
+    /// matches nothing. None falls back to the standard path.
+    #[inline]
+    pub(crate) fn lossless_float_key(f: f64) -> Option<i64> {
+        let v = f as i64;
+        (v as f64 == f).then_some(v)
     }
 
     /// Extract PK value from params slice directly (avoids ExecutionContext overhead)
@@ -383,7 +385,7 @@ impl Executor {
                 }
                 match &params[*idx] {
                     Value::Integer(i) => Some(*i),
-                    Value::Float(f) => Some(*f as i64),
+                    Value::Float(f) => Self::lossless_float_key(*f),
                     _ => None,
                 }
             }
@@ -501,6 +503,12 @@ impl Executor {
             return None;
         }
 
+        // Quick reject: LIMIT 0 or OFFSET would change the result
+        if !Self::pk_fast_path_limit_ok(stmt) {
+            *compiled_guard = CompiledExecution::NotOptimizable(self.engine.schema_epoch());
+            return None;
+        }
+
         // Must be SELECT *
         // Don't set NotOptimizable here - other fast paths (like COUNT DISTINCT) may handle this
         if stmt.columns.len() != 1 || !matches!(&stmt.columns[0], Expression::Star(_)) {
@@ -516,25 +524,35 @@ impl Executor {
             }
         };
 
-        // Try to extract PK lookup info
-        match self.extract_pk_lookup_info(table_name, where_clause, ctx) {
-            Some(info) => {
+        // Try to extract the PK lookup structure. Only a STRUCTURAL reject
+        // may poison the slot: a value-dependent failure (e.g. a text or
+        // NULL parameter this execution) must leave the compiled lookup in
+        // place so later executions with an integer parameter still
+        // fast-path.
+        match self.extract_pk_lookup_structure(table_name, where_clause) {
+            Some((pk_value_source, schema)) => {
                 // Build and cache compiled lookup
                 // Use schema's column_names_arc() directly - O(1) Arc clone on execution
-                let column_names = info.schema.column_names_arc();
+                let column_names = schema.column_names_arc();
                 let cached_epoch = self.engine.schema_epoch();
                 let compiled_lookup = CompiledPkLookup {
-                    table_name: SmartString::new(&info.table_name),
-                    schema: info.schema.clone(),
+                    table_name: SmartString::new(table_name),
+                    schema: schema.clone(),
                     column_names,
-                    pk_value_source: info.pk_value_source.clone(),
+                    pk_value_source: pk_value_source.clone(),
                     cached_epoch,
                 };
                 *compiled_guard = CompiledExecution::PkLookup(compiled_lookup);
                 drop(compiled_guard);
 
-                // Execute
-                Some(self.execute_pk_lookup(info))
+                // Resolve this execution's value; on failure fall back to
+                // the standard path (the stored PkLookup stays valid).
+                let pk_value = self.extract_pk_value_fast(&pk_value_source, ctx)?;
+                Some(self.execute_pk_lookup(PkLookupInfo {
+                    table_name: table_name.to_string(),
+                    pk_value,
+                    schema,
+                }))
             }
             None => {
                 *compiled_guard = CompiledExecution::NotOptimizable(self.engine.schema_epoch());

--- a/src/executor/pk_fast_path.rs
+++ b/src/executor/pk_fast_path.rs
@@ -320,16 +320,8 @@ impl Executor {
         ctx: &ExecutionContext,
         compiled: &RwLock<CompiledExecution>,
     ) -> Option<Result<Box<dyn QueryResult>>> {
-        // Quick reject: explicit transaction (use try_lock for fast rejection)
-        {
-            let active_tx = match self.active_transaction.try_lock() {
-                Ok(guard) => guard,
-                Err(_) => return None, // Lock contention - fall back to normal path
-            };
-            if active_tx.is_some() {
-                return None;
-            }
-        }
+        // Caller (try_compiled_fast_paths) guarantees no explicit transaction
+        // is active; this path reads committed state only.
 
         // Try read lock first - check if already compiled
         {

--- a/src/executor/pk_fast_path.rs
+++ b/src/executor/pk_fast_path.rs
@@ -219,14 +219,8 @@ impl Executor {
         let source = match val_expr {
             Expression::IntegerLiteral(lit) => PkValueSource::Literal(lit.value),
             Expression::FloatLiteral(lit) => {
-                // Only lossless float keys qualify: truncating 5.5 to 5
-                // would serve row 5 where correct execution matches nothing.
-                let v = lit.value as i64;
-                if v as f64 == lit.value {
-                    PkValueSource::Literal(v)
-                } else {
-                    return None;
-                }
+                // Only lossless float keys qualify; see lossless_float_key
+                PkValueSource::Literal(Self::lossless_float_key(lit.value)?)
             }
             Expression::Parameter(param) => {
                 // Named parameters (e.g., :name); positional ($1, $2, ...)
@@ -368,8 +362,17 @@ impl Executor {
     /// A float key qualifies only when it converts to i64 without loss:
     /// truncating 5.5 to 5 would serve row 5 where correct execution
     /// matches nothing. None falls back to the standard path.
+    ///
+    /// The range check must happen BEFORE the cast: 2^63 saturates to
+    /// i64::MAX, and i64::MAX rounds back to 2^63 as f64, so a naive
+    /// round-trip equality check passes at the boundary.
     #[inline]
     pub(crate) fn lossless_float_key(f: f64) -> Option<i64> {
+        const I64_MIN_F: f64 = -9_223_372_036_854_775_808.0; // -2^63, exact
+        const I64_MAX_PLUS_1_F: f64 = 9_223_372_036_854_775_808.0; // 2^63, not representable as i64
+        if !(I64_MIN_F..I64_MAX_PLUS_1_F).contains(&f) {
+            return None; // Also rejects NaN and infinities
+        }
         let v = f as i64;
         (v as f64 == f).then_some(v)
     }
@@ -559,5 +562,39 @@ impl Executor {
                 None
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Executor;
+
+    #[test]
+    fn lossless_float_key_boundaries() {
+        // Exact conversions pass
+        assert_eq!(Executor::lossless_float_key(5.0), Some(5));
+        assert_eq!(Executor::lossless_float_key(-5.0), Some(-5));
+        assert_eq!(Executor::lossless_float_key(0.0), Some(0));
+        // i64::MIN is exactly representable as f64
+        assert_eq!(
+            Executor::lossless_float_key(-9_223_372_036_854_775_808.0),
+            Some(i64::MIN)
+        );
+        // Fractional values reject
+        assert_eq!(Executor::lossless_float_key(5.5), None);
+        assert_eq!(Executor::lossless_float_key(-0.5), None);
+        // 2^63 saturates to i64::MAX under `as i64` and i64::MAX rounds
+        // back to 2^63, so a naive round-trip check passes; the range
+        // check must reject it
+        assert_eq!(
+            Executor::lossless_float_key(9_223_372_036_854_775_808.0),
+            None
+        );
+        assert_eq!(Executor::lossless_float_key(1e19), None);
+        assert_eq!(Executor::lossless_float_key(-1e19), None);
+        // Non-finite rejects
+        assert_eq!(Executor::lossless_float_key(f64::NAN), None);
+        assert_eq!(Executor::lossless_float_key(f64::INFINITY), None);
+        assert_eq!(Executor::lossless_float_key(f64::NEG_INFINITY), None);
     }
 }

--- a/src/executor/planner.rs
+++ b/src/executor/planner.rs
@@ -46,6 +46,8 @@ pub struct QueryPlanner {
     engine: Arc<MVCCEngine>,
     /// Cache of table statistics to avoid repeated lookups
     stats_cache: std::sync::RwLock<StringMap<CachedStats>>,
+    /// Monotonic base for the LRU access stamps
+    base: crate::common::time_compat::Instant,
 }
 
 /// Default TTL for cached statistics (5 minutes)
@@ -57,7 +59,6 @@ const STATS_CACHE_TTL_SECS: u64 = 300;
 const MAX_STATS_CACHE_SIZE: usize = 1000;
 
 /// Cached statistics for a table
-#[derive(Clone)]
 struct CachedStats {
     table_stats: TableStats,
     column_stats: StringMap<ColumnStatsCache>,
@@ -65,8 +66,9 @@ struct CachedStats {
     zone_maps: Option<TableZoneMap>,
     /// Timestamp when this cache entry was created
     cached_at: crate::common::time_compat::Instant,
-    /// Timestamp of last access (for LRU eviction)
-    last_accessed: crate::common::time_compat::Instant,
+    /// Seconds since planner creation at last access (for LRU eviction).
+    /// Atomic so cache hits can touch it under the read lock.
+    last_accessed: std::sync::atomic::AtomicU64,
 }
 
 impl CachedStats {
@@ -76,8 +78,9 @@ impl CachedStats {
     }
 
     /// Update last accessed time
-    fn touch(&mut self) {
-        self.last_accessed = crate::common::time_compat::Instant::now();
+    fn touch(&self, now_secs: u64) {
+        self.last_accessed
+            .store(now_secs, std::sync::atomic::Ordering::Relaxed);
     }
 }
 
@@ -105,7 +108,13 @@ impl QueryPlanner {
         Self {
             engine,
             stats_cache: std::sync::RwLock::new(StringMap::new()),
+            base: crate::common::time_compat::Instant::now(),
         }
+    }
+
+    /// Seconds since planner creation (monotonic LRU stamp)
+    fn now_secs(&self) -> u64 {
+        self.base.elapsed().as_secs()
     }
 
     /// Invalidate cached statistics for a table
@@ -133,24 +142,18 @@ impl QueryPlanner {
     pub fn get_table_stats(&self, table_name: &str) -> Option<TableStats> {
         let key = table_name.to_lowercase();
 
-        // Check cache first - use read lock then upgrade to write for LRU touch
         {
             let cache = self.stats_cache.read().unwrap();
             if let Some(cached) = cache.get(&key) {
-                // Return cached stats if still fresh and valid (row_count > 0)
-                if !cached.is_stale() && cached.table_stats.row_count > 0 {
-                    let result = cached.table_stats.clone();
-                    // We need to touch the entry - drop read lock first
-                    drop(cache);
-                    // Update last_accessed for LRU
-                    if let Ok(mut write_cache) = self.stats_cache.write() {
-                        if let Some(entry) = write_cache.get_mut(&key) {
-                            entry.touch();
-                        }
-                    }
-                    return Some(result);
+                // A fresh entry is authoritative either way: row_count == 0
+                // is the cached "no stats collected" verdict, kept so every
+                // statement does not re-probe the system tables until
+                // ANALYZE invalidates the entry or the TTL expires.
+                if !cached.is_stale() {
+                    cached.touch(self.now_secs());
+                    return (cached.table_stats.row_count > 0).then(|| cached.table_stats.clone());
                 }
-                // Stats are stale or invalid, will reload below
+                // Stats are stale, will reload below
             }
         }
 
@@ -201,15 +204,8 @@ impl QueryPlanner {
             let cache = self.stats_cache.read().unwrap();
             if let Some(cached) = cache.get(&table_key) {
                 if !cached.is_stale() {
-                    let result = cached.column_stats.get(&col_key).cloned();
-                    // Touch the entry for LRU
-                    drop(cache);
-                    if let Ok(mut write_cache) = self.stats_cache.write() {
-                        if let Some(entry) = write_cache.get_mut(&table_key) {
-                            entry.touch();
-                        }
-                    }
-                    return result;
+                    cached.touch(self.now_secs());
+                    return cached.column_stats.get(&col_key).cloned();
                 }
                 true // Stale, need to reload
             } else {
@@ -224,21 +220,10 @@ impl QueryPlanner {
 
         // Try cache again
         let cache = self.stats_cache.read().unwrap();
-        let result = cache
-            .get(&table_key)
-            .and_then(|c| c.column_stats.get(&col_key).cloned());
-
-        // Touch the entry for LRU if found
-        if result.is_some() {
-            drop(cache);
-            if let Ok(mut write_cache) = self.stats_cache.write() {
-                if let Some(entry) = write_cache.get_mut(&table_key) {
-                    entry.touch();
-                }
-            }
-        }
-
-        result
+        cache.get(&table_key).and_then(|c| {
+            c.touch(self.now_secs());
+            c.column_stats.get(&col_key).cloned()
+        })
     }
 
     /// Get zone maps for a table (from table, not system tables)
@@ -260,19 +245,20 @@ impl QueryPlanner {
             .iter()
             .any(|t| t.eq_ignore_ascii_case(SYS_COLUMN_STATS));
 
-        if !has_table_stats {
-            // No statistics available - return default
-            return Ok(TableStats::default());
-        }
-
-        // Read table statistics
-        let table_stats = self.read_table_stats(&*tx, table_name)?;
-
-        // Read column statistics if available
-        let column_stats = if has_column_stats {
-            self.read_column_stats(&*tx, table_name)?
+        // With no stats collected, cache the default (row_count == 0) entry
+        // below as a negative verdict: get_table_stats treats a fresh zero
+        // entry as authoritative, so statements stop re-probing the system
+        // tables until ANALYZE invalidates the entry or the TTL expires.
+        let (table_stats, column_stats) = if !has_table_stats {
+            (TableStats::default(), StringMap::new())
         } else {
-            StringMap::new()
+            let table_stats = self.read_table_stats(&*tx, table_name)?;
+            let column_stats = if has_column_stats {
+                self.read_column_stats(&*tx, table_name)?
+            } else {
+                StringMap::new()
+            };
+            (table_stats, column_stats)
         };
 
         // Cache the stats with current timestamp
@@ -284,22 +270,21 @@ impl QueryPlanner {
                 // Find the least recently used entry (oldest last_accessed time)
                 if let Some(lru_key) = cache
                     .iter()
-                    .min_by_key(|(_, v)| v.last_accessed)
+                    .min_by_key(|(_, v)| v.last_accessed.load(std::sync::atomic::Ordering::Relaxed))
                     .map(|(k, _)| k.clone())
                 {
                     cache.remove(&lru_key);
                 }
             }
 
-            let now = crate::common::time_compat::Instant::now();
             cache.insert(
                 table_name.to_lowercase(),
                 CachedStats {
                     table_stats: table_stats.clone(),
                     column_stats,
                     zone_maps: None, // Zone maps are stored in the table, not here
-                    cached_at: now,
-                    last_accessed: now,
+                    cached_at: crate::common::time_compat::Instant::now(),
+                    last_accessed: std::sync::atomic::AtomicU64::new(self.now_secs()),
                 },
             );
         }

--- a/src/executor/planner.rs
+++ b/src/executor/planner.rs
@@ -66,15 +66,21 @@ struct CachedStats {
     zone_maps: Option<TableZoneMap>,
     /// Timestamp when this cache entry was created
     cached_at: crate::common::time_compat::Instant,
+    /// Engine stats epoch at creation: ANALYZE through any handle bumps
+    /// the engine epoch, so entries cached by other executors go stale
+    /// immediately instead of waiting out the TTL.
+    stats_epoch: u64,
     /// Seconds since planner creation at last access (for LRU eviction).
     /// Atomic so cache hits can touch it under the read lock.
     last_accessed: std::sync::atomic::AtomicU64,
 }
 
 impl CachedStats {
-    /// Check if this cache entry is stale (older than TTL)
-    fn is_stale(&self) -> bool {
-        self.cached_at.elapsed().as_secs() > STATS_CACHE_TTL_SECS
+    /// Check if this cache entry is stale (older than TTL, or superseded
+    /// by an ANALYZE elsewhere)
+    fn is_stale(&self, current_stats_epoch: u64) -> bool {
+        self.stats_epoch != current_stats_epoch
+            || self.cached_at.elapsed().as_secs() > STATS_CACHE_TTL_SECS
     }
 
     /// Update last accessed time
@@ -143,13 +149,14 @@ impl QueryPlanner {
         let key = table_name.to_lowercase();
 
         {
+            let current_epoch = self.engine.stats_epoch();
             let cache = self.stats_cache.read().unwrap();
             if let Some(cached) = cache.get(&key) {
                 // A fresh entry is authoritative either way: row_count == 0
                 // is the cached "no stats collected" verdict, kept so every
                 // statement does not re-probe the system tables until
                 // ANALYZE invalidates the entry or the TTL expires.
-                if !cached.is_stale() {
+                if !cached.is_stale(current_epoch) {
                     cached.touch(self.now_secs());
                     return (cached.table_stats.row_count > 0).then(|| cached.table_stats.clone());
                 }
@@ -201,9 +208,10 @@ impl QueryPlanner {
 
         // Check cache first
         let should_reload = {
+            let current_epoch = self.engine.stats_epoch();
             let cache = self.stats_cache.read().unwrap();
             if let Some(cached) = cache.get(&table_key) {
-                if !cached.is_stale() {
+                if !cached.is_stale(current_epoch) {
                     cached.touch(self.now_secs());
                     return cached.column_stats.get(&col_key).cloned();
                 }
@@ -284,6 +292,7 @@ impl QueryPlanner {
                     column_stats,
                     zone_maps: None, // Zone maps are stored in the table, not here
                     cached_at: crate::common::time_compat::Instant::now(),
+                    stats_epoch: self.engine.stats_epoch(),
                     last_accessed: std::sync::atomic::AtomicU64::new(self.now_secs()),
                 },
             );
@@ -1467,5 +1476,21 @@ mod tests {
         let decision = planner.plan_runtime_join(1000, 1000, true);
         // Explanation should not be empty
         assert!(!decision.explanation.is_empty());
+    }
+
+    #[test]
+    fn cached_stats_go_stale_on_epoch_change() {
+        let entry = CachedStats {
+            table_stats: TableStats::default(),
+            column_stats: StringMap::new(),
+            zone_maps: None,
+            cached_at: crate::common::time_compat::Instant::now(),
+            stats_epoch: 1,
+            last_accessed: std::sync::atomic::AtomicU64::new(0),
+        };
+        assert!(!entry.is_stale(1));
+        // ANALYZE through another handle bumps the engine epoch: the pinned
+        // verdict (including a negative row_count == 0 one) must reload.
+        assert!(entry.is_stale(2));
     }
 }

--- a/src/executor/planner.rs
+++ b/src/executor/planner.rs
@@ -242,6 +242,11 @@ impl QueryPlanner {
 
     /// Load statistics from system tables
     fn load_stats_from_system_tables(&self, table_name: &str) -> Result<TableStats> {
+        // Capture the epoch BEFORE reading: if an ANALYZE on another handle
+        // commits and bumps between the read and the cache insert, the
+        // entry carries the pre-read epoch and the next access sees it as
+        // stale instead of serving old stats stamped fresh for the TTL.
+        let stats_epoch_before_read = self.engine.stats_epoch();
         let tx = self.engine.begin_transaction()?;
 
         // Check if system tables exist
@@ -292,7 +297,7 @@ impl QueryPlanner {
                     column_stats,
                     zone_maps: None, // Zone maps are stored in the table, not here
                     cached_at: crate::common::time_compat::Instant::now(),
-                    stats_epoch: self.engine.stats_epoch(),
+                    stats_epoch: stats_epoch_before_read,
                     last_accessed: std::sync::atomic::AtomicU64::new(self.now_secs()),
                 },
             );

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -195,6 +195,18 @@ impl Executor {
         stmt: &SelectStatement,
         ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        self.execute_select_with_plan(stmt, ctx, None)
+    }
+
+    /// `execute_select` with the cached plan's classification slot, so
+    /// repeated executions skip the AST hash and the global
+    /// classification-cache mutex after the first resolution.
+    pub(crate) fn execute_select_with_plan(
+        &self,
+        stmt: &SelectStatement,
+        ctx: &ExecutionContext,
+        plan_classification: Option<&std::sync::OnceLock<Arc<QueryClassification>>>,
+    ) -> Result<Box<dyn QueryResult>> {
         // Start timeout guard ONLY at the top level (query_depth == 0).
         // For nested queries (subqueries, views), the parent's TimeoutGuard handles timeout.
         // This ensures the timeout applies to the entire query, not each nested call.
@@ -237,10 +249,22 @@ impl Executor {
         // OPTIMIZATION: Get cached query classification ONCE at entry point
         // This classification is passed through the call chain to avoid
         // redundant hash computations and cache lookups (was 10+ calls per query)
-        let classification = get_classification(stmt);
+        let classification = match plan_classification {
+            Some(slot) => slot.get_or_init(|| get_classification(stmt)).clone(),
+            None => get_classification(stmt),
+        };
 
         // Evaluate LIMIT/OFFSET early (needed for set operations optimization)
-        let limit = if let Some(ref limit_expr) = stmt.limit {
+        // Literal fast path: `LIMIT 10` needs no compile/cache/VM round trip
+        let limit = if let Some(Expression::IntegerLiteral(lit)) = stmt.limit.as_deref() {
+            if lit.value < 0 {
+                return Err(Error::Parse(format!(
+                    "LIMIT must be non-negative, got {}",
+                    lit.value
+                )));
+            }
+            Some(lit.value as usize)
+        } else if let Some(ref limit_expr) = stmt.limit {
             match ExpressionEval::compile(limit_expr, &[])?
                 .with_context(ctx)
                 .eval_slice(&Row::new())?
@@ -275,7 +299,15 @@ impl Executor {
             None
         };
 
-        let offset = if let Some(ref offset_expr) = stmt.offset {
+        let offset = if let Some(Expression::IntegerLiteral(lit)) = stmt.offset.as_deref() {
+            if lit.value < 0 {
+                return Err(Error::Parse(format!(
+                    "OFFSET must be non-negative, got {}",
+                    lit.value
+                )));
+            }
+            lit.value as usize
+        } else if let Some(ref offset_expr) = stmt.offset {
             match ExpressionEval::compile(offset_expr, &[])
                 .ok()
                 .and_then(|eval| eval.with_context(ctx).eval_slice(&Row::new()).ok())
@@ -1952,8 +1984,9 @@ impl Executor {
             (table, Some(tx))
         };
 
-        // Build column list from schema (using cached version to avoid repeated clones)
-        let all_columns: Vec<String> = table.schema().column_names_owned().to_vec();
+        // Build column list from schema: refcount bump, not a per-statement
+        // deep clone of every column name
+        let all_columns = table.schema().column_names_arc();
         // Get pre-cached lowercase column names to avoid per-query to_lowercase() calls
         let all_columns_lower = table.schema().column_names_lower_arc();
 
@@ -3033,7 +3066,7 @@ impl Executor {
 
                 // OPTIMIZATION: Wrap all_columns in Arc once, reuse for all rows (only if needed)
                 let all_columns_arc: Option<CompactArc<Vec<String>>> = if has_correlated {
-                    Some(CompactArc::new(all_columns.clone()))
+                    Some(all_columns.clone())
                 } else {
                     None
                 };
@@ -3605,7 +3638,7 @@ impl Executor {
                 let rows_for_cache: Vec<Row> = projected_rows.rows().cloned().collect();
                 self.semantic_cache.insert(
                     table_name,
-                    all_columns.clone(),
+                    all_columns.to_vec(),
                     rows_for_cache,
                     Some(where_expr.clone()),
                 );

--- a/src/executor/query_cache.rs
+++ b/src/executor/query_cache.rs
@@ -47,6 +47,8 @@ use crate::common::CompactArc;
 use crate::core::Schema;
 use crate::parser::ast::Statement;
 
+use super::query_classification::QueryClassification;
+
 /// Convert to lowercase without allocation if already lowercase.
 #[inline]
 fn to_lowercase_cow(s: &str) -> Cow<'_, str> {
@@ -225,6 +227,8 @@ pub struct CachedPlanRef {
     pub param_count: usize,
     /// Shared reference to compiled execution state (lazily populated)
     pub compiled: Arc<RwLock<CompiledExecution>>,
+    /// Classification of the SELECT, resolved once per plan (lazily populated)
+    pub classification: Arc<std::sync::OnceLock<Arc<QueryClassification>>>,
 }
 
 /// Represents a parsed and prepared statement stored in the cache
@@ -246,6 +250,8 @@ pub struct CachedQueryPlan {
     pub normalized_query: SmartString,
     /// Compiled execution state (lazily populated on first execution)
     pub compiled: Arc<RwLock<CompiledExecution>>,
+    /// Classification of the SELECT, resolved once per plan (lazily populated)
+    pub classification: Arc<std::sync::OnceLock<Arc<QueryClassification>>>,
 }
 
 impl CachedQueryPlan {
@@ -266,6 +272,7 @@ impl CachedQueryPlan {
             param_count,
             normalized_query,
             compiled: Arc::new(RwLock::new(CompiledExecution::Unknown)),
+            classification: Arc::new(std::sync::OnceLock::new()),
         }
     }
 }
@@ -319,6 +326,7 @@ impl QueryCache {
             has_params: plan.has_params,
             param_count: plan.param_count,
             compiled: plan.compiled.clone(), // Share compiled state
+            classification: plan.classification.clone(),
         })
     }
 
@@ -343,6 +351,7 @@ impl QueryCache {
 
         // Create the compiled state upfront - shared between stored plan and returned ref
         let compiled = Arc::new(RwLock::new(CompiledExecution::Unknown));
+        let classification = Arc::new(std::sync::OnceLock::new());
 
         if let Ok(mut plans) = self.plans.write() {
             // Check if we need to prune the cache
@@ -364,6 +373,7 @@ impl QueryCache {
                     param_count,
                     normalized_query: normalized_key, // moved, not cloned
                     compiled: compiled.clone(),       // Arc clone - cheap
+                    classification: classification.clone(),
                 },
             );
         }
@@ -374,6 +384,7 @@ impl QueryCache {
             has_params,
             param_count,
             compiled,
+            classification,
         }
     }
 

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -37,7 +37,10 @@ use crate::parser::ast::{Expression, SelectStatement};
 const CLASSIFICATION_CACHE_SIZE: usize = 512;
 
 /// Global cache for query classifications
-static CLASSIFICATION_CACHE: Mutex<Option<LruCache<u64, Arc<QueryClassification>>>> =
+/// Dual-hash key: two independent 64-bit hashes over the same inputs
+type ClassificationKey = (u64, u64);
+
+static CLASSIFICATION_CACHE: Mutex<Option<LruCache<ClassificationKey, Arc<QueryClassification>>>> =
     Mutex::new(None);
 
 /// Clear the classification cache. Call on database drop to release memory.
@@ -973,70 +976,88 @@ fn is_aggregate_function(name: &str) -> bool {
 /// Compute a cache key for a SELECT statement
 /// Only hashes structural elements that affect classification (not literal values)
 /// Uses FxHasher which is 2-5x faster than SipHash for small keys.
-fn compute_classification_key(stmt: &SelectStatement) -> u64 {
-    let mut hasher = FxHasher::default();
+fn compute_classification_key(stmt: &SelectStatement) -> ClassificationKey {
+    // Two independent algorithms over the same inputs; a single unverified
+    // 64-bit hash is not collision-safe as a cache identity (PR #36
+    // lesson), and a collision here pins the wrong classification into the
+    // plan's OnceLock.
+    let mut h1 = FxHasher::default();
+    hash_classification_inputs(stmt, &mut h1);
 
+    use std::hash::BuildHasher;
+    let mut h2 = ahash::RandomState::with_seeds(
+        0x9e37_79b9_7f4a_7c15,
+        0xf39c_c060_5ced_c834,
+        0x1082_276b_f3a2_7251,
+        0x8f4c_a136_bef1_39c9,
+    )
+    .build_hasher();
+    hash_classification_inputs(stmt, &mut h2);
+
+    (h1.finish(), h2.finish())
+}
+
+/// Hash every statement input the classifier reads.
+fn hash_classification_inputs<H: std::hash::Hasher>(stmt: &SelectStatement, hasher: &mut H) {
     // Hash structural properties
-    stmt.distinct.hash(&mut hasher);
-    stmt.distinct_on.len().hash(&mut hasher);
-    stmt.columns.len().hash(&mut hasher);
-    stmt.group_by.columns.len().hash(&mut hasher);
-    stmt.order_by.len().hash(&mut hasher);
-    stmt.limit.is_some().hash(&mut hasher);
-    stmt.offset.is_some().hash(&mut hasher);
-    stmt.having.is_some().hash(&mut hasher);
-    stmt.with.is_some().hash(&mut hasher);
-    stmt.set_operations.len().hash(&mut hasher);
+    stmt.distinct.hash(hasher);
+    stmt.distinct_on.len().hash(hasher);
+    stmt.columns.len().hash(hasher);
+    stmt.group_by.columns.len().hash(hasher);
+    stmt.order_by.len().hash(hasher);
+    stmt.limit.is_some().hash(hasher);
+    stmt.offset.is_some().hash(hasher);
+    stmt.having.is_some().hash(hasher);
+    stmt.with.is_some().hash(hasher);
+    stmt.set_operations.len().hash(hasher);
 
     // Hash DISTINCT ON expression structures
     for expr in &stmt.distinct_on {
-        hash_expression_structure(expr, &mut hasher);
+        hash_expression_structure(expr, hasher);
     }
 
     // Hash column expression types (not values)
     for col in &stmt.columns {
-        hash_expression_structure(col, &mut hasher);
+        hash_expression_structure(col, hasher);
     }
 
     // Hash WHERE clause structure if present
     if let Some(ref where_clause) = stmt.where_clause {
-        hash_expression_structure(where_clause, &mut hasher);
+        hash_expression_structure(where_clause, hasher);
     }
 
     // Hash ORDER BY expressions (critical for correlated subquery detection)
     // Without this, queries with same ORDER BY count but different expressions
     // would incorrectly share classification (e.g., "ORDER BY 1" vs "ORDER BY (SELECT ...)")
     for ob in &stmt.order_by {
-        hash_expression_structure(&ob.expression, &mut hasher);
-        ob.ascending.hash(&mut hasher);
-        ob.nulls_first.hash(&mut hasher);
+        hash_expression_structure(&ob.expression, hasher);
+        ob.ascending.hash(hasher);
+        ob.nulls_first.hash(hasher);
     }
 
     // Hash GROUP BY expressions
     for gb in &stmt.group_by.columns {
-        hash_expression_structure(gb, &mut hasher);
+        hash_expression_structure(gb, hasher);
     }
 
     // Hash HAVING clause if present
     if let Some(ref having) = stmt.having {
-        hash_expression_structure(having, &mut hasher);
+        hash_expression_structure(having, hasher);
     }
 
     // Hash FROM structure: without it `SELECT * FROM a` and
     // `SELECT * FROM a JOIN b ON ...` share a key and trade
     // classifications (has_joins, join_count, is_simple_scan).
-    stmt.table_expr.is_some().hash(&mut hasher);
+    stmt.table_expr.is_some().hash(hasher);
     if let Some(ref table_expr) = stmt.table_expr {
-        hash_table_expr_structure(table_expr, &mut hasher);
+        hash_table_expr_structure(table_expr, hasher);
     }
-
-    hasher.finish()
 }
 
 /// Hash the join/derived-table shape of a FROM expression, mirroring what
 /// `analyze_table_source` reads: join nesting, join types, and source
 /// discriminants.
-fn hash_table_expr_structure(expr: &Expression, hasher: &mut FxHasher) {
+fn hash_table_expr_structure<H: std::hash::Hasher>(expr: &Expression, hasher: &mut H) {
     std::mem::discriminant(expr).hash(hasher);
     match expr {
         Expression::JoinSource(join) => {
@@ -1055,7 +1076,7 @@ fn hash_table_expr_structure(expr: &Expression, hasher: &mut FxHasher) {
 }
 
 /// Hash the structural elements of an expression (discriminants, not values)
-fn hash_expression_structure(expr: &Expression, hasher: &mut FxHasher) {
+fn hash_expression_structure<H: std::hash::Hasher>(expr: &Expression, hasher: &mut H) {
     std::mem::discriminant(expr).hash(hasher);
 
     match expr {
@@ -1091,6 +1112,9 @@ fn hash_expression_structure(expr: &Expression, hasher: &mut FxHasher) {
             hash_expression_structure(&cast.expr, hasher);
         }
         Expression::Case(case) => {
+            if let Some(ref value) = case.value {
+                hash_expression_structure(value, hasher);
+            }
             case.when_clauses.len().hash(hasher);
             for wc in &case.when_clauses {
                 hash_expression_structure(&wc.condition, hasher);
@@ -1113,9 +1137,40 @@ fn hash_expression_structure(expr: &Expression, hasher: &mut FxHasher) {
         }
         Expression::List(list) => {
             list.elements.len().hash(hasher);
+            // Children matter: the classifier walks IN-list elements for
+            // non-determinism, so `IN (1, 2)` and `IN (1, RANDOM())` must
+            // not share a key.
+            for e in &list.elements {
+                hash_expression_structure(e, hasher);
+            }
+        }
+        Expression::ExpressionList(list) => {
+            list.expressions.len().hash(hasher);
+            for e in &list.expressions {
+                hash_expression_structure(e, hasher);
+            }
+        }
+        Expression::Like(like) => {
+            like.operator.hash(hasher);
+            hash_expression_structure(&like.left, hasher);
+            hash_expression_structure(&like.pattern, hasher);
+            if let Some(ref escape) = like.escape {
+                hash_expression_structure(escape, hasher);
+            }
+        }
+        Expression::Distinct(distinct) => {
+            hash_expression_structure(&distinct.expr, hasher);
+        }
+        Expression::InHashSet(in_hash) => {
+            hash_expression_structure(&in_hash.column, hasher);
+            in_hash.values.len().hash(hasher);
         }
         Expression::ScalarSubquery(subquery) => {
-            // Hash subquery WHERE structure to distinguish correlated vs uncorrelated
+            // The classifier reads subquery columns (non-determinism) and
+            // WHERE structure (correlation); both belong in the key.
+            for col in &subquery.subquery.columns {
+                hash_expression_structure(col, hasher);
+            }
             if let Some(ref where_clause) = subquery.subquery.where_clause {
                 hash_expression_structure(where_clause, hasher);
             }
@@ -1133,7 +1188,9 @@ fn hash_expression_structure(expr: &Expression, hasher: &mut FxHasher) {
             }
         }
         Expression::AllAny(all_any) => {
-            // Hash ALL/ANY subquery WHERE structure
+            // The classifier reads the left side (non-determinism) and the
+            // subquery WHERE structure (correlation)
+            hash_expression_structure(&all_any.left, hasher);
             if let Some(ref where_clause) = all_any.subquery.where_clause {
                 hash_expression_structure(where_clause, hasher);
             }
@@ -1283,5 +1340,29 @@ mod tests {
         assert!(!c_plain.has_joins);
         assert!(c_joined.has_joins);
         assert!(c_joined.join_count >= 1);
+    }
+
+    #[test]
+    fn classification_key_distinguishes_in_list_children() {
+        let parse = |sql: &str| {
+            let mut parser = crate::parser::Parser::new(sql);
+            let mut program = parser.parse_program().unwrap();
+            match program.statements.pop().unwrap() {
+                crate::parser::ast::Statement::Select(s) => s,
+                other => panic!("expected SELECT, got {:?}", other),
+            }
+        };
+        let deterministic = parse("SELECT * FROM t WHERE x IN (1, 2)");
+        let random = parse("SELECT * FROM t WHERE x IN (1, RANDOM())");
+
+        let k_det = compute_classification_key(&deterministic);
+        let k_rand = compute_classification_key(&random);
+        assert_ne!(k_det, k_rand, "IN-list children must be part of the key");
+
+        clear_cache();
+        let c_det = get_classification(&deterministic);
+        let c_rand = get_classification(&random);
+        assert!(!c_det.has_nondeterministic_functions);
+        assert!(c_rand.has_nondeterministic_functions);
     }
 }

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -1022,7 +1022,36 @@ fn compute_classification_key(stmt: &SelectStatement) -> u64 {
         hash_expression_structure(having, &mut hasher);
     }
 
+    // Hash FROM structure: without it `SELECT * FROM a` and
+    // `SELECT * FROM a JOIN b ON ...` share a key and trade
+    // classifications (has_joins, join_count, is_simple_scan).
+    stmt.table_expr.is_some().hash(&mut hasher);
+    if let Some(ref table_expr) = stmt.table_expr {
+        hash_table_expr_structure(table_expr, &mut hasher);
+    }
+
     hasher.finish()
+}
+
+/// Hash the join/derived-table shape of a FROM expression, mirroring what
+/// `analyze_table_source` reads: join nesting, join types, and source
+/// discriminants.
+fn hash_table_expr_structure(expr: &Expression, hasher: &mut FxHasher) {
+    std::mem::discriminant(expr).hash(hasher);
+    match expr {
+        Expression::JoinSource(join) => {
+            join.join_type.hash(hasher);
+            hash_table_expr_structure(&join.left, hasher);
+            hash_table_expr_structure(&join.right, hasher);
+        }
+        Expression::Aliased(aliased) => {
+            hash_table_expr_structure(&aliased.expression, hasher);
+        }
+        Expression::TableSource(ts) => {
+            ts.name.value_lower.hash(hasher);
+        }
+        _ => {}
+    }
 }
 
 /// Hash the structural elements of an expression (discriminants, not values)
@@ -1225,5 +1254,34 @@ mod tests {
         // Second call - should hit cache (same Arc)
         let class2 = get_classification(&stmt);
         assert!(Arc::ptr_eq(&class1, &class2));
+    }
+
+    #[test]
+    fn classification_key_distinguishes_join_shape() {
+        // Same SELECT list, WHERE, ORDER BY (all absent); only FROM differs.
+        let parse = |sql: &str| {
+            let mut parser = crate::parser::Parser::new(sql);
+            let mut program = parser.parse_program().unwrap();
+            match program.statements.pop().unwrap() {
+                crate::parser::ast::Statement::Select(s) => s,
+                other => panic!("expected SELECT, got {:?}", other),
+            }
+        };
+        let plain = parse("SELECT * FROM a");
+        let joined = parse("SELECT * FROM a JOIN b ON a.id = b.id");
+        let left_joined = parse("SELECT * FROM a LEFT JOIN b ON a.id = b.id");
+
+        let k_plain = compute_classification_key(&plain);
+        let k_joined = compute_classification_key(&joined);
+        let k_left = compute_classification_key(&left_joined);
+        assert_ne!(k_plain, k_joined, "join shape must be part of the key");
+        assert_ne!(k_joined, k_left, "join type must be part of the key");
+
+        clear_cache();
+        let c_plain = get_classification(&plain);
+        let c_joined = get_classification(&joined);
+        assert!(!c_plain.has_joins);
+        assert!(c_joined.has_joins);
+        assert!(c_joined.join_count >= 1);
     }
 }

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -1054,9 +1054,27 @@ fn hash_classification_inputs<H: std::hash::Hasher>(stmt: &SelectStatement, hash
     }
 }
 
+/// Hash what a subquery's classification depends on: correlation reads the
+/// FROM table/alias list plus WHERE and SELECT columns
+/// (`is_subquery_correlated`), and non-determinism reads the columns.
+fn hash_subquery_structure<H: std::hash::Hasher>(subquery: &SelectStatement, hasher: &mut H) {
+    subquery.columns.len().hash(hasher);
+    for col in &subquery.columns {
+        hash_expression_structure(col, hasher);
+    }
+    subquery.table_expr.is_some().hash(hasher);
+    if let Some(ref table_expr) = subquery.table_expr {
+        hash_table_expr_structure(table_expr, hasher);
+    }
+    if let Some(ref where_clause) = subquery.where_clause {
+        hash_expression_structure(where_clause, hasher);
+    }
+}
+
 /// Hash the join/derived-table shape of a FROM expression, mirroring what
-/// `analyze_table_source` reads: join nesting, join types, and source
-/// discriminants.
+/// `analyze_table_source` and `collect_tables_recursive` read: join
+/// nesting, join types, and source names WITH aliases (the alias decides
+/// whether a qualified reference is local or an outer correlation).
 fn hash_table_expr_structure<H: std::hash::Hasher>(expr: &Expression, hasher: &mut H) {
     std::mem::discriminant(expr).hash(hasher);
     match expr {
@@ -1066,10 +1084,30 @@ fn hash_table_expr_structure<H: std::hash::Hasher>(expr: &Expression, hasher: &m
             hash_table_expr_structure(&join.right, hasher);
         }
         Expression::Aliased(aliased) => {
+            aliased.alias.value_lower.hash(hasher);
             hash_table_expr_structure(&aliased.expression, hasher);
         }
         Expression::TableSource(ts) => {
             ts.name.value_lower.hash(hasher);
+            ts.alias.is_some().hash(hasher);
+            if let Some(ref alias) = ts.alias {
+                alias.value_lower.hash(hasher);
+            }
+        }
+        Expression::Identifier(ident) => {
+            ident.value_lower.hash(hasher);
+        }
+        Expression::SubquerySource(subquery) => {
+            if let Some(ref alias) = subquery.alias {
+                alias.value_lower.hash(hasher);
+            }
+            hash_subquery_structure(&subquery.subquery, hasher);
+        }
+        Expression::FunctionTableSource(fs) => {
+            fs.function.value_lower.hash(hasher);
+            if let Some(ref alias) = fs.alias {
+                alias.value_lower.hash(hasher);
+            }
         }
         _ => {}
     }
@@ -1166,34 +1204,20 @@ fn hash_expression_structure<H: std::hash::Hasher>(expr: &Expression, hasher: &m
             in_hash.values.len().hash(hasher);
         }
         Expression::ScalarSubquery(subquery) => {
-            // The classifier reads subquery columns (non-determinism) and
-            // WHERE structure (correlation); both belong in the key.
-            for col in &subquery.subquery.columns {
-                hash_expression_structure(col, hasher);
-            }
-            if let Some(ref where_clause) = subquery.subquery.where_clause {
-                hash_expression_structure(where_clause, hasher);
-            }
+            hash_subquery_structure(&subquery.subquery, hasher);
         }
         Expression::SubquerySource(subquery) => {
-            // Hash subquery WHERE structure to distinguish correlated vs uncorrelated
-            if let Some(ref where_clause) = subquery.subquery.where_clause {
-                hash_expression_structure(where_clause, hasher);
+            if let Some(ref alias) = subquery.alias {
+                alias.value_lower.hash(hasher);
             }
+            hash_subquery_structure(&subquery.subquery, hasher);
         }
         Expression::Exists(exists) => {
-            // Hash EXISTS subquery WHERE structure to distinguish correlated vs uncorrelated
-            if let Some(ref where_clause) = exists.subquery.where_clause {
-                hash_expression_structure(where_clause, hasher);
-            }
+            hash_subquery_structure(&exists.subquery, hasher);
         }
         Expression::AllAny(all_any) => {
-            // The classifier reads the left side (non-determinism) and the
-            // subquery WHERE structure (correlation)
             hash_expression_structure(&all_any.left, hasher);
-            if let Some(ref where_clause) = all_any.subquery.where_clause {
-                hash_expression_structure(where_clause, hasher);
-            }
+            hash_subquery_structure(&all_any.subquery, hasher);
         }
         Expression::QualifiedIdentifier(qi) => {
             // CRITICAL: Hash the qualifier (table name/alias) to distinguish correlated references
@@ -1364,5 +1388,37 @@ mod tests {
         let c_rand = get_classification(&random);
         assert!(!c_det.has_nondeterministic_functions);
         assert!(c_rand.has_nondeterministic_functions);
+    }
+
+    #[test]
+    fn classification_key_distinguishes_subquery_aliases() {
+        let parse = |sql: &str| {
+            let mut parser = crate::parser::Parser::new(sql);
+            let mut program = parser.parse_program().unwrap();
+            match program.statements.pop().unwrap() {
+                crate::parser::ast::Statement::Select(s) => s,
+                other => panic!("expected SELECT, got {:?}", other),
+            }
+        };
+        // Identical except the inner FROM alias: with `o` the qualified
+        // `o.id` resolves locally (uncorrelated), with `i` it refers to
+        // the outer table (correlated).
+        let local =
+            parse("SELECT * FROM outer_t o WHERE EXISTS (SELECT 1 FROM inner_t o WHERE o.id = 1)");
+        let correlated =
+            parse("SELECT * FROM outer_t o WHERE EXISTS (SELECT 1 FROM inner_t i WHERE o.id = 1)");
+
+        let k_local = compute_classification_key(&local);
+        let k_corr = compute_classification_key(&correlated);
+        assert_ne!(
+            k_local, k_corr,
+            "subquery FROM aliases must be part of the key"
+        );
+
+        clear_cache();
+        let c_local = get_classification(&local);
+        let c_corr = get_classification(&correlated);
+        assert!(!c_local.where_has_correlated_subqueries);
+        assert!(c_corr.where_has_correlated_subqueries);
     }
 }

--- a/src/executor/result.rs
+++ b/src/executor/result.rs
@@ -1711,8 +1711,8 @@ impl QueryResult for ProjectedResult {
 pub struct ScannerResult {
     /// The underlying scanner
     scanner: Box<dyn crate::storage::traits::Scanner>,
-    /// Column names
-    columns: Vec<String>,
+    /// Column names (shared with the schema cache, not cloned per statement)
+    columns: CompactArc<Vec<String>>,
     /// Current row (cloned from scanner since scanner.row() returns a reference)
     current_row: Row,
     /// Whether we have a valid current row
@@ -1721,7 +1721,10 @@ pub struct ScannerResult {
 
 impl ScannerResult {
     /// Create a new scanner result
-    pub fn new(scanner: Box<dyn crate::storage::traits::Scanner>, columns: Vec<String>) -> Self {
+    pub fn new(
+        scanner: Box<dyn crate::storage::traits::Scanner>,
+        columns: CompactArc<Vec<String>>,
+    ) -> Self {
         Self {
             scanner,
             columns,

--- a/src/executor/statistics.rs
+++ b/src/executor/statistics.rs
@@ -92,6 +92,9 @@ impl Executor {
             // and stats_cache write lock
             if success {
                 self.get_query_planner().invalidate_stats_cache(table_name);
+                // Other handles (Database::clone) have their own planners;
+                // the engine-wide epoch makes their cached verdicts stale.
+                self.engine.bump_stats_epoch();
             }
         }
 

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -437,6 +437,10 @@ pub struct MVCCEngine {
     /// Schema epoch counter - increments on any CREATE/ALTER/DROP TABLE
     /// Used for fast cache invalidation without HashMap lookup
     schema_epoch: AtomicU64,
+    /// Statistics epoch counter - increments on ANALYZE. Shared across all
+    /// executors on this engine so per-executor stats caches can spot
+    /// stats written through another handle.
+    stats_epoch: AtomicU64,
     /// Handle for the background cleanup thread (None if not started)
     cleanup_handle: Mutex<Option<CleanupHandle>>,
     /// Cached reverse FK mapping: parent_table → Vec<(child_table, FK constraint)>
@@ -523,6 +527,7 @@ impl MVCCEngine {
             loading_from_disk: Arc::new(AtomicBool::new(false)),
             file_lock: Mutex::new(None),
             schema_epoch: AtomicU64::new(0),
+            stats_epoch: AtomicU64::new(0),
             cleanup_handle: Mutex::new(None),
             fk_reverse_cache: RwLock::new((u64::MAX, StringMap::default())),
             snapshot_timestamps: RwLock::new(FxHashMap::default()),
@@ -5939,6 +5944,21 @@ impl MVCCEngine {
         }
 
         Ok(())
+    }
+}
+
+impl MVCCEngine {
+    /// Current statistics epoch (bumped by ANALYZE on any handle sharing
+    /// this engine).
+    #[inline]
+    pub fn stats_epoch(&self) -> u64 {
+        self.stats_epoch.load(Ordering::Acquire)
+    }
+
+    /// Bump after publishing new statistics rows, so per-executor stats
+    /// caches on other handles reload instead of serving a stale verdict.
+    pub fn bump_stats_epoch(&self) {
+        self.stats_epoch.fetch_add(1, Ordering::Release);
     }
 }
 

--- a/tests/pk_fast_path_limit_test.rs
+++ b/tests/pk_fast_path_limit_test.rs
@@ -18,16 +18,23 @@
 
 use stoolap::api::Database;
 
+/// One database per test: under `cargo test` all tests share a process,
+/// and `memory://` DSNs are registry-shared within it.
+fn test_db(name: &str) -> Database {
+    let db = Database::open(&format!("memory://pk_fast_path_limit_{}", name)).unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (5, 'x')", ()).unwrap();
+    db
+}
+
 fn row_count(db: &Database, sql: &str) -> usize {
     db.query(sql, ()).unwrap().collect_vec().unwrap().len()
 }
 
 #[test]
 fn pk_lookup_respects_limit_zero() {
-    let db = Database::open("memory://").unwrap();
-    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
-        .unwrap();
-    db.execute("INSERT INTO t VALUES (5, 'x')", ()).unwrap();
+    let db = test_db("pk_lookup_respects_limit_zero");
 
     // Run twice: the second execution takes the cached/compiled path.
     assert_eq!(row_count(&db, "SELECT * FROM t WHERE id = 5 LIMIT 0"), 0);
@@ -36,10 +43,7 @@ fn pk_lookup_respects_limit_zero() {
 
 #[test]
 fn pk_lookup_respects_offset() {
-    let db = Database::open("memory://").unwrap();
-    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
-        .unwrap();
-    db.execute("INSERT INTO t VALUES (5, 'x')", ()).unwrap();
+    let db = test_db("pk_lookup_respects_offset");
 
     assert_eq!(
         row_count(&db, "SELECT * FROM t WHERE id = 5 LIMIT 10 OFFSET 1"),
@@ -53,10 +57,7 @@ fn pk_lookup_respects_offset() {
 
 #[test]
 fn pk_lookup_with_limit_one_still_returns_the_row() {
-    let db = Database::open("memory://").unwrap();
-    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
-        .unwrap();
-    db.execute("INSERT INTO t VALUES (5, 'x')", ()).unwrap();
+    let db = test_db("pk_lookup_with_limit_one_still_returns_the_row");
 
     assert_eq!(row_count(&db, "SELECT * FROM t WHERE id = 5 LIMIT 1"), 1);
     assert_eq!(row_count(&db, "SELECT * FROM t WHERE id = 5 LIMIT 1"), 1);
@@ -64,10 +65,7 @@ fn pk_lookup_with_limit_one_still_returns_the_row() {
 
 #[test]
 fn prepared_pk_lookup_respects_limit_zero() {
-    let db = Database::open("memory://").unwrap();
-    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
-        .unwrap();
-    db.execute("INSERT INTO t VALUES (5, 'x')", ()).unwrap();
+    let db = test_db("prepared_pk_lookup_respects_limit_zero");
 
     let stmt = db.prepare("SELECT * FROM t WHERE id = $1 LIMIT 0").unwrap();
     for _ in 0..3 {
@@ -84,10 +82,7 @@ fn prepared_pk_lookup_respects_limit_zero() {
 
 #[test]
 fn prepared_pk_lookup_survives_wrongly_typed_first_execution() {
-    let db = Database::open("memory://").unwrap();
-    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
-        .unwrap();
-    db.execute("INSERT INTO t VALUES (5, 'x')", ()).unwrap();
+    let db = test_db("prepared_pk_lookup_survives_wrongly_typed_first_execution");
 
     let stmt = db.prepare("SELECT * FROM t WHERE id = $1").unwrap();
 

--- a/tests/pk_fast_path_limit_test.rs
+++ b/tests/pk_fast_path_limit_test.rs
@@ -1,0 +1,109 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The PK-lookup fast path must respect LIMIT 0 and OFFSET: a fast-path
+//! answer that ignores them returns a row where correct execution
+//! returns an empty set.
+
+use stoolap::api::Database;
+
+fn row_count(db: &Database, sql: &str) -> usize {
+    db.query(sql, ()).unwrap().collect_vec().unwrap().len()
+}
+
+#[test]
+fn pk_lookup_respects_limit_zero() {
+    let db = Database::open("memory://").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (5, 'x')", ()).unwrap();
+
+    // Run twice: the second execution takes the cached/compiled path.
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE id = 5 LIMIT 0"), 0);
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE id = 5 LIMIT 0"), 0);
+}
+
+#[test]
+fn pk_lookup_respects_offset() {
+    let db = Database::open("memory://").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (5, 'x')", ()).unwrap();
+
+    assert_eq!(
+        row_count(&db, "SELECT * FROM t WHERE id = 5 LIMIT 10 OFFSET 1"),
+        0
+    );
+    assert_eq!(
+        row_count(&db, "SELECT * FROM t WHERE id = 5 LIMIT 10 OFFSET 1"),
+        0
+    );
+}
+
+#[test]
+fn pk_lookup_with_limit_one_still_returns_the_row() {
+    let db = Database::open("memory://").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (5, 'x')", ()).unwrap();
+
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE id = 5 LIMIT 1"), 1);
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE id = 5 LIMIT 1"), 1);
+}
+
+#[test]
+fn prepared_pk_lookup_respects_limit_zero() {
+    let db = Database::open("memory://").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (5, 'x')", ()).unwrap();
+
+    let stmt = db.prepare("SELECT * FROM t WHERE id = $1 LIMIT 0").unwrap();
+    for _ in 0..3 {
+        assert_eq!(stmt.query((5,)).unwrap().collect_vec().unwrap().len(), 0);
+    }
+
+    let stmt = db
+        .prepare("SELECT * FROM t WHERE id = $1 LIMIT 5 OFFSET 2")
+        .unwrap();
+    for _ in 0..3 {
+        assert_eq!(stmt.query((5,)).unwrap().collect_vec().unwrap().len(), 0);
+    }
+}
+
+#[test]
+fn prepared_pk_lookup_survives_wrongly_typed_first_execution() {
+    let db = Database::open("memory://").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (5, 'x')", ()).unwrap();
+
+    let stmt = db.prepare("SELECT * FROM t WHERE id = $1").unwrap();
+
+    // First execution with a text parameter: no match, standard path
+    assert_eq!(
+        stmt.query(("abc",)).unwrap().collect_vec().unwrap().len(),
+        0
+    );
+    // Later integer executions must still return the row (and may fast-path)
+    for _ in 0..3 {
+        assert_eq!(stmt.query((5,)).unwrap().collect_vec().unwrap().len(), 1);
+    }
+    // Interleave wrong and right types
+    assert_eq!(
+        stmt.query(("abc",)).unwrap().collect_vec().unwrap().len(),
+        0
+    );
+    assert_eq!(stmt.query((5,)).unwrap().collect_vec().unwrap().len(), 1);
+}


### PR DESCRIPTION
Wave A of the executor performance campaign (from the 72-finding agent audit). Targets the fixed cost every cached/prepared statement pays before real work starts.

## Changes

1. **One transaction-state capture per statement.** `execute_cached` / `execute_with_cached_plan` capture the active-transaction id once and pass it down. Before, a cached SELECT could take the `active_transaction` mutex up to 6 times (PK probe, COUNT(DISTINCT) probe, COUNT(*) probe, execute_statement injection, plus execution-time acquisitions). The compiled probes are now lock-free and gated by the caller (same contract as the existing `_with_params` variants); the probe battery is deduplicated into one `try_compiled_fast_paths` helper used by all three entry points. `execute_statement` no longer unconditionally clones the `ExecutionContext` in autocommit, and the redundant uncompiled PK-detection pass is skipped when the compiled battery already ran (any None from the compiled probe implies None from the uncompiled one).
2. **Negative statistics caching** (`planner.rs`). A fresh cache entry with `row_count == 0` is now the authoritative "no stats collected" verdict. Before, every SELECT-with-WHERE on a non-ANALYZEd table paid `begin_transaction` + `list_tables` + two system-table existence scans, per statement, forever. The only stats writer (`execute_analyze`) already invalidates the entry per table (verified: statistics.rs:94); the 300s TTL bounds staleness for external changes. The LRU `touch()` is now an atomic stamp under the read lock instead of a write-lock round trip per cache hit.
3. **Classification attached to the cached plan** (`OnceLock<Arc<QueryClassification>>` in `CachedQueryPlan`/`CachedPlanRef`). Classification is a pure function of the immutable AST, so repeated executions skip the full-AST structural hash and the process-global classification-cache mutex. First execution still populates through the global cache (cross-plan dedup preserved).
4. **Column names as the schema's cached Arc.** `execute_simple_table_scan` used `column_names_owned().to_vec()`, a deep clone of every column name per SELECT; now the cached `CompactArc` flows through, and `ScannerResult` stores the Arc. One site (`execute_temporal_query`, AS OF path) intentionally keeps its clone: not a hot path.
5. **Literal LIMIT/OFFSET fast path.** `LIMIT 10` no longer goes through expression compile + global program cache + VM execution per statement.

Deferred to Wave D by design: the `subquery.to_string()` cache keys (audit items at index_optimizer.rs:907 / subquery.rs:1704). That is a cache-identity change; per the PR #36 lesson it needs dual-hash keys plus a collision discrimination test, and it belongs with the subquery-cache cluster.

## Measurements

Release build, `memory://`, 10K-row table, best of 3 runs (micro-bench in session scratchpad, not committed):

| Scenario | main | this PR | speedup |
|---|---|---|---|
| prepared point PK SELECT | 1464 ns | 915 ns | **1.60x** |
| same-SQL point SELECT (plan cache) | 1547 ns | 999 ns | 1.55x |
| WHERE + LIMIT 10 (literal) | 2122 ns | 1423 ns | 1.49x |
| COUNT range, no ANALYZE | 109.2 us | 77.0 us | 1.42x |
| COUNT range, ANALYZE'd | 102.4 us | 80.4 us | 1.27x |

## Safety notes for review

- The probe battery runs only when no explicit transaction is active; INSERT's compiled path is exempt and handles the transaction itself (unchanged behavior).
- Skipping the uncompiled PK probe after the compiled battery is safe because both share the same detection outcome: NotOptimizable epochs, param-type mismatches, and epoch-changed recompiles all end in the same fallback.
- Negative stats entries can only go stale if something writes sys stats without invalidating; the only writer is ANALYZE, which invalidates.

## Verification

fmt + clippy `-D warnings` clean; both suites green, 4890/4890 each (default and `test-filedb`).