### PR TITLE
perf(dml): pre-compile the memory WHERE for UPDATE and DELETE scans

### DIFF
--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -2257,23 +2257,36 @@ impl Executor {
             // Extract params before the closure so they can be captured
             let params = ctx.params();
             let named_params = ctx.named_params();
+            // Pre-compile the memory WHERE once: evaluate_bool re-hashes
+            // the AST per row through the program cache. Subquery-bearing
+            // clauses stay on the evaluator (compiled placeholder subquery
+            // ops cannot run standalone), as do clauses that fail to
+            // compile.
+            let memory_where_program = memory_where_clause
+                .as_ref()
+                .filter(|expr| !Self::expr_contains_subquery(expr))
+                .and_then(|expr| compile_expression(expr, &column_names).ok());
             let mut setter = |mut row: Row| -> Result<(Row, bool)> {
-                // If we need in-memory WHERE filtering, check the condition first
-                if needs_memory_filter {
-                    evaluator.set_row_array(&row);
-                    if let Some(ref where_expr) = memory_where_clause {
-                        match evaluator.evaluate_bool(where_expr) {
-                            Ok(true) => {}
-                            _ => return Ok((row, false)),
-                        }
-                    }
-                }
-
                 // Execute pre-compiled programs (no recompilation per row)
                 let updates_to_apply: Vec<(usize, Value)> = {
                     let exec_ctx = ExecuteContext::new(&row)
                         .with_params(params)
                         .with_named_params(named_params);
+
+                    // In-memory WHERE filtering shares the row context
+                    if needs_memory_filter {
+                        if let Some(ref program) = memory_where_program {
+                            if !vm.execute_bool(program, &exec_ctx) {
+                                return Ok((row, false));
+                            }
+                        } else if let Some(ref where_expr) = memory_where_clause {
+                            evaluator.set_row_array(&row);
+                            match evaluator.evaluate_bool(where_expr) {
+                                Ok(true) => {}
+                                _ => return Ok((row, false)),
+                            }
+                        }
+                    }
 
                     let mut updates = Vec::with_capacity(compiled_updates.len());
                     for (k, (idx, col_type, vec_dims, program)) in
@@ -2654,6 +2667,19 @@ impl Executor {
             // Initialize with prefixed column names to support alias.column syntax
             evaluator.init_columns(&column_names_with_prefix);
 
+            // Pre-compile the memory WHERE once with the same prefixed
+            // columns: evaluate_bool re-hashes the AST per row through the
+            // program cache. Subquery-bearing clauses stay on the evaluator
+            // (compiled placeholder subquery ops cannot run standalone).
+            use super::expression::{compile_expression, ExecuteContext, ExprVM};
+            let mut delete_vm = ExprVM::new();
+            let params = ctx.params();
+            let named_params = ctx.named_params();
+            let memory_where_program = memory_where_clause
+                .as_ref()
+                .filter(|expr| !Self::expr_contains_subquery(expr))
+                .and_then(|expr| compile_expression(expr, &column_names_with_prefix).ok());
+
             // Scan all rows and collect IDs of rows to delete
             let column_indices: Vec<usize> = (0..column_count).collect();
             let mut scanner = table.scan(&column_indices, where_expr.as_deref())?;
@@ -2750,6 +2776,15 @@ impl Executor {
                                     false
                                 }
                             }
+                        } else if let Some(ref program) = memory_where_program {
+                            let mut exec_ctx = ExecuteContext::new(row);
+                            if !params.is_empty() {
+                                exec_ctx = exec_ctx.with_params(params);
+                            }
+                            if !named_params.is_empty() {
+                                exec_ctx = exec_ctx.with_named_params(named_params);
+                            }
+                            delete_vm.execute_bool(program, &exec_ctx)
                         } else {
                             matches!(evaluator.evaluate_bool(where_expr), Ok(true))
                         }

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -2265,13 +2265,26 @@ impl Executor {
             let memory_where_program = memory_where_clause
                 .as_ref()
                 .filter(|expr| !Self::expr_contains_subquery(expr))
-                .and_then(|expr| compile_expression(expr, &column_names).ok());
+                .and_then(|expr| {
+                    // The executor's registry, not the global one: custom
+                    // function overrides must behave like the evaluator
+                    // path this replaces
+                    super::expression::compile_expression_with_context(
+                        expr,
+                        &column_names,
+                        None,
+                        &self.function_registry,
+                    )
+                    .ok()
+                });
+            let transaction_id = ctx.transaction_id();
             let mut setter = |mut row: Row| -> Result<(Row, bool)> {
                 // Execute pre-compiled programs (no recompilation per row)
                 let updates_to_apply: Vec<(usize, Value)> = {
                     let exec_ctx = ExecuteContext::new(&row)
                         .with_params(params)
-                        .with_named_params(named_params);
+                        .with_named_params(named_params)
+                        .with_transaction_id(transaction_id);
 
                     // In-memory WHERE filtering shares the row context
                     if needs_memory_filter {
@@ -2671,14 +2684,23 @@ impl Executor {
             // columns: evaluate_bool re-hashes the AST per row through the
             // program cache. Subquery-bearing clauses stay on the evaluator
             // (compiled placeholder subquery ops cannot run standalone).
-            use super::expression::{compile_expression, ExecuteContext, ExprVM};
+            use super::expression::{ExecuteContext, ExprVM};
             let mut delete_vm = ExprVM::new();
             let params = ctx.params();
             let named_params = ctx.named_params();
             let memory_where_program = memory_where_clause
                 .as_ref()
                 .filter(|expr| !Self::expr_contains_subquery(expr))
-                .and_then(|expr| compile_expression(expr, &column_names_with_prefix).ok());
+                .and_then(|expr| {
+                    super::expression::compile_expression_with_context(
+                        expr,
+                        &column_names_with_prefix,
+                        None,
+                        &self.function_registry,
+                    )
+                    .ok()
+                });
+            let transaction_id = ctx.transaction_id();
 
             // Scan all rows and collect IDs of rows to delete
             let column_indices: Vec<usize> = (0..column_count).collect();
@@ -2777,7 +2799,8 @@ impl Executor {
                                 }
                             }
                         } else if let Some(ref program) = memory_where_program {
-                            let mut exec_ctx = ExecuteContext::new(row);
+                            let mut exec_ctx =
+                                ExecuteContext::new(row).with_transaction_id(transaction_id);
                             if !params.is_empty() {
                                 exec_ctx = exec_ctx.with_params(params);
                             }

--- a/src/executor/dml_fast_path.rs
+++ b/src/executor/dml_fast_path.rs
@@ -872,7 +872,7 @@ impl Executor {
 
     /// Conservative subquery detection for SET expressions; anything
     /// unrecognized that can carry one is treated as containing one
-    fn expr_contains_subquery(expr: &Expression) -> bool {
+    pub(crate) fn expr_contains_subquery(expr: &Expression) -> bool {
         match expr {
             Expression::ScalarSubquery(_)
             | Expression::Exists(_)

--- a/tests/dml_where_context_test.rs
+++ b/tests/dml_where_context_test.rs
@@ -1,0 +1,135 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The pre-compiled memory-WHERE path must carry the execution context's
+//! transaction id, matching the evaluator path it replaced.
+
+use stoolap::api::Database;
+
+#[test]
+fn update_memory_where_sees_transaction_id() {
+    let db = Database::open("memory://dmlctx_upd").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 0)", ()).unwrap();
+
+    let mut tx = db.begin().unwrap();
+    // CURRENT_TRANSACTION_ID() is not pushable, forcing the memory filter
+    let n = tx
+        .execute(
+            "UPDATE t SET a = 1 WHERE id + 0 = 1 AND CURRENT_TRANSACTION_ID() > 0",
+            (),
+        )
+        .unwrap();
+    assert_eq!(n, 1, "WHERE must see the transaction id, not NULL");
+    tx.commit().unwrap();
+    let a: i64 = db.query_one("SELECT a FROM t WHERE id = 1", ()).unwrap();
+    assert_eq!(a, 1);
+}
+
+#[test]
+fn delete_memory_where_sees_transaction_id() {
+    let db = Database::open("memory://dmlctx_del").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 0)", ()).unwrap();
+
+    let mut tx = db.begin().unwrap();
+    let n = tx
+        .execute(
+            "DELETE FROM t WHERE id + 0 = 1 AND CURRENT_TRANSACTION_ID() > 0",
+            (),
+        )
+        .unwrap();
+    assert_eq!(n, 1);
+    tx.commit().unwrap();
+    let c: i64 = db.query_one("SELECT COUNT(*) FROM t", ()).unwrap();
+    assert_eq!(c, 0);
+}
+
+mod registry_override {
+    use std::sync::Arc;
+    use stoolap::core::{Result, Value};
+    use stoolap::executor::Executor;
+    use stoolap::functions::registry::FunctionRegistry;
+    use stoolap::functions::{
+        FunctionDataType, FunctionInfo, FunctionSignature, FunctionType, ScalarFunction,
+    };
+    use stoolap::storage::mvcc::engine::MVCCEngine;
+
+    /// ABS override that always returns -1: distinguishes the executor's
+    /// registry from the global one
+    #[derive(Default)]
+    struct AbsAlwaysNeg;
+
+    impl ScalarFunction for AbsAlwaysNeg {
+        fn name(&self) -> &str {
+            "ABS"
+        }
+        fn info(&self) -> FunctionInfo {
+            FunctionInfo::new(
+                "ABS",
+                FunctionType::Scalar,
+                "test override",
+                FunctionSignature::new(FunctionDataType::Float, vec![FunctionDataType::Any], 1, 1),
+            )
+        }
+        fn evaluate(&self, args: &[Value]) -> Result<Value> {
+            let _ = args;
+            Ok(Value::Integer(-1))
+        }
+        fn clone_box(&self) -> Box<dyn ScalarFunction> {
+            Box::new(AbsAlwaysNeg)
+        }
+    }
+
+    fn count(executor: &Executor, sql: &str) -> i64 {
+        let mut r = executor.execute(sql).unwrap();
+        assert!(r.next());
+        match r.row().get(0) {
+            Some(Value::Integer(n)) => *n,
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn residual_where_uses_the_executors_registry() {
+        let mut engine = MVCCEngine::in_memory();
+        stoolap::storage::traits::Engine::open(&mut engine).unwrap();
+        let engine = Arc::new(engine);
+        let registry = FunctionRegistry::new();
+        registry.register_scalar::<AbsAlwaysNeg>();
+        let executor = Executor::with_function_registry(engine, Arc::new(registry));
+
+        executor
+            .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER)")
+            .unwrap();
+        executor.execute("INSERT INTO t VALUES (1, 10)").unwrap();
+
+        // The row-selection phase runs with builtin ABS (ABS(10) = 10,
+        // row selected); the residual re-check in the setter must use the
+        // EXECUTOR's registry, whose ABS returns -1 and rejects the row.
+        // Matching the pre-existing evaluator behavior means: no update.
+        executor
+            .execute("UPDATE t SET a = 1 WHERE id + 0 = 1 AND ABS(a) = 10")
+            .unwrap();
+
+        assert_eq!(
+            count(&executor, "SELECT COUNT(*) FROM t WHERE a = 1"),
+            0,
+            "the residual re-check must run the executor's ABS override"
+        );
+        assert_eq!(count(&executor, "SELECT COUNT(*) FROM t WHERE a = 10"), 1);
+    }
+}


### PR DESCRIPTION
Wave B2.5 of the executor perf campaign: partial-pushdown UPDATE/DELETE paid a per-row AST double-hash + program-cache lookup for the memory WHERE via `CompiledEvaluator::evaluate_bool`. The clause now compiles once per statement; each row runs `vm.execute_bool` only, and UPDATE shares a single ExecuteContext between the WHERE check and the SET programs.

## Deliberate non-changes (the audit's caution was warranted)

- **The setter's WHERE re-evaluation stays.** `select_row_ids_for_dml` filters through the full SELECT executor, which runs on a separate snapshot (the statement's transaction is not installed in autocommit), so the per-row re-check against the statement's own snapshot is load-bearing for cross-snapshot consistency. This PR only makes it cheap.
- **Subquery-bearing clauses stay on the evaluator path** — same guard as the SET fast path in #42: the expression compiler emits placeholder subquery ops that cannot run standalone. Clauses that fail to compile also fall back; behavior is byte-identical (`execute_bool` is exactly what the evaluator ran underneath).
- DELETE compiles with the same prefixed column list its evaluator uses (`alias.column` resolution preserved exactly).

## Measurements

| Bench | main | this PR |
|---|---|---|
| 10K-row UPDATE, memory-filter WHERE | 3.72 ms | **3.29 ms** (1.13x) |
| point UPDATE shapes | unchanged | unchanged (different path) |

Per-row WHERE cost drops ~43ns/row on scan-heavy DML.

## Scope

Remaining small audit items for this family (upsert row clone without conflict, DELETE per-row storage calls for RETURNING/FK) are queued behind Wave C — diminishing returns relative to what C holds.

## Verification

Both suites 4916/4916; fmt + clippy -D warnings clean. Existing update/delete/correlated-WHERE tests exercise both the program path and the evaluator fallback.