### PR TITLE
perf(executor): per-row clones and re-hashing in result pipeline and sort loops

### DIFF
--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -995,12 +995,20 @@ impl Executor {
         let mut outer_row_map: FxHashMap<CompactArc<str>, Value> =
             FxHashMap::with_capacity_and_hasher(estimated_entries, Default::default());
 
+        // Pre-compile plain expression sources once for the row loop
+        let source_programs: Vec<Option<super::expression::SharedProgram>> = column_sources
+            .iter()
+            .map(|s| match s {
+                ColumnSource::Expression(expr) => evaluator.compile_cached(expr).ok(),
+                _ => None,
+            })
+            .collect();
+
         for (id, row) in agg_rows {
             // Use CompactVec directly to avoid Vec→CompactVec conversion
             let mut new_values: CompactVec<Value> = CompactVec::with_capacity(column_sources.len());
-            evaluator.set_row_array(&row);
 
-            for source in &column_sources {
+            for (src_idx, source) in column_sources.iter().enumerate() {
                 let value = match source {
                     ColumnSource::AggColumn(col_name) => {
                         if let Some(&idx) = agg_col_index_map.get(col_name) {
@@ -1009,10 +1017,12 @@ impl Executor {
                             Value::null_unknown()
                         }
                     }
-                    ColumnSource::Expression(expr) => {
-                        // Evaluate the expression using the aggregated row as context
-                        evaluator.evaluate(expr).unwrap_or(Value::null_unknown())
-                    }
+                    ColumnSource::Expression(_) => match &source_programs[src_idx] {
+                        Some(p) => evaluator
+                            .evaluate_program(p, &row)
+                            .unwrap_or(Value::null_unknown()),
+                        None => Value::null_unknown(),
+                    },
                     ColumnSource::CorrelatedExpression(expr) => {
                         // Build outer row context using pre-computed column names
                         outer_row_map.clear();

--- a/src/executor/expression/evaluator_bridge.rs
+++ b/src/executor/expression/evaluator_bridge.rs
@@ -32,6 +32,13 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use crate::api::params::ParamVec;
+
+// Shared empty defaults: constructors hand these out with an Arc bump
+// instead of allocating fresh empty collections per instance
+static EMPTY_PARAMS: std::sync::LazyLock<CompactArc<ParamVec>> =
+    std::sync::LazyLock::new(|| CompactArc::new(ParamVec::new()));
+static EMPTY_NAMED_PARAMS: std::sync::LazyLock<Arc<FxHashMap<String, Value>>> =
+    std::sync::LazyLock::new(|| Arc::new(FxHashMap::default()));
 use crate::common::{CompactArc, StringMap};
 use lru::LruCache;
 use parking_lot::Mutex;
@@ -567,8 +574,8 @@ impl RowFilter {
         let program = compile_expression(expr, columns)?;
         Ok(Self {
             program,
-            params: CompactArc::new(ParamVec::new()),
-            named_params: Arc::new(FxHashMap::default()),
+            params: EMPTY_PARAMS.clone(),
+            named_params: EMPTY_NAMED_PARAMS.clone(),
             transaction_id: None,
         })
     }
@@ -616,8 +623,8 @@ impl RowFilter {
 
         Ok(Self {
             program,
-            params: CompactArc::new(ParamVec::new()),
-            named_params: Arc::new(FxHashMap::default()),
+            params: EMPTY_PARAMS.clone(),
+            named_params: EMPTY_NAMED_PARAMS.clone(),
             transaction_id: None,
         })
     }
@@ -650,8 +657,8 @@ impl RowFilter {
     pub fn from_program(program: SharedProgram) -> Self {
         Self {
             program,
-            params: CompactArc::new(ParamVec::new()),
-            named_params: Arc::new(FxHashMap::default()),
+            params: EMPTY_PARAMS.clone(),
+            named_params: EMPTY_NAMED_PARAMS.clone(),
             transaction_id: None,
         }
     }
@@ -828,8 +835,8 @@ impl JoinFilter {
             .map_err(|e| Error::internal(format!("Compile error: {}", e)))?;
         Ok(Self {
             program: CompactArc::new(program),
-            params: CompactArc::new(ParamVec::new()),
-            named_params: Arc::new(FxHashMap::default()),
+            params: EMPTY_PARAMS.clone(),
+            named_params: EMPTY_NAMED_PARAMS.clone(),
         })
     }
 
@@ -932,8 +939,8 @@ impl ExpressionEval {
         Ok(Self {
             program,
             vm: ExprVM::new(),
-            params: CompactArc::new(ParamVec::new()),
-            named_params: Arc::new(FxHashMap::default()),
+            params: EMPTY_PARAMS.clone(),
+            named_params: EMPTY_NAMED_PARAMS.clone(),
             outer_row: None,
             transaction_id: None,
         })
@@ -1003,8 +1010,8 @@ impl ExpressionEval {
         Ok(Self {
             program,
             vm: ExprVM::new(),
-            params: CompactArc::new(ParamVec::new()),
-            named_params: Arc::new(FxHashMap::default()),
+            params: EMPTY_PARAMS.clone(),
+            named_params: EMPTY_NAMED_PARAMS.clone(),
             outer_row: None,
             transaction_id: None,
         })
@@ -1015,8 +1022,8 @@ impl ExpressionEval {
         Self {
             program,
             vm: ExprVM::new(),
-            params: CompactArc::new(ParamVec::new()),
-            named_params: Arc::new(FxHashMap::default()),
+            params: EMPTY_PARAMS.clone(),
+            named_params: EMPTY_NAMED_PARAMS.clone(),
             outer_row: None,
             transaction_id: None,
         }
@@ -1224,8 +1231,8 @@ impl MultiExpressionEval {
         Ok(Self {
             programs,
             vm: ExprVM::new(),
-            params: CompactArc::new(ParamVec::new()),
-            named_params: Arc::new(FxHashMap::default()),
+            params: EMPTY_PARAMS.clone(),
+            named_params: EMPTY_NAMED_PARAMS.clone(),
             transaction_id: None,
         })
     }
@@ -1266,8 +1273,8 @@ impl MultiExpressionEval {
         Ok(Self {
             programs,
             vm: ExprVM::new(),
-            params: CompactArc::new(ParamVec::new()),
-            named_params: Arc::new(FxHashMap::default()),
+            params: EMPTY_PARAMS.clone(),
+            named_params: EMPTY_NAMED_PARAMS.clone(),
             transaction_id: None,
         })
     }
@@ -1452,8 +1459,8 @@ impl<'a> CompiledEvaluator<'a> {
             columns_arc_id: 0,
             columns2: None,
             outer_columns: None,
-            params: CompactArc::new(ParamVec::new()),
-            named_params: Arc::new(FxHashMap::default()),
+            params: EMPTY_PARAMS.clone(),
+            named_params: EMPTY_NAMED_PARAMS.clone(),
             outer_row: None,
             transaction_id: None,
             expression_aliases: StringMap::new(),
@@ -1476,7 +1483,7 @@ impl<'a> CompiledEvaluator<'a> {
         self.columns_arc_id = 0;
         self.columns2 = None;
         self.outer_columns = None;
-        self.params = CompactArc::new(ParamVec::new());
+        self.params = EMPTY_PARAMS.clone();
         self.named_params = Arc::new(FxHashMap::default());
         self.outer_row = None;
         self.transaction_id = None;
@@ -2030,6 +2037,30 @@ impl<'a> CompiledEvaluator<'a> {
 
         // Execute
         self.vm.execute_cow(&program, &ctx)
+    }
+
+    /// Compile and cache an expression, returning the shared program for
+    /// repeated `evaluate_program` calls in per-row loops
+    pub fn compile_cached(&mut self, expr: &Expression) -> Result<SharedProgram> {
+        self.get_or_compile(expr)
+    }
+
+    /// Evaluate a pre-compiled program against the given row directly,
+    /// without storing a per-row copy in the evaluator and without
+    /// re-hashing the expression. Not for join mode (single row only).
+    pub fn evaluate_program(&mut self, program: &SharedProgram, row: &Row) -> Result<Value> {
+        let mut ctx = ExecuteContext::new(row);
+        if !self.params.is_empty() {
+            ctx = ctx.with_params(&self.params);
+        }
+        if !self.named_params.is_empty() {
+            ctx = ctx.with_named_params(&self.named_params);
+        }
+        if let Some(ref outer) = self.outer_row {
+            ctx = ctx.with_outer_row(outer);
+        }
+        ctx = ctx.with_transaction_id(self.transaction_id);
+        self.vm.execute_cow(program, &ctx)
     }
 
     /// Evaluate an expression as a boolean (for WHERE/HAVING clauses)

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -700,15 +700,22 @@ impl Executor {
                         })
                         .collect()
                 } else {
+                    // Pre-compile each ORDER BY expression once; per row
+                    // only the VM runs (no row clone, no expression re-hash)
+                    let programs: Vec<Option<super::expression::SharedProgram>> = stmt
+                        .order_by
+                        .iter()
+                        .map(|ob| evaluator.compile_cached(&ob.expression).ok())
+                        .collect();
                     rows.iter()
                         .map(|(_, row)| {
-                            evaluator.set_row_array(row);
-                            stmt.order_by
+                            programs
                                 .iter()
-                                .map(|ob| {
-                                    evaluator
-                                        .evaluate(&ob.expression)
-                                        .unwrap_or_else(|_| Value::null_unknown())
+                                .map(|p| match p {
+                                    Some(p) => evaluator
+                                        .evaluate_program(p, row)
+                                        .unwrap_or_else(|_| Value::null_unknown()),
+                                    None => Value::null_unknown(),
                                 })
                                 .collect()
                         })
@@ -4234,22 +4241,34 @@ impl Executor {
                         evaluator = evaluator.with_context(ctx);
                         evaluator.init_columns(&all_columns);
 
-                        // Compute sort keys and indices
+                        // Compute sort keys and indices; compile and
+                        // evaluation errors both defer to the standard path
                         let mut keys_ok = true;
-                        let mut sort_keys: Vec<Vec<Value>> = Vec::with_capacity(final_rows.len());
-                        'keys: for (_, row) in final_rows.iter() {
-                            evaluator.set_row_array(row);
-                            let mut keys = Vec::with_capacity(stmt.order_by.len());
-                            for ob in &stmt.order_by {
-                                match evaluator.evaluate(&ob.expression) {
-                                    Ok(v) => keys.push(v),
-                                    Err(_) => {
-                                        keys_ok = false;
-                                        break 'keys;
-                                    }
+                        let mut programs = Vec::with_capacity(stmt.order_by.len());
+                        for ob in &stmt.order_by {
+                            match evaluator.compile_cached(&ob.expression) {
+                                Ok(p) => programs.push(p),
+                                Err(_) => {
+                                    keys_ok = false;
+                                    break;
                                 }
                             }
-                            sort_keys.push(keys);
+                        }
+                        let mut sort_keys: Vec<Vec<Value>> = Vec::with_capacity(final_rows.len());
+                        if keys_ok {
+                            'keys: for (_, row) in final_rows.iter() {
+                                let mut keys = Vec::with_capacity(programs.len());
+                                for p in &programs {
+                                    match evaluator.evaluate_program(p, row) {
+                                        Ok(v) => keys.push(v),
+                                        Err(_) => {
+                                            keys_ok = false;
+                                            break 'keys;
+                                        }
+                                    }
+                                }
+                                sort_keys.push(keys);
+                            }
                         }
                         if keys_ok {
                             // Sort by indices with the shared NULL-aware

--- a/src/executor/result.rs
+++ b/src/executor/result.rs
@@ -1214,13 +1214,11 @@ impl TopNResult {
                     row,
                     compare: std::sync::Arc::clone(&compare),
                 });
-            } else if let Some(worst) = heap.peek() {
+            } else if let Some(mut worst) = heap.peek_mut() {
+                // Replace in place: one sift-down on drop instead of a
+                // pop + push double sift
                 if compare(&row, &worst.row) == std::cmp::Ordering::Less {
-                    heap.pop();
-                    heap.push(HeapRow {
-                        row,
-                        compare: std::sync::Arc::clone(&compare),
-                    });
+                    worst.row = row;
                 }
             }
         }
@@ -1348,14 +1346,6 @@ impl DistinctResult {
         }
         hasher.finish()
     }
-
-    /// Extract distinct column values from a row
-    fn extract_distinct_values(&self, row: &Row) -> Vec<Value> {
-        row.iter()
-            .take(self.distinct_column_count)
-            .cloned()
-            .collect()
-    }
 }
 
 impl QueryResult for DistinctResult {
@@ -1369,12 +1359,16 @@ impl QueryResult for DistinctResult {
             let row = self.inner.row();
             let hash = self.hash_row(row);
 
-            // Extract distinct values first for duplicate check
-            let values = self.extract_distinct_values(row);
-
-            // Check if we've seen this combination before
+            // Compare by reference so duplicate rows allocate nothing
+            let prefix_len = row.len().min(self.distinct_column_count);
             let is_dup = if let Some(seen_rows) = self.seen.get(&hash) {
-                seen_rows.contains(&values)
+                seen_rows.iter().any(|seen| {
+                    seen.len() == prefix_len
+                        && seen
+                            .iter()
+                            .zip(row.iter().take(self.distinct_column_count))
+                            .all(|(a, b)| a == b)
+                })
             } else {
                 false
             };
@@ -1382,6 +1376,12 @@ impl QueryResult for DistinctResult {
             if !is_dup {
                 // New unique row found - take ownership and mark as seen
                 self.current_row = self.inner.take_row();
+                let values = self
+                    .current_row
+                    .iter()
+                    .take(self.distinct_column_count)
+                    .cloned()
+                    .collect();
                 self.seen.entry(hash).or_default().push(values);
                 self.has_current = true;
                 return true;
@@ -1472,13 +1472,30 @@ impl DistinctOnResult {
             .collect()
     }
 
-    fn hash_key(&self, key: &[Value]) -> u64 {
+    fn hash_key_from_row(&self, row: &Row) -> u64 {
         use std::hash::{Hash, Hasher};
         let mut hasher = FxHasher::default();
-        for value in key {
-            value.hash(&mut hasher);
+        for &i in &self.key_indices {
+            match row.get(i) {
+                Some(v) => v.hash(&mut hasher),
+                None => Value::null_unknown().hash(&mut hasher),
+            }
         }
         hasher.finish()
+    }
+
+    /// Reference comparison against a stored key, matching extract_key's
+    /// null_unknown fallback for missing indices
+    fn row_matches_key(&self, row: &Row, key: &[Value]) -> bool {
+        key.len() == self.key_indices.len()
+            && self
+                .key_indices
+                .iter()
+                .zip(key.iter())
+                .all(|(&i, kv)| match row.get(i) {
+                    Some(v) => v == kv,
+                    None => Value::null_unknown() == *kv,
+                })
     }
 }
 
@@ -1490,12 +1507,11 @@ impl QueryResult for DistinctOnResult {
     fn next(&mut self) -> bool {
         while self.inner.next() {
             let row = self.inner.row();
-            let key = self.extract_key(row);
-            let hash = self.hash_key(&key);
+            let hash = self.hash_key_from_row(row);
 
-            // Check if we've seen this key before
+            // Compare by reference so duplicate rows allocate nothing
             let is_dup = if let Some(seen_keys) = self.seen.get(&hash) {
-                seen_keys.contains(&key)
+                seen_keys.iter().any(|k| self.row_matches_key(row, k))
             } else {
                 false
             };
@@ -1504,8 +1520,9 @@ impl QueryResult for DistinctOnResult {
                 continue; // already emitted a row for this group
             }
 
-            self.seen.entry(hash).or_default().push(key);
             self.current_row = self.inner.take_row();
+            let key = self.extract_key(&self.current_row);
+            self.seen.entry(hash).or_default().push(key);
             self.has_current = true;
             return true;
         }
@@ -1667,14 +1684,21 @@ impl QueryResult for ProjectedResult {
 
     fn next(&mut self) -> bool {
         if self.inner.next() {
-            // Project the row to keep only the first N columns
-            // OPTIMIZATION: Use Inline storage - no Arc overhead for intermediate results
-            self.current_row.reserve_inline(self.keep_columns);
-            self.current_row.clear_inline();
             let full_row = self.inner.row();
-            for i in 0..self.keep_columns {
-                self.current_row
-                    .push_inline(full_row.get(i).cloned().unwrap_or(Value::null_unknown()));
+            if !full_row.is_shared() && full_row.len() >= self.keep_columns {
+                // Owned row: take it and truncate in place, no clones
+                let mut row = self.inner.take_row();
+                row.truncate(self.keep_columns);
+                self.current_row = row;
+            } else {
+                // Shared (or short) row: clone only the kept prefix
+                self.current_row.reserve_inline(self.keep_columns);
+                self.current_row.clear_inline();
+                let full_row = self.inner.row();
+                for i in 0..self.keep_columns {
+                    self.current_row
+                        .push_inline(full_row.get(i).cloned().unwrap_or(Value::null_unknown()));
+                }
             }
             true
         } else {
@@ -2069,9 +2093,11 @@ impl QueryResult for ColumnarResult {
         self.current_row.reserve_inline(self.data.len());
         // Materialize row from column data - clear_inline preserves capacity
         self.current_row.clear_inline();
-        for col_data in &self.data {
-            // Safety: we verified all columns have num_rows elements
-            self.current_row.push_inline(col_data[next_idx].clone());
+        for col_data in &mut self.data {
+            // Iteration is forward-only and close() clears the buffers,
+            // so each cell moves out instead of cloning
+            self.current_row
+                .push_inline(std::mem::take(&mut col_data[next_idx]));
         }
 
         true


### PR DESCRIPTION
Wave C2 of the executor perf campaign: per-row multipliers in the result pipeline and the sort/projection loops.

## result pipeline (result.rs)

1. **TopNResult** replaces the heap's worst element through `peek_mut`: one sift-down on drop instead of `pop` + `push` (two sifts), and no per-replacement `HeapRow` allocation or comparator `Arc` clone.
2. **DistinctResult / DistinctOnResult** check duplicates by reference against the stored keys; the key `Vec` is allocated and its values cloned only when a new unique row is actually kept. Duplicate-heavy streams previously paid a full key extraction per input row and dropped it.
3. **ProjectedResult** (ORDER BY columns dropped from output) takes the inner row and truncates in place when it is Owned; Shared and short rows keep the old clone-the-prefix path, since `truncate` on a Shared row would materialize the whole row.
4. **ColumnarResult** moves cells out of the columnar buffers with `mem::take` instead of cloning; iteration is forward-only and `close()` clears the buffers anyway.

## evaluator bridge

5. New `compile_cached` + `evaluate_program` API. `evaluate(expr)` per row pays two full recursive AST hashes (FxHasher + seeded ahash) for the local-cache lookup, and `set_row_array` deep-clones every Owned row. The new pair compiles once before the loop and runs the VM directly against a borrowed row: no per-row clone, no per-row hashing. Migrated: the complex ORDER BY sort-key loop, the INL join inline sort, and the aggregation projection loop. The correlated branches keep their per-row evaluators (subquery execution dominates there).
6. Evaluator constructors reuse shared empty `ParamVec`/`FxHashMap` statics instead of allocating fresh empty collections that `with_context` immediately overwrites (11 sites).

## Numbers (selbench, best of 3, 10K rows)

| bench | main | this PR | delta |
|---|---|---|---|
| order_by_expr_sort (`ORDER BY (age*2 + id%7) DESC`) | 2560us | 381us | **6.7x** |
| distinct_dup_heavy (80 keys / 10K rows) | 273us | 190us | **1.43x** |
| join_order_by (INL, 10K join) | 2347us | 1982us | 1.18x |
| order_by_limit / order_by_extra_col / window_row_number | flat | flat | within noise |

Honest scoping: the ProjectedResult/ColumnarResult/TopN items are micro (bounded by LIMIT or dominated by window computation); the measurable wins are the DISTINCT dedup and the prepared-program loops.

## Verification

- Both suites 4927/4927, differential oracle 9/9, fmt + clippy clean.
- No semantic changes intended anywhere: dedup equality still goes through `Value` `PartialEq` on exactly the same key values, hashes are computed over the same values in the same order, and the sort loops produce identical keys (compile errors now defer before the first row instead of on it).
