### PR TITLE
perf(executor): join reorder in place, top-K ORDER BY LIMIT; fix radix NULL order

### DIFF
--- a/src/core/value.rs
+++ b/src/core/value.rs
@@ -414,7 +414,7 @@ impl Value {
         // Timestamp ↔ Text: try parsing the text side as a timestamp
         match (self, other) {
             (Value::Timestamp(ts), Value::Text(s)) => {
-                if let Ok(parsed) = parse_timestamp(s) {
+                if let Some(parsed) = parse_timestamp_for_compare(s) {
                     return Ok(ts.cmp(&parsed));
                 }
             }
@@ -423,12 +423,12 @@ impl Value {
             {
                 // SAFETY: Json data is always valid UTF-8
                 let s = std::str::from_utf8(&data[1..]).unwrap_or("");
-                if let Ok(parsed) = parse_timestamp(s) {
+                if let Some(parsed) = parse_timestamp_for_compare(s) {
                     return Ok(ts.cmp(&parsed));
                 }
             }
             (Value::Text(s), Value::Timestamp(ts)) => {
-                if let Ok(parsed) = parse_timestamp(s) {
+                if let Some(parsed) = parse_timestamp_for_compare(s) {
                     return Ok(parsed.cmp(ts));
                 }
             }
@@ -437,7 +437,7 @@ impl Value {
             {
                 // SAFETY: Json data is always valid UTF-8
                 let s = std::str::from_utf8(&data[1..]).unwrap_or("");
-                if let Ok(parsed) = parse_timestamp(s) {
+                if let Some(parsed) = parse_timestamp_for_compare(s) {
                     return Ok(parsed.cmp(ts));
                 }
             }
@@ -1334,6 +1334,34 @@ impl<T: Into<Value>> From<Option<T>> for Value {
 // =========================================================================
 // Helper functions
 // =========================================================================
+
+/// One memoized text-to-timestamp parse: (source string, parse result)
+type TsParseEntry = (Box<str>, Option<DateTime<Utc>>);
+
+thread_local! {
+    /// Small memo for text-to-timestamp parses in comparisons: a query
+    /// comparing a timestamp column to a string constant otherwise runs a
+    /// full chrono parse of the same constant for every row. Failed parses
+    /// are cached too (the fallback string compare also repeats per row).
+    static TS_COMPARE_PARSE_CACHE: std::cell::RefCell<Vec<TsParseEntry>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// `parse_timestamp` with a per-thread memo, for per-row comparison paths
+fn parse_timestamp_for_compare(s: &str) -> Option<DateTime<Utc>> {
+    TS_COMPARE_PARSE_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some((_, parsed)) = cache.iter().find(|(k, _)| &**k == s) {
+            return *parsed;
+        }
+        let parsed = parse_timestamp(s).ok();
+        if cache.len() >= 8 {
+            cache.remove(0);
+        }
+        cache.push((s.into(), parsed));
+        parsed
+    })
+}
 
 /// Parse a timestamp string with multiple format support
 pub fn parse_timestamp(s: &str) -> Result<DateTime<Utc>> {

--- a/src/core/value.rs
+++ b/src/core/value.rs
@@ -1343,22 +1343,25 @@ thread_local! {
     /// comparing a timestamp column to a string constant otherwise runs a
     /// full chrono parse of the same constant for every row. Failed parses
     /// are cached too (the fallback string compare also repeats per row).
-    static TS_COMPARE_PARSE_CACHE: std::cell::RefCell<Vec<TsParseEntry>> =
-        const { std::cell::RefCell::new(Vec::new()) };
+    /// Two slots cover the constant shapes (equality, range bounds) while
+    /// keeping the miss cost for per-row text data at two comparisons.
+    static TS_COMPARE_PARSE_CACHE: std::cell::RefCell<([Option<TsParseEntry>; 2], usize)> =
+        const { std::cell::RefCell::new(([None, None], 0)) };
 }
 
 /// `parse_timestamp` with a per-thread memo, for per-row comparison paths
 fn parse_timestamp_for_compare(s: &str) -> Option<DateTime<Utc>> {
     TS_COMPARE_PARSE_CACHE.with(|cache| {
         let mut cache = cache.borrow_mut();
-        if let Some((_, parsed)) = cache.iter().find(|(k, _)| &**k == s) {
-            return *parsed;
+        let (slots, next) = &mut *cache;
+        for entry in slots.iter().flatten() {
+            if &*entry.0 == s {
+                return entry.1;
+            }
         }
         let parsed = parse_timestamp(s).ok();
-        if cache.len() >= 8 {
-            cache.remove(0);
-        }
-        cache.push((s.into(), parsed));
+        slots[*next] = Some((s.into(), parsed));
+        *next = (*next + 1) % 2;
         parsed
     })
 }

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -92,7 +92,7 @@ use super::result::{
 use super::utils::compute_join_projection;
 use super::utils::{
     add_table_qualifier, build_column_index_map, collect_table_qualifiers,
-    combine_predicates_with_and, compare_values, dummy_token, expression_contains_aggregate,
+    combine_predicates_with_and, dummy_token, expression_contains_aggregate,
     extract_base_column_name, extract_join_keys_and_residual, filter_references_column,
     flatten_and_predicates, get_table_alias_from_expr, strip_table_qualifier,
     substitute_filter_column,
@@ -4221,8 +4221,14 @@ impl Executor {
                     // untruncated rows. An ORDER BY expression the join-local
                     // evaluator cannot resolve (SELECT aliases, positions)
                     // also defers ordering to the standard path.
+                    // A bare integer literal in ORDER BY is an output
+                    // ordinal, which only the standard path resolves
+                    let has_positional = stmt
+                        .order_by
+                        .iter()
+                        .any(|ob| matches!(ob.expression, Expression::IntegerLiteral(_)));
                     let mut order_limit_applied = false;
-                    if !has_agg && !has_window && !stmt.order_by.is_empty() {
+                    if !has_agg && !has_window && !has_positional && !stmt.order_by.is_empty() {
                         // Build sort specs by evaluating ORDER BY expressions
                         let mut evaluator = CompiledEvaluator::new(&self.function_registry);
                         evaluator = evaluator.with_context(ctx);
@@ -4246,39 +4252,16 @@ impl Executor {
                             sort_keys.push(keys);
                         }
                         if keys_ok {
-                            // Sort by indices using sort_unstable_by for ~10-20% speedup
+                            // Sort by indices with the shared NULL-aware
+                            // comparator (the standard path's semantics)
                             let mut indices: Vec<usize> = (0..final_rows.len()).collect();
                             indices.sort_unstable_by(|&a, &b| {
-                                for (i, ob) in stmt.order_by.iter().enumerate() {
-                                    let av = &sort_keys[a][i];
-                                    let bv = &sort_keys[b][i];
-                                    let asc = ob.ascending;
-                                    let nulls_first = ob.nulls_first.unwrap_or(!asc);
-
-                                    let cmp = if av.is_null() && bv.is_null() {
-                                        Ordering::Equal
-                                    } else if av.is_null() {
-                                        if nulls_first {
-                                            Ordering::Less
-                                        } else {
-                                            Ordering::Greater
-                                        }
-                                    } else if bv.is_null() {
-                                        if nulls_first {
-                                            Ordering::Greater
-                                        } else {
-                                            Ordering::Less
-                                        }
-                                    } else {
-                                        compare_values(av, bv)
-                                    };
-
-                                    let cmp = if asc { cmp } else { cmp.reverse() };
-                                    if cmp != Ordering::Equal {
-                                        return cmp;
-                                    }
-                                }
-                                Ordering::Equal
+                                Self::compare_by_sort_keys_impl(
+                                    &sort_keys[a],
+                                    &sort_keys[b],
+                                    &stmt.order_by,
+                                    stmt.order_by.len(),
+                                )
                             });
 
                             // Apply LIMIT/OFFSET while reordering: with a

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -4012,7 +4012,7 @@ impl Executor {
                     && !classification.has_aggregation;
 
                 let join_limit = if can_push_limit {
-                    stmt.limit.as_ref().and_then(|limit_expr| {
+                    let limit = stmt.limit.as_ref().and_then(|limit_expr| {
                         ExpressionEval::compile(limit_expr, &[])
                             .ok()
                             .and_then(|e| e.with_context(ctx).eval_slice(&Row::new()).ok())
@@ -4020,7 +4020,22 @@ impl Executor {
                                 Value::Integer(n) if n >= 0 => Some(n as u64),
                                 _ => None,
                             })
-                    })
+                    });
+                    // OFFSET rows are skipped after collection, so early
+                    // termination must gather LIMIT + OFFSET rows; a
+                    // non-evaluable OFFSET disables the pushdown
+                    match &stmt.offset {
+                        None => limit,
+                        Some(off_expr) => limit.and_then(|l| {
+                            ExpressionEval::compile(off_expr, &[])
+                                .ok()
+                                .and_then(|e| e.with_context(ctx).eval_slice(&Row::new()).ok())
+                                .and_then(|v| match v {
+                                    Value::Integer(n) if n >= 0 => Some(l.saturating_add(n as u64)),
+                                    _ => None,
+                                })
+                        }),
+                    }
                 } else {
                     None
                 };
@@ -4197,134 +4212,150 @@ impl Executor {
                         filter.retain_checked(&mut final_rows)?;
                     }
 
-                    // Apply ORDER BY if present
-                    if !stmt.order_by.is_empty() {
+                    // Check for aggregation/window functions that need special handling
+                    let has_agg = classification.has_aggregation;
+                    let has_window = classification.has_window_functions;
+
+                    // Apply ORDER BY if present. Aggregation/window queries
+                    // fall through to the standard path, which must see the
+                    // untruncated rows. An ORDER BY expression the join-local
+                    // evaluator cannot resolve (SELECT aliases, positions)
+                    // also defers ordering to the standard path.
+                    let mut order_limit_applied = false;
+                    if !has_agg && !has_window && !stmt.order_by.is_empty() {
                         // Build sort specs by evaluating ORDER BY expressions
                         let mut evaluator = CompiledEvaluator::new(&self.function_registry);
                         evaluator = evaluator.with_context(ctx);
                         evaluator.init_columns(&all_columns);
 
                         // Compute sort keys and indices
-                        let sort_keys: Vec<Vec<Value>> = final_rows
-                            .iter()
-                            .map(|(_, row)| {
-                                evaluator.set_row_array(row);
-                                stmt.order_by
-                                    .iter()
-                                    .map(|ob| {
-                                        evaluator
-                                            .evaluate(&ob.expression)
-                                            .unwrap_or(Value::null_unknown())
-                                    })
-                                    .collect()
-                            })
-                            .collect();
-
-                        // Sort by indices using sort_unstable_by for ~10-20% speedup
-                        let mut indices: Vec<usize> = (0..final_rows.len()).collect();
-                        indices.sort_unstable_by(|&a, &b| {
-                            for (i, ob) in stmt.order_by.iter().enumerate() {
-                                let av = &sort_keys[a][i];
-                                let bv = &sort_keys[b][i];
-                                let asc = ob.ascending;
-                                let nulls_first = ob.nulls_first.unwrap_or(!asc);
-
-                                let cmp = if av.is_null() && bv.is_null() {
-                                    Ordering::Equal
-                                } else if av.is_null() {
-                                    if nulls_first {
-                                        Ordering::Less
-                                    } else {
-                                        Ordering::Greater
+                        let mut keys_ok = true;
+                        let mut sort_keys: Vec<Vec<Value>> = Vec::with_capacity(final_rows.len());
+                        'keys: for (_, row) in final_rows.iter() {
+                            evaluator.set_row_array(row);
+                            let mut keys = Vec::with_capacity(stmt.order_by.len());
+                            for ob in &stmt.order_by {
+                                match evaluator.evaluate(&ob.expression) {
+                                    Ok(v) => keys.push(v),
+                                    Err(_) => {
+                                        keys_ok = false;
+                                        break 'keys;
                                     }
-                                } else if bv.is_null() {
-                                    if nulls_first {
-                                        Ordering::Greater
-                                    } else {
-                                        Ordering::Less
-                                    }
-                                } else {
-                                    compare_values(av, bv)
-                                };
-
-                                let cmp = if asc { cmp } else { cmp.reverse() };
-                                if cmp != Ordering::Equal {
-                                    return cmp;
                                 }
                             }
-                            Ordering::Equal
-                        });
+                            sort_keys.push(keys);
+                        }
+                        if keys_ok {
+                            // Sort by indices using sort_unstable_by for ~10-20% speedup
+                            let mut indices: Vec<usize> = (0..final_rows.len()).collect();
+                            indices.sort_unstable_by(|&a, &b| {
+                                for (i, ob) in stmt.order_by.iter().enumerate() {
+                                    let av = &sort_keys[a][i];
+                                    let bv = &sort_keys[b][i];
+                                    let asc = ob.ascending;
+                                    let nulls_first = ob.nulls_first.unwrap_or(!asc);
 
-                        // Apply LIMIT/OFFSET while reordering: with a
-                        // limit only the needed rows move; otherwise the
-                        // permutation happens in place instead of
-                        // deep-cloning every joined row
-                        let offset = stmt
-                            .offset
-                            .as_ref()
-                            .and_then(|e| {
-                                ExpressionEval::compile(e, &[])
-                                    .ok()
-                                    .and_then(|eval| {
-                                        eval.with_context(ctx).eval_slice(&Row::new()).ok()
-                                    })
-                                    .and_then(|v| match v {
-                                        Value::Integer(n) if n >= 0 => Some(n as usize),
-                                        _ => None,
-                                    })
-                            })
-                            .unwrap_or(0);
+                                    let cmp = if av.is_null() && bv.is_null() {
+                                        Ordering::Equal
+                                    } else if av.is_null() {
+                                        if nulls_first {
+                                            Ordering::Less
+                                        } else {
+                                            Ordering::Greater
+                                        }
+                                    } else if bv.is_null() {
+                                        if nulls_first {
+                                            Ordering::Greater
+                                        } else {
+                                            Ordering::Less
+                                        }
+                                    } else {
+                                        compare_values(av, bv)
+                                    };
 
-                        let limit = stmt
-                            .limit
-                            .as_ref()
-                            .and_then(|e| {
-                                ExpressionEval::compile(e, &[])
-                                    .ok()
-                                    .and_then(|eval| {
-                                        eval.with_context(ctx).eval_slice(&Row::new()).ok()
-                                    })
-                                    .and_then(|v| match v {
-                                        Value::Integer(n) if n >= 0 => Some(n as usize),
-                                        _ => None,
-                                    })
-                            })
-                            .unwrap_or(usize::MAX);
-
-                        if offset > 0 || limit != usize::MAX {
-                            final_rows = indices
-                                .into_iter()
-                                .skip(offset)
-                                .take(limit)
-                                .map(|i| (final_rows[i].0, std::mem::take(&mut final_rows[i].1)))
-                                .collect();
-                        } else {
-                            // In-place cycle-based permutation (same
-                            // pattern as the single-table ORDER BY path)
-                            let n = final_rows.len();
-                            let mut indices = indices;
-                            for start in 0..n {
-                                if indices[start] == start || indices[start] == usize::MAX {
-                                    continue;
-                                }
-                                let mut current = start;
-                                loop {
-                                    let target = indices[current];
-                                    if target == start {
-                                        indices[current] = usize::MAX;
-                                        break;
+                                    let cmp = if asc { cmp } else { cmp.reverse() };
+                                    if cmp != Ordering::Equal {
+                                        return cmp;
                                     }
-                                    final_rows.swap(current, target);
-                                    indices[current] = usize::MAX;
-                                    current = target;
+                                }
+                                Ordering::Equal
+                            });
+
+                            // Apply LIMIT/OFFSET while reordering: with a
+                            // limit only the needed rows move; otherwise the
+                            // permutation happens in place instead of
+                            // deep-cloning every joined row
+                            let offset = stmt
+                                .offset
+                                .as_ref()
+                                .and_then(|e| {
+                                    ExpressionEval::compile(e, &[])
+                                        .ok()
+                                        .and_then(|eval| {
+                                            eval.with_context(ctx).eval_slice(&Row::new()).ok()
+                                        })
+                                        .and_then(|v| match v {
+                                            Value::Integer(n) if n >= 0 => Some(n as usize),
+                                            _ => None,
+                                        })
+                                })
+                                .unwrap_or(0);
+
+                            let limit = stmt
+                                .limit
+                                .as_ref()
+                                .and_then(|e| {
+                                    ExpressionEval::compile(e, &[])
+                                        .ok()
+                                        .and_then(|eval| {
+                                            eval.with_context(ctx).eval_slice(&Row::new()).ok()
+                                        })
+                                        .and_then(|v| match v {
+                                            Value::Integer(n) if n >= 0 => Some(n as usize),
+                                            _ => None,
+                                        })
+                                })
+                                .unwrap_or(usize::MAX);
+
+                            // Sorted here; when the statement's LIMIT/OFFSET
+                            // evaluated they are applied below, so the standard
+                            // path must not apply OFFSET a second time
+                            order_limit_applied = (stmt.limit.is_none() || limit != usize::MAX)
+                                && (stmt.offset.is_none() || offset > 0);
+
+                            if offset > 0 || limit != usize::MAX {
+                                final_rows = indices
+                                    .into_iter()
+                                    .skip(offset)
+                                    .take(limit)
+                                    .map(|i| {
+                                        (final_rows[i].0, std::mem::take(&mut final_rows[i].1))
+                                    })
+                                    .collect();
+                            } else {
+                                // In-place cycle-based permutation (same
+                                // pattern as the single-table ORDER BY path)
+                                let n = final_rows.len();
+                                let mut indices = indices;
+                                for start in 0..n {
+                                    if indices[start] == start || indices[start] == usize::MAX {
+                                        continue;
+                                    }
+                                    let mut current = start;
+                                    loop {
+                                        let target = indices[current];
+                                        if target == start {
+                                            indices[current] = usize::MAX;
+                                            break;
+                                        }
+                                        final_rows.swap(current, target);
+                                        indices[current] = usize::MAX;
+                                        current = target;
+                                    }
                                 }
                             }
                         }
                     }
-
-                    // Check for aggregation/window functions that need special handling
-                    let has_agg = classification.has_aggregation;
-                    let has_window = classification.has_window_functions;
 
                     if has_agg || has_window {
                         // Fall through to standard path for aggregation/window handling
@@ -4336,7 +4367,7 @@ impl Executor {
                             CompactArc::clone(&output_columns),
                             final_rows,
                         );
-                        return Ok((Box::new(result), output_columns, false, None));
+                        return Ok((Box::new(result), output_columns, order_limit_applied, None));
                     } else {
                         // Project rows according to SELECT expressions
                         let projected_rows = self.project_rows_with_alias(
@@ -4358,7 +4389,7 @@ impl Executor {
                             CompactArc::clone(&output_columns),
                             projected_rows,
                         );
-                        return Ok((Box::new(result), output_columns, false, None));
+                        return Ok((Box::new(result), output_columns, order_limit_applied, None));
                     }
                 }
             }
@@ -4385,7 +4416,7 @@ impl Executor {
                 && cross_filter.is_none()
             {
                 // Compute limit value
-                stmt.limit.as_ref().and_then(|limit_expr| {
+                let limit = stmt.limit.as_ref().and_then(|limit_expr| {
                     ExpressionEval::compile(limit_expr, &[])
                         .ok()
                         .and_then(|e| e.with_context(ctx).eval_slice(&Row::new()).ok())
@@ -4393,7 +4424,22 @@ impl Executor {
                             Value::Integer(n) if (0..=100).contains(&n) => Some(n as u64),
                             _ => None,
                         })
-                })
+                });
+                // OFFSET rows are skipped after collection, so the
+                // early-termination budget is LIMIT + OFFSET; a
+                // non-evaluable OFFSET disables streaming
+                match &stmt.offset {
+                    None => limit,
+                    Some(off_expr) => limit.and_then(|l| {
+                        ExpressionEval::compile(off_expr, &[])
+                            .ok()
+                            .and_then(|e| e.with_context(ctx).eval_slice(&Row::new()).ok())
+                            .and_then(|v| match v {
+                                Value::Integer(n) if n >= 0 => Some(l.saturating_add(n as u64)),
+                                _ => None,
+                            })
+                    }),
+                }
             } else {
                 None
             };
@@ -4703,7 +4749,7 @@ impl Executor {
             && !classification.has_aggregation;
 
         let join_limit = if can_push_limit {
-            stmt.limit.as_ref().and_then(|limit_expr| {
+            let limit = stmt.limit.as_ref().and_then(|limit_expr| {
                 ExpressionEval::compile(limit_expr, &[])
                     .ok()
                     .and_then(|e| e.with_context(ctx).eval_slice(&Row::new()).ok())
@@ -4711,7 +4757,22 @@ impl Executor {
                         Value::Integer(n) if n >= 0 => Some(n as u64),
                         _ => None,
                     })
-            })
+            });
+            // OFFSET rows are skipped after collection, so early
+            // termination must gather LIMIT + OFFSET rows; a
+            // non-evaluable OFFSET disables the pushdown
+            match &stmt.offset {
+                None => limit,
+                Some(off_expr) => limit.and_then(|l| {
+                    ExpressionEval::compile(off_expr, &[])
+                        .ok()
+                        .and_then(|e| e.with_context(ctx).eval_slice(&Row::new()).ok())
+                        .and_then(|v| match v {
+                            Value::Integer(n) if n >= 0 => Some(l.saturating_add(n as u64)),
+                            _ => None,
+                        })
+                }),
+            }
         } else {
             None
         };

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -189,6 +189,54 @@ fn partition_where_for_join(
 }
 
 impl Executor {
+    /// Multi-column ORDER BY comparator over precomputed sort keys, with
+    /// NULLS FIRST/LAST semantics (default: NULLS LAST for ASC, FIRST for
+    /// DESC)
+    fn compare_by_sort_keys_impl(
+        a_keys: &[Value],
+        b_keys: &[Value],
+        order_by: &[crate::parser::ast::OrderByExpression],
+        num_order_cols: usize,
+    ) -> Ordering {
+        for (i, ob) in order_by.iter().take(num_order_cols).enumerate() {
+            let ascending = ob.ascending;
+            let nulls_first = ob.nulls_first;
+            let a_val = a_keys.get(i);
+            let b_val = b_keys.get(i);
+
+            let a_is_null = a_val.is_none() || a_val.map(|v| v.is_null()).unwrap_or(true);
+            let b_is_null = b_val.is_none() || b_val.map(|v| v.is_null()).unwrap_or(true);
+
+            if a_is_null || b_is_null {
+                if a_is_null && b_is_null {
+                    continue;
+                }
+                let nulls_come_first = nulls_first.unwrap_or(!ascending);
+                return if a_is_null {
+                    if nulls_come_first {
+                        Ordering::Less
+                    } else {
+                        Ordering::Greater
+                    }
+                } else if nulls_come_first {
+                    Ordering::Greater
+                } else {
+                    Ordering::Less
+                };
+            }
+
+            let cmp = match (a_val, b_val) {
+                (Some(av), Some(bv)) => av.partial_cmp(bv).unwrap_or(Ordering::Equal),
+                _ => Ordering::Equal,
+            };
+            let cmp = if !ascending { cmp.reverse() } else { cmp };
+            if cmp != Ordering::Equal {
+                return cmp;
+            }
+        }
+        Ordering::Equal
+    }
+
     /// Execute a SELECT statement
     pub(crate) fn execute_select(
         &self,
@@ -670,53 +718,36 @@ impl Executor {
                 // Create indices and sort them based on sort_keys
                 let mut indices: Vec<usize> = (0..rows.len()).collect();
 
+                // Top-K: with LIMIT (and no DISTINCT ON, which dedups after
+                // the sort), select the needed prefix in O(n) and sort only
+                // that, instead of sorting all n rows
+                let top_k = if stmt.distinct_on.is_empty() {
+                    limit
+                        .map(|l| l.saturating_add(offset))
+                        .filter(|&k| k > 0 && k < indices.len())
+                } else {
+                    None
+                };
+                if let Some(k) = top_k {
+                    indices.select_nth_unstable_by(k - 1, |&a_idx, &b_idx| {
+                        Self::compare_by_sort_keys_impl(
+                            &sort_keys[a_idx],
+                            &sort_keys[b_idx],
+                            &stmt.order_by,
+                            num_order_cols,
+                        )
+                    });
+                    indices.truncate(k);
+                }
+
                 // Use sort_unstable_by for ~10-20% speedup (stability not needed for ORDER BY)
                 indices.sort_unstable_by(|&a_idx, &b_idx| {
-                    let a_keys = &sort_keys[a_idx];
-                    let b_keys = &sort_keys[b_idx];
-
-                    for i in 0..num_order_cols {
-                        let ascending = stmt.order_by[i].ascending;
-                        let nulls_first = stmt.order_by[i].nulls_first;
-                        let a_val = a_keys.get(i);
-                        let b_val = b_keys.get(i);
-
-                        // Check if either value is NULL
-                        let a_is_null =
-                            a_val.is_none() || a_val.map(|v| v.is_null()).unwrap_or(true);
-                        let b_is_null =
-                            b_val.is_none() || b_val.map(|v| v.is_null()).unwrap_or(true);
-
-                        // Handle NULL comparison
-                        if a_is_null || b_is_null {
-                            if a_is_null && b_is_null {
-                                continue; // Both NULL, move to next column
-                            }
-                            // Default: NULLS LAST for ASC, NULLS FIRST for DESC
-                            let nulls_come_first = nulls_first.unwrap_or(!ascending);
-                            return if a_is_null {
-                                if nulls_come_first {
-                                    Ordering::Less
-                                } else {
-                                    Ordering::Greater
-                                }
-                            } else if nulls_come_first {
-                                Ordering::Greater
-                            } else {
-                                Ordering::Less
-                            };
-                        }
-
-                        let cmp = match (a_val, b_val) {
-                            (Some(av), Some(bv)) => av.partial_cmp(bv).unwrap_or(Ordering::Equal),
-                            _ => Ordering::Equal,
-                        };
-                        let cmp = if !ascending { cmp.reverse() } else { cmp };
-                        if cmp != Ordering::Equal {
-                            return cmp;
-                        }
-                    }
-                    Ordering::Equal
+                    Self::compare_by_sort_keys_impl(
+                        &sort_keys[a_idx],
+                        &sort_keys[b_idx],
+                        &stmt.order_by,
+                        num_order_cols,
+                    )
                 });
 
                 // Reorder rows using sorted indices
@@ -4224,10 +4255,10 @@ impl Executor {
                             Ordering::Equal
                         });
 
-                        // Reorder rows
-                        final_rows = indices.into_iter().map(|i| final_rows[i].clone()).collect();
-
-                        // Apply LIMIT/OFFSET after sorting
+                        // Apply LIMIT/OFFSET while reordering: with a
+                        // limit only the needed rows move; otherwise the
+                        // permutation happens in place instead of
+                        // deep-cloning every joined row
                         let offset = stmt
                             .offset
                             .as_ref()
@@ -4260,7 +4291,35 @@ impl Executor {
                             })
                             .unwrap_or(usize::MAX);
 
-                        final_rows = final_rows.into_iter().skip(offset).take(limit).collect();
+                        if offset > 0 || limit != usize::MAX {
+                            final_rows = indices
+                                .into_iter()
+                                .skip(offset)
+                                .take(limit)
+                                .map(|i| (final_rows[i].0, std::mem::take(&mut final_rows[i].1)))
+                                .collect();
+                        } else {
+                            // In-place cycle-based permutation (same
+                            // pattern as the single-table ORDER BY path)
+                            let n = final_rows.len();
+                            let mut indices = indices;
+                            for start in 0..n {
+                                if indices[start] == start || indices[start] == usize::MAX {
+                                    continue;
+                                }
+                                let mut current = start;
+                                loop {
+                                    let target = indices[current];
+                                    if target == start {
+                                        indices[current] = usize::MAX;
+                                        break;
+                                    }
+                                    final_rows.swap(current, target);
+                                    indices[current] = usize::MAX;
+                                    current = target;
+                                }
+                            }
+                        }
                     }
 
                     // Check for aggregation/window functions that need special handling

--- a/src/executor/result.rs
+++ b/src/executor/result.rs
@@ -1015,27 +1015,42 @@ impl OrderedResult {
             }
         }
 
-        // All integers - use radix sort on (id, Row) tuples
-        // We use radsort which handles negative numbers correctly
+        // Partition NULL rows out before the radix pass: the default
+        // ordering is NULLS LAST for ASC and NULLS FIRST for DESC (like
+        // the comparison paths), and a sentinel key would both invert
+        // that and collide with real i64::MIN/MAX values.
+        let mut nulls = RowVec::new();
+        let mut non_nulls = RowVec::with_capacity(rows.len());
+        for pair in rows.drain(..) {
+            let is_null = pair.1.get(col_idx).map(|v| v.is_null()).unwrap_or(true);
+            if is_null {
+                nulls.push(pair);
+            } else {
+                non_nulls.push(pair);
+            }
+        }
+
+        // radsort handles negative numbers correctly; for descending we
+        // apply the monotone-decreasing map -i - 1 (radix is ascending
+        // only)
         if ascending {
-            radsort::sort_by_key(rows, |(_, row)| {
-                match row.get(col_idx) {
-                    Some(Value::Integer(i)) => *i,
-                    _ => i64::MIN, // NULLs sort first in ascending order
-                }
+            radsort::sort_by_key(&mut non_nulls, |(_, row)| match row.get(col_idx) {
+                Some(Value::Integer(i)) => *i,
+                _ => 0,
             });
         } else {
-            // For descending, we negate the key (radix sort is ascending only)
-            // But we need to be careful with i64::MIN
-            radsort::sort_by_key(rows, |(_, row)| {
-                match row.get(col_idx) {
-                    Some(Value::Integer(i)) => {
-                        // Negate for descending order, handle overflow
-                        i.wrapping_neg().wrapping_sub(1)
-                    }
-                    _ => i64::MAX, // NULLs sort last in descending order
-                }
+            radsort::sort_by_key(&mut non_nulls, |(_, row)| match row.get(col_idx) {
+                Some(Value::Integer(i)) => i.wrapping_neg().wrapping_sub(1),
+                _ => 0,
             });
+        }
+
+        if ascending {
+            rows.extend(non_nulls);
+            rows.extend(nulls);
+        } else {
+            rows.extend(nulls);
+            rows.extend(non_nulls);
         }
 
         true
@@ -1049,7 +1064,10 @@ impl OrderedResult {
             for spec in order_specs {
                 match row.get(spec.col_idx) {
                     Some(Value::Integer(_)) => continue,
-                    Some(Value::Null(_)) => continue,
+                    // NULLs need FIRST/LAST placement the composite
+                    // sentinel keys cannot express; the comparison sort
+                    // fallback handles them with the correct default
+                    Some(Value::Null(_)) => return false,
                     _ => return false,
                 }
             }

--- a/tests/differential_oracle_test.rs
+++ b/tests/differential_oracle_test.rs
@@ -709,8 +709,15 @@ fn test_oracle_order_by() {
     let qr = query_sqlite(&sqlite, sql);
     assert_ordered_equal(sql, &sr, &qr);
 
-    // ORDER BY with NULLs - add , id tiebreaker, compare row-by-row (not re-sorted)
-    let sql = "SELECT id, name, score FROM t ORDER BY score ASC, id ASC";
+    // ORDER BY with NULLs: the default placement differs by design
+    // (Stoolap follows the SQL standard / PostgreSQL, SQLite sorts NULLs
+    // smallest), so pin both explicit forms instead
+    let sql = "SELECT id, name, score FROM t ORDER BY score ASC NULLS FIRST, id ASC";
+    let sr = query_stoolap(&stoolap, sql);
+    let qr = query_sqlite(&sqlite, sql);
+    assert_ordered_equal(sql, &sr, &qr);
+
+    let sql = "SELECT id, name, score FROM t ORDER BY score ASC NULLS LAST, id ASC";
     let sr = query_stoolap(&stoolap, sql);
     let qr = query_sqlite(&sqlite, sql);
     assert_ordered_equal(sql, &sr, &qr);

--- a/tests/order_limit_test.rs
+++ b/tests/order_limit_test.rs
@@ -246,3 +246,78 @@ fn join_order_by_alias_sorts_correctly() {
     let zs: Vec<i64> = rows.iter().map(|r| r.get(0).unwrap()).collect();
     assert_eq!(zs, (15..25).rev().collect::<Vec<i64>>());
 }
+
+#[test]
+fn join_order_by_ordinal_resolves_to_column() {
+    let db = Database::open("memory://topk_join_ordinal").unwrap();
+    db.execute("CREATE TABLE a (id INTEGER PRIMARY KEY, x INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE b (id INTEGER PRIMARY KEY, y INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..30i64 {
+        tx.execute("INSERT INTO a VALUES ($1, $2)", (i, i)).unwrap();
+        tx.execute("INSERT INTO b VALUES ($1, $2)", (i, i)).unwrap();
+    }
+    tx.commit().unwrap();
+
+    // ORDER BY 1 is positional: it must resolve to the first output
+    // column, not the constant integer 1
+    let rows = db
+        .query(
+            "SELECT a.x FROM a JOIN b ON a.id = b.id ORDER BY 1 DESC LIMIT 10 OFFSET 5",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let xs: Vec<i64> = rows.iter().map(|r| r.get(0).unwrap()).collect();
+    assert_eq!(xs, (15..25).rev().collect::<Vec<i64>>());
+}
+
+#[test]
+fn join_order_by_desc_null_placement() {
+    let db = Database::open("memory://topk_join_desc_nulls").unwrap();
+    db.execute("CREATE TABLE a (id INTEGER PRIMARY KEY, x INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE b (id INTEGER PRIMARY KEY, y INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..10i64 {
+        if i < 2 {
+            tx.execute("INSERT INTO a VALUES ($1, NULL)", (i,)).unwrap();
+        } else {
+            tx.execute("INSERT INTO a VALUES ($1, $2)", (i, i)).unwrap();
+        }
+        tx.execute("INSERT INTO b VALUES ($1, $2)", (i, i)).unwrap();
+    }
+    tx.commit().unwrap();
+
+    let fetch = |sql: &str| -> Vec<Option<i64>> {
+        db.query(sql, ())
+            .unwrap()
+            .collect_vec()
+            .unwrap()
+            .iter()
+            .map(|r| r.get(0).unwrap())
+            .collect()
+    };
+
+    // Default DESC places NULLs first (AST contract)
+    let got = fetch("SELECT a.x FROM a JOIN b ON a.id = b.id ORDER BY a.x DESC");
+    let mut expected: Vec<Option<i64>> = vec![None, None];
+    expected.extend((2..10).rev().map(Some));
+    assert_eq!(got, expected, "default DESC");
+
+    // Explicit NULLS LAST under DESC must be honored, not inverted
+    let got = fetch("SELECT a.x FROM a JOIN b ON a.id = b.id ORDER BY a.x DESC NULLS LAST");
+    let mut expected: Vec<Option<i64>> = (2..10).rev().map(Some).collect();
+    expected.extend([None, None]);
+    assert_eq!(got, expected, "explicit NULLS LAST");
+
+    // Explicit NULLS FIRST under DESC
+    let got = fetch("SELECT a.x FROM a JOIN b ON a.id = b.id ORDER BY a.x DESC NULLS FIRST");
+    let mut expected: Vec<Option<i64>> = vec![None, None];
+    expected.extend((2..10).rev().map(Some));
+    assert_eq!(got, expected, "explicit NULLS FIRST");
+}

--- a/tests/order_limit_test.rs
+++ b/tests/order_limit_test.rs
@@ -119,3 +119,130 @@ fn join_order_by_is_sorted_and_complete() {
     let xs: Vec<i64> = top.iter().map(|r| r.get(0).unwrap()).collect();
     assert_eq!(xs, vec![299, 298, 297, 296, 295]);
 }
+
+#[test]
+fn join_order_by_offset_applies_once() {
+    let db = Database::open("memory://topk_join_offset").unwrap();
+    db.execute("CREATE TABLE a (id INTEGER PRIMARY KEY, x INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE b (id INTEGER PRIMARY KEY, y INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..30i64 {
+        tx.execute("INSERT INTO a VALUES ($1, $2)", (i, i)).unwrap();
+        tx.execute("INSERT INTO b VALUES ($1, $2)", (i, i)).unwrap();
+    }
+    tx.commit().unwrap();
+
+    // INL-eligible: PK join key, no WHERE. OFFSET must apply exactly once.
+    let rows = db
+        .query(
+            "SELECT a.x FROM a JOIN b ON a.id = b.id ORDER BY a.x ASC LIMIT 10 OFFSET 5",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let xs: Vec<i64> = rows.iter().map(|r| r.get(0).unwrap()).collect();
+    assert_eq!(xs, (5..15).collect::<Vec<i64>>());
+}
+
+#[test]
+fn complex_order_by_limit_matches_full_sort() {
+    let db = Database::open("memory://topk_complex").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..400i64 {
+        tx.execute("INSERT INTO t VALUES ($1, $2)", (i, i)).unwrap();
+    }
+    tx.commit().unwrap();
+
+    // Expression ORDER BY routes through the complex-sort path (the
+    // select_nth top-K hook)
+    let rows = db
+        .query(
+            "SELECT id FROM t ORDER BY v % 7 ASC, id DESC LIMIT 5 OFFSET 3",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let expected = db
+        .query("SELECT id FROM t ORDER BY v % 7 ASC, id DESC", ())
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 5);
+    for (i, r) in rows.iter().enumerate() {
+        let got: i64 = r.get(0).unwrap();
+        let want: i64 = expected[i + 3].get(0).unwrap();
+        assert_eq!(got, want, "row {i} diverges from full sort");
+    }
+}
+
+#[test]
+fn join_limit_offset_without_order_by_returns_full_count() {
+    let db = Database::open("memory://topk_join_offset_noorder").unwrap();
+    db.execute("CREATE TABLE a (id INTEGER PRIMARY KEY, x INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE b (id INTEGER PRIMARY KEY, y INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..30i64 {
+        tx.execute("INSERT INTO a VALUES ($1, $2)", (i, i)).unwrap();
+        tx.execute("INSERT INTO b VALUES ($1, $2)", (i, i)).unwrap();
+    }
+    tx.commit().unwrap();
+
+    // Early-termination pushdown must collect OFFSET extra rows.
+    // PK join key routes to index nested loop
+    let rows = db
+        .query(
+            "SELECT a.x FROM a JOIN b ON a.id = b.id LIMIT 10 OFFSET 5",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 10, "INL join undercounts with OFFSET");
+
+    // Non-indexed join key routes to the hash/streaming join executor
+    let rows = db
+        .query(
+            "SELECT a.x FROM a JOIN b ON a.x = b.y LIMIT 10 OFFSET 5",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 10, "hash join undercounts with OFFSET");
+}
+
+#[test]
+fn join_order_by_alias_sorts_correctly() {
+    let db = Database::open("memory://topk_join_alias").unwrap();
+    db.execute("CREATE TABLE a (id INTEGER PRIMARY KEY, x INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE b (id INTEGER PRIMARY KEY, y INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..30i64 {
+        tx.execute("INSERT INTO a VALUES ($1, $2)", (i, i)).unwrap();
+        tx.execute("INSERT INTO b VALUES ($1, $2)", (i, i)).unwrap();
+    }
+    tx.commit().unwrap();
+
+    // ORDER BY references a SELECT alias: the join-local sort cannot
+    // resolve it, so ordering must fall through to the standard path
+    let rows = db
+        .query(
+            "SELECT a.x AS z FROM a JOIN b ON a.id = b.id ORDER BY z DESC LIMIT 10 OFFSET 5",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let zs: Vec<i64> = rows.iter().map(|r| r.get(0).unwrap()).collect();
+    assert_eq!(zs, (15..25).rev().collect::<Vec<i64>>());
+}

--- a/tests/order_limit_test.rs
+++ b/tests/order_limit_test.rs
@@ -1,0 +1,121 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! ORDER BY + LIMIT top-K selection and the in-place JOIN reorder must
+//! preserve ordering semantics, including NULLS placement and OFFSET.
+
+use stoolap::api::Database;
+
+#[test]
+fn order_by_limit_offset_matches_full_sort() {
+    let db = Database::open("memory://topk_basic").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER, w INTEGER)",
+        (),
+    )
+    .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..500i64 {
+        // v cycles so there are plenty of ties; w breaks them
+        tx.execute("INSERT INTO t VALUES ($1, $2, $3)", (i, i % 7, i))
+            .unwrap();
+    }
+    // A few NULLs in v
+    for i in 500..510i64 {
+        tx.execute("INSERT INTO t (id, w) VALUES ($1, $2)", (i, i))
+            .unwrap();
+    }
+    tx.commit().unwrap();
+
+    // Deterministic two-column ordering with OFFSET through the top-K path
+    let rows = db
+        .query(
+            "SELECT v, w FROM t ORDER BY v DESC, w ASC LIMIT 10 OFFSET 5",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let expected = db
+        .query("SELECT v, w FROM t ORDER BY v DESC, w ASC", ())
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 10);
+    for (i, r) in rows.iter().enumerate() {
+        let (v1, w1): (Option<i64>, i64) = (r.get(0).ok(), r.get(1).unwrap());
+        let e = &expected[i + 5];
+        let (v2, w2): (Option<i64>, i64) = (e.get(0).ok(), e.get(1).unwrap());
+        assert_eq!((v1, w1), (v2, w2), "row {i} diverges from full sort");
+    }
+
+    // NULLS placement: default DESC puts NULLs first
+    let first = db
+        .query("SELECT v FROM t ORDER BY v DESC LIMIT 3", ())
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    for r in &first {
+        assert!(r.get::<i64>(0).is_err(), "DESC default is NULLS FIRST");
+    }
+}
+
+#[test]
+fn join_order_by_is_sorted_and_complete() {
+    let db = Database::open("memory://topk_join").unwrap();
+    db.execute("CREATE TABLE a (id INTEGER PRIMARY KEY, x INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE b (id INTEGER PRIMARY KEY, y INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..300i64 {
+        tx.execute("INSERT INTO a VALUES ($1, $2)", (i, 299 - i))
+            .unwrap();
+        tx.execute("INSERT INTO b VALUES ($1, $2)", (i, i * 3))
+            .unwrap();
+    }
+    tx.commit().unwrap();
+
+    let rows = db
+        .query(
+            "SELECT a.x, b.y FROM a JOIN b ON a.id = b.id ORDER BY a.x ASC",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 300, "in-place permutation must keep all rows");
+    let mut prev = -1i64;
+    for r in &rows {
+        let x: i64 = r.get(0).unwrap();
+        assert!(x > prev, "rows must be sorted ascending");
+        prev = x;
+    }
+    // Pairing stays intact after the permutation
+    let (x0, y0): (i64, i64) = (rows[0].get(0).unwrap(), rows[0].get(1).unwrap());
+    assert_eq!(x0, 0);
+    assert_eq!(y0, 299 * 3);
+
+    // And with LIMIT via the take-path
+    let top = db
+        .query(
+            "SELECT a.x FROM a JOIN b ON a.id = b.id ORDER BY a.x DESC LIMIT 5",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let xs: Vec<i64> = top.iter().map(|r| r.get(0).unwrap()).collect();
+    assert_eq!(xs, vec![299, 298, 297, 296, 295]);
+}

--- a/tests/result_coverage_test.rs
+++ b/tests/result_coverage_test.rs
@@ -307,7 +307,8 @@ fn test_order_by_with_nulls() {
     db.execute("INSERT INTO items VALUES (3, 10)", ())
         .expect("Failed to insert");
 
-    // Default behavior: NULLS FIRST for ASC in Stoolap
+    // Default: NULLS LAST for ASC (SQL standard; see OrderByExpression's
+    // nulls_first contract in the AST)
     let result = db
         .query("SELECT value FROM items ORDER BY value ASC", ())
         .expect("Query failed");
@@ -318,11 +319,11 @@ fn test_order_by_with_nulls() {
         values.push(row.get::<i64>(0).ok());
     }
 
-    // NULLs are at the beginning for ASC (default behavior)
+    // NULLs are at the end for ASC (default behavior)
     assert_eq!(values.len(), 3);
-    assert_eq!(values[0], None);
-    assert_eq!(values[1], Some(10));
-    assert_eq!(values[2], Some(30));
+    assert_eq!(values[0], Some(10));
+    assert_eq!(values[1], Some(30));
+    assert_eq!(values[2], None);
 }
 
 #[test]
@@ -342,7 +343,8 @@ fn test_order_by_with_nulls_desc() {
     db.execute("INSERT INTO items VALUES (3, 10)", ())
         .expect("Failed to insert");
 
-    // Default behavior: NULLS LAST for DESC in Stoolap
+    // Default: NULLS FIRST for DESC (SQL standard; see OrderByExpression's
+    // nulls_first contract in the AST)
     let result = db
         .query("SELECT value FROM items ORDER BY value DESC", ())
         .expect("Query failed");
@@ -353,11 +355,11 @@ fn test_order_by_with_nulls_desc() {
         values.push(row.get::<i64>(0).ok());
     }
 
-    // NULLs are at the end for DESC (default behavior)
+    // NULLs are at the start for DESC (default behavior)
     assert_eq!(values.len(), 3);
-    assert_eq!(values[0], Some(30));
-    assert_eq!(values[1], Some(10));
-    assert_eq!(values[2], None);
+    assert_eq!(values[0], None);
+    assert_eq!(values[1], Some(30));
+    assert_eq!(values[2], Some(10));
 }
 
 #[test]


### PR DESCRIPTION
Wave C1 of the executor perf campaign — plus a NULL-ordering bug the new tests caught on main.

## Perf

1. **JOIN + ORDER BY reorders in place** (the audit big-win): the join path deep-cloned every `(i64, Row)` into a new vector; it now uses the same cycle permutation as the single-table path, and with LIMIT/OFFSET only the needed rows move. 10K-row join sort: 2.63ms → 2.52ms.
2. **ORDER BY + LIMIT top-K**: `select_nth_unstable_by` partitions the needed prefix in O(n), then only that prefix sorts. The NULL-aware multi-column comparator is factored into one helper shared by selection and sort (and no longer duplicated).
3. **Timestamp parse memo**: text-to-timestamp parses in comparisons memoize per thread (failed parses too). Honest scoping note: the audit's headline scenario (`WHERE ts > 'string'` re-parsing per row) turned out to be already neutralized by #40's plan-time coercion; the memo remains as cheap insurance for residual VM-evaluated shapes.

## Correctness — user-visible change, decision yours

The ordering tests exposed that **adding LIMIT flipped NULL placement**: `ORDER BY v DESC` returned `[5, 3, NULL]` without LIMIT but `[NULL, 5]` with `LIMIT 2` — the radix path encoded NULLs as sentinel keys (ASC first / DESC last, SQLite-style) while every comparator path follows the SQL standard (ASC last / DESC first).

Which side is intended? The evidence conflicted: two coverage tests documented the radix behavior as "default in Stoolap", but the **AST contract** (`OrderByExpression.nulls_first`: "None = default — NULLS LAST for ASC, NULLS FIRST for DESC in SQL standard"), the parser comment, and three comparator implementations all say SQL standard. I aligned the radix path to the AST contract: NULL rows are partitioned and placed per the default (also fixing the sentinel collision where real `i64::MIN`/`i64::MAX` values tied with NULLs), the multi-column composite radix falls back to comparison sort when NULLs are present, and the two coverage tests now assert the contract.

One more data point from CI: the differential oracle's feature-gated NULL-ordering query also pinned SQLite's default and failed. It now asserts the two explicit `NULLS FIRST`/`NULLS LAST` forms, which both engines execute identically, so the oracle stays strong on ordering while the defaults are allowed to differ (PostgreSQL has the same default as the AST contract).

**If you prefer the SQLite convention instead** (NULLs smallest everywhere), say so — then the comparators, AST doc, and parser comment change and the radix stays. Either way this belongs in the v0.4.1 release notes as a behavior note for no-LIMIT ORDER BY with NULLs.

## Verification

- New tests: top-K path compared row-by-row against the full sort (ties, OFFSET, NULLS), join reorder integrity in both branches (permutation and take-path)
- Both suites 4921/4921; CI-mode `cargo test` passes on the new file; fmt + clippy clean

## Adversarial review round (002e2511)

The reviewer could not refute the four changes above (cycle permutation direction, mem::take safety, select_nth semantics, radix partition all verified), but found a family of **pre-existing LIMIT/OFFSET bugs on the exact lines this PR touches**. All fixed with red-first tests in `tests/order_limit_test.rs`:

1. **P1: INL join ORDER BY + OFFSET applied OFFSET twice.** The join block applied `skip(offset).take(limit)` inline, then returned `limit_offset_applied = false`, so the standard path wrapped the rows in `TopNResult` and drained OFFSET again (`LIMIT 10 OFFSET 5` over 30 rows returned 5 wrong rows). The block now reports the flag truthfully when the inline sort + LIMIT/OFFSET fully covered the statement. Side effect: the redundant second sort is gone, and the join ORDER BY tests now pin the inline permutation for real.
2. **JOIN + LIMIT + OFFSET without ORDER BY undercounted.** All three early-termination sites (batch INL, JoinExecutor, streaming hash join) collected only LIMIT rows while OFFSET is skipped after collection (returned 5 rows instead of 10). The collection budget is now LIMIT+OFFSET; a non-evaluable OFFSET disables the pushdown.
3. **INL inline sort produced garbage order for `ORDER BY <select-alias>`.** Key-evaluation errors were swallowed into NULL keys (broken on main too). Errors now defer ordering to the standard path, and aggregation/window queries no longer enter the inline sort/truncation at all.

Also from the review: the timestamp memo is now a fixed two-slot round-robin array (miss cost: two comparisons, no Vec shift).

**Follow-ups the review flagged (pre-existing, not touched here):**
- `try_order_by_index_optimization` returns B-tree order = NULLS FIRST always and silently ignores explicit `NULLS FIRST`/`NULLS LAST` on the index-ordered fast path.
- Window int/float sort fast paths use MAX sentinels (real `i64::MAX`/`f64::MAX` values tie with NULLs) and window ORDER BY ignores `nulls_first` entirely.

Both suites 4925/4925 after the round; CI-mode passes; fmt + clippy clean.

