### PR TITLE
fix: float constants against INTEGER columns compare numerically

### DIFF
--- a/src/core/value.rs
+++ b/src/core/value.rs
@@ -390,7 +390,21 @@ impl Value {
             return self.compare_same_type(other);
         }
 
-        // Cross-type numeric comparison (integer vs float)
+        // Cross-type numeric comparison (integer vs float), exact at the
+        // extremes where `i as f64` rounds
+        match (self, other) {
+            (Value::Integer(i), Value::Float(f)) => {
+                if let Some(ord) = cmp_i64_f64(*i, *f) {
+                    return Ok(ord);
+                }
+            }
+            (Value::Float(f), Value::Integer(i)) => {
+                if let Some(ord) = cmp_i64_f64(*i, *f) {
+                    return Ok(ord.reverse());
+                }
+            }
+            _ => {}
+        }
         if self.data_type().is_numeric() && other.data_type().is_numeric() {
             let v1 = self.as_float64().unwrap();
             let v2 = other.as_float64().unwrap();
@@ -892,7 +906,7 @@ impl PartialEq for Value {
             // Cross-type numeric comparison: Integer vs Float
             // This is critical for queries like WHERE id = 5.0 or WHERE price = 100
             (Value::Integer(i), Value::Float(f)) | (Value::Float(f), Value::Integer(i)) => {
-                *f == (*i as f64)
+                cmp_i64_f64(*i, *f) == Some(std::cmp::Ordering::Equal)
             }
             (Value::Text(a), Value::Text(b)) => a == b,
             (Value::Boolean(a), Value::Boolean(b)) => a == b,
@@ -904,6 +918,73 @@ impl PartialEq for Value {
 }
 
 impl Eq for Value {}
+
+/// Compare an i64 with an f64 exactly. `i as f64` rounds above 2^53, so
+/// e.g. i64::MAX as f64 == 2^63 and a naive float comparison calls
+/// i64::MAX equal to 9223372036854775808.0, which no i64 equals.
+pub fn cmp_i64_f64(i: i64, f: f64) -> Option<std::cmp::Ordering> {
+    use std::cmp::Ordering;
+    if f.is_nan() {
+        return None;
+    }
+    const I64_MIN_F: f64 = -9_223_372_036_854_775_808.0; // -2^63, exact
+    const I64_MAX_PLUS_1_F: f64 = 9_223_372_036_854_775_808.0; // 2^63
+    if f < I64_MIN_F {
+        return Some(Ordering::Greater);
+    }
+    if f >= I64_MAX_PLUS_1_F {
+        return Some(Ordering::Less);
+    }
+    // f is in i64 range: trunc converts exactly
+    let ft = f.trunc();
+    let fi = ft as i64;
+    Some(match i.cmp(&fi) {
+        Ordering::Equal => {
+            let frac = f - ft;
+            if frac > 0.0 {
+                Ordering::Less
+            } else if frac < 0.0 {
+                Ordering::Greater
+            } else {
+                Ordering::Equal
+            }
+        }
+        ord => ord,
+    })
+}
+
+/// Operator wrappers over `cmp_i64_f64`. NaN compares false except `!=`,
+/// matching IEEE semantics of the casts they replace.
+#[inline]
+pub fn i64_eq_f64(i: i64, f: f64) -> bool {
+    cmp_i64_f64(i, f) == Some(std::cmp::Ordering::Equal)
+}
+#[inline]
+pub fn i64_ne_f64(i: i64, f: f64) -> bool {
+    cmp_i64_f64(i, f) != Some(std::cmp::Ordering::Equal)
+}
+#[inline]
+pub fn i64_lt_f64(i: i64, f: f64) -> bool {
+    cmp_i64_f64(i, f) == Some(std::cmp::Ordering::Less)
+}
+#[inline]
+pub fn i64_le_f64(i: i64, f: f64) -> bool {
+    matches!(
+        cmp_i64_f64(i, f),
+        Some(std::cmp::Ordering::Less) | Some(std::cmp::Ordering::Equal)
+    )
+}
+#[inline]
+pub fn i64_gt_f64(i: i64, f: f64) -> bool {
+    cmp_i64_f64(i, f) == Some(std::cmp::Ordering::Greater)
+}
+#[inline]
+pub fn i64_ge_f64(i: i64, f: f64) -> bool {
+    matches!(
+        cmp_i64_f64(i, f),
+        Some(std::cmp::Ordering::Greater) | Some(std::cmp::Ordering::Equal)
+    )
+}
 
 /// Maximum i64 value that can be safely hashed as i64 without f64 conversion.
 /// Integers in the range [I64_SAFE_MIN, I64_SAFE_MAX] have unique f64 representations,
@@ -1876,5 +1957,28 @@ mod tests {
         // Verify they're equal in PartialEq
         assert_eq!(nan1, nan2);
         assert_eq!(nan2, nan3);
+    }
+
+    #[test]
+    fn cmp_i64_f64_is_exact_at_extremes() {
+        use std::cmp::Ordering::*;
+        // In-range basics
+        assert_eq!(cmp_i64_f64(5, 5.0), Some(Equal));
+        assert_eq!(cmp_i64_f64(5, 5.5), Some(Less));
+        assert_eq!(cmp_i64_f64(-5, -5.5), Some(Greater));
+        // i64::MAX as f64 rounds to 2^63; the naive cast comparison calls
+        // them equal, the exact comparison must not
+        assert_eq!(cmp_i64_f64(i64::MAX, 9_223_372_036_854_775_808.0), Some(Less));
+        assert_eq!(cmp_i64_f64(i64::MAX, 9_223_372_036_854_774_784.0), Some(Greater));
+        assert_eq!(cmp_i64_f64(i64::MIN, -9_223_372_036_854_775_808.0), Some(Equal));
+        // Out-of-range floats
+        assert_eq!(cmp_i64_f64(i64::MAX, 1e19), Some(Less));
+        assert_eq!(cmp_i64_f64(i64::MIN, -1e19), Some(Greater));
+        assert_eq!(cmp_i64_f64(0, f64::INFINITY), Some(Less));
+        assert_eq!(cmp_i64_f64(0, f64::NEG_INFINITY), Some(Greater));
+        assert_eq!(cmp_i64_f64(0, f64::NAN), None);
+        // PartialEq consequences
+        assert_ne!(Value::Integer(i64::MAX), Value::Float(9_223_372_036_854_775_808.0));
+        assert_eq!(Value::Integer(5), Value::Float(5.0));
     }
 }

--- a/src/core/value.rs
+++ b/src/core/value.rs
@@ -953,6 +953,15 @@ pub fn cmp_i64_f64(i: i64, f: f64) -> Option<std::cmp::Ordering> {
     })
 }
 
+/// The exact f64 for an i64, when one exists. Overflow-safe at
+/// i64::MIN (which IS exactly representable; an `i.abs()` range check
+/// both panics there and wrongly rejects it).
+#[inline]
+pub fn lossless_f64_from_i64(i: i64) -> Option<f64> {
+    let f = i as f64;
+    (cmp_i64_f64(i, f) == Some(std::cmp::Ordering::Equal)).then_some(f)
+}
+
 /// Operator wrappers over `cmp_i64_f64`. NaN compares false except `!=`,
 /// matching IEEE semantics of the casts they replace.
 #[inline]

--- a/src/core/value.rs
+++ b/src/core/value.rs
@@ -1968,9 +1968,18 @@ mod tests {
         assert_eq!(cmp_i64_f64(-5, -5.5), Some(Greater));
         // i64::MAX as f64 rounds to 2^63; the naive cast comparison calls
         // them equal, the exact comparison must not
-        assert_eq!(cmp_i64_f64(i64::MAX, 9_223_372_036_854_775_808.0), Some(Less));
-        assert_eq!(cmp_i64_f64(i64::MAX, 9_223_372_036_854_774_784.0), Some(Greater));
-        assert_eq!(cmp_i64_f64(i64::MIN, -9_223_372_036_854_775_808.0), Some(Equal));
+        assert_eq!(
+            cmp_i64_f64(i64::MAX, 9_223_372_036_854_775_808.0),
+            Some(Less)
+        );
+        assert_eq!(
+            cmp_i64_f64(i64::MAX, 9_223_372_036_854_774_784.0),
+            Some(Greater)
+        );
+        assert_eq!(
+            cmp_i64_f64(i64::MIN, -9_223_372_036_854_775_808.0),
+            Some(Equal)
+        );
         // Out-of-range floats
         assert_eq!(cmp_i64_f64(i64::MAX, 1e19), Some(Less));
         assert_eq!(cmp_i64_f64(i64::MIN, -1e19), Some(Greater));
@@ -1978,7 +1987,10 @@ mod tests {
         assert_eq!(cmp_i64_f64(0, f64::NEG_INFINITY), Some(Greater));
         assert_eq!(cmp_i64_f64(0, f64::NAN), None);
         // PartialEq consequences
-        assert_ne!(Value::Integer(i64::MAX), Value::Float(9_223_372_036_854_775_808.0));
+        assert_ne!(
+            Value::Integer(i64::MAX),
+            Value::Float(9_223_372_036_854_775_808.0)
+        );
         assert_eq!(Value::Integer(5), Value::Float(5.0));
     }
 }

--- a/src/core/value.rs
+++ b/src/core/value.rs
@@ -1168,20 +1168,16 @@ impl Ord for Value {
         // This MUST be consistent with PartialEq where Integer(5) == Float(5.0)
         match (self, other) {
             (Value::Integer(i), Value::Float(f)) => {
-                let i_as_f64 = *i as f64;
-                // Handle NaN: NaN is ordered last
-                if f.is_nan() {
-                    return Ordering::Less; // Any number < NaN
-                }
-                return i_as_f64.partial_cmp(f).unwrap_or(Ordering::Equal);
+                // Exact comparison: `i as f64` rounds above 2^53 and would
+                // make Ord call i64::MAX equal to Float(2^63), breaking the
+                // Eq/Ord consistency the BTree indexes rely on.
+                // NaN orders last (cmp_i64_f64 returns None only for NaN).
+                return crate::core::value::cmp_i64_f64(*i, *f).unwrap_or(Ordering::Less);
             }
             (Value::Float(f), Value::Integer(i)) => {
-                let i_as_f64 = *i as f64;
-                // Handle NaN: NaN is ordered last
-                if f.is_nan() {
-                    return Ordering::Greater; // NaN > any number
-                }
-                return f.partial_cmp(&i_as_f64).unwrap_or(Ordering::Equal);
+                return crate::core::value::cmp_i64_f64(*i, *f)
+                    .map(Ordering::reverse)
+                    .unwrap_or(Ordering::Greater);
             }
             _ => {} // Continue to same-type comparison
         }
@@ -1992,5 +1988,21 @@ mod tests {
             Value::Float(9_223_372_036_854_775_808.0)
         );
         assert_eq!(Value::Integer(5), Value::Float(5.0));
+
+        // Eq/Ord/PartialOrd must agree at the extremes: a BTree index
+        // merges keys that Ord calls Equal
+        let i = Value::Integer(i64::MAX);
+        let f = Value::Float(9_223_372_036_854_775_808.0);
+        assert_eq!(i.cmp(&f), Less);
+        assert_eq!(f.cmp(&i), Greater);
+        assert_eq!(i.partial_cmp(&f), Some(Less));
+        assert_eq!(Value::Integer(5).cmp(&Value::Float(5.0)), Equal);
+        assert_eq!(
+            Value::Integer(i64::MIN).cmp(&Value::Float(-9_223_372_036_854_775_808.0)),
+            Equal
+        );
+        // NaN ordering: NaN last, both directions consistent
+        assert_eq!(Value::Integer(0).cmp(&Value::Float(f64::NAN)), Less);
+        assert_eq!(Value::Float(f64::NAN).cmp(&Value::Integer(0)), Greater);
     }
 }

