### PR TITLE
perf(dml): cut fixed costs on the prepared INSERT path

### DIFF
--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -158,6 +158,73 @@ fn try_extract_simple_value(expr: &Expression, ctx: &ExecutionContext) -> Option
     None
 }
 
+/// Evaluate one default slot for a row: run the per-row program when the
+/// default is non-literal, else clone the constant template value.
+fn eval_default_slot(
+    vm: &mut super::expression::ExprVM,
+    exec_ctx: &super::expression::ExecuteContext,
+    program: &Option<(super::expression::SharedProgram, DataType)>,
+    template_val: &Value,
+) -> Value {
+    match program {
+        Some((program, target)) => match vm.execute_cow(program, exec_ctx) {
+            Ok(v) => v.into_coerce_to_type(*target),
+            Err(_) => Value::null_unknown(),
+        },
+        None => template_val.clone(),
+    }
+}
+
+/// Per-statement default machinery: constant defaults land in the value
+/// template; non-literal defaults compile ONCE and execute PER ROW, so
+/// DEFAULT (RANDOM()) differs per row. Parse and compile failures degrade
+/// the slot to NULL, preserving evaluate_default_expr's swallowed-error
+/// behavior for defaults.
+#[allow(clippy::type_complexity)]
+fn build_default_slots(
+    schema: &crate::core::Schema,
+) -> (
+    Vec<Value>,
+    Vec<Option<(super::expression::SharedProgram, DataType)>>,
+) {
+    use super::expression::compile_expression;
+    let n = schema.columns.len();
+    let mut values = Vec::with_capacity(n);
+    let mut programs: Vec<Option<(super::expression::SharedProgram, DataType)>> = vec![None; n];
+    for (i, c) in schema.columns.iter().enumerate() {
+        let Some(expr_str) = c.default_expr.as_ref() else {
+            values.push(Value::null_unknown());
+            continue;
+        };
+        let target = c.data_type;
+        let sql = format!("SELECT {}", expr_str);
+        let Ok(stmts) = crate::parser::parse_sql(&sql) else {
+            values.push(Value::null_unknown());
+            continue;
+        };
+        let Some(crate::parser::ast::Statement::Select(select)) = stmts.first() else {
+            values.push(Value::null_unknown());
+            continue;
+        };
+        let Some(expr) = select.columns.first() else {
+            values.push(Value::null_unknown());
+            continue;
+        };
+        if let Some(lit) = try_extract_literal(expr) {
+            values.push(lit.into_coerce_to_type(target));
+            continue;
+        }
+        match compile_expression(expr, &[]) {
+            Ok(program) => {
+                values.push(Value::null_unknown());
+                programs[i] = Some((program, target));
+            }
+            Err(_) => values.push(Value::null_unknown()),
+        }
+    }
+    (values, programs)
+}
+
 /// Pre-compiled upsert expressions built once per INSERT statement and reused for every
 /// conflicting row. Without this, `apply_on_duplicate_update` recompiles expressions and
 /// re-parses CHECK constraint SQL on every conflict, causing O(n) allocation churn.
