### PR TITLE
perf(dml): expression SET values on the PK fast-update path

### DIFF
--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -86,7 +86,7 @@ fn conflict_matches_target(conflict_target: &[Identifier], schema: &Schema, erro
 
 /// Validate type coercion didn't silently fail.
 /// Returns an error if a non-null value became null during coercion.
-fn validate_coercion(
+pub(crate) fn validate_coercion(
     original: &Value,
     coerced: &Value,
     column_name: &str,
@@ -2218,6 +2218,13 @@ impl Executor {
                         .collect()
                 };
 
+            // Column names for coercion errors, captured before the setter
+            // borrows the table mutably
+            let update_col_names: Vec<String> = compiled_updates
+                .iter()
+                .map(|(idx, _, _, _)| schema.columns[*idx].name.to_string())
+                .collect();
+
             // Pre-compile CHECK constraints for columns being updated (once, not per row)
             let compiled_check_exprs: Vec<(usize, String, String, SharedProgram)> =
                 compiled_updates
@@ -2269,26 +2276,23 @@ impl Executor {
                         .with_named_params(named_params);
 
                     let mut updates = Vec::with_capacity(compiled_updates.len());
-                    for (idx, col_type, vec_dims, program) in &compiled_updates {
-                        if let Ok(v) = vm.execute_cow(program, &exec_ctx) {
-                            let coerced = v.into_coerce_to_type(*col_type);
-                            // Validate vector dimensions
-                            if *col_type == DataType::Vector && *vec_dims > 0 {
-                                if let Value::Extension(data) = &coerced {
-                                    if data.first() == Some(&(DataType::Vector as u8)) {
-                                        let got_dim =
-                                            u16::try_from((data.len() - 1) / 4).unwrap_or(u16::MAX);
-                                        if got_dim != *vec_dims {
-                                            return Err(Error::VectorDimensionMismatch {
-                                                expected: *vec_dims,
-                                                got: got_dim,
-                                            });
-                                        }
-                                    }
-                                }
-                            }
-                            updates.push((*idx, coerced));
-                        }
+                    for (k, (idx, col_type, vec_dims, program)) in
+                        compiled_updates.iter().enumerate()
+                    {
+                        // Propagate VM errors (overflow etc.): silently
+                        // skipping a SET column would half-apply the row.
+                        // Coercion validates like INSERT and the fast path
+                        // (vector dims, no silent non-null-to-NULL).
+                        let v = vm.execute_cow(program, &exec_ctx)?;
+                        let coerced = v.coerce_to_type(*col_type);
+                        validate_coercion(
+                            &v,
+                            &coerced,
+                            &update_col_names[k],
+                            *col_type,
+                            *vec_dims,
+                        )?;
+                        updates.push((*idx, coerced));
                     }
                     updates
                 };

--- a/src/executor/dml_fast_path.rs
+++ b/src/executor/dml_fast_path.rs
@@ -273,6 +273,7 @@ impl Executor {
             UpdateValueSource::Literal(v) => Some(v.clone()),
             UpdateValueSource::Parameter(idx) => params.get(*idx).cloned(),
             UpdateValueSource::NamedParameter(_) => None, // No ctx available in slice path
+            UpdateValueSource::Expression(_) => None,     // Needs a row context; normal path
         }
     }
 
@@ -303,12 +304,16 @@ impl Executor {
                     let pk_column_name = update.pk_column_name.clone();
                     let schema = update.schema.clone();
                     drop(compiled_guard);
+                    // Expression sources bail above, so no row programs
+                    // and no parameters are needed here
                     return Some(self.execute_pk_update_minimal(
                         &table_name,
                         &pk_column_name,
                         &schema,
                         pk_value,
                         updates,
+                        &[],
+                        &ExecutionContext::new(),
                     ));
                 }
                 None // Epoch changed, use normal path
@@ -354,6 +359,7 @@ impl Executor {
     }
 
     /// Execute PK update with minimal data (avoids cloning CompiledPkUpdate)
+    #[allow(clippy::too_many_arguments)]
     fn execute_pk_update_minimal(
         &self,
         table_name: &str,
@@ -361,6 +367,12 @@ impl Executor {
         schema: &CompactArc<Schema>,
         pk_value: i64,
         updates: Vec<(usize, Value)>,
+        expr_updates: &[(
+            usize,
+            super::expression::SharedProgram,
+            crate::core::DataType,
+        )],
+        ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
         // Create auto-commit transaction
         let tx = self.engine.begin_transaction()?;
@@ -374,8 +386,31 @@ impl Executor {
         );
         pk_expr.prepare_for_schema(schema);
 
-        // Execute update with simple setter
+        // Execute update with simple setter. Row expressions all read the
+        // ORIGINAL row (SET a = b, b = a swaps), then everything applies.
+        let mut vm = super::expression::ExprVM::new();
+        let params = ctx.params();
+        let named_params = ctx.named_params();
         let mut setter = |mut row: Row| -> Result<(Row, bool)> {
+            if !expr_updates.is_empty() {
+                let mut computed = Vec::with_capacity(expr_updates.len());
+                {
+                    let mut exec_ctx = super::expression::ExecuteContext::new(&row);
+                    if !params.is_empty() {
+                        exec_ctx = exec_ctx.with_params(params);
+                    }
+                    if !named_params.is_empty() {
+                        exec_ctx = exec_ctx.with_named_params(named_params);
+                    }
+                    for (idx, program, col_type) in expr_updates {
+                        let value = vm.execute_cow(program, &exec_ctx)?;
+                        computed.push((*idx, value.coerce_to_type(*col_type)));
+                    }
+                }
+                for (idx, value) in computed {
+                    let _ = row.set(idx, value);
+                }
+            }
             for (idx, new_value) in &updates {
                 let _ = row.set(*idx, new_value.clone());
             }
@@ -454,8 +489,14 @@ impl Executor {
         pk_value: i64,
         ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
-        // Extract values from compiled sources
+        // Extract constant values; row expressions run per update inside
+        // the setter (they read the current row, e.g. SET n = n + 1)
         let mut updates = Vec::with_capacity(compiled.updates.len());
+        let mut expr_updates: Vec<(
+            usize,
+            super::expression::SharedProgram,
+            crate::core::DataType,
+        )> = Vec::new();
         for u in &compiled.updates {
             let value = match &u.value_source {
                 UpdateValueSource::Literal(v) => v.clone(),
@@ -470,6 +511,10 @@ impl Executor {
                     Some(v) => v.clone(),
                     None => continue,
                 },
+                UpdateValueSource::Expression(program) => {
+                    expr_updates.push((u.column_idx, program.clone(), u.column_type));
+                    continue;
+                }
             };
             updates.push((u.column_idx, value.coerce_to_type(u.column_type)));
         }
@@ -480,6 +525,8 @@ impl Executor {
             &compiled.schema,
             pk_value,
             updates,
+            &expr_updates,
+            ctx,
         )
     }
 
@@ -614,7 +661,7 @@ impl Executor {
             };
             let col_type = schema.columns[col_idx].data_type;
 
-            let value_source = match self.extract_value_source(expr) {
+            let value_source = match self.extract_value_source(expr, schema.column_names_owned()) {
                 Some(s) => s,
                 None => {
                     *compiled_guard = CompiledExecution::NotOptimizable(self.engine.schema_epoch());
@@ -729,7 +776,11 @@ impl Executor {
     }
 
     /// Extract value source (literal or parameter) from expression
-    fn extract_value_source(&self, expr: &Expression) -> Option<UpdateValueSource> {
+    fn extract_value_source(
+        &self,
+        expr: &Expression,
+        schema_columns: &[String],
+    ) -> Option<UpdateValueSource> {
         match expr {
             Expression::IntegerLiteral(lit) => {
                 Some(UpdateValueSource::Literal(Value::Integer(lit.value)))
@@ -766,7 +817,73 @@ impl Executor {
                     Some(UpdateValueSource::Parameter(param_idx))
                 }
             }
-            _ => None, // Complex expression
+            // Row expressions (e.g. SET n = n + 1) compile once per plan
+            // against the schema columns. Subquery-bearing expressions must
+            // take the normal path: the compiler emits placeholder ops for
+            // them that only the full planner can resolve.
+            _ => {
+                if Self::expr_contains_subquery(expr) {
+                    return None;
+                }
+                use super::expression::compile_expression;
+                compile_expression(expr, schema_columns)
+                    .ok()
+                    .map(UpdateValueSource::Expression)
+            }
+        }
+    }
+
+    /// Conservative subquery detection for SET expressions; anything
+    /// unrecognized that can carry one is treated as containing one
+    fn expr_contains_subquery(expr: &Expression) -> bool {
+        match expr {
+            Expression::ScalarSubquery(_)
+            | Expression::Exists(_)
+            | Expression::AllAny(_)
+            | Expression::SubquerySource(_)
+            | Expression::In(_)
+            | Expression::InHashSet(_)
+            | Expression::CteReference(_) => true,
+            Expression::Infix(i) => {
+                Self::expr_contains_subquery(&i.left) || Self::expr_contains_subquery(&i.right)
+            }
+            Expression::Prefix(p) => Self::expr_contains_subquery(&p.right),
+            Expression::FunctionCall(f) => f.arguments.iter().any(Self::expr_contains_subquery),
+            Expression::Cast(c) => Self::expr_contains_subquery(&c.expr),
+            Expression::Aliased(a) => Self::expr_contains_subquery(&a.expression),
+            Expression::Case(c) => {
+                c.value
+                    .as_ref()
+                    .is_some_and(|v| Self::expr_contains_subquery(v))
+                    || c.when_clauses.iter().any(|w| {
+                        Self::expr_contains_subquery(&w.condition)
+                            || Self::expr_contains_subquery(&w.then_result)
+                    })
+                    || c.else_value
+                        .as_ref()
+                        .is_some_and(|v| Self::expr_contains_subquery(v))
+            }
+            Expression::Between(b) => {
+                Self::expr_contains_subquery(&b.expr)
+                    || Self::expr_contains_subquery(&b.lower)
+                    || Self::expr_contains_subquery(&b.upper)
+            }
+            Expression::Like(l) => {
+                Self::expr_contains_subquery(&l.left) || Self::expr_contains_subquery(&l.pattern)
+            }
+            Expression::List(l) => l.elements.iter().any(Self::expr_contains_subquery),
+            Expression::ExpressionList(l) => l.expressions.iter().any(Self::expr_contains_subquery),
+            // Simple leaves cannot carry a subquery
+            Expression::Identifier(_)
+            | Expression::QualifiedIdentifier(_)
+            | Expression::IntegerLiteral(_)
+            | Expression::FloatLiteral(_)
+            | Expression::StringLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_)
+            | Expression::Parameter(_) => false,
+            // Unknown container: be conservative
+            _ => true,
         }
     }
 }

--- a/src/executor/dml_fast_path.rs
+++ b/src/executor/dml_fast_path.rs
@@ -297,7 +297,20 @@ impl Executor {
                     let mut updates = Vec::with_capacity(update.updates.len());
                     for u in &update.updates {
                         let value = Self::extract_update_value_from_slice(&u.value_source, params)?;
-                        updates.push((u.column_idx, value.coerce_to_type(u.column_type)));
+                        let coerced = value.coerce_to_type(u.column_type);
+                        if super::dml::validate_coercion(
+                            &value,
+                            &coerced,
+                            &update.schema.columns[u.column_idx].name,
+                            u.column_type,
+                            u.column_vector_dims,
+                        )
+                        .is_err()
+                        {
+                            // Let the normal path produce the full error
+                            return None;
+                        }
+                        updates.push((u.column_idx, coerced));
                     }
                     // Clone only what we need (cheap: SmartString + Arc)
                     let table_name = update.table_name.clone();
@@ -371,6 +384,7 @@ impl Executor {
             usize,
             super::expression::SharedProgram,
             crate::core::DataType,
+            u16,
         )],
         ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
@@ -402,9 +416,17 @@ impl Executor {
                     if !named_params.is_empty() {
                         exec_ctx = exec_ctx.with_named_params(named_params);
                     }
-                    for (idx, program, col_type) in expr_updates {
+                    for (idx, program, col_type, vector_dims) in expr_updates {
                         let value = vm.execute_cow(program, &exec_ctx)?;
-                        computed.push((*idx, value.coerce_to_type(*col_type)));
+                        let coerced = value.coerce_to_type(*col_type);
+                        super::dml::validate_coercion(
+                            &value,
+                            &coerced,
+                            &schema.columns[*idx].name,
+                            *col_type,
+                            *vector_dims,
+                        )?;
+                        computed.push((*idx, coerced));
                     }
                 }
                 for (idx, value) in computed {
@@ -496,6 +518,7 @@ impl Executor {
             usize,
             super::expression::SharedProgram,
             crate::core::DataType,
+            u16,
         )> = Vec::new();
         for u in &compiled.updates {
             let value = match &u.value_source {
@@ -512,11 +535,24 @@ impl Executor {
                     None => continue,
                 },
                 UpdateValueSource::Expression(program) => {
-                    expr_updates.push((u.column_idx, program.clone(), u.column_type));
+                    expr_updates.push((
+                        u.column_idx,
+                        program.clone(),
+                        u.column_type,
+                        u.column_vector_dims,
+                    ));
                     continue;
                 }
             };
-            updates.push((u.column_idx, value.coerce_to_type(u.column_type)));
+            let coerced = value.coerce_to_type(u.column_type);
+            super::dml::validate_coercion(
+                &value,
+                &coerced,
+                &compiled.schema.columns[u.column_idx].name,
+                u.column_type,
+                u.column_vector_dims,
+            )?;
+            updates.push((u.column_idx, coerced));
         }
 
         self.execute_pk_update_minimal(
@@ -673,6 +709,7 @@ impl Executor {
                 column_idx: col_idx,
                 column_type: col_type,
                 value_source,
+                column_vector_dims: schema.columns[col_idx].vector_dimensions,
             });
         }
 
@@ -848,7 +885,15 @@ impl Executor {
                 Self::expr_contains_subquery(&i.left) || Self::expr_contains_subquery(&i.right)
             }
             Expression::Prefix(p) => Self::expr_contains_subquery(&p.right),
-            Expression::FunctionCall(f) => f.arguments.iter().any(Self::expr_contains_subquery),
+            Expression::FunctionCall(f) => {
+                f.arguments.iter().any(Self::expr_contains_subquery)
+                    || f.filter
+                        .as_ref()
+                        .is_some_and(|e| Self::expr_contains_subquery(e))
+                    || f.order_by
+                        .iter()
+                        .any(|ob| Self::expr_contains_subquery(&ob.expression))
+            }
             Expression::Cast(c) => Self::expr_contains_subquery(&c.expr),
             Expression::Aliased(a) => Self::expr_contains_subquery(&a.expression),
             Expression::Case(c) => {
@@ -869,7 +914,11 @@ impl Executor {
                     || Self::expr_contains_subquery(&b.upper)
             }
             Expression::Like(l) => {
-                Self::expr_contains_subquery(&l.left) || Self::expr_contains_subquery(&l.pattern)
+                Self::expr_contains_subquery(&l.left)
+                    || Self::expr_contains_subquery(&l.pattern)
+                    || l.escape
+                        .as_ref()
+                        .is_some_and(|e| Self::expr_contains_subquery(e))
             }
             Expression::List(l) => l.elements.iter().any(Self::expr_contains_subquery),
             Expression::ExpressionList(l) => l.expressions.iter().any(Self::expr_contains_subquery),
@@ -881,6 +930,7 @@ impl Executor {
             | Expression::StringLiteral(_)
             | Expression::BooleanLiteral(_)
             | Expression::NullLiteral(_)
+            | Expression::IntervalLiteral(_)
             | Expression::Parameter(_) => false,
             // Unknown container: be conservative
             _ => true,

--- a/src/executor/query_cache.rs
+++ b/src/executor/query_cache.rs
@@ -97,7 +97,7 @@ pub struct CompiledUpdateColumn {
 }
 
 /// How to get the update value
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum UpdateValueSource {
     /// Value is a literal
     Literal(crate::core::Value),
@@ -105,6 +105,22 @@ pub enum UpdateValueSource {
     Parameter(usize),
     /// Value comes from a named parameter (e.g., :new_name)
     NamedParameter(SmartString),
+    /// Value is a row expression (e.g. SET n = n + 1), compiled once per
+    /// plan and executed per update against the current row
+    Expression(crate::executor::expression::SharedProgram),
+}
+
+impl std::fmt::Debug for UpdateValueSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UpdateValueSource::Literal(v) => f.debug_tuple("Literal").field(v).finish(),
+            UpdateValueSource::Parameter(i) => f.debug_tuple("Parameter").field(i).finish(),
+            UpdateValueSource::NamedParameter(n) => {
+                f.debug_tuple("NamedParameter").field(n).finish()
+            }
+            UpdateValueSource::Expression(_) => f.write_str("Expression(<compiled>)"),
+        }
+    }
 }
 
 /// Pre-compiled state for PK-based UPDATE (UPDATE table SET col = val WHERE pk = value)

--- a/src/executor/query_cache.rs
+++ b/src/executor/query_cache.rs
@@ -94,6 +94,9 @@ pub struct CompiledUpdateColumn {
     pub column_type: crate::core::DataType,
     /// How to get the new value (literal or parameter)
     pub value_source: UpdateValueSource,
+    /// Vector dimensions of the target column (0 for non-vector columns);
+    /// updates must validate like the full path (VectorDimensionMismatch)
+    pub column_vector_dims: u16,
 }
 
 /// How to get the update value

--- a/tests/update_path_test.rs
+++ b/tests/update_path_test.rs
@@ -1,0 +1,112 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Expression SET values on the PK fast-update path: compiled once per
+//! plan, executed per update against the current row.
+
+use stoolap::api::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://update_path_{}", name)).unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10, 20)", ()).unwrap();
+    db
+}
+
+#[test]
+fn prepared_expression_update_reads_current_row() {
+    let db = setup("expr");
+    let stmt = db.prepare("UPDATE t SET a = a + 1 WHERE id = $1").unwrap();
+    for _ in 0..5 {
+        assert_eq!(stmt.execute((1i64,)).unwrap(), 1);
+    }
+    let a: i64 = db.query_one("SELECT a FROM t WHERE id = 1", ()).unwrap();
+    assert_eq!(a, 15, "each execution must read the then-current row");
+}
+
+#[test]
+fn multi_assignment_reads_original_row() {
+    let db = setup("swap");
+    // All SET expressions read the ORIGINAL row: this swaps
+    db.execute("UPDATE t SET a = b, b = a WHERE id = 1", ())
+        .unwrap();
+    let r = db
+        .query("SELECT a, b FROM t WHERE id = 1", ())
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let (a, b): (i64, i64) = (r[0].get(0).unwrap(), r[0].get(1).unwrap());
+    assert_eq!((a, b), (20, 10));
+}
+
+#[test]
+fn expression_update_with_parameter_inside() {
+    let db = setup("exprparam");
+    let stmt = db.prepare("UPDATE t SET a = a + $1 WHERE id = $2").unwrap();
+    stmt.execute((5i64, 1i64)).unwrap();
+    stmt.execute((7i64, 1i64)).unwrap();
+    let a: i64 = db.query_one("SELECT a FROM t WHERE id = 1", ()).unwrap();
+    assert_eq!(a, 22);
+}
+
+#[test]
+fn expression_update_null_propagates() {
+    let db = setup("exprnull");
+    db.execute("INSERT INTO t VALUES (2, NULL, 1)", ()).unwrap();
+    db.execute("UPDATE t SET a = a + 1 WHERE id = 2", ())
+        .unwrap();
+    let n: i64 = db
+        .query_one("SELECT COUNT(*) FROM t WHERE id = 2 AND a IS NULL", ())
+        .unwrap();
+    assert_eq!(n, 1);
+}
+
+#[test]
+fn expression_update_still_respects_check_constraints() {
+    let db = Database::open("memory://update_path_check").unwrap();
+    db.execute(
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, age INTEGER CHECK (age >= 0))",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO c VALUES (1, 0)", ()).unwrap();
+    // Fast path bails for CHECK-constrained columns; the full path must
+    // reject the violating decrement
+    let stmt = db
+        .prepare("UPDATE c SET age = age - 1 WHERE id = $1")
+        .unwrap();
+    assert!(stmt.execute((1i64,)).is_err());
+    let age: i64 = db.query_one("SELECT age FROM c WHERE id = 1", ()).unwrap();
+    assert_eq!(age, 0);
+}
+
+#[test]
+fn scalar_subquery_set_takes_the_full_path() {
+    let db = setup("subq");
+    db.execute("INSERT INTO t VALUES (2, 99, 0)", ()).unwrap();
+    let stmt = db
+        .prepare("UPDATE t SET a = (SELECT MAX(a) FROM t) WHERE id = $1")
+        .unwrap();
+    stmt.execute((1i64,)).unwrap();
+    let a: i64 = db.query_one("SELECT a FROM t WHERE id = 1", ()).unwrap();
+    assert_eq!(a, 99);
+    // Repeat through the cached plan
+    stmt.execute((1i64,)).unwrap();
+    let a: i64 = db.query_one("SELECT a FROM t WHERE id = 1", ()).unwrap();
+    assert_eq!(a, 99);
+}

--- a/tests/update_path_test.rs
+++ b/tests/update_path_test.rs
@@ -110,3 +110,68 @@ fn scalar_subquery_set_takes_the_full_path() {
     let a: i64 = db.query_one("SELECT a FROM t WHERE id = 1", ()).unwrap();
     assert_eq!(a, 99);
 }
+
+#[test]
+fn vector_dimension_validation_on_fast_update_path() {
+    let db = Database::open("memory://update_path_vec").unwrap();
+    db.execute("CREATE TABLE v (id INTEGER PRIMARY KEY, emb VECTOR(3))", ())
+        .unwrap();
+    db.execute("INSERT INTO v VALUES (1, CAST('[1,2,3]' AS VECTOR))", ())
+        .unwrap();
+
+    // Expression SET with a wrong-dimension vector must be rejected like
+    // the full path (VectorDimensionMismatch), not silently stored
+    let stmt = db
+        .prepare("UPDATE v SET emb = CAST('[1,2]' AS VECTOR) WHERE id = $1")
+        .unwrap();
+    assert!(stmt.execute((1i64,)).is_err());
+
+    // Same through a parameter source
+    let two_dim: Vec<f32> = vec![1.0, 2.0];
+    let stmt2 = db.prepare("UPDATE v SET emb = $1 WHERE id = $2").unwrap();
+    let _ = two_dim;
+    let res = stmt2.execute(("[1,2]", 1i64));
+    assert!(res.is_err(), "wrong-dimension vector text must not store");
+
+    // The stored row is unchanged and correct updates still work
+    let stmt3 = db
+        .prepare("UPDATE v SET emb = CAST('[4,5,6]' AS VECTOR) WHERE id = $1")
+        .unwrap();
+    stmt3.execute((1i64,)).unwrap();
+}
+
+#[test]
+fn set_errors_are_consistent_across_paths() {
+    let db = Database::open("memory://update_path_err").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 9223372036854775807, 0)", ())
+        .unwrap();
+
+    // Overflow must fail the statement on BOTH paths, applying nothing
+    assert!(db
+        .execute("UPDATE t SET a = a + 1, b = 5 WHERE id = 1", ())
+        .is_err());
+    let mut tx = db.begin().unwrap();
+    assert!(tx
+        .execute("UPDATE t SET a = a + 1, b = 5 WHERE id = 1", ())
+        .is_err());
+    drop(tx);
+    let b: i64 = db.query_one("SELECT b FROM t WHERE id = 1", ()).unwrap();
+    assert_eq!(b, 0, "no partial application on either path");
+
+    // Non-null-to-NULL coercion must error on BOTH paths
+    assert!(db
+        .execute("UPDATE t SET a = 'abc' WHERE id = 1", ())
+        .is_err());
+    let mut tx = db.begin().unwrap();
+    assert!(tx
+        .execute("UPDATE t SET a = 'abc' WHERE id = 1", ())
+        .is_err());
+    drop(tx);
+    let a: i64 = db.query_one("SELECT a FROM t WHERE id = 1", ()).unwrap();
+    assert_eq!(a, 9223372036854775807);
+}


### PR DESCRIPTION
Wave B2 of the executor perf campaign: `UPDATE t SET n = n + 1 WHERE id = $1` — the most common UPDATE shape — fell off the PK fast path because SET only supported literal/parameter sources, and the full path recompiles the SET expression through the global program cache on every execution (AST double-hash + mutex). This is also where the +23% UPDATE-by-ID regression from the cache-key collision-proofing (#36) lived.

## Changes

- `UpdateValueSource::Expression(SharedProgram)`: row expressions compile once per plan against the schema columns; the minimal-update setter executes them per update against the current row.
- Semantics: all SET expressions read the ORIGINAL row (`SET a = b, b = a` swaps — probed identical to the full path), parameters inside expressions (`SET a = a + $1`) resolve through the execution context, NULL propagates.
- Safety: subquery-bearing expressions are rejected by a conservative walker and take the full path — the expression compiler emits placeholder subquery ops that only the full planner can resolve; the existing `bug_03` regression test caught exactly this during development. All existing fast-path guards are untouched (CHECK-constrained columns, FK tables, RETURNING, PK-column updates still fall back), and the `_with_params` probe declines Expression sources.

## Measurements

| Bench | main | this PR |
|---|---|---|
| UPDATE by ID (`SET balance = balance + 1`) | 0.70-0.76 us | **0.59-0.65 us** |
| prepared `SET a = a + 1 WHERE id = $1` (micro) | full path | 707-730 ns (fast path) |

Back at the pre-#36 level; the shape no longer touches the global program cache per execution.

## Scope note

The remaining audit items for this wave (post-SELECT WHERE re-evaluation in UPDATE — needs an MVCC-visibility argument, per-row update Vec hoist, upsert full-row clone, DELETE batching for RETURNING/FK) follow as a separate PR to keep this one reviewable.

## Verification

- Both suites 4914/4914 (default + test-filedb); CI-mode `cargo test` passes on the new file
- New tests: incremental reads through the cached plan, multi-assignment swap, parameters inside SET expressions, NULL propagation, CHECK enforcement via the full path, scalar-subquery SET correctness
- fmt + clippy -D warnings clean