--- a/src/executor/expression/vm.rs
+++ b/src/executor/expression/vm.rs
@@ -406,8 +406,12 @@ impl ExprVM {
                     let result = match (&a, &b) {
                         (Value::Integer(x), Value::Integer(y)) => Value::Boolean(*x < *y),
                         (Value::Float(x), Value::Float(y)) => Value::Boolean(*x < *y),
-                        (Value::Integer(x), Value::Float(y)) => Value::Boolean((*x as f64) < *y),
-                        (Value::Float(x), Value::Integer(y)) => Value::Boolean(*x < (*y as f64)),
+                        (Value::Integer(x), Value::Float(y)) => {
+                            Value::Boolean(crate::core::value::i64_lt_f64(*x, *y))
+                        }
+                        (Value::Float(x), Value::Integer(y)) => {
+                            Value::Boolean(crate::core::value::i64_gt_f64(*y, *x))
+                        }
                         _ => self.compare_values(&a, &b, std::cmp::Ordering::Less),
                     };
                     self.stack.push(result);
@@ -421,8 +425,12 @@ impl ExprVM {
                     let result = match (&a, &b) {
                         (Value::Integer(x), Value::Integer(y)) => Value::Boolean(*x <= *y),
                         (Value::Float(x), Value::Float(y)) => Value::Boolean(*x <= *y),
-                        (Value::Integer(x), Value::Float(y)) => Value::Boolean((*x as f64) <= *y),
-                        (Value::Float(x), Value::Integer(y)) => Value::Boolean(*x <= (*y as f64)),
+                        (Value::Integer(x), Value::Float(y)) => {
+                            Value::Boolean(crate::core::value::i64_le_f64(*x, *y))
+                        }
+                        (Value::Float(x), Value::Integer(y)) => {
+                            Value::Boolean(crate::core::value::i64_ge_f64(*y, *x))
+                        }
                         _ => match a.partial_cmp(&b) {
                             Some(std::cmp::Ordering::Less) | Some(std::cmp::Ordering::Equal) => {
                                 Value::Boolean(true)
@@ -442,8 +450,12 @@ impl ExprVM {
                     let result = match (&a, &b) {
                         (Value::Integer(x), Value::Integer(y)) => Value::Boolean(*x > *y),
                         (Value::Float(x), Value::Float(y)) => Value::Boolean(*x > *y),
-                        (Value::Integer(x), Value::Float(y)) => Value::Boolean((*x as f64) > *y),
-                        (Value::Float(x), Value::Integer(y)) => Value::Boolean(*x > (*y as f64)),
+                        (Value::Integer(x), Value::Float(y)) => {
+                            Value::Boolean(crate::core::value::i64_gt_f64(*x, *y))
+                        }
+                        (Value::Float(x), Value::Integer(y)) => {
+                            Value::Boolean(crate::core::value::i64_lt_f64(*y, *x))
+                        }
                         _ => self.compare_values(&a, &b, std::cmp::Ordering::Greater),
                     };
                     self.stack.push(result);
@@ -457,8 +469,12 @@ impl ExprVM {
                     let result = match (&a, &b) {
                         (Value::Integer(x), Value::Integer(y)) => Value::Boolean(*x >= *y),
                         (Value::Float(x), Value::Float(y)) => Value::Boolean(*x >= *y),
-                        (Value::Integer(x), Value::Float(y)) => Value::Boolean((*x as f64) >= *y),
-                        (Value::Float(x), Value::Integer(y)) => Value::Boolean(*x >= (*y as f64)),
+                        (Value::Integer(x), Value::Float(y)) => {
+                            Value::Boolean(crate::core::value::i64_ge_f64(*x, *y))
+                        }
+                        (Value::Float(x), Value::Integer(y)) => {
+                            Value::Boolean(crate::core::value::i64_le_f64(*y, *x))
+                        }
                         _ => match a.partial_cmp(&b) {
                             Some(std::cmp::Ordering::Greater) | Some(std::cmp::Ordering::Equal) => {
                                 Value::Boolean(true)
@@ -2128,8 +2144,12 @@ impl ExprVM {
                     let result = match (&*a, &*b) {
                         (Value::Integer(x), Value::Integer(y)) => Value::Boolean(*x < *y),
                         (Value::Float(x), Value::Float(y)) => Value::Boolean(*x < *y),
-                        (Value::Integer(x), Value::Float(y)) => Value::Boolean((*x as f64) < *y),
-                        (Value::Float(x), Value::Integer(y)) => Value::Boolean(*x < (*y as f64)),
+                        (Value::Integer(x), Value::Float(y)) => {
+                            Value::Boolean(crate::core::value::i64_lt_f64(*x, *y))
+                        }
+                        (Value::Float(x), Value::Integer(y)) => {
+                            Value::Boolean(crate::core::value::i64_gt_f64(*y, *x))
+                        }
                         _ => self.compare_values(&a, &b, std::cmp::Ordering::Less),
                     };
                     stack.push(Cow::Owned(result));
@@ -2142,8 +2162,12 @@ impl ExprVM {
                     let result = match (&*a, &*b) {
                         (Value::Integer(x), Value::Integer(y)) => Value::Boolean(*x <= *y),
                         (Value::Float(x), Value::Float(y)) => Value::Boolean(*x <= *y),
-                        (Value::Integer(x), Value::Float(y)) => Value::Boolean((*x as f64) <= *y),
-                        (Value::Float(x), Value::Integer(y)) => Value::Boolean(*x <= (*y as f64)),
+                        (Value::Integer(x), Value::Float(y)) => {
+                            Value::Boolean(crate::core::value::i64_le_f64(*x, *y))
+                        }
+                        (Value::Float(x), Value::Integer(y)) => {
+                            Value::Boolean(crate::core::value::i64_ge_f64(*y, *x))
+                        }
                         _ => match (*a).partial_cmp(&*b) {
                             Some(std::cmp::Ordering::Less) | Some(std::cmp::Ordering::Equal) => {
                                 Value::Boolean(true)
@@ -2162,8 +2186,12 @@ impl ExprVM {
                     let result = match (&*a, &*b) {
                         (Value::Integer(x), Value::Integer(y)) => Value::Boolean(*x > *y),
                         (Value::Float(x), Value::Float(y)) => Value::Boolean(*x > *y),
-                        (Value::Integer(x), Value::Float(y)) => Value::Boolean((*x as f64) > *y),
-                        (Value::Float(x), Value::Integer(y)) => Value::Boolean(*x > (*y as f64)),
+                        (Value::Integer(x), Value::Float(y)) => {
+                            Value::Boolean(crate::core::value::i64_gt_f64(*x, *y))
+                        }
+                        (Value::Float(x), Value::Integer(y)) => {
+                            Value::Boolean(crate::core::value::i64_lt_f64(*y, *x))
+                        }
                         _ => self.compare_values(&a, &b, std::cmp::Ordering::Greater),
                     };
                     stack.push(Cow::Owned(result));
@@ -2176,8 +2204,12 @@ impl ExprVM {
                     let result = match (&*a, &*b) {
                         (Value::Integer(x), Value::Integer(y)) => Value::Boolean(*x >= *y),
                         (Value::Float(x), Value::Float(y)) => Value::Boolean(*x >= *y),
-                        (Value::Integer(x), Value::Float(y)) => Value::Boolean((*x as f64) >= *y),
-                        (Value::Float(x), Value::Integer(y)) => Value::Boolean(*x >= (*y as f64)),
+                        (Value::Integer(x), Value::Float(y)) => {
+                            Value::Boolean(crate::core::value::i64_ge_f64(*x, *y))
+                        }
+                        (Value::Float(x), Value::Integer(y)) => {
+                            Value::Boolean(crate::core::value::i64_le_f64(*y, *x))
+                        }
                         _ => match (*a).partial_cmp(&*b) {
                             Some(std::cmp::Ordering::Greater) | Some(std::cmp::Ordering::Equal) => {
                                 Value::Boolean(true)
@@ -2795,63 +2827,63 @@ impl ExprVM {
         match op {
             Op::GtColumnConst(idx, Value::Integer(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Integer(v)) => *v > *threshold,
-                Some(Value::Float(v)) => *v > *threshold as f64,
+                Some(Value::Float(v)) => crate::core::value::i64_lt_f64(*threshold, *v),
                 _ => false,
             },
             Op::GtColumnConst(idx, Value::Float(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Float(v)) => *v > *threshold,
-                Some(Value::Integer(v)) => (*v as f64) > *threshold,
+                Some(Value::Integer(v)) => crate::core::value::i64_gt_f64(*v, *threshold),
                 _ => false,
             },
             Op::LtColumnConst(idx, Value::Integer(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Integer(v)) => *v < *threshold,
-                Some(Value::Float(v)) => *v < *threshold as f64,
+                Some(Value::Float(v)) => crate::core::value::i64_gt_f64(*threshold, *v),
                 _ => false,
             },
             Op::LtColumnConst(idx, Value::Float(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Float(v)) => *v < *threshold,
-                Some(Value::Integer(v)) => (*v as f64) < *threshold,
+                Some(Value::Integer(v)) => crate::core::value::i64_lt_f64(*v, *threshold),
                 _ => false,
             },
             Op::GeColumnConst(idx, Value::Integer(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Integer(v)) => *v >= *threshold,
-                Some(Value::Float(v)) => *v >= *threshold as f64,
+                Some(Value::Float(v)) => crate::core::value::i64_le_f64(*threshold, *v),
                 _ => false,
             },
             Op::GeColumnConst(idx, Value::Float(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Float(v)) => *v >= *threshold,
-                Some(Value::Integer(v)) => (*v as f64) >= *threshold,
+                Some(Value::Integer(v)) => crate::core::value::i64_ge_f64(*v, *threshold),
                 _ => false,
             },
             Op::LeColumnConst(idx, Value::Integer(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Integer(v)) => *v <= *threshold,
-                Some(Value::Float(v)) => *v <= *threshold as f64,
+                Some(Value::Float(v)) => crate::core::value::i64_ge_f64(*threshold, *v),
                 _ => false,
             },
             Op::LeColumnConst(idx, Value::Float(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Float(v)) => *v <= *threshold,
-                Some(Value::Integer(v)) => (*v as f64) <= *threshold,
+                Some(Value::Integer(v)) => crate::core::value::i64_le_f64(*v, *threshold),
                 _ => false,
             },
             Op::EqColumnConst(idx, Value::Integer(val)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Integer(v)) => *v == *val,
-                Some(Value::Float(v)) => *v == *val as f64,
+                Some(Value::Float(v)) => crate::core::value::i64_eq_f64(*val, *v),
                 _ => false,
             },
             Op::EqColumnConst(idx, Value::Float(val)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Float(v)) => *v == *val,
-                Some(Value::Integer(v)) => (*v as f64) == *val,
+                Some(Value::Integer(v)) => crate::core::value::i64_eq_f64(*v, *val),
                 _ => false,
             },
             Op::NeColumnConst(idx, Value::Integer(val)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Integer(v)) => *v != *val,
-                Some(Value::Float(v)) => *v != *val as f64,
+                Some(Value::Float(v)) => crate::core::value::i64_ne_f64(*val, *v),
                 Some(Value::Null(_)) => false,
                 _ => true,
             },
             Op::NeColumnConst(idx, Value::Float(val)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Float(v)) => *v != *val,
-                Some(Value::Integer(v)) => (*v as f64) != *val,
+                Some(Value::Integer(v)) => crate::core::value::i64_ne_f64(*v, *val),
                 Some(Value::Null(_)) => false,
                 _ => true,
             },
@@ -2860,28 +2892,34 @@ impl ExprVM {
             Op::BetweenColumnConst(idx, Value::Integer(lo), Value::Integer(hi)) => {
                 match ctx.row.get(*idx as usize) {
                     Some(Value::Integer(v)) => *v >= *lo && *v <= *hi,
-                    Some(Value::Float(v)) => *v >= *lo as f64 && *v <= *hi as f64,
+                    Some(Value::Float(v)) => {
+                        crate::core::value::i64_le_f64(*lo, *v)
+                            && crate::core::value::i64_ge_f64(*hi, *v)
+                    }
                     _ => false,
                 }
             }
             Op::BetweenColumnConst(idx, Value::Float(lo), Value::Float(hi)) => {
                 match ctx.row.get(*idx as usize) {
                     Some(Value::Float(v)) => *v >= *lo && *v <= *hi,
-                    Some(Value::Integer(v)) => (*v as f64) >= *lo && (*v as f64) <= *hi,
+                    Some(Value::Integer(v)) => {
+                        crate::core::value::i64_ge_f64(*v, *lo)
+                            && crate::core::value::i64_le_f64(*v, *hi)
+                    }
                     _ => false,
                 }
             }
             Op::BetweenColumnConst(idx, Value::Integer(lo), Value::Float(hi)) => {
                 match ctx.row.get(*idx as usize) {
-                    Some(Value::Float(v)) => *v >= *lo as f64 && *v <= *hi,
-                    Some(Value::Integer(v)) => (*v as f64) >= *lo as f64 && (*v as f64) <= *hi,
+                    Some(Value::Float(v)) => crate::core::value::i64_le_f64(*lo, *v) && *v <= *hi,
+                    Some(Value::Integer(v)) => *v >= *lo && crate::core::value::i64_le_f64(*v, *hi),
                     _ => false,
                 }
             }
             Op::BetweenColumnConst(idx, Value::Float(lo), Value::Integer(hi)) => {
                 match ctx.row.get(*idx as usize) {
-                    Some(Value::Float(v)) => *v >= *lo && *v <= *hi as f64,
-                    Some(Value::Integer(v)) => (*v as f64) >= *lo && (*v as f64) <= *hi as f64,
+                    Some(Value::Float(v)) => *v >= *lo && crate::core::value::i64_ge_f64(*hi, *v),
+                    Some(Value::Integer(v)) => crate::core::value::i64_ge_f64(*v, *lo) && *v <= *hi,
                     _ => false,
                 }
             }
@@ -2928,73 +2966,73 @@ impl ExprVM {
         match op {
             Op::GtColumnConst(idx, Value::Integer(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Integer(v)) => Some(*v > *threshold),
-                Some(Value::Float(v)) => Some(*v > *threshold as f64),
+                Some(Value::Float(v)) => Some(crate::core::value::i64_lt_f64(*threshold, *v)),
                 Some(Value::Null(_)) | None => None,
                 _ => Some(false),
             },
             Op::GtColumnConst(idx, Value::Float(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Float(v)) => Some(*v > *threshold),
-                Some(Value::Integer(v)) => Some((*v as f64) > *threshold),
+                Some(Value::Integer(v)) => Some(crate::core::value::i64_gt_f64(*v, *threshold)),
                 Some(Value::Null(_)) | None => None,
                 _ => Some(false),
             },
             Op::LtColumnConst(idx, Value::Integer(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Integer(v)) => Some(*v < *threshold),
-                Some(Value::Float(v)) => Some(*v < *threshold as f64),
+                Some(Value::Float(v)) => Some(crate::core::value::i64_gt_f64(*threshold, *v)),
                 Some(Value::Null(_)) | None => None,
                 _ => Some(false),
             },
             Op::LtColumnConst(idx, Value::Float(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Float(v)) => Some(*v < *threshold),
-                Some(Value::Integer(v)) => Some((*v as f64) < *threshold),
+                Some(Value::Integer(v)) => Some(crate::core::value::i64_lt_f64(*v, *threshold)),
                 Some(Value::Null(_)) | None => None,
                 _ => Some(false),
             },
             Op::GeColumnConst(idx, Value::Integer(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Integer(v)) => Some(*v >= *threshold),
-                Some(Value::Float(v)) => Some(*v >= *threshold as f64),
+                Some(Value::Float(v)) => Some(crate::core::value::i64_le_f64(*threshold, *v)),
                 Some(Value::Null(_)) | None => None,
                 _ => Some(false),
             },
             Op::GeColumnConst(idx, Value::Float(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Float(v)) => Some(*v >= *threshold),
-                Some(Value::Integer(v)) => Some((*v as f64) >= *threshold),
+                Some(Value::Integer(v)) => Some(crate::core::value::i64_ge_f64(*v, *threshold)),
                 Some(Value::Null(_)) | None => None,
                 _ => Some(false),
             },
             Op::LeColumnConst(idx, Value::Integer(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Integer(v)) => Some(*v <= *threshold),
-                Some(Value::Float(v)) => Some(*v <= *threshold as f64),
+                Some(Value::Float(v)) => Some(crate::core::value::i64_ge_f64(*threshold, *v)),
                 Some(Value::Null(_)) | None => None,
                 _ => Some(false),
             },
             Op::LeColumnConst(idx, Value::Float(threshold)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Float(v)) => Some(*v <= *threshold),
-                Some(Value::Integer(v)) => Some((*v as f64) <= *threshold),
+                Some(Value::Integer(v)) => Some(crate::core::value::i64_le_f64(*v, *threshold)),
                 Some(Value::Null(_)) | None => None,
                 _ => Some(false),
             },
             Op::EqColumnConst(idx, Value::Integer(val)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Integer(v)) => Some(*v == *val),
-                Some(Value::Float(v)) => Some(*v == *val as f64),
+                Some(Value::Float(v)) => Some(crate::core::value::i64_eq_f64(*val, *v)),
                 Some(Value::Null(_)) | None => None,
                 _ => Some(false),
             },
             Op::EqColumnConst(idx, Value::Float(val)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Float(v)) => Some(*v == *val),
-                Some(Value::Integer(v)) => Some((*v as f64) == *val),
+                Some(Value::Integer(v)) => Some(crate::core::value::i64_eq_f64(*v, *val)),
                 Some(Value::Null(_)) | None => None,
                 _ => Some(false),
             },
             Op::NeColumnConst(idx, Value::Integer(val)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Integer(v)) => Some(*v != *val),
-                Some(Value::Float(v)) => Some(*v != *val as f64),
+                Some(Value::Float(v)) => Some(crate::core::value::i64_ne_f64(*val, *v)),
                 Some(Value::Null(_)) | None => None,
                 _ => Some(true),
             },
             Op::NeColumnConst(idx, Value::Float(val)) => match ctx.row.get(*idx as usize) {
                 Some(Value::Float(v)) => Some(*v != *val),
-                Some(Value::Integer(v)) => Some((*v as f64) != *val),
+                Some(Value::Integer(v)) => Some(crate::core::value::i64_ne_f64(*v, *val)),
                 Some(Value::Null(_)) | None => None,
                 _ => Some(true),
             },
@@ -3005,7 +3043,10 @@ impl ExprVM {
             Op::BetweenColumnConst(idx, Value::Integer(lo), Value::Integer(hi)) => {
                 match ctx.row.get(*idx as usize) {
                     Some(Value::Integer(v)) => Some(*v >= *lo && *v <= *hi),
-                    Some(Value::Float(v)) => Some(*v >= *lo as f64 && *v <= *hi as f64),
+                    Some(Value::Float(v)) => Some(
+                        crate::core::value::i64_le_f64(*lo, *v)
+                            && crate::core::value::i64_ge_f64(*hi, *v),
+                    ),
                     Some(Value::Null(_)) | None => None,
                     _ => Some(false),
                 }
@@ -3013,14 +3054,19 @@ impl ExprVM {
             Op::BetweenColumnConst(idx, Value::Float(lo), Value::Float(hi)) => {
                 match ctx.row.get(*idx as usize) {
                     Some(Value::Float(v)) => Some(*v >= *lo && *v <= *hi),
-                    Some(Value::Integer(v)) => Some((*v as f64) >= *lo && (*v as f64) <= *hi),
+                    Some(Value::Integer(v)) => Some(
+                        crate::core::value::i64_ge_f64(*v, *lo)
+                            && crate::core::value::i64_le_f64(*v, *hi),
+                    ),
                     Some(Value::Null(_)) | None => None,
                     _ => Some(false),
                 }
             }
             Op::BetweenColumnConst(idx, Value::Integer(lo), Value::Float(hi)) => {
                 match ctx.row.get(*idx as usize) {
-                    Some(Value::Float(v)) => Some(*v >= *lo as f64 && *v <= *hi),
+                    Some(Value::Float(v)) => {
+                        Some(crate::core::value::i64_le_f64(*lo, *v) && *v <= *hi)
+                    }
                     Some(Value::Integer(v)) => {
                         Some((*v as f64) >= *lo as f64 && (*v as f64) <= *hi)
                     }
@@ -3030,7 +3076,9 @@ impl ExprVM {
             }
             Op::BetweenColumnConst(idx, Value::Float(lo), Value::Integer(hi)) => {
                 match ctx.row.get(*idx as usize) {
-                    Some(Value::Float(v)) => Some(*v >= *lo && *v <= *hi as f64),
+                    Some(Value::Float(v)) => {
+                        Some(*v >= *lo && crate::core::value::i64_ge_f64(*hi, *v))
+                    }
                     Some(Value::Integer(v)) => {
                         Some((*v as f64) >= *lo && (*v as f64) <= *hi as f64)
                     }
@@ -3203,7 +3251,7 @@ impl ExprVM {
     fn gt_float(col_val: &Value, threshold: f64) -> Value {
         match col_val {
             Value::Float(v) => Value::Boolean(*v > threshold),
-            Value::Integer(v) => Value::Boolean((*v as f64) > threshold),
+            Value::Integer(v) => Value::Boolean(crate::core::value::i64_gt_f64(*v, threshold)),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(false),
         }
@@ -3225,7 +3273,7 @@ impl ExprVM {
     fn lt_float(col_val: &Value, threshold: f64) -> Value {
         match col_val {
             Value::Float(v) => Value::Boolean(*v < threshold),
-            Value::Integer(v) => Value::Boolean((*v as f64) < threshold),
+            Value::Integer(v) => Value::Boolean(crate::core::value::i64_lt_f64(*v, threshold)),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(false),
         }
@@ -3247,7 +3295,7 @@ impl ExprVM {
     fn ge_float(col_val: &Value, threshold: f64) -> Value {
         match col_val {
             Value::Float(v) => Value::Boolean(*v >= threshold),
-            Value::Integer(v) => Value::Boolean((*v as f64) >= threshold),
+            Value::Integer(v) => Value::Boolean(crate::core::value::i64_ge_f64(*v, threshold)),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(false),
         }
@@ -3269,7 +3317,7 @@ impl ExprVM {
     fn le_float(col_val: &Value, threshold: f64) -> Value {
         match col_val {
             Value::Float(v) => Value::Boolean(*v <= threshold),
-            Value::Integer(v) => Value::Boolean((*v as f64) <= threshold),
+            Value::Integer(v) => Value::Boolean(crate::core::value::i64_le_f64(*v, threshold)),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(false),
         }
@@ -3280,7 +3328,7 @@ impl ExprVM {
     fn eq_int(col_val: &Value, val: i64) -> Value {
         match col_val {
             Value::Integer(v) => Value::Boolean(*v == val),
-            Value::Float(v) => Value::Boolean(*v == val as f64),
+            Value::Float(v) => Value::Boolean(crate::core::value::i64_eq_f64(val, *v)),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(false),
         }
@@ -3291,7 +3339,7 @@ impl ExprVM {
     fn eq_float(col_val: &Value, val: f64) -> Value {
         match col_val {
             Value::Float(v) => Value::Boolean(*v == val),
-            Value::Integer(v) => Value::Boolean((*v as f64) == val),
+            Value::Integer(v) => Value::Boolean(crate::core::value::i64_eq_f64(*v, val)),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(false),
         }
@@ -3302,7 +3350,7 @@ impl ExprVM {
     fn ne_int(col_val: &Value, val: i64) -> Value {
         match col_val {
             Value::Integer(v) => Value::Boolean(*v != val),
-            Value::Float(v) => Value::Boolean(*v != val as f64),
+            Value::Float(v) => Value::Boolean(crate::core::value::i64_ne_f64(val, *v)),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(true),
         }
@@ -3313,7 +3361,7 @@ impl ExprVM {
     fn ne_float(col_val: &Value, val: f64) -> Value {
         match col_val {
             Value::Float(v) => Value::Boolean(*v != val),
-            Value::Integer(v) => Value::Boolean((*v as f64) != val),
+            Value::Integer(v) => Value::Boolean(crate::core::value::i64_ne_f64(*v, val)),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(true),
         }
@@ -3335,7 +3383,9 @@ impl ExprVM {
     fn between_float(col_val: &Value, low: f64, high: f64) -> Value {
         match col_val {
             Value::Float(v) => Value::Boolean(*v >= low && *v <= high),
-            Value::Integer(v) => Value::Boolean((*v as f64) >= low && (*v as f64) <= high),
+            Value::Integer(v) => Value::Boolean(
+                crate::core::value::i64_ge_f64(*v, low) && crate::core::value::i64_le_f64(*v, high),
+            ),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(false),
         }

--- a/src/executor/expression/vm.rs
+++ b/src/executor/expression/vm.rs
@@ -717,10 +717,10 @@ impl ExprVM {
                             Self::between_float(col_val, *lo, *hi)
                         }
                         (Value::Integer(lo), Value::Float(hi)) => {
-                            Self::between_float(col_val, *lo as f64, *hi)
+                            Self::between_mixed_int_lo(col_val, *lo, *hi)
                         }
                         (Value::Float(lo), Value::Integer(hi)) => {
-                            Self::between_float(col_val, *lo, *hi as f64)
+                            Self::between_mixed_int_hi(col_val, *lo, *hi)
                         }
                         _ if col_val.is_null() || low.is_null() || high.is_null() => {
                             Value::Null(DataType::Boolean)
@@ -1399,23 +1399,27 @@ impl ExprVM {
                             Value::Boolean(*v >= *lo && *v <= *hi)
                         }
                         (Value::Integer(v), Value::Integer(lo), Value::Float(hi)) => {
-                            Value::Boolean((*v as f64) >= (*lo as f64) && (*v as f64) <= *hi)
+                            Value::Boolean(*v >= *lo && crate::core::value::i64_le_f64(*v, *hi))
                         }
                         (Value::Integer(v), Value::Float(lo), Value::Integer(hi)) => {
-                            Value::Boolean((*v as f64) >= *lo && (*v as f64) <= (*hi as f64))
+                            Value::Boolean(crate::core::value::i64_ge_f64(*v, *lo) && *v <= *hi)
                         }
                         (Value::Float(v), Value::Integer(lo), Value::Integer(hi)) => {
-                            Value::Boolean(*v >= (*lo as f64) && *v <= (*hi as f64))
+                            Value::Boolean(
+                                crate::core::value::i64_le_f64(*lo, *v)
+                                    && crate::core::value::i64_ge_f64(*hi, *v),
+                            )
                         }
                         (Value::Float(v), Value::Integer(lo), Value::Float(hi)) => {
-                            Value::Boolean(*v >= (*lo as f64) && *v <= *hi)
+                            Value::Boolean(crate::core::value::i64_le_f64(*lo, *v) && *v <= *hi)
                         }
                         (Value::Float(v), Value::Float(lo), Value::Integer(hi)) => {
-                            Value::Boolean(*v >= *lo && *v <= (*hi as f64))
+                            Value::Boolean(*v >= *lo && crate::core::value::i64_ge_f64(*hi, *v))
                         }
-                        (Value::Integer(v), Value::Float(lo), Value::Float(hi)) => {
-                            Value::Boolean((*v as f64) >= *lo && (*v as f64) <= *hi)
-                        }
+                        (Value::Integer(v), Value::Float(lo), Value::Float(hi)) => Value::Boolean(
+                            crate::core::value::i64_ge_f64(*v, *lo)
+                                && crate::core::value::i64_le_f64(*v, *hi),
+                        ),
                         _ if val.is_null() || low.is_null() || high.is_null() => {
                             Value::Null(DataType::Boolean)
                         }
@@ -1439,23 +1443,27 @@ impl ExprVM {
                             Value::Boolean(*v < *lo || *v > *hi)
                         }
                         (Value::Integer(v), Value::Integer(lo), Value::Float(hi)) => {
-                            Value::Boolean((*v as f64) < (*lo as f64) || (*v as f64) > *hi)
+                            Value::Boolean(*v < *lo || crate::core::value::i64_gt_f64(*v, *hi))
                         }
                         (Value::Integer(v), Value::Float(lo), Value::Integer(hi)) => {
-                            Value::Boolean((*v as f64) < *lo || (*v as f64) > (*hi as f64))
+                            Value::Boolean(crate::core::value::i64_lt_f64(*v, *lo) || *v > *hi)
                         }
                         (Value::Float(v), Value::Integer(lo), Value::Integer(hi)) => {
-                            Value::Boolean(*v < (*lo as f64) || *v > (*hi as f64))
+                            Value::Boolean(
+                                crate::core::value::i64_gt_f64(*lo, *v)
+                                    || crate::core::value::i64_lt_f64(*hi, *v),
+                            )
                         }
                         (Value::Float(v), Value::Integer(lo), Value::Float(hi)) => {
-                            Value::Boolean(*v < (*lo as f64) || *v > *hi)
+                            Value::Boolean(crate::core::value::i64_gt_f64(*lo, *v) || *v > *hi)
                         }
                         (Value::Float(v), Value::Float(lo), Value::Integer(hi)) => {
-                            Value::Boolean(*v < *lo || *v > (*hi as f64))
+                            Value::Boolean(*v < *lo || crate::core::value::i64_lt_f64(*hi, *v))
                         }
-                        (Value::Integer(v), Value::Float(lo), Value::Float(hi)) => {
-                            Value::Boolean((*v as f64) < *lo || (*v as f64) > *hi)
-                        }
+                        (Value::Integer(v), Value::Float(lo), Value::Float(hi)) => Value::Boolean(
+                            crate::core::value::i64_lt_f64(*v, *lo)
+                                || crate::core::value::i64_gt_f64(*v, *hi),
+                        ),
                         _ if val.is_null() || low.is_null() || high.is_null() => {
                             Value::Null(DataType::Boolean)
                         }
@@ -3068,7 +3076,7 @@ impl ExprVM {
                         Some(crate::core::value::i64_le_f64(*lo, *v) && *v <= *hi)
                     }
                     Some(Value::Integer(v)) => {
-                        Some((*v as f64) >= *lo as f64 && (*v as f64) <= *hi)
+                        Some(*v >= *lo && crate::core::value::i64_le_f64(*v, *hi))
                     }
                     Some(Value::Null(_)) | None => None,
                     _ => Some(false),
@@ -3080,7 +3088,7 @@ impl ExprVM {
                         Some(*v >= *lo && crate::core::value::i64_ge_f64(*hi, *v))
                     }
                     Some(Value::Integer(v)) => {
-                        Some((*v as f64) >= *lo && (*v as f64) <= *hi as f64)
+                        Some(crate::core::value::i64_ge_f64(*v, *lo) && *v <= *hi)
                     }
                     Some(Value::Null(_)) | None => None,
                     _ => Some(false),
@@ -3240,7 +3248,7 @@ impl ExprVM {
     fn gt_int(col_val: &Value, threshold: i64) -> Value {
         match col_val {
             Value::Integer(v) => Value::Boolean(*v > threshold),
-            Value::Float(v) => Value::Boolean(*v > threshold as f64),
+            Value::Float(v) => Value::Boolean(crate::core::value::i64_lt_f64(threshold, *v)),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(false),
         }
@@ -3262,7 +3270,7 @@ impl ExprVM {
     fn lt_int(col_val: &Value, threshold: i64) -> Value {
         match col_val {
             Value::Integer(v) => Value::Boolean(*v < threshold),
-            Value::Float(v) => Value::Boolean(*v < (threshold as f64)),
+            Value::Float(v) => Value::Boolean(crate::core::value::i64_gt_f64(threshold, *v)),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(false),
         }
@@ -3284,7 +3292,7 @@ impl ExprVM {
     fn ge_int(col_val: &Value, threshold: i64) -> Value {
         match col_val {
             Value::Integer(v) => Value::Boolean(*v >= threshold),
-            Value::Float(v) => Value::Boolean(*v >= threshold as f64),
+            Value::Float(v) => Value::Boolean(crate::core::value::i64_le_f64(threshold, *v)),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(false),
         }
@@ -3306,7 +3314,7 @@ impl ExprVM {
     fn le_int(col_val: &Value, threshold: i64) -> Value {
         match col_val {
             Value::Integer(v) => Value::Boolean(*v <= threshold),
-            Value::Float(v) => Value::Boolean(*v <= threshold as f64),
+            Value::Float(v) => Value::Boolean(crate::core::value::i64_ge_f64(threshold, *v)),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(false),
         }
@@ -3367,12 +3375,37 @@ impl ExprVM {
         }
     }
 
+    /// BETWEEN with an integer lower bound and float upper bound, exact
+    /// above 2^53 for both cell types
+    #[inline(always)]
+    fn between_mixed_int_lo(col_val: &Value, lo: i64, hi: f64) -> Value {
+        match col_val {
+            Value::Integer(v) => Value::Boolean(*v >= lo && crate::core::value::i64_le_f64(*v, hi)),
+            Value::Float(v) => Value::Boolean(crate::core::value::i64_le_f64(lo, *v) && *v <= hi),
+            Value::Null(_) => Value::Null(DataType::Boolean),
+            _ => Value::Boolean(false),
+        }
+    }
+
+    /// BETWEEN with a float lower bound and integer upper bound
+    #[inline(always)]
+    fn between_mixed_int_hi(col_val: &Value, lo: f64, hi: i64) -> Value {
+        match col_val {
+            Value::Integer(v) => Value::Boolean(crate::core::value::i64_ge_f64(*v, lo) && *v <= hi),
+            Value::Float(v) => Value::Boolean(*v >= lo && crate::core::value::i64_ge_f64(hi, *v)),
+            Value::Null(_) => Value::Null(DataType::Boolean),
+            _ => Value::Boolean(false),
+        }
+    }
+
     /// Inline BETWEEN check for integer bounds
     #[inline(always)]
     fn between_int(col_val: &Value, low: i64, high: i64) -> Value {
         match col_val {
             Value::Integer(v) => Value::Boolean(*v >= low && *v <= high),
-            Value::Float(v) => Value::Boolean(*v >= low as f64 && *v <= high as f64),
+            Value::Float(v) => Value::Boolean(
+                crate::core::value::i64_le_f64(low, *v) && crate::core::value::i64_ge_f64(high, *v),
+            ),
             Value::Null(_) => Value::Null(DataType::Boolean),
             _ => Value::Boolean(false),
         }

--- a/src/executor/hash_table.rs
+++ b/src/executor/hash_table.rs
@@ -454,8 +454,10 @@ fn values_equal(a: &Value, b: &Value) -> bool {
         (Value::Timestamp(x), Value::Timestamp(y)) => x == y,
         (Value::Extension(x), Value::Extension(y)) => x == y,
         // Cross-type numeric comparison: convert integer to float and compare bits
-        (Value::Integer(x), Value::Float(y)) => (*x as f64).to_bits() == y.to_bits(),
-        (Value::Float(x), Value::Integer(y)) => x.to_bits() == (*y as f64).to_bits(),
+        // Exact above 2^53: `i as f64` rounds and would join i64::MAX
+        // with Float(2^63)
+        (Value::Integer(x), Value::Float(y)) => crate::core::value::i64_eq_f64(*x, *y),
+        (Value::Float(x), Value::Integer(y)) => crate::core::value::i64_eq_f64(*y, *x),
         _ => false,
     }
 }

--- a/src/executor/pushdown/mod.rs
+++ b/src/executor/pushdown/mod.rs
@@ -109,11 +109,9 @@ impl<'a> PushdownContext<'a> {
             // 2^53, so a large integer constant against a FLOAT column
             // stays an Integer and compares exactly downstream.
             (Some(crate::core::DataType::Float), Value::Integer(i)) => {
-                let f = *i as f64;
-                if f as i64 == *i && i.abs() < (1_i64 << 53) {
-                    Value::Float(f)
-                } else {
-                    value
+                match crate::core::value::lossless_f64_from_i64(*i) {
+                    Some(f) => Value::Float(f),
+                    None => value,
                 }
             }
             (Some(col_type), _) => value.into_coerce_to_type(col_type),

--- a/src/executor/pushdown/mod.rs
+++ b/src/executor/pushdown/mod.rs
@@ -105,6 +105,17 @@ impl<'a> PushdownContext<'a> {
                     None => value,
                 }
             }
+            // Same rule in the other direction: `i as f64` rounds above
+            // 2^53, so a large integer constant against a FLOAT column
+            // stays an Integer and compares exactly downstream.
+            (Some(crate::core::DataType::Float), Value::Integer(i)) => {
+                let f = *i as f64;
+                if f as i64 == *i && i.abs() < (1_i64 << 53) {
+                    Value::Float(f)
+                } else {
+                    value
+                }
+            }
             (Some(col_type), _) => value.into_coerce_to_type(col_type),
             (None, _) => value,
         }

--- a/src/executor/pushdown/mod.rs
+++ b/src/executor/pushdown/mod.rs
@@ -89,12 +89,24 @@ impl<'a> PushdownContext<'a> {
         self.schema.has_column(name)
     }
 
-    /// Coerce value to column type if known
+    /// Coerce a WHERE-clause constant to the column type for pushdown.
+    ///
+    /// This must preserve COMPARISON semantics, not storage semantics:
+    /// `into_coerce_to_type` truncates Float to Integer the way an INSERT
+    /// would, which would turn `n = 5.5` into `n = 5` and match the wrong
+    /// rows. A float constant against an INTEGER column converts only when
+    /// lossless; otherwise it stays a Float and the storage comparison
+    /// compares numerically.
     pub fn coerce_to_column_type(&self, column: &str, value: Value) -> Value {
-        if let Some(col_type) = self.column_type(column) {
-            value.into_coerce_to_type(col_type)
-        } else {
-            value
+        match (self.column_type(column), &value) {
+            (Some(crate::core::DataType::Integer), Value::Float(f)) => {
+                match crate::executor::Executor::lossless_float_key(*f) {
+                    Some(i) => Value::Integer(i),
+                    None => value,
+                }
+            }
+            (Some(col_type), _) => value.into_coerce_to_type(col_type),
+            (None, _) => value,
         }
     }
 }

--- a/src/executor/semantic_cache.rs
+++ b/src/executor/semantic_cache.rs
@@ -978,11 +978,11 @@ fn check_range_subsumption(cached: &Expression, new: &Expression) -> Option<Subs
     match (&cached_infix.op_type, &new_infix.op_type) {
         // Greater than: new > cached means new is stricter
         (InfixOperator::GreaterThan, InfixOperator::GreaterThan) => {
-            if new_val > cached_val {
+            if new_val.exact_cmp(&cached_val) == Some(std::cmp::Ordering::Greater) {
                 Some(SubsumptionResult::Subsumed {
                     filter: Box::new(new.clone()),
                 })
-            } else if (new_val - cached_val).abs() < f64::EPSILON {
+            } else if new_val == cached_val {
                 Some(SubsumptionResult::Identical)
             } else {
                 None
@@ -991,7 +991,7 @@ fn check_range_subsumption(cached: &Expression, new: &Expression) -> Option<Subs
         // Equal values are NOT identical here: new `>= v` includes v,
         // cached `> v` does not.
         (InfixOperator::GreaterThan, InfixOperator::GreaterEqual) => {
-            if new_val > cached_val {
+            if new_val.exact_cmp(&cached_val) == Some(std::cmp::Ordering::Greater) {
                 Some(SubsumptionResult::Subsumed {
                     filter: Box::new(new.clone()),
                 })
@@ -1002,8 +1002,11 @@ fn check_range_subsumption(cached: &Expression, new: &Expression) -> Option<Subs
 
         (InfixOperator::GreaterEqual, InfixOperator::GreaterThan)
         | (InfixOperator::GreaterEqual, InfixOperator::GreaterEqual) => {
-            if new_val >= cached_val {
-                if (new_val - cached_val).abs() < f64::EPSILON
+            if matches!(
+                new_val.exact_cmp(&cached_val),
+                Some(std::cmp::Ordering::Greater) | Some(std::cmp::Ordering::Equal)
+            ) {
+                if new_val == cached_val
                     && matches!(cached_infix.op_type, InfixOperator::GreaterEqual)
                     && matches!(new_infix.op_type, InfixOperator::GreaterEqual)
                 {
@@ -1020,11 +1023,11 @@ fn check_range_subsumption(cached: &Expression, new: &Expression) -> Option<Subs
 
         // Less than: new < cached means new is stricter
         (InfixOperator::LessThan, InfixOperator::LessThan) => {
-            if new_val < cached_val {
+            if new_val.exact_cmp(&cached_val) == Some(std::cmp::Ordering::Less) {
                 Some(SubsumptionResult::Subsumed {
                     filter: Box::new(new.clone()),
                 })
-            } else if (new_val - cached_val).abs() < f64::EPSILON {
+            } else if new_val == cached_val {
                 Some(SubsumptionResult::Identical)
             } else {
                 None
@@ -1033,7 +1036,7 @@ fn check_range_subsumption(cached: &Expression, new: &Expression) -> Option<Subs
         // Equal values are NOT identical here: new `<= v` includes v,
         // cached `< v` does not.
         (InfixOperator::LessThan, InfixOperator::LessEqual) => {
-            if new_val < cached_val {
+            if new_val.exact_cmp(&cached_val) == Some(std::cmp::Ordering::Less) {
                 Some(SubsumptionResult::Subsumed {
                     filter: Box::new(new.clone()),
                 })
@@ -1044,8 +1047,11 @@ fn check_range_subsumption(cached: &Expression, new: &Expression) -> Option<Subs
 
         (InfixOperator::LessEqual, InfixOperator::LessThan)
         | (InfixOperator::LessEqual, InfixOperator::LessEqual) => {
-            if new_val <= cached_val {
-                if (new_val - cached_val).abs() < f64::EPSILON
+            if matches!(
+                new_val.exact_cmp(&cached_val),
+                Some(std::cmp::Ordering::Less) | Some(std::cmp::Ordering::Equal)
+            ) {
+                if new_val == cached_val
                     && matches!(cached_infix.op_type, InfixOperator::LessEqual)
                     && matches!(new_infix.op_type, InfixOperator::LessEqual)
                 {
@@ -1062,7 +1068,7 @@ fn check_range_subsumption(cached: &Expression, new: &Expression) -> Option<Subs
 
         // Equality: values must match for identity
         (InfixOperator::Equal, InfixOperator::Equal) => {
-            if (new_val - cached_val).abs() < f64::EPSILON {
+            if new_val == cached_val {
                 Some(SubsumptionResult::Identical)
             } else {
                 None
@@ -1173,23 +1179,26 @@ enum NumericValue {
 }
 
 impl NumericValue {
-    fn as_f64(&self) -> f64 {
-        match self {
-            NumericValue::Integer(i) => *i as f64,
-            NumericValue::Float(f) => *f,
+    /// Exact ordering: cache identity decisions must never round.
+    /// None only for NaN.
+    fn exact_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        use crate::core::value::cmp_i64_f64;
+        match (self, other) {
+            (NumericValue::Integer(a), NumericValue::Integer(b)) => Some(a.cmp(b)),
+            (NumericValue::Float(a), NumericValue::Float(b)) => a.partial_cmp(b),
+            (NumericValue::Integer(a), NumericValue::Float(b)) => cmp_i64_f64(*a, *b),
+            (NumericValue::Float(a), NumericValue::Integer(b)) => {
+                cmp_i64_f64(*b, *a).map(std::cmp::Ordering::reverse)
+            }
         }
     }
 }
 
 impl PartialEq for NumericValue {
     fn eq(&self, other: &Self) -> bool {
-        // For database predicate comparison, exact integer comparison is preferred,
-        // but for floats we use a reasonable tolerance (1e-10) rather than f64::EPSILON
-        // which is too strict (~2.2e-16) and can cause false negatives.
-        match (self, other) {
-            (NumericValue::Integer(a), NumericValue::Integer(b)) => a == b,
-            _ => (self.as_f64() - other.as_f64()).abs() < 1e-10,
-        }
+        // Exact: a tolerance here lets two different predicates share a
+        // cache identity, and Identical hits serve cached rows unfiltered.
+        self.exact_cmp(other) == Some(std::cmp::Ordering::Equal)
     }
 }
 
@@ -1216,11 +1225,13 @@ fn values_equal(a: &NumericValue, b: &NumericValue) -> bool {
     a == b
 }
 
-/// Extract numeric value from a literal expression
-fn extract_numeric_value(expr: &Expression) -> Option<f64> {
+/// Extract numeric value from a literal expression, keeping integer
+/// precision: `i as f64` rounds above 2^53, and two large-integer
+/// predicates differing by 1 must not be judged identical.
+fn extract_numeric_value(expr: &Expression) -> Option<NumericValue> {
     match expr {
-        Expression::IntegerLiteral(lit) => Some(lit.value as f64),
-        Expression::FloatLiteral(lit) => Some(lit.value),
+        Expression::IntegerLiteral(lit) => Some(NumericValue::Integer(lit.value)),
+        Expression::FloatLiteral(lit) => Some(NumericValue::Float(lit.value)),
         _ => None,
     }
 }

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -472,9 +472,10 @@ pub fn values_equal(a: &Value, b: &Value) -> bool {
         (Value::Null(_), Value::Null(_)) => false, // NULL != NULL in SQL
         (Value::Timestamp(x), Value::Timestamp(y)) => x == y,
         (Value::Extension(x), Value::Extension(y)) => x == y,
-        // Cross-type comparisons - try numeric
+        // Cross-type comparisons - exact numeric equality (epsilon-based
+        // equality matched near-values, and `i as f64` rounds above 2^53)
         (Value::Integer(x), Value::Float(y)) | (Value::Float(y), Value::Integer(x)) => {
-            (*x as f64 - y).abs() < f64::EPSILON
+            crate::core::value::i64_eq_f64(*x, *y)
         }
         _ => false,
     }
@@ -490,13 +491,14 @@ pub fn compare_values(a: &Value, b: &Value) -> Ordering {
         (Value::Null(_), Value::Null(_)) => Ordering::Equal,
         (Value::Timestamp(x), Value::Timestamp(y)) => x.cmp(y),
         (Value::Extension(x), Value::Extension(y)) => x.cmp(y),
-        // Cross-type comparisons - try numeric
+        // Cross-type comparisons - exact numeric ordering, consistent
+        // with Value::compare (merge join consumes ORDER BY output)
         (Value::Integer(x), Value::Float(y)) => {
-            (*x as f64).partial_cmp(y).unwrap_or(Ordering::Equal)
+            crate::core::value::cmp_i64_f64(*x, *y).unwrap_or(Ordering::Less)
         }
-        (Value::Float(x), Value::Integer(y)) => {
-            x.partial_cmp(&(*y as f64)).unwrap_or(Ordering::Equal)
-        }
+        (Value::Float(x), Value::Integer(y)) => crate::core::value::cmp_i64_f64(*y, *x)
+            .map(Ordering::reverse)
+            .unwrap_or(Ordering::Greater),
         // NULL sorts last
         (Value::Null(_), _) => Ordering::Greater,
         (_, Value::Null(_)) => Ordering::Less,

--- a/src/storage/expression/between.rs
+++ b/src/storage/expression/between.rs
@@ -114,6 +114,10 @@ impl BetweenExpr {
 
     /// Compare integers with bounds
     #[inline]
+    fn has_float_bound(&self) -> bool {
+        matches!(self.lower_bound, Value::Float(_)) || matches!(self.upper_bound, Value::Float(_))
+    }
+
     fn check_integer(&self, val: i64, lower: i64, upper: i64) -> bool {
         if self.inclusive {
             val >= lower && val <= upper
@@ -177,13 +181,25 @@ impl Expression for BetweenExpr {
         let in_range =
             match col_value {
                 Value::Integer(val) => {
-                    let lower = self.lower_bound.as_int64().ok_or_else(|| {
-                        crate::core::Error::type_conversion("lower bound", "integer")
-                    })?;
-                    let upper = self.upper_bound.as_int64().ok_or_else(|| {
-                        crate::core::Error::type_conversion("upper bound", "integer")
-                    })?;
-                    self.check_integer(*val, lower, upper)
+                    // Float bounds must compare numerically, not truncate:
+                    // BETWEEN 5.1 AND 5.9 is empty for integers, not [5, 5]
+                    if self.has_float_bound() {
+                        let lower = self.lower_bound.as_float64().ok_or_else(|| {
+                            crate::core::Error::type_conversion("lower bound", "float")
+                        })?;
+                        let upper = self.upper_bound.as_float64().ok_or_else(|| {
+                            crate::core::Error::type_conversion("upper bound", "float")
+                        })?;
+                        self.check_float(*val as f64, lower, upper)
+                    } else {
+                        let lower = self.lower_bound.as_int64().ok_or_else(|| {
+                            crate::core::Error::type_conversion("lower bound", "integer")
+                        })?;
+                        let upper = self.upper_bound.as_int64().ok_or_else(|| {
+                            crate::core::Error::type_conversion("upper bound", "integer")
+                        })?;
+                        self.check_integer(*val, lower, upper)
+                    }
                 }
 
                 Value::Float(val) => {
@@ -239,7 +255,15 @@ impl Expression for BetweenExpr {
 
         let in_range = match col_value {
             Value::Integer(val) => {
-                if let (Some(lower), Some(upper)) =
+                if self.has_float_bound() {
+                    if let (Some(lower), Some(upper)) =
+                        (self.lower_bound.as_float64(), self.upper_bound.as_float64())
+                    {
+                        self.check_float(*val as f64, lower, upper)
+                    } else {
+                        return false;
+                    }
+                } else if let (Some(lower), Some(upper)) =
                     (self.lower_bound.as_int64(), self.upper_bound.as_int64())
                 {
                     self.check_integer(*val, lower, upper)

--- a/src/storage/expression/between.rs
+++ b/src/storage/expression/between.rs
@@ -112,28 +112,122 @@ impl BetweenExpr {
         self.not
     }
 
-    /// Compare integers with bounds
-    #[inline]
-    fn has_float_bound(&self) -> bool {
-        matches!(self.lower_bound, Value::Float(_)) || matches!(self.upper_bound, Value::Float(_))
+    /// val >= lower bound (or > when exclusive), exact PER BOUND TYPE:
+    /// converting an Integer bound through f64 rounds above 2^53
+    /// (Integer(i64::MAX) would become 2^63).
+    fn int_cell_lower_ok(&self, val: i64, bound: &Value) -> Option<bool> {
+        use crate::core::value::{i64_ge_f64, i64_gt_f64};
+        Some(match bound {
+            Value::Integer(lo) => {
+                if self.inclusive {
+                    val >= *lo
+                } else {
+                    val > *lo
+                }
+            }
+            Value::Float(lo) => {
+                if self.inclusive {
+                    i64_ge_f64(val, *lo)
+                } else {
+                    i64_gt_f64(val, *lo)
+                }
+            }
+            _ => {
+                let lo = bound.as_int64()?;
+                if self.inclusive {
+                    val >= lo
+                } else {
+                    val > lo
+                }
+            }
+        })
     }
 
-    fn check_integer(&self, val: i64, lower: i64, upper: i64) -> bool {
-        if self.inclusive {
-            val >= lower && val <= upper
-        } else {
-            val > lower && val < upper
-        }
+    /// val <= upper bound (or < when exclusive), exact per bound type
+    fn int_cell_upper_ok(&self, val: i64, bound: &Value) -> Option<bool> {
+        use crate::core::value::{i64_le_f64, i64_lt_f64};
+        Some(match bound {
+            Value::Integer(hi) => {
+                if self.inclusive {
+                    val <= *hi
+                } else {
+                    val < *hi
+                }
+            }
+            Value::Float(hi) => {
+                if self.inclusive {
+                    i64_le_f64(val, *hi)
+                } else {
+                    i64_lt_f64(val, *hi)
+                }
+            }
+            _ => {
+                let hi = bound.as_int64()?;
+                if self.inclusive {
+                    val <= hi
+                } else {
+                    val < hi
+                }
+            }
+        })
     }
 
-    /// Compare floats with bounds
-    #[inline]
-    fn check_float(&self, val: f64, lower: f64, upper: f64) -> bool {
-        if self.inclusive {
-            val >= lower && val <= upper
-        } else {
-            val > lower && val < upper
-        }
+    /// Float cell >= lower bound, exact per bound type
+    fn float_cell_lower_ok(&self, val: f64, bound: &Value) -> Option<bool> {
+        use crate::core::value::{i64_le_f64, i64_lt_f64};
+        Some(match bound {
+            Value::Float(lo) => {
+                if self.inclusive {
+                    val >= *lo
+                } else {
+                    val > *lo
+                }
+            }
+            Value::Integer(lo) => {
+                if self.inclusive {
+                    i64_le_f64(*lo, val)
+                } else {
+                    i64_lt_f64(*lo, val)
+                }
+            }
+            _ => {
+                let lo = bound.as_float64()?;
+                if self.inclusive {
+                    val >= lo
+                } else {
+                    val > lo
+                }
+            }
+        })
+    }
+
+    /// Float cell <= upper bound, exact per bound type
+    fn float_cell_upper_ok(&self, val: f64, bound: &Value) -> Option<bool> {
+        use crate::core::value::{i64_ge_f64, i64_gt_f64};
+        Some(match bound {
+            Value::Float(hi) => {
+                if self.inclusive {
+                    val <= *hi
+                } else {
+                    val < *hi
+                }
+            }
+            Value::Integer(hi) => {
+                if self.inclusive {
+                    i64_ge_f64(*hi, val)
+                } else {
+                    i64_gt_f64(*hi, val)
+                }
+            }
+            _ => {
+                let hi = bound.as_float64()?;
+                if self.inclusive {
+                    val <= hi
+                } else {
+                    val < hi
+                }
+            }
+        })
     }
 
     /// Compare strings with bounds
@@ -178,62 +272,55 @@ impl Expression for BetweenExpr {
         }
 
         // Type-specific comparisons
-        let in_range =
-            match col_value {
-                Value::Integer(val) => {
-                    // Float bounds must compare numerically, not truncate:
-                    // BETWEEN 5.1 AND 5.9 is empty for integers, not [5, 5]
-                    if self.has_float_bound() {
-                        let lower = self.lower_bound.as_float64().ok_or_else(|| {
-                            crate::core::Error::type_conversion("lower bound", "float")
-                        })?;
-                        let upper = self.upper_bound.as_float64().ok_or_else(|| {
-                            crate::core::Error::type_conversion("upper bound", "float")
-                        })?;
-                        self.check_float(*val as f64, lower, upper)
-                    } else {
-                        let lower = self.lower_bound.as_int64().ok_or_else(|| {
-                            crate::core::Error::type_conversion("lower bound", "integer")
-                        })?;
-                        let upper = self.upper_bound.as_int64().ok_or_else(|| {
-                            crate::core::Error::type_conversion("upper bound", "integer")
-                        })?;
-                        self.check_integer(*val, lower, upper)
-                    }
-                }
+        let in_range = match col_value {
+            Value::Integer(val) => {
+                // Each bound compares in its own type: float bounds must
+                // not truncate (BETWEEN 5.1 AND 5.9 is empty for
+                // integers), and integer bounds must not round through
+                // f64 (Integer(i64::MAX) is not 2^63)
+                let lower_ok = self
+                    .int_cell_lower_ok(*val, &self.lower_bound)
+                    .ok_or_else(|| crate::core::Error::type_conversion("lower bound", "integer"))?;
+                let upper_ok = self
+                    .int_cell_upper_ok(*val, &self.upper_bound)
+                    .ok_or_else(|| crate::core::Error::type_conversion("upper bound", "integer"))?;
+                lower_ok && upper_ok
+            }
 
-                Value::Float(val) => {
-                    let lower = self.lower_bound.as_float64().ok_or_else(|| {
-                        crate::core::Error::type_conversion("lower bound", "float")
-                    })?;
-                    let upper = self.upper_bound.as_float64().ok_or_else(|| {
-                        crate::core::Error::type_conversion("upper bound", "float")
-                    })?;
-                    self.check_float(*val, lower, upper)
-                }
+            Value::Float(val) => {
+                let lower_ok = self
+                    .float_cell_lower_ok(*val, &self.lower_bound)
+                    .ok_or_else(|| crate::core::Error::type_conversion("lower bound", "float"))?;
+                let upper_ok = self
+                    .float_cell_upper_ok(*val, &self.upper_bound)
+                    .ok_or_else(|| crate::core::Error::type_conversion("upper bound", "float"))?;
+                lower_ok && upper_ok
+            }
 
-                Value::Text(val) => {
-                    let lower = self.lower_bound.as_string().ok_or_else(|| {
-                        crate::core::Error::type_conversion("lower bound", "string")
-                    })?;
-                    let upper = self.upper_bound.as_string().ok_or_else(|| {
-                        crate::core::Error::type_conversion("upper bound", "string")
-                    })?;
-                    self.check_string(val, &lower, &upper)
-                }
+            Value::Text(val) => {
+                let lower = self
+                    .lower_bound
+                    .as_string()
+                    .ok_or_else(|| crate::core::Error::type_conversion("lower bound", "string"))?;
+                let upper = self
+                    .upper_bound
+                    .as_string()
+                    .ok_or_else(|| crate::core::Error::type_conversion("upper bound", "string"))?;
+                self.check_string(val, &lower, &upper)
+            }
 
-                Value::Timestamp(val) => {
-                    let lower = self.lower_bound.as_timestamp().ok_or_else(|| {
-                        crate::core::Error::type_conversion("lower bound", "timestamp")
-                    })?;
-                    let upper = self.upper_bound.as_timestamp().ok_or_else(|| {
-                        crate::core::Error::type_conversion("upper bound", "timestamp")
-                    })?;
-                    self.check_timestamp(*val, lower, upper)
-                }
+            Value::Timestamp(val) => {
+                let lower = self.lower_bound.as_timestamp().ok_or_else(|| {
+                    crate::core::Error::type_conversion("lower bound", "timestamp")
+                })?;
+                let upper = self.upper_bound.as_timestamp().ok_or_else(|| {
+                    crate::core::Error::type_conversion("upper bound", "timestamp")
+                })?;
+                self.check_timestamp(*val, lower, upper)
+            }
 
-                _ => false,
-            };
+            _ => false,
+        };
 
         // Apply NOT if this is a NOT BETWEEN expression
         Ok(if self.not { !in_range } else { in_range })
@@ -255,30 +342,22 @@ impl Expression for BetweenExpr {
 
         let in_range = match col_value {
             Value::Integer(val) => {
-                if self.has_float_bound() {
-                    if let (Some(lower), Some(upper)) =
-                        (self.lower_bound.as_float64(), self.upper_bound.as_float64())
-                    {
-                        self.check_float(*val as f64, lower, upper)
-                    } else {
-                        return false;
-                    }
-                } else if let (Some(lower), Some(upper)) =
-                    (self.lower_bound.as_int64(), self.upper_bound.as_int64())
-                {
-                    self.check_integer(*val, lower, upper)
-                } else {
-                    return false;
+                match (
+                    self.int_cell_lower_ok(*val, &self.lower_bound),
+                    self.int_cell_upper_ok(*val, &self.upper_bound),
+                ) {
+                    (Some(lo), Some(hi)) => lo && hi,
+                    _ => return false,
                 }
             }
 
             Value::Float(val) => {
-                if let (Some(lower), Some(upper)) =
-                    (self.lower_bound.as_float64(), self.upper_bound.as_float64())
-                {
-                    self.check_float(*val, lower, upper)
-                } else {
-                    return false;
+                match (
+                    self.float_cell_lower_ok(*val, &self.lower_bound),
+                    self.float_cell_upper_ok(*val, &self.upper_bound),
+                ) {
+                    (Some(lo), Some(hi)) => lo && hi,
+                    _ => return false,
                 }
             }
 

--- a/src/storage/expression/comparison.rs
+++ b/src/storage/expression/comparison.rs
@@ -201,6 +201,21 @@ impl ComparisonExpr {
         }
     }
 
+    /// Apply the configured operator to a column-vs-value ordering
+    #[inline]
+    fn check_ordering(&self, ord: std::cmp::Ordering) -> bool {
+        use std::cmp::Ordering;
+        match self.operator {
+            Operator::Eq => ord == Ordering::Equal,
+            Operator::Ne => ord != Ordering::Equal,
+            Operator::Gt => ord == Ordering::Greater,
+            Operator::Gte => ord != Ordering::Less,
+            Operator::Lt => ord == Ordering::Less,
+            Operator::Lte => ord != Ordering::Greater,
+            _ => false,
+        }
+    }
+
     /// Compare two floats with the configured operator
     #[inline]
     fn compare_floats(&self, col_val: f64, cmp_val: f64) -> bool {
@@ -313,12 +328,19 @@ impl Expression for ComparisonExpr {
                 Ok(self.compare_timestamps(*col_val, *cmp_val))
             }
 
-            // Cross-type numeric comparisons (integer vs float)
+            // Cross-type numeric comparisons (integer vs float), exact at
+            // the extremes where `i as f64` rounds
             (ComparisonValue::Integer(cmp_val), Value::Float(col_val)) => {
-                Ok(self.compare_floats(*col_val, *cmp_val as f64))
+                match crate::core::value::cmp_i64_f64(*cmp_val, *col_val) {
+                    Some(ord) => Ok(self.check_ordering(ord.reverse())),
+                    None => Ok(false),
+                }
             }
             (ComparisonValue::Float(cmp_val), Value::Integer(col_val)) => {
-                Ok(self.compare_floats(*col_val as f64, *cmp_val))
+                match crate::core::value::cmp_i64_f64(*col_val, *cmp_val) {
+                    Some(ord) => Ok(self.check_ordering(ord)),
+                    None => Ok(false),
+                }
             }
 
             // Type mismatch
@@ -370,12 +392,19 @@ impl Expression for ComparisonExpr {
             (ComparisonValue::Timestamp(cmp_val), Value::Timestamp(col_val)) => {
                 self.compare_timestamps(*col_val, *cmp_val)
             }
-            // Cross-type numeric
+            // Cross-type numeric, exact at the extremes where `i as f64`
+            // rounds
             (ComparisonValue::Integer(cmp_val), Value::Float(col_val)) => {
-                self.compare_floats(*col_val, *cmp_val as f64)
+                match crate::core::value::cmp_i64_f64(*cmp_val, *col_val) {
+                    Some(ord) => self.check_ordering(ord.reverse()),
+                    None => false,
+                }
             }
             (ComparisonValue::Float(cmp_val), Value::Integer(col_val)) => {
-                self.compare_floats(*col_val as f64, *cmp_val)
+                match crate::core::value::cmp_i64_f64(*col_val, *cmp_val) {
+                    Some(ord) => self.check_ordering(ord),
+                    None => false,
+                }
             }
             _ => false,
         }

--- a/src/storage/expression/comparison.rs
+++ b/src/storage/expression/comparison.rs
@@ -333,13 +333,14 @@ impl Expression for ComparisonExpr {
             (ComparisonValue::Integer(cmp_val), Value::Float(col_val)) => {
                 match crate::core::value::cmp_i64_f64(*cmp_val, *col_val) {
                     Some(ord) => Ok(self.check_ordering(ord.reverse())),
-                    None => Ok(false),
+                    // NaN cell: only <> is true (IEEE), matching the VM arms
+                    None => Ok(self.operator == Operator::Ne),
                 }
             }
             (ComparisonValue::Float(cmp_val), Value::Integer(col_val)) => {
                 match crate::core::value::cmp_i64_f64(*col_val, *cmp_val) {
                     Some(ord) => Ok(self.check_ordering(ord)),
-                    None => Ok(false),
+                    None => Ok(self.operator == Operator::Ne),
                 }
             }
 
@@ -397,13 +398,14 @@ impl Expression for ComparisonExpr {
             (ComparisonValue::Integer(cmp_val), Value::Float(col_val)) => {
                 match crate::core::value::cmp_i64_f64(*cmp_val, *col_val) {
                     Some(ord) => self.check_ordering(ord.reverse()),
-                    None => false,
+                    // NaN cell: only <> is true (IEEE), matching the VM arms
+                    None => self.operator == Operator::Ne,
                 }
             }
             (ComparisonValue::Float(cmp_val), Value::Integer(col_val)) => {
                 match crate::core::value::cmp_i64_f64(*col_val, *cmp_val) {
                     Some(ord) => self.check_ordering(ord),
-                    None => false,
+                    None => self.operator == Operator::Ne,
                 }
             }
             _ => false,

--- a/src/storage/expression/compiled.rs
+++ b/src/storage/expression/compiled.rs
@@ -643,6 +643,57 @@ impl CompiledFilter {
         Self::compile(expr, schema)
     }
 
+    /// Compile a float-constant comparison against an INTEGER column with
+    /// exact numeric semantics. A whole-number float in i64 range becomes
+    /// the equivalent integer filter; a fractional in-range float rewrites
+    /// ordering comparisons to exact integer bounds (`n < 5.5` is
+    /// `n <= 5`, `n > -5.5` is `n >= -5`); everything else (fractional
+    /// equality, out-of-range, NaN) falls back to the dynamic path whose
+    /// generic comparison is numeric.
+    fn compile_float_vs_integer_column(
+        expr: &ComparisonExpr,
+        col_idx: usize,
+        op: Operator,
+        f: f64,
+    ) -> Self {
+        const I64_MIN_F: f64 = -9_223_372_036_854_775_808.0; // -2^63, exact
+        const I64_MAX_PLUS_1_F: f64 = 9_223_372_036_854_775_808.0; // 2^63
+
+        if !(I64_MIN_F..I64_MAX_PLUS_1_F).contains(&f) {
+            return CompiledFilter::Dynamic(expr.clone_box());
+        }
+
+        if f.fract() == 0.0 {
+            let i = f as i64;
+            return match op {
+                Operator::Eq => CompiledFilter::IntegerEq { col_idx, value: i },
+                Operator::Ne => CompiledFilter::IntegerNe { col_idx, value: i },
+                Operator::Gt => CompiledFilter::IntegerGt { col_idx, value: i },
+                Operator::Gte => CompiledFilter::IntegerGte { col_idx, value: i },
+                Operator::Lt => CompiledFilter::IntegerLt { col_idx, value: i },
+                Operator::Lte => CompiledFilter::IntegerLte { col_idx, value: i },
+                _ => CompiledFilter::Dynamic(expr.clone_box()),
+            };
+        }
+
+        // Fractional: |f| < 2^53 (f64 has no fractional values beyond),
+        // so floor and floor + 1 stay in i64 range.
+        let floor = f.floor() as i64;
+        match op {
+            Operator::Lt | Operator::Lte => CompiledFilter::IntegerLte {
+                col_idx,
+                value: floor,
+            },
+            Operator::Gt | Operator::Gte => CompiledFilter::IntegerGte {
+                col_idx,
+                value: floor + 1,
+            },
+            // No integer equals a fractional value; the dynamic generic
+            // comparison keeps exact Eq/Ne and NULL semantics.
+            _ => CompiledFilter::Dynamic(expr.clone_box()),
+        }
+    }
+
     fn compile_comparison(expr: &ComparisonExpr, schema: &Schema) -> Self {
         let col_name = expr.get_column_name().unwrap_or("");
         let col_idx = match super::find_column_index(schema, col_name) {
@@ -670,6 +721,17 @@ impl CompiledFilter {
             }
             Value::Float(f) => {
                 let f = *f;
+                // The Float-typed filters pattern-match Value::Float cells,
+                // so against an INTEGER column they would never match. Map
+                // the comparison onto exact integer semantics instead.
+                let col_is_integer = schema
+                    .columns
+                    .get(col_idx)
+                    .map(|c| c.data_type == crate::core::DataType::Integer)
+                    .unwrap_or(false);
+                if col_is_integer {
+                    return Self::compile_float_vs_integer_column(expr, col_idx, op, f);
+                }
                 match op {
                     Operator::Eq => CompiledFilter::FloatEq { col_idx, value: f },
                     Operator::Ne => CompiledFilter::FloatNe { col_idx, value: f },
@@ -910,12 +972,38 @@ impl CompiledFilter {
         let (low, high) = expr.get_bounds();
         let is_negated = expr.is_negated();
 
+        let col_is_integer = schema
+            .columns
+            .get(col_idx)
+            .map(|c| c.data_type == crate::core::DataType::Integer)
+            .unwrap_or(false);
+
         let between_filter = match (low, high) {
             (Value::Integer(min), Value::Integer(max)) => CompiledFilter::IntegerBetween {
                 col_idx,
                 min: *min,
                 max: *max,
             },
+            // Float bounds against an INTEGER column: FloatBetween never
+            // matches integer cells, and truncating would turn
+            // BETWEEN 5.1 AND 5.9 into [5, 5]. Exact integer bounds are
+            // [ceil(min), floor(max)]; out-of-range bounds fall back to
+            // the dynamic path.
+            (Value::Float(min), Value::Float(max)) if col_is_integer => {
+                const I64_MIN_F: f64 = -9_223_372_036_854_775_808.0;
+                const I64_MAX_PLUS_1_F: f64 = 9_223_372_036_854_775_808.0;
+                let (min_c, max_f) = (min.ceil(), max.floor());
+                if !(I64_MIN_F..I64_MAX_PLUS_1_F).contains(&min_c)
+                    || !(I64_MIN_F..I64_MAX_PLUS_1_F).contains(&max_f)
+                {
+                    return CompiledFilter::Dynamic(expr.clone_box());
+                }
+                CompiledFilter::IntegerBetween {
+                    col_idx,
+                    min: min_c as i64,
+                    max: max_f as i64,
+                }
+            }
             (Value::Float(min), Value::Float(max)) => CompiledFilter::FloatBetween {
                 col_idx,
                 min: *min,

--- a/src/storage/expression/compiled.rs
+++ b/src/storage/expression/compiled.rs
@@ -709,6 +709,29 @@ impl CompiledFilter {
         match value {
             Value::Integer(i) => {
                 let i = *i;
+                // Integer-typed filters never match float cells; against a
+                // FLOAT column use the float variant when the constant is
+                // exactly representable, else the dynamic exact path.
+                let col_is_float = schema
+                    .columns
+                    .get(col_idx)
+                    .map(|c| c.data_type == crate::core::DataType::Float)
+                    .unwrap_or(false);
+                if col_is_float {
+                    let f = i as f64;
+                    if !(f as i64 == i && i.abs() < (1_i64 << 53)) {
+                        return CompiledFilter::Dynamic(expr.clone_box());
+                    }
+                    return match op {
+                        Operator::Eq => CompiledFilter::FloatEq { col_idx, value: f },
+                        Operator::Ne => CompiledFilter::FloatNe { col_idx, value: f },
+                        Operator::Gt => CompiledFilter::FloatGt { col_idx, value: f },
+                        Operator::Gte => CompiledFilter::FloatGte { col_idx, value: f },
+                        Operator::Lt => CompiledFilter::FloatLt { col_idx, value: f },
+                        Operator::Lte => CompiledFilter::FloatLte { col_idx, value: f },
+                        _ => CompiledFilter::Dynamic(expr.clone_box()),
+                    };
+                }
                 match op {
                     Operator::Eq => CompiledFilter::IntegerEq { col_idx, value: i },
                     Operator::Ne => CompiledFilter::IntegerNe { col_idx, value: i },

--- a/src/storage/expression/compiled.rs
+++ b/src/storage/expression/compiled.rs
@@ -718,10 +718,9 @@ impl CompiledFilter {
                     .map(|c| c.data_type == crate::core::DataType::Float)
                     .unwrap_or(false);
                 if col_is_float {
-                    let f = i as f64;
-                    if !(f as i64 == i && i.abs() < (1_i64 << 53)) {
+                    let Some(f) = crate::core::value::lossless_f64_from_i64(i) else {
                         return CompiledFilter::Dynamic(expr.clone_box());
-                    }
+                    };
                     return match op {
                         Operator::Eq => CompiledFilter::FloatEq { col_idx, value: f },
                         Operator::Ne => CompiledFilter::FloatNe { col_idx, value: f },

--- a/src/storage/expression/in_list.rs
+++ b/src/storage/expression/in_list.rs
@@ -253,14 +253,16 @@ impl InListExpr {
         match &self.hashed {
             HashedValues::Integers(set) => set.contains(val),
             _ => {
-                // Fallback to linear search
+                // Fallback to linear search. Float list values compare
+                // numerically first: as_int64 would truncate 5.5 to 5 and
+                // match the wrong integers.
                 for v in &self.values {
-                    if let Some(list_val) = v.as_int64() {
-                        if val == list_val {
+                    if let Value::Float(f) = v {
+                        if val as f64 == *f {
                             return true;
                         }
-                    } else if let Some(list_val) = v.as_float64() {
-                        if val as f64 == list_val {
+                    } else if let Some(list_val) = v.as_int64() {
+                        if val == list_val {
                             return true;
                         }
                     }

--- a/src/storage/expression/in_list.rs
+++ b/src/storage/expression/in_list.rs
@@ -157,8 +157,12 @@ impl InListExpr {
                         Value::Integer(i) => {
                             set.insert(*i);
                         }
-                        // Only include floats if they are whole numbers.
-                        Value::Float(f) if f.fract() == 0.0 => {
+                        // Only include floats with an exact i64 equivalent:
+                        // 2^63 is whole but saturates to i64::MAX under the
+                        // cast, matching a value no i64 equals.
+                        Value::Float(f)
+                            if crate::executor::Executor::lossless_float_key(*f).is_some() =>
+                        {
                             set.insert(*f as i64);
                         }
                         Value::Float(_) => {
@@ -258,7 +262,7 @@ impl InListExpr {
                 // match the wrong integers.
                 for v in &self.values {
                     if let Value::Float(f) = v {
-                        if val as f64 == *f {
+                        if crate::core::value::i64_eq_f64(val, *f) {
                             return true;
                         }
                     } else if let Some(list_val) = v.as_int64() {
@@ -277,13 +281,23 @@ impl InListExpr {
     fn check_float(&self, val: f64) -> bool {
         // Floats use linear search due to precision issues with hashing
         for v in &self.values {
-            if let Some(list_val) = v.as_float64() {
-                if val == list_val {
-                    return true;
+            match v {
+                Value::Float(f) => {
+                    if val == *f {
+                        return true;
+                    }
                 }
-            } else if let Some(list_val) = v.as_int64() {
-                if val == list_val as f64 {
-                    return true;
+                Value::Integer(i) => {
+                    if crate::core::value::i64_eq_f64(*i, val) {
+                        return true;
+                    }
+                }
+                _ => {
+                    if let Some(list_val) = v.as_float64() {
+                        if val == list_val {
+                            return true;
+                        }
+                    }
                 }
             }
         }

--- a/src/storage/expression/range.rs
+++ b/src/storage/expression/range.rs
@@ -24,6 +24,9 @@ use crate::core::{DataType, Result, Row, Schema, Value};
 /// Pre-computed bounds for different types
 #[derive(Debug, Clone)]
 pub struct RangeBounds {
+    /// Whether either bound was a float (integer cells then compare as f64)
+    pub has_float_bound: bool,
+
     /// Integer bounds
     pub int_min: i64,
     pub int_max: i64,
@@ -47,6 +50,7 @@ pub struct RangeBounds {
 impl Default for RangeBounds {
     fn default() -> Self {
         Self {
+            has_float_bound: false,
             int_min: 0,
             int_max: 0,
             float_min: 0.0,
@@ -151,6 +155,7 @@ impl RangeExpr {
                 let f = *v;
                 self.bounds.float_min = f;
                 self.bounds.int_min = f as i64;
+                self.bounds.has_float_bound = true;
                 self.bounds.data_type = DataType::Float;
             }
             Value::Text(v) => {
@@ -192,6 +197,7 @@ impl RangeExpr {
                 let f = *v;
                 self.bounds.float_max = f;
                 self.bounds.int_max = f as i64;
+                self.bounds.has_float_bound = true;
                 if self.bounds.data_type == DataType::Null {
                     self.bounds.data_type = DataType::Float;
                 }
@@ -234,7 +240,7 @@ impl RangeExpr {
     /// BETWEEN 5.1 AND 5.9 into [5, 5] and match 5.
     #[inline]
     fn check_integer(&self, val: i64) -> bool {
-        if self.bounds.data_type == DataType::Float {
+        if self.bounds.has_float_bound || self.bounds.data_type == DataType::Float {
             return self.check_float(val as f64);
         }
         // Check minimum

--- a/src/storage/expression/range.rs
+++ b/src/storage/expression/range.rs
@@ -24,8 +24,11 @@ use crate::core::{DataType, Result, Row, Schema, Value};
 /// Pre-computed bounds for different types
 #[derive(Debug, Clone)]
 pub struct RangeBounds {
-    /// Whether either bound was a float (integer cells then compare as f64)
-    pub has_float_bound: bool,
+    /// Per-bound types: integer cells compare each bound in the bound's
+    /// own type, exactly (converting either side through f64 rounds
+    /// above 2^53)
+    pub min_is_float: bool,
+    pub max_is_float: bool,
 
     /// Integer bounds
     pub int_min: i64,
@@ -50,7 +53,8 @@ pub struct RangeBounds {
 impl Default for RangeBounds {
     fn default() -> Self {
         Self {
-            has_float_bound: false,
+            min_is_float: false,
+            max_is_float: false,
             int_min: 0,
             int_max: 0,
             float_min: 0.0,
@@ -155,7 +159,7 @@ impl RangeExpr {
                 let f = *v;
                 self.bounds.float_min = f;
                 self.bounds.int_min = f as i64;
-                self.bounds.has_float_bound = true;
+                self.bounds.min_is_float = true;
                 self.bounds.data_type = DataType::Float;
             }
             Value::Text(v) => {
@@ -197,7 +201,7 @@ impl RangeExpr {
                 let f = *v;
                 self.bounds.float_max = f;
                 self.bounds.int_max = f as i64;
-                self.bounds.has_float_bound = true;
+                self.bounds.max_is_float = true;
                 if self.bounds.data_type == DataType::Null {
                     self.bounds.data_type = DataType::Float;
                 }
@@ -235,57 +239,72 @@ impl RangeExpr {
         }
     }
 
-    /// Check integer bounds. With Float-typed bounds the integer cell is
-    /// compared as f64: the truncated int_min/int_max would turn
-    /// BETWEEN 5.1 AND 5.9 into [5, 5] and match 5.
+    /// Check integer bounds, each bound in its own type: a float bound
+    /// must not truncate (5.1..5.9 is not [5, 5]) and an integer bound
+    /// must not round through f64 (Integer(i64::MAX) is not 2^63).
     #[inline]
     fn check_integer(&self, val: i64) -> bool {
-        if self.bounds.has_float_bound || self.bounds.data_type == DataType::Float {
-            return self.check_float(val as f64);
-        }
-        // Check minimum
-        if self.include_min {
-            if val < self.bounds.int_min {
-                return false;
+        use crate::core::value::{i64_ge_f64, i64_gt_f64, i64_le_f64, i64_lt_f64};
+
+        let lower_ok = if self.bounds.min_is_float {
+            if self.include_min {
+                i64_ge_f64(val, self.bounds.float_min)
+            } else {
+                i64_gt_f64(val, self.bounds.float_min)
             }
-        } else if val <= self.bounds.int_min {
+        } else if self.include_min {
+            val >= self.bounds.int_min
+        } else {
+            val > self.bounds.int_min
+        };
+        if !lower_ok {
             return false;
         }
 
-        // Check maximum
-        if self.include_max {
-            if val > self.bounds.int_max {
-                return false;
+        if self.bounds.max_is_float {
+            if self.include_max {
+                i64_le_f64(val, self.bounds.float_max)
+            } else {
+                i64_lt_f64(val, self.bounds.float_max)
             }
-        } else if val >= self.bounds.int_max {
-            return false;
+        } else if self.include_max {
+            val <= self.bounds.int_max
+        } else {
+            val < self.bounds.int_max
         }
-
-        true
     }
 
-    /// Check float bounds
+    /// Check float bounds, each bound in its own type
     #[inline]
     fn check_float(&self, val: f64) -> bool {
-        // Check minimum
-        if self.include_min {
-            if val < self.bounds.float_min {
-                return false;
+        use crate::core::value::{i64_ge_f64, i64_gt_f64, i64_le_f64, i64_lt_f64};
+
+        let lower_ok = if self.bounds.min_is_float {
+            if self.include_min {
+                val >= self.bounds.float_min
+            } else {
+                val > self.bounds.float_min
             }
-        } else if val <= self.bounds.float_min {
+        } else if self.include_min {
+            i64_le_f64(self.bounds.int_min, val)
+        } else {
+            i64_lt_f64(self.bounds.int_min, val)
+        };
+        if !lower_ok {
             return false;
         }
 
-        // Check maximum
-        if self.include_max {
-            if val > self.bounds.float_max {
-                return false;
+        if self.bounds.max_is_float {
+            if self.include_max {
+                val <= self.bounds.float_max
+            } else {
+                val < self.bounds.float_max
             }
-        } else if val >= self.bounds.float_max {
-            return false;
+        } else if self.include_max {
+            i64_ge_f64(self.bounds.int_max, val)
+        } else {
+            i64_gt_f64(self.bounds.int_max, val)
         }
-
-        true
     }
 
     /// Check string bounds
@@ -672,5 +691,54 @@ mod tests {
     fn test_get_column_name() {
         let expr = RangeExpr::inclusive("id", Value::integer(1), Value::integer(10));
         assert_eq!(expr.get_column_name(), Some("id"));
+    }
+
+    #[test]
+    fn mixed_bounds_are_exact_at_extremes() {
+        let schema = test_schema();
+
+        // [Integer(i64::MAX), Float(2^63)]: i64::MAX - 1 is below the
+        // integer lower bound; rounding it through f64 would accept it
+        let mut expr = RangeExpr::inclusive(
+            "id",
+            Value::integer(i64::MAX),
+            Value::float(9_223_372_036_854_775_808.0),
+        );
+        expr.prepare_for_schema(&schema);
+
+        let below = Row::from_values(vec![
+            Value::integer(i64::MAX - 1),
+            Value::float(0.0),
+            Value::text("x"),
+        ]);
+        assert!(!expr.evaluate(&below).unwrap());
+        assert!(!expr.evaluate_fast(&below));
+
+        let at_max = Row::from_values(vec![
+            Value::integer(i64::MAX),
+            Value::float(0.0),
+            Value::text("x"),
+        ]);
+        assert!(expr.evaluate(&at_max).unwrap());
+        assert!(expr.evaluate_fast(&at_max));
+
+        // Float cell 2^63 against an Integer(i64::MAX) upper bound:
+        // above the bound, must reject
+        let mut expr = RangeExpr::inclusive("score", Value::integer(0), Value::integer(i64::MAX));
+        expr.prepare_for_schema(&schema);
+        let high = Row::from_values(vec![
+            Value::integer(1),
+            Value::float(9_223_372_036_854_775_808.0),
+            Value::text("x"),
+        ]);
+        assert!(!expr.evaluate(&high).unwrap());
+        assert!(!expr.evaluate_fast(&high));
+
+        // Fractional float bounds stay empty for integers
+        let mut expr = RangeExpr::inclusive("id", Value::float(5.1), Value::float(5.9));
+        expr.prepare_for_schema(&schema);
+        let five = Row::from_values(vec![Value::integer(5), Value::float(0.0), Value::text("x")]);
+        assert!(!expr.evaluate(&five).unwrap());
+        assert!(!expr.evaluate_fast(&five));
     }
 }

--- a/src/storage/expression/range.rs
+++ b/src/storage/expression/range.rs
@@ -229,9 +229,14 @@ impl RangeExpr {
         }
     }
 
-    /// Check integer bounds
+    /// Check integer bounds. With Float-typed bounds the integer cell is
+    /// compared as f64: the truncated int_min/int_max would turn
+    /// BETWEEN 5.1 AND 5.9 into [5, 5] and match 5.
     #[inline]
     fn check_integer(&self, val: i64) -> bool {
+        if self.bounds.data_type == DataType::Float {
+            return self.check_float(val as f64);
+        }
         // Check minimum
         if self.include_min {
             if val < self.bounds.int_min {

--- a/src/storage/volume/scanner.rs
+++ b/src/storage/volume/scanner.rs
@@ -479,7 +479,12 @@ impl VolumeScanner {
                             .saturating_add(dt.timestamp_subsec_nanos() as i64)
                     }))
                 }
-                (Value::Integer(v), crate::core::DataType::Float) => {
+                // Only lossless integers: `i as f64` rounds above 2^53 and
+                // the pre-filter must never reject rows the full filter
+                // accepts
+                (Value::Integer(v), crate::core::DataType::Float)
+                    if (*v as f64) as i64 == *v && v.abs() < (1_i64 << 53) =>
+                {
                     TypedTarget::Float64(*v as f64)
                 }
                 _ => continue,

--- a/src/storage/volume/scanner.rs
+++ b/src/storage/volume/scanner.rs
@@ -483,7 +483,7 @@ impl VolumeScanner {
                 // the pre-filter must never reject rows the full filter
                 // accepts
                 (Value::Integer(v), crate::core::DataType::Float)
-                    if (*v as f64) as i64 == *v && v.abs() < (1_i64 << 53) =>
+                    if crate::core::value::lossless_f64_from_i64(*v).is_some() =>
                 {
                     TypedTarget::Float64(*v as f64)
                 }

--- a/tests/float_int_where_test.rs
+++ b/tests/float_int_where_test.rs
@@ -181,3 +181,140 @@ fn integer_column_float_aggregate_pushdown() {
         .unwrap();
     assert_eq!(s, 3); // 0 + 1 + 2
 }
+
+#[test]
+fn in_list_out_of_range_whole_float_does_not_match_extremes() {
+    let db = Database::open("memory://float_int_inrange").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 9223372036854775807)", ())
+        .unwrap();
+
+    // 2^63 is whole but saturates to i64::MAX under a cast
+    assert_eq!(
+        row_count(&db, "SELECT * FROM t WHERE n IN (1, 9223372036854775808.0)"),
+        0
+    );
+    assert_eq!(
+        row_count(
+            &db,
+            "SELECT * FROM t WHERE n NOT IN (1, 9223372036854775808.0)"
+        ),
+        1
+    );
+    // 2^53 + 1 rounds to 2^53 as f64; the linear fallback must not match
+    db.execute("INSERT INTO t VALUES (2, 9007199254740993)", ())
+        .unwrap();
+    assert_eq!(
+        row_count(&db, "SELECT * FROM t WHERE n IN (1.5, 9007199254740992.0)"),
+        0
+    );
+}
+
+#[test]
+fn join_on_integer_float_keys_is_exact_at_extremes() {
+    let db = Database::open("memory://float_int_join").unwrap();
+    db.execute("CREATE TABLE a (id INTEGER PRIMARY KEY, i INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE b (id INTEGER PRIMARY KEY, f FLOAT)", ())
+        .unwrap();
+    db.execute("INSERT INTO a VALUES (1, 9223372036854775807)", ())
+        .unwrap();
+    db.execute("INSERT INTO b VALUES (1, 9223372036854775808.0)", ())
+        .unwrap();
+
+    // i64::MAX must not join Float(2^63)
+    assert_eq!(row_count(&db, "SELECT * FROM a JOIN b ON a.i = b.f"), 0);
+    // NOTE: representable cross-type pairs (42 vs 42.0) do not hash-join
+    // on main either; the join hash table buckets Integer and Float keys
+    // separately. Tracked as a separate pre-existing bug.
+}
+
+#[test]
+fn float_column_integer_threshold_is_exact_at_extremes() {
+    let db = Database::open("memory://float_int_thresh").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, f FLOAT)", ())
+        .unwrap();
+    // Largest f64 below i64::MAX
+    db.execute("INSERT INTO t VALUES (1, 9223372036854774784.0)", ())
+        .unwrap();
+
+    // cell < threshold, so >= must reject; a rounded cast accepts it
+    assert_eq!(
+        row_count(&db, "SELECT * FROM t WHERE f >= 9223372036854774785"),
+        0
+    );
+    assert_eq!(
+        row_count(&db, "SELECT * FROM t WHERE f < 9223372036854774785"),
+        1
+    );
+}
+
+#[test]
+fn semantic_cache_distinguishes_large_integer_predicates() {
+    let db = Database::open("memory://float_int_semcache").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 9223372036854775807)", ())
+        .unwrap();
+
+    // Warm the cache with the broader predicate, then run one that differs
+    // only below f64 precision: they must not share a cache identity
+    assert_eq!(
+        row_count(&db, "SELECT * FROM t WHERE n > 9223372036854775806"),
+        1
+    );
+    assert_eq!(
+        row_count(&db, "SELECT * FROM t WHERE n > 9223372036854775807"),
+        0
+    );
+}
+
+#[test]
+fn between_mixed_bounds_are_exact_at_extremes() {
+    let db = Database::open("memory://float_int_btwmix").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 9223372036854775807)", ())
+        .unwrap();
+
+    // Integer lower bound must not round through f64: i64::MAX stays
+    // within [i64::MAX, 2^63]
+    assert_eq!(
+        row_count(
+            &db,
+            "SELECT * FROM t WHERE n BETWEEN 9223372036854775807 AND 9223372036854775808.0"
+        ),
+        1
+    );
+    // i64::MAX - 1 is below the integer lower bound
+    db.execute("UPDATE t SET n = 9223372036854775806 WHERE id = 1", ())
+        .unwrap();
+    assert_eq!(
+        row_count(
+            &db,
+            "SELECT * FROM t WHERE n BETWEEN 9223372036854775807 AND 9223372036854775808.0"
+        ),
+        0
+    );
+
+    // Float cell against an integer upper bound: 2^63 is above i64::MAX
+    db.execute("CREATE TABLE tf (id INTEGER PRIMARY KEY, f FLOAT)", ())
+        .unwrap();
+    db.execute("INSERT INTO tf VALUES (1, 9223372036854775808.0)", ())
+        .unwrap();
+    assert_eq!(
+        row_count(
+            &db,
+            "SELECT * FROM tf WHERE f BETWEEN 0 AND 9223372036854775807"
+        ),
+        0
+    );
+    assert_eq!(
+        row_count(
+            &db,
+            "SELECT * FROM tf WHERE f BETWEEN 9223372036854775807 AND 1e19"
+        ),
+        1
+    );
+}

--- a/tests/float_int_where_test.rs
+++ b/tests/float_int_where_test.rs
@@ -318,3 +318,29 @@ fn between_mixed_bounds_are_exact_at_extremes() {
         1
     );
 }
+
+#[test]
+fn i64_min_against_float_column_does_not_panic() {
+    let db = Database::open("memory://float_int_min").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, f FLOAT)", ())
+        .unwrap();
+    // -2^63 is exactly representable as f64
+    db.execute("INSERT INTO t VALUES (1, -9223372036854775808.0)", ())
+        .unwrap();
+
+    let stmt = db.prepare("SELECT * FROM t WHERE f = $1").unwrap();
+    for _ in 0..2 {
+        assert_eq!(
+            stmt.query((i64::MIN,))
+                .unwrap()
+                .collect_vec()
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+    assert_eq!(
+        row_count(&db, "SELECT * FROM t WHERE f <= -9223372036854775807"),
+        1
+    );
+}

--- a/tests/float_int_where_test.rs
+++ b/tests/float_int_where_test.rs
@@ -1,0 +1,183 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Float constants compared against INTEGER columns must compare
+//! numerically, never by truncating the float to i64.
+
+use stoolap::api::Database;
+
+fn row_count(db: &Database, sql: &str) -> usize {
+    db.query(sql, ()).unwrap().collect_vec().unwrap().len()
+}
+
+#[test]
+fn pk_lookup_float_literal_matches_standard_path() {
+    let db = Database::open(&format!("memory://float_int_{}", line!())).unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (5, 'x')", ()).unwrap();
+
+    // id = 5.5 matches nothing; a fast path that truncates 5.5 to 5 is wrong
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE id = 5.5"), 0);
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE id = 5.5"), 0);
+    // id = 5.0 equals integer 5
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE id = 5.0"), 1);
+}
+
+#[test]
+fn pk_update_delete_float_key_does_not_touch_truncated_row() {
+    let db = Database::open(&format!("memory://float_int_{}", line!())).unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (5, 'x')", ()).unwrap();
+
+    // UPDATE via fractional literal key must not touch row 5
+    for _ in 0..2 {
+        let n = db
+            .execute("UPDATE t SET v = 'y' WHERE id = 5.5", ())
+            .unwrap();
+        assert_eq!(n, 0);
+    }
+    let v: String = db.query_one("SELECT v FROM t WHERE id = 5", ()).unwrap();
+    assert_eq!(v, "x");
+
+    // Same through a prepared statement with a float parameter
+    let stmt = db.prepare("UPDATE t SET v = 'z' WHERE id = $1").unwrap();
+    for _ in 0..2 {
+        assert_eq!(stmt.execute((5.5f64,)).unwrap(), 0);
+    }
+    let v: String = db.query_one("SELECT v FROM t WHERE id = 5", ()).unwrap();
+    assert_eq!(v, "x");
+
+    // DELETE via fractional key must not delete row 5
+    for _ in 0..2 {
+        assert_eq!(db.execute("DELETE FROM t WHERE id = 5.5", ()).unwrap(), 0);
+    }
+    let n: i64 = db.query_one("SELECT COUNT(*) FROM t", ()).unwrap();
+    assert_eq!(n, 1);
+}
+
+#[test]
+fn pk_lookup_float_at_i64_boundary_does_not_hit_max_row() {
+    let db = Database::open(&format!("memory://float_int_{}", line!())).unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (9223372036854775807, 'max')", ())
+        .unwrap();
+
+    // 2^63 is not representable as i64; a saturating cast targets i64::MAX
+    for _ in 0..2 {
+        assert_eq!(
+            row_count(&db, "SELECT * FROM t WHERE id = 9223372036854775808.0"),
+            0
+        );
+    }
+    let stmt = db.prepare("SELECT * FROM t WHERE id = $1").unwrap();
+    for _ in 0..2 {
+        assert_eq!(
+            stmt.query((9.223372036854776e18f64,))
+                .unwrap()
+                .collect_vec()
+                .unwrap()
+                .len(),
+            0
+        );
+    }
+    // UPDATE/DELETE must not touch the i64::MAX row either
+    assert_eq!(
+        db.execute("UPDATE t SET v = 'y' WHERE id = 9223372036854775808.0", ())
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        db.execute("DELETE FROM t WHERE id = 9223372036854775808.0", ())
+            .unwrap(),
+        0
+    );
+    let v: String = db
+        .query_one("SELECT v FROM t WHERE id = 9223372036854775807", ())
+        .unwrap();
+    assert_eq!(v, "max");
+}
+
+#[test]
+fn integer_column_float_comparisons_are_numeric() {
+    let db = Database::open("memory://float_int_cmp").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (5, 5)", ()).unwrap();
+
+    // Equality and inequality: 5 vs 5.4 / 5.5
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE n = 5.4"), 0);
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE n != 5.5"), 1);
+    // Ordering: 5 < 5.5, 5 > 4.5, 5 <= 4.5 false, 5 >= 5.5 false
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE n < 5.5"), 1);
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE n > 4.5"), 1);
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE n <= 4.5"), 0);
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE n >= 5.5"), 0);
+    // Exact float boundaries still match
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE n = 5.0"), 1);
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE n <= 5.0"), 1);
+    // The same comparisons on the PK column (index-probe path)
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE id < 5.5"), 1);
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE id >= 5.5"), 0);
+    // Expression on the left defeats pushdown; VM path must agree
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE n + 0 = 5.5"), 0);
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE n + 0 < 5.5"), 1);
+}
+
+#[test]
+fn integer_column_float_in_list_and_between() {
+    let db = Database::open("memory://float_int_inlist").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (5, 5)", ()).unwrap();
+
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE n IN (5.5, 6.5)"), 0);
+    assert_eq!(row_count(&db, "SELECT * FROM t WHERE n IN (5.0, 6.5)"), 1);
+    assert_eq!(
+        row_count(&db, "SELECT * FROM t WHERE n BETWEEN 5.1 AND 5.9"),
+        0
+    );
+    assert_eq!(
+        row_count(&db, "SELECT * FROM t WHERE n BETWEEN 4.5 AND 5.5"),
+        1
+    );
+}
+
+#[test]
+fn integer_column_float_aggregate_pushdown() {
+    let db = Database::open("memory://float_int_agg").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..1000i64 {
+        tx.execute("INSERT INTO t VALUES ($1, $2)", (i, i)).unwrap();
+    }
+    tx.commit().unwrap();
+
+    // 0..=999: values > 499.5 are 500..=999 -> 500 rows
+    let c: i64 = db
+        .query_one("SELECT COUNT(*) FROM t WHERE n > 499.5", ())
+        .unwrap();
+    assert_eq!(c, 500);
+    let c: i64 = db
+        .query_one("SELECT COUNT(*) FROM t WHERE n = 499.5", ())
+        .unwrap();
+    assert_eq!(c, 0);
+    let s: i64 = db
+        .query_one("SELECT SUM(n) FROM t WHERE n < 2.5", ())
+        .unwrap();
+    assert_eq!(s, 3); // 0 + 1 + 2
+}


### PR DESCRIPTION
Found while hardening the PK fast path in #39: the fast paths truncated float keys, and it turned out the standard path does too, at several independent layers. This PR fixes the family engine-wide.

## Symptoms (all red-first tests on main)

- `WHERE n = 5.4` matched n = 5; `WHERE n != 5.5` matched nothing
- `WHERE n < 5.5` returned zero rows for n = 5
- `WHERE n IN (5.5, 6.5)` matched n = 5
- `WHERE n BETWEEN 5.1 AND 5.9` matched n = 5
- `SELECT COUNT(*) WHERE n > 499.5` counted through the truncated bound
- `UPDATE t SET ... WHERE id = 5.5` mutated row 5; DELETE likewise
- `WHERE id = 9223372036854775808.0` (2^63) matched the i64::MAX row

## Root causes and fixes, by layer

1. **Plan-time coercion (the main root)**: `pushdown` coerced WHERE constants with `into_coerce_to_type`, the INSERT-style storage coercion, turning `n = 5.5` into `n = 5` before anything else ran. WHERE constants now convert Float to Integer only losslessly and otherwise stay floats.
2. **Compiled storage filters**: the typed variants were chosen by constant type only, so a Float filter against an INTEGER column never matched anything (`n < 5.5` returned zero rows once layer 1 stopped truncating). Selection is now schema-aware, and fractional ranges rewrite to exact integer bounds (`n < 5.5` is `n <= 5`, `n > -5.5` is `n >= -5`, BETWEEN gets `[ceil, floor]`), which keeps these index- and zone-map-friendly. Fractional equality falls to the dynamic path, which compares numerically.
3. **Between/Range/InList storage expressions**: integer cells now compare float bounds and float list values numerically instead of through `as_int64`.
4. **Exact extreme comparison**: `i as f64` rounds above 2^53, so `Integer(i64::MAX) == Float(2^63)` was true across PartialEq, Value::compare, the storage comparison, and the fused VM ops. New `core::value::cmp_i64_f64` compares exactly over the full range (unit-tested at the boundaries); all cross-type numeric comparison sites now use it, including 49 fused VM op arms in both directions. Arithmetic casts are untouched.

## Verification

- 6 end-to-end regression tests, each proven red on main before the fix, plus unit tests for `cmp_i64_f64` boundaries
- fmt + clippy -D warnings clean
- Both suites green: 4895/4895 default, 4895/4895 test-filedb; the new integration test also passes under CI-mode `cargo test`
- Perf numbers on the hot comparison paths follow as a comment. The integer-vs-integer fast arms are untouched; the exact comparison only runs on cross-type (float-vs-integer) arms.