@@ -354,20 +421,19 @@ impl Executor {
         let column_names: Vec<String>;
         // Pre-compute ALL column types for default values and check constraints
         let all_column_types: Vec<crate::core::DataType>;
-        // Pre-compute default values and check expressions for all columns
-        let default_exprs: Vec<Option<String>>;
+        // Per-statement default slots: constant values plus per-row programs
+        let default_values: Vec<Value>;
+        let default_programs: Vec<Option<(super::expression::SharedProgram, DataType)>>;
         // OPTIMIZATION: Only collect columns that have CHECK constraints (saves 3ms clone overhead)
         let check_exprs: Vec<(usize, String, String)>; // (col_idx, column_name, check_expr)
         {
             let schema = table.schema();
             schema_column_count = schema.columns.len();
 
-            // Extract default and check expressions from schema
-            default_exprs = schema
-                .columns
-                .iter()
-                .map(|c| c.default_expr.clone())
-                .collect();
+            // Build default slots from schema
+            let (dv, dp) = build_default_slots(schema);
+            default_values = dv;
+            default_programs = dp;
             // Only collect columns that actually have CHECK constraints
             check_exprs = schema
                 .columns
@@ -492,20 +558,6 @@ impl Executor {
             }
 
             // Process each row from the SELECT result (streaming or materialized)
-            // DEFAULT expressions evaluate once per statement (matching
-            // the compiled path): each evaluation re-parses the default
-            // SQL, so per-row evaluation costs a parser run per row.
-            let default_template: Vec<Value> = (0..schema_column_count)
-                .map(|i| {
-                    default_exprs[i]
-                        .as_ref()
-                        .map(|expr| {
-                            self.evaluate_default_expr(expr, all_column_types[i])
-                                .unwrap_or_else(|_| Value::null_unknown())
-                        })
-                        .unwrap_or_else(Value::null_unknown)
-                })
-                .collect();
             while select_result.next() {
                 let select_row = select_result.row();
                 if select_row.len() != column_indices.len() {
@@ -519,7 +571,17 @@ impl Executor {
                 // Build row values - initialize with DEFAULT values for missing columns
                 // This matches the behavior of regular INSERT
                 let mut row_values = Vec::with_capacity(schema_column_count);
-                row_values.extend(default_template.iter().cloned());
+                for i in 0..schema_column_count {
+                    row_values.push(match &default_programs[i] {
+                        // Non-literal defaults run per row (RANDOM() must
+                        // differ per row); constant defaults clone
+                        Some((program, target)) => match vm.execute_cow(program, &base_exec_ctx) {
+                            Ok(v) => v.into_coerce_to_type(*target),
+                            Err(_) => Value::null_unknown(),
+                        },
+                        None => default_values[i].clone(),
+                    });
+                }
 
                 // Fill in values from SELECT using pre-computed indices with type coercion
                 for (i, value) in select_row.iter().enumerate() {
@@ -773,20 +835,6 @@ impl Executor {
                 None
             };
 
-            // DEFAULT expressions evaluate once per statement (matching
-            // the compiled path): each evaluation re-parses the default
-            // SQL, so per-row evaluation costs a parser run per row.
-            let default_template: Vec<Value> = (0..schema_column_count)
-                .map(|i| {
-                    default_exprs[i]
-                        .as_ref()
-                        .map(|expr| {
-                            self.evaluate_default_expr(expr, all_column_types[i])
-                                .unwrap_or_else(|_| Value::null_unknown())
-                        })
-                        .unwrap_or_else(Value::null_unknown)
-                })
-                .collect();
             for value_row in &stmt.values {
                 if value_row.len() != column_indices.len() {
                     return Err(Error::InvalidArgument(format!(
@@ -798,7 +846,17 @@ impl Executor {
 
                 // Build row values - need Vec for error handling paths
                 let mut row_values = Vec::with_capacity(schema_column_count);
-                row_values.extend(default_template.iter().cloned());
+                for i in 0..schema_column_count {
+                    row_values.push(match &default_programs[i] {
+                        // Non-literal defaults run per row (RANDOM() must
+                        // differ per row); constant defaults clone
+                        Some((program, target)) => match vm.execute_cow(program, &base_exec_ctx) {
+                            Ok(v) => v.into_coerce_to_type(*target),
+                            Err(_) => Value::null_unknown(),
+                        },
+                        None => default_values[i].clone(),
+                    });
+                }
                 // Fill in provided values using pre-computed indices with type coercion
                 for (i, expr) in value_row.iter().enumerate() {
                     // Handle DEFAULT keyword - skip this column to use pre-initialized default
@@ -980,20 +1038,6 @@ impl Executor {
             }
         } else {
             // Fast path: normal INSERT without clones
-            // DEFAULT expressions evaluate once per statement (matching
-            // the compiled path): each evaluation re-parses the default
-            // SQL, so per-row evaluation costs a parser run per row.
-            let default_template: Vec<Value> = (0..schema_column_count)
-                .map(|i| {
-                    default_exprs[i]
-                        .as_ref()
-                        .map(|expr| {
-                            self.evaluate_default_expr(expr, all_column_types[i])
-                                .unwrap_or_else(|_| Value::null_unknown())
-                        })
-                        .unwrap_or_else(Value::null_unknown)
-                })
-                .collect();
             for value_row in &stmt.values {
                 if value_row.len() != column_indices.len() {
                     return Err(Error::InvalidArgument(format!(
@@ -1005,7 +1049,17 @@ impl Executor {
 
                 // Build row values - initialize with DEFAULT values for missing columns
                 let mut row_values = Vec::with_capacity(schema_column_count);
-                row_values.extend(default_template.iter().cloned());
+                for i in 0..schema_column_count {
+                    row_values.push(match &default_programs[i] {
+                        // Non-literal defaults run per row (RANDOM() must
+                        // differ per row); constant defaults clone
+                        Some((program, target)) => match vm.execute_cow(program, &base_exec_ctx) {
+                            Ok(v) => v.into_coerce_to_type(*target),
+                            Err(_) => Value::null_unknown(),
+                        },
+                        None => default_values[i].clone(),
+                    });
+                }
 
                 // Fill in provided values using pre-computed indices with type coercion
                 for (i, expr) in value_row.iter().enumerate() {
@@ -1185,7 +1239,7 @@ impl Executor {
             column_types,
             column_vector_dims,
             column_names,
-            _all_column_types,
+            default_programs,
             default_row_template,
             compiled_checks,
         ) = if let Some(cached) = cached_insert {
@@ -1195,7 +1249,7 @@ impl Executor {
                 cached.column_types,
                 cached.column_vector_dims,
                 cached.column_names,
-                cached.all_column_types,
+                cached.default_programs,
                 cached.default_row_template,
                 cached.compiled_checks,
             )
@@ -1204,58 +1258,53 @@ impl Executor {
             let schema = table.schema();
             let schema_column_count = schema.columns.len();
 
-            // Only collect columns that actually have CHECK constraints,
-            // pre-compiling each check once per plan (parse failures skip
-            // validation, matching validate_check_constraint)
-            let compiled_checks: Vec<(
+            // Pre-compile CHECK constraints once per plan. Parse failures
+            // skip validation (matching validate_check_constraint), but a
+            // COMPILE failure must fail the INSERT: the per-row path
+            // propagated it, and swallowing it here would silently disable
+            // the constraint (e.g. after RENAME COLUMN leaves a stale
+            // check_expr).
+            let mut compiled_checks: Vec<(
                 usize,
                 SmartString,
                 SmartString,
                 super::expression::SharedProgram,
-            )> = schema
-                .columns
-                .iter()
-                .enumerate()
-                .filter_map(|(idx, c)| {
-                    let check_expr = c.check_expr.as_ref()?;
-                    let sql = format!("SELECT {}", check_expr);
-                    let stmts = crate::parser::parse_sql(&sql).ok()?;
-                    if let Some(crate::parser::ast::Statement::Select(select)) = stmts.first() {
-                        let expr = select.columns.first()?;
-                        let columns = vec![c.name.to_string()];
-                        let program = compile_expression(expr, &columns).ok()?;
-                        Some((
-                            idx,
-                            SmartString::new(&c.name),
-                            SmartString::new(check_expr),
-                            program,
-                        ))
-                    } else {
-                        None
-                    }
-                })
-                .collect();
+            )> = Vec::new();
+            for (idx, c) in schema.columns.iter().enumerate() {
+                let Some(check_expr) = c.check_expr.as_ref() else {
+                    continue;
+                };
+                let sql = format!("SELECT {}", check_expr);
+                let Ok(stmts) = crate::parser::parse_sql(&sql) else {
+                    continue;
+                };
+                let Some(crate::parser::ast::Statement::Select(select)) = stmts.first() else {
+                    continue;
+                };
+                let Some(expr) = select.columns.first() else {
+                    continue;
+                };
+                let columns = vec![c.name.to_string()];
+                let program = compile_expression(expr, &columns).map_err(|e| {
+                    Error::internal(format!(
+                        "CHECK constraint on column '{}' failed to compile: {}",
+                        c.name, e
+                    ))
+                })?;
+                compiled_checks.push((
+                    idx,
+                    SmartString::new(&c.name),
+                    SmartString::new(check_expr),
+                    program,
+                ));
+            }
 
             let all_column_types: Vec<DataType> =
                 schema.columns.iter().map(|c| c.data_type).collect();
 
-            // Pre-evaluate all default expressions into a template row
-            // This avoids re-evaluating defaults on every INSERT
-            let default_row_template: Vec<Value> = schema
-                .columns
-                .iter()
-                .enumerate()
-                .map(|(i, c)| {
-                    if let Some(ref default_expr) = c.default_expr {
-                        match self.evaluate_default_expr(default_expr, all_column_types[i]) {
-                            Ok(val) => val,
-                            Err(_) => Value::null_unknown(),
-                        }
-                    } else {
-                        Value::null_unknown()
-                    }
-                })
-                .collect();
+            // Constant defaults land in the template; non-literal defaults
+            // compile once and execute per row
+            let (default_row_template, default_programs) = build_default_slots(schema);
 
             let (column_indices, column_types, column_vector_dims, column_names) =
                 if stmt.columns.is_empty() {
@@ -1305,7 +1354,7 @@ impl Executor {
                 column_types: Arc::new(column_types.clone()),
                 column_vector_dims: Arc::new(column_vector_dims.clone()),
                 column_names: Arc::new(column_names.clone()),
-                all_column_types: Arc::new(all_column_types.clone()),
+                default_programs: Arc::new(default_programs.clone()),
                 default_row_template: Arc::new(default_row_template.clone()),
                 compiled_checks: Arc::new(compiled_checks.clone()),
                 cached_epoch: current_epoch,
@@ -1321,7 +1370,7 @@ impl Executor {
                 Arc::new(column_types),
                 Arc::new(column_vector_dims),
                 Arc::new(column_names),
-                Arc::new(all_column_types),
+                Arc::new(default_programs),
                 Arc::new(default_row_template),
                 Arc::new(compiled_checks),
             )
@@ -1411,7 +1460,12 @@ impl Executor {
                         row_values.push(coerced);
                     } else {
                         // Column not in insert list - use default
-                        row_values.push(default_val.clone());
+                        row_values.push(eval_default_slot(
+                            &mut vm,
+                            &base_exec_ctx,
+                            &default_programs[col_idx],
+                            default_val,
+                        ));
                     }
                 }
 
@@ -1484,8 +1538,13 @@ impl Executor {
                         // Column in insert list - evaluate expression
                         let expr = &value_list[value_pos];
                         if matches!(expr, Expression::Default(_)) {
-                            // DEFAULT keyword - use pre-evaluated default
-                            row_values.push(default_val.clone());
+                            // DEFAULT keyword - same per-row slot machinery
+                            row_values.push(eval_default_slot(
+                                &mut vm,
+                                &base_exec_ctx,
+                                &default_programs[col_idx],
+                                default_val,
+                            ));
                         } else {
                             // OPTIMIZATION: literals and bound parameters
                             // resolve directly (avoids VM compilation)
@@ -1510,7 +1569,12 @@ impl Executor {
                         }
                     } else {
                         // Column not in insert list - use default
-                        row_values.push(default_val.clone());
+                        row_values.push(eval_default_slot(
+                            &mut vm,
+                            &base_exec_ctx,
+                            &default_programs[col_idx],
+                            default_val,
+                        ));
                     }
                 }
 
@@ -2945,20 +3009,32 @@ impl Executor {
             .iter()
             .filter_map(|(idx, _, _, _)| {
                 let col = &schema.columns[*idx];
-                col.check_expr.as_ref().and_then(|check_expr| {
-                    let sql = format!("SELECT {}", check_expr);
-                    let stmts = parse_sql(&sql).ok()?;
-                    if let Some(crate::parser::ast::Statement::Select(select)) = stmts.first() {
-                        let expr = select.columns.first()?;
-                        let columns = vec![col.name.to_string()];
-                        let program = compile_expression(expr, &columns).ok()?;
-                        Some((*idx, col.name.to_string(), check_expr.to_string(), program))
-                    } else {
-                        None
-                    }
-                })
+                let check_expr = col.check_expr.as_ref()?;
+                let sql = format!("SELECT {}", check_expr);
+                // Parse failures skip validation (matching
+                // validate_check_constraint); compile failures propagate
+                let Ok(stmts) = parse_sql(&sql) else {
+                    return None;
+                };
+                let crate::parser::ast::Statement::Select(select) = stmts.first()? else {
+                    return None;
+                };
+                let expr = select.columns.first()?;
+                let columns = vec![col.name.to_string()];
+                Some(
+                    compile_expression(expr, &columns)
+                        .map(|program| {
+                            (*idx, col.name.to_string(), check_expr.to_string(), program)
+                        })
+                        .map_err(|e| {
+                            Error::internal(format!(
+                                "CHECK constraint on column '{}' failed to compile: {}",
+                                col.name, e
+                            ))
+                        }),
+                )
             })
-            .collect();
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(CompiledUpsert {
             compiled_updates,

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -139,6 +139,25 @@ fn try_extract_literal(expr: &Expression) -> Option<Value> {
     }
 }
 
+/// Literal extraction plus direct parameter resolution: a bound $n is
+/// already a Value in the context, and routing it through the program
+/// cache costs an AST hash plus a global mutex per parameter per row.
+#[inline]
+fn try_extract_simple_value(expr: &Expression, ctx: &ExecutionContext) -> Option<Value> {
+    if let Some(v) = try_extract_literal(expr) {
+        return Some(v);
+    }
+    if let Expression::Parameter(param) = expr {
+        if let Some(name) = param.name.strip_prefix(':') {
+            return ctx.get_named_param(name).cloned();
+        }
+        if param.index > 0 {
+            return ctx.params().get(param.index - 1).cloned();
+        }
+    }
+    None
+}
+
 /// Pre-compiled upsert expressions built once per INSERT statement and reused for every
 /// conflicting row. Without this, `apply_on_duplicate_update` recompiles expressions and
 /// re-parses CHECK constraint SQL on every conflict, causing O(n) allocation churn.
@@ -473,6 +492,20 @@ impl Executor {
             }
 
             // Process each row from the SELECT result (streaming or materialized)
+            // DEFAULT expressions evaluate once per statement (matching
+            // the compiled path): each evaluation re-parses the default
+            // SQL, so per-row evaluation costs a parser run per row.
+            let default_template: Vec<Value> = (0..schema_column_count)
+                .map(|i| {
+                    default_exprs[i]
+                        .as_ref()
+                        .map(|expr| {
+                            self.evaluate_default_expr(expr, all_column_types[i])
+                                .unwrap_or_else(|_| Value::null_unknown())
+                        })
+                        .unwrap_or_else(Value::null_unknown)
+                })
+                .collect();
             while select_result.next() {
                 let select_row = select_result.row();
                 if select_row.len() != column_indices.len() {
@@ -486,17 +519,7 @@ impl Executor {
                 // Build row values - initialize with DEFAULT values for missing columns
                 // This matches the behavior of regular INSERT
                 let mut row_values = Vec::with_capacity(schema_column_count);
-                for i in 0..schema_column_count {
-                    if let Some(ref default_expr) = default_exprs[i] {
-                        let default_type = all_column_types[i];
-                        match self.evaluate_default_expr(default_expr, default_type) {
-                            Ok(val) => row_values.push(val),
-                            Err(_) => row_values.push(Value::null_unknown()),
-                        }
-                    } else {
-                        row_values.push(Value::null_unknown());
-                    }
-                }
+                row_values.extend(default_template.iter().cloned());
 
                 // Fill in values from SELECT using pre-computed indices with type coercion
                 for (i, value) in select_row.iter().enumerate() {
@@ -750,6 +773,20 @@ impl Executor {
                 None
             };
 
+            // DEFAULT expressions evaluate once per statement (matching
+            // the compiled path): each evaluation re-parses the default
+            // SQL, so per-row evaluation costs a parser run per row.
+            let default_template: Vec<Value> = (0..schema_column_count)
+                .map(|i| {
+                    default_exprs[i]
+                        .as_ref()
+                        .map(|expr| {
+                            self.evaluate_default_expr(expr, all_column_types[i])
+                                .unwrap_or_else(|_| Value::null_unknown())
+                        })
+                        .unwrap_or_else(Value::null_unknown)
+                })
+                .collect();
             for value_row in &stmt.values {
                 if value_row.len() != column_indices.len() {
                     return Err(Error::InvalidArgument(format!(
@@ -761,17 +798,7 @@ impl Executor {
 
                 // Build row values - need Vec for error handling paths
                 let mut row_values = Vec::with_capacity(schema_column_count);
-                for i in 0..schema_column_count {
-                    if let Some(ref default_expr) = default_exprs[i] {
-                        let default_type = all_column_types[i];
-                        match self.evaluate_default_expr(default_expr, default_type) {
-                            Ok(val) => row_values.push(val),
-                            Err(_) => row_values.push(Value::null_unknown()),
-                        }
-                    } else {
-                        row_values.push(Value::null_unknown());
-                    }
-                }
+                row_values.extend(default_template.iter().cloned());
                 // Fill in provided values using pre-computed indices with type coercion
                 for (i, expr) in value_row.iter().enumerate() {
                     // Handle DEFAULT keyword - skip this column to use pre-initialized default
@@ -953,6 +980,20 @@ impl Executor {
             }
         } else {
             // Fast path: normal INSERT without clones
+            // DEFAULT expressions evaluate once per statement (matching
+            // the compiled path): each evaluation re-parses the default
+            // SQL, so per-row evaluation costs a parser run per row.
+            let default_template: Vec<Value> = (0..schema_column_count)
+                .map(|i| {
+                    default_exprs[i]
+                        .as_ref()
+                        .map(|expr| {
+                            self.evaluate_default_expr(expr, all_column_types[i])
+                                .unwrap_or_else(|_| Value::null_unknown())
+                        })
+                        .unwrap_or_else(Value::null_unknown)
+                })
+                .collect();
             for value_row in &stmt.values {
                 if value_row.len() != column_indices.len() {
                     return Err(Error::InvalidArgument(format!(
@@ -964,18 +1005,7 @@ impl Executor {
 
                 // Build row values - initialize with DEFAULT values for missing columns
                 let mut row_values = Vec::with_capacity(schema_column_count);
-                for i in 0..schema_column_count {
-                    if let Some(ref default_expr) = default_exprs[i] {
-                        // Evaluate the default expression using the actual column type
-                        let default_type = all_column_types[i];
-                        match self.evaluate_default_expr(default_expr, default_type) {
-                            Ok(val) => row_values.push(val),
-                            Err(_) => row_values.push(Value::null_unknown()),
-                        }
-                    } else {
-                        row_values.push(Value::null_unknown());
-                    }
-                }
+                row_values.extend(default_template.iter().cloned());
 
                 // Fill in provided values using pre-computed indices with type coercion
                 for (i, expr) in value_row.iter().enumerate() {
@@ -1155,9 +1185,9 @@ impl Executor {
             column_types,
             column_vector_dims,
             column_names,
-            all_column_types,
+            _all_column_types,
             default_row_template,
-            check_exprs,
+            compiled_checks,
         ) = if let Some(cached) = cached_insert {
             // Use cached values (Arc clone is cheap)
             (
@@ -1167,22 +1197,42 @@ impl Executor {
                 cached.column_names,
                 cached.all_column_types,
                 cached.default_row_template,
-                cached.check_exprs,
+                cached.compiled_checks,
             )
         } else {
             // Compile and cache
             let schema = table.schema();
             let schema_column_count = schema.columns.len();
 
-            // Only collect columns that actually have CHECK constraints
-            let check_exprs: Vec<(usize, SmartString, SmartString)> = schema
+            // Only collect columns that actually have CHECK constraints,
+            // pre-compiling each check once per plan (parse failures skip
+            // validation, matching validate_check_constraint)
+            let compiled_checks: Vec<(
+                usize,
+                SmartString,
+                SmartString,
+                super::expression::SharedProgram,
+            )> = schema
                 .columns
                 .iter()
                 .enumerate()
                 .filter_map(|(idx, c)| {
-                    c.check_expr
-                        .as_ref()
-                        .map(|expr| (idx, SmartString::new(&c.name), SmartString::new(expr)))
+                    let check_expr = c.check_expr.as_ref()?;
+                    let sql = format!("SELECT {}", check_expr);
+                    let stmts = crate::parser::parse_sql(&sql).ok()?;
+                    if let Some(crate::parser::ast::Statement::Select(select)) = stmts.first() {
+                        let expr = select.columns.first()?;
+                        let columns = vec![c.name.to_string()];
+                        let program = compile_expression(expr, &columns).ok()?;
+                        Some((
+                            idx,
+                            SmartString::new(&c.name),
+                            SmartString::new(check_expr),
+                            program,
+                        ))
+                    } else {
+                        None
+                    }
                 })
                 .collect();
 
@@ -1257,7 +1307,7 @@ impl Executor {
                 column_names: Arc::new(column_names.clone()),
                 all_column_types: Arc::new(all_column_types.clone()),
                 default_row_template: Arc::new(default_row_template.clone()),
-                check_exprs: Arc::new(check_exprs.clone()),
+                compiled_checks: Arc::new(compiled_checks.clone()),
                 cached_epoch: current_epoch,
             };
 
@@ -1273,7 +1323,7 @@ impl Executor {
                 Arc::new(column_names),
                 Arc::new(all_column_types),
                 Arc::new(default_row_template),
-                Arc::new(check_exprs),
+                Arc::new(compiled_checks),
             )
         };
 
@@ -1365,15 +1415,30 @@ impl Executor {
                     }
                 }
 
-                // Validate CHECK constraints
-                for (col_idx, col_name, check_expr) in check_exprs.iter() {
-                    let col_type = all_column_types[*col_idx];
-                    self.validate_check_constraint(
-                        check_expr,
-                        col_name,
-                        &row_values[*col_idx],
-                        col_type,
-                    )?;
+                // Validate CHECK constraints via the pre-compiled programs
+                // (NULL passes per the SQL standard)
+                for (col_idx, col_name, check_expr, program) in compiled_checks.iter() {
+                    let col_value = &row_values[*col_idx];
+                    if col_value.is_null() {
+                        continue;
+                    }
+                    let check_row = Row::from_values(vec![col_value.clone()]);
+                    let check_ctx = ExecuteContext::new(&check_row);
+                    let result = vm.execute_cow(program, &check_ctx)?;
+                    let is_truthy = match &result {
+                        Value::Boolean(b) => *b,
+                        Value::Null(_) => true, // NULL passes CHECK (SQL standard)
+                        Value::Integer(i) => *i != 0,
+                        Value::Float(f) => *f != 0.0,
+                        Value::Text(t) => !t.is_empty(),
+                        _ => true, // Timestamp, Extension, etc. are truthy
+                    };
+                    if !is_truthy {
+                        return Err(Error::CheckConstraintViolation {
+                            column: col_name.to_string(),
+                            expression: check_expr.to_string(),
+                        });
+                    }
                 }
 
                 // Insert row
@@ -1422,9 +1487,10 @@ impl Executor {
                             // DEFAULT keyword - use pre-evaluated default
                             row_values.push(default_val.clone());
                         } else {
-                            // OPTIMIZATION: Try literal extraction first (avoids VM compilation)
-                            let value = if let Some(lit_val) = try_extract_literal(expr) {
-                                lit_val
+                            // OPTIMIZATION: literals and bound parameters
+                            // resolve directly (avoids VM compilation)
+                            let value = if let Some(simple) = try_extract_simple_value(expr, ctx) {
+                                simple
                             } else {
                                 // Fall back to VM evaluation for complex expressions
                                 let program = compile_expression(expr, &[])?;
@@ -1448,15 +1514,29 @@ impl Executor {
                     }
                 }
 
-                // Validate CHECK constraints
-                for (col_idx, col_name, check_expr) in check_exprs.iter() {
-                    let col_type = all_column_types[*col_idx];
-                    self.validate_check_constraint(
-                        check_expr,
-                        col_name,
-                        &row_values[*col_idx],
-                        col_type,
-                    )?;
+                // Validate CHECK constraints via the pre-compiled programs
+                for (col_idx, col_name, check_expr, program) in compiled_checks.iter() {
+                    let col_value = &row_values[*col_idx];
+                    if col_value.is_null() {
+                        continue;
+                    }
+                    let check_row = Row::from_values(vec![col_value.clone()]);
+                    let check_ctx = ExecuteContext::new(&check_row);
+                    let result = vm.execute_cow(program, &check_ctx)?;
+                    let is_truthy = match &result {
+                        Value::Boolean(b) => *b,
+                        Value::Null(_) => true, // NULL passes CHECK (SQL standard)
+                        Value::Integer(i) => *i != 0,
+                        Value::Float(f) => *f != 0.0,
+                        Value::Text(t) => !t.is_empty(),
+                        _ => true, // Timestamp, Extension, etc. are truthy
+                    };
+                    if !is_truthy {
+                        return Err(Error::CheckConstraintViolation {
+                            column: col_name.to_string(),
+                            expression: check_expr.to_string(),
+                        });
+                    }
                 }
 
                 // Insert row

--- a/src/executor/query_cache.rs
+++ b/src/executor/query_cache.rs
@@ -153,10 +153,19 @@ pub struct CompiledInsert {
     pub column_vector_dims: Arc<Vec<u16>>,
     /// Column names for error messages (Arc for zero-copy sharing)
     pub column_names: Arc<Vec<SmartString>>,
-    /// All column types in the schema (for default value evaluation)
-    pub all_column_types: Arc<Vec<crate::core::DataType>>,
-    /// Pre-evaluated default values for all columns (avoids re-evaluation per row)
-    /// Each element is either the default Value or null_unknown if no default.
+    /// Per-row default programs: Some for non-literal defaults, which
+    /// must execute per row (DEFAULT (RANDOM()) differs per row)
+    #[allow(clippy::type_complexity)]
+    pub default_programs: Arc<
+        Vec<
+            Option<(
+                crate::executor::expression::SharedProgram,
+                crate::core::DataType,
+            )>,
+        >,
+    >,
+    /// Constant default values for all columns (null_unknown when the
+    /// column has no default or a per-row program)
     pub default_row_template: Arc<Vec<crate::core::Value>>,
     /// CHECK constraints, pre-compiled once per plan:
     /// (column_idx, column_name, check_expr, program). Re-parsing the

--- a/src/executor/query_cache.rs
+++ b/src/executor/query_cache.rs
@@ -141,7 +141,7 @@ pub struct CompiledPkDelete {
 
 /// Pre-compiled state for INSERT statements
 /// Caches schema-derived information to avoid recomputation on every INSERT execution
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CompiledInsert {
     /// Table name (already lowercased, SmartString for inline storage)
     pub table_name: SmartString,
@@ -158,10 +158,31 @@ pub struct CompiledInsert {
     /// Pre-evaluated default values for all columns (avoids re-evaluation per row)
     /// Each element is either the default Value or null_unknown if no default.
     pub default_row_template: Arc<Vec<crate::core::Value>>,
-    /// CHECK constraint expressions: (column_idx, column_name, check_expr)
-    pub check_exprs: Arc<Vec<(usize, SmartString, SmartString)>>,
+    /// CHECK constraints, pre-compiled once per plan:
+    /// (column_idx, column_name, check_expr, program). Re-parsing the
+    /// check SQL per row costs a tokenizer plus parser run per inserted
+    /// row per constrained column.
+    pub compiled_checks: Arc<
+        Vec<(
+            usize,
+            SmartString,
+            SmartString,
+            crate::executor::expression::SharedProgram,
+        )>,
+    >,
     /// Schema epoch at compilation time (for fast cache invalidation)
     pub cached_epoch: u64,
+}
+
+impl std::fmt::Debug for CompiledInsert {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompiledInsert")
+            .field("table_name", &self.table_name)
+            .field("column_indices", &self.column_indices)
+            .field("cached_epoch", &self.cached_epoch)
+            .field("compiled_checks", &self.compiled_checks.len())
+            .finish_non_exhaustive()
+    }
 }
 
 /// Pre-compiled state for COUNT(DISTINCT col) queries

--- a/tests/insert_path_test.rs
+++ b/tests/insert_path_test.rs
@@ -95,3 +95,55 @@ fn insert_defaults_apply_from_statement_template() {
         .unwrap();
     assert_eq!(s, "new");
 }
+
+#[test]
+fn volatile_defaults_evaluate_per_row() {
+    let db = Database::open("memory://insert_path_volatile").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, r FLOAT DEFAULT (RANDOM()))",
+        (),
+    )
+    .unwrap();
+
+    // Plain multi-row insert: each row must get its own RANDOM()
+    db.execute("INSERT INTO t (id) VALUES (1), (2), (3), (4)", ())
+        .unwrap();
+    let distinct: i64 = db.query_one("SELECT COUNT(DISTINCT r) FROM t", ()).unwrap();
+    assert_eq!(
+        distinct, 4,
+        "each row must evaluate DEFAULT RANDOM() itself"
+    );
+
+    // Prepared path: values must differ across executions too
+    let stmt = db.prepare("INSERT INTO t (id) VALUES ($1)").unwrap();
+    for id in 5..9i64 {
+        stmt.execute((id,)).unwrap();
+    }
+    let distinct: i64 = db.query_one("SELECT COUNT(DISTINCT r) FROM t", ()).unwrap();
+    assert_eq!(distinct, 8);
+
+    // DEFAULT keyword goes through the same per-row evaluation
+    db.execute("INSERT INTO t VALUES (9, DEFAULT), (10, DEFAULT)", ())
+        .unwrap();
+    let distinct: i64 = db.query_one("SELECT COUNT(DISTINCT r) FROM t", ()).unwrap();
+    assert_eq!(distinct, 10);
+}
+
+#[test]
+fn uncompilable_check_still_rejects_inserts() {
+    let db = Database::open("memory://insert_path_badcheck").unwrap();
+    // The check references a column that cannot resolve in the check's
+    // single-column context; DDL does not validate it
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER CHECK (nosuch > 0))",
+        (),
+    )
+    .unwrap();
+
+    // The old per-row path errored on every insert; a compile failure must
+    // not silently disable the constraint
+    let stmt = db.prepare("INSERT INTO t VALUES ($1, $2)").unwrap();
+    assert!(stmt.execute((1i64, 5i64)).is_err());
+    let n: i64 = db.query_one("SELECT COUNT(*) FROM t", ()).unwrap();
+    assert_eq!(n, 0);
+}

--- a/tests/insert_path_test.rs
+++ b/tests/insert_path_test.rs
@@ -1,0 +1,97 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Prepared-INSERT fast paths: direct parameter resolution, pre-compiled
+//! CHECK constraints, and per-statement DEFAULT evaluation.
+
+use stoolap::api::Database;
+
+#[test]
+fn prepared_insert_parameters_roundtrip() {
+    let db = Database::open("memory://insert_path_params").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, age INTEGER, score FLOAT)",
+        (),
+    )
+    .unwrap();
+
+    let stmt = db.prepare("INSERT INTO t VALUES ($1, $2, $3, $4)").unwrap();
+    stmt.execute((1i64, "alice", 30i64, 1.5f64)).unwrap();
+    stmt.execute((2i64, "bob", Option::<i64>::None, 2.5f64))
+        .unwrap();
+
+    let name: String = db.query_one("SELECT name FROM t WHERE id = 1", ()).unwrap();
+    assert_eq!(name, "alice");
+    let age: Option<i64> = db
+        .query_opt("SELECT age FROM t WHERE id = 2 AND age IS NOT NULL", ())
+        .unwrap();
+    assert!(age.is_none());
+    let s: f64 = db
+        .query_one("SELECT score FROM t WHERE id = 2", ())
+        .unwrap();
+    assert_eq!(s, 2.5);
+}
+
+#[test]
+fn prepared_insert_check_constraints_still_enforced() {
+    let db = Database::open("memory://insert_path_check").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, age INTEGER CHECK (age >= 0))",
+        (),
+    )
+    .unwrap();
+
+    let stmt = db.prepare("INSERT INTO t VALUES ($1, $2)").unwrap();
+    // Passing row inserts
+    stmt.execute((1i64, 30i64)).unwrap();
+    // Violation must error and mention the column; nothing inserted
+    let err = stmt.execute((2i64, -5i64)).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("age"), "error should name the column: {msg}");
+    // NULL passes CHECK per the SQL standard
+    stmt.execute((3i64, Option::<i64>::None)).unwrap();
+
+    let n: i64 = db.query_one("SELECT COUNT(*) FROM t", ()).unwrap();
+    assert_eq!(n, 2);
+    // The compiled plan still enforces on later executions
+    assert!(stmt.execute((4i64, -1i64)).is_err());
+}
+
+#[test]
+fn insert_defaults_apply_from_statement_template() {
+    let db = Database::open("memory://insert_path_default").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, status TEXT DEFAULT 'new', score INTEGER DEFAULT 7)",
+        (),
+    )
+    .unwrap();
+
+    db.execute("INSERT INTO t (id) VALUES (1), (2), (3)", ())
+        .unwrap();
+    let n: i64 = db
+        .query_one(
+            "SELECT COUNT(*) FROM t WHERE status = 'new' AND score = 7",
+            (),
+        )
+        .unwrap();
+    assert_eq!(n, 3);
+
+    // DEFAULT keyword in the VALUES list uses the same template
+    db.execute("INSERT INTO t VALUES (4, DEFAULT, DEFAULT)", ())
+        .unwrap();
+    let s: String = db
+        .query_one("SELECT status FROM t WHERE id = 4", ())
+        .unwrap();
+    assert_eq!(s, "new");
+}


### PR DESCRIPTION
Wave B1 of the executor perf campaign (audit big-wins 2 and 3): the hottest OLTP write path stops paying parse/hash/lock costs per row.

## Changes

1. **Direct parameter resolution.** Every `$n` in a prepared INSERT went through `compile_expression_cached` on every execution (per row for multi-row VALUES): a full AST hash, the global PROGRAM_CACHE mutex, and a VM run, to fetch a value already sitting in `ctx.params()`. `try_extract_simple_value` now resolves positional and named parameters directly; complex expressions still take the VM.
2. **CHECK constraints pre-compile once per plan** into `CompiledInsert` (`SharedProgram`, the same pattern `execute_update` and the upsert path already use) instead of `format!("SELECT {check}")` + tokenizer + parser + compile per inserted row per constrained column. Truthiness rules, NULL-passes, and skip-on-parse-failure semantics preserved exactly; both compiled-path validation sites (VALUES loop and INSERT..SELECT) converted. `CompiledInsert` gets a manual `Debug` since programs aren't `Debug`.
3. **DEFAULT expressions evaluate once per statement** in the plain `execute_insert` paths (three sites), matching the compiled path's per-plan template. Previously each row re-parsed the default SQL.

## Measurements

Release, `memory://`, best of 3 (micro-bench in session scratchpad):

| Scenario | main | this PR | speedup |
|---|---|---|---|
| prepared INSERT, 2 CHECK constraints | 1941 ns | 629 ns | **3.09x** |
| prepared INSERT, plain | 721 ns | 621 ns | 1.16x |
| prepared INSERT, 4-row VALUES | 1642 ns | 1426 ns | 1.15x |

A table with CHECK constraints now inserts at nearly the same rate as one without.

## Verification

- New tests: parameter round-trips including NULL and text, CHECK violations still raised through the compiled plan (error names the column; later executions still enforce), NULL passes CHECK, DEFAULT templates for multi-row and `DEFAULT` keyword inserts
- fmt + clippy `-D warnings` clean; both suites green 4906/4906; the new test file passes under CI-mode `cargo test`