### PR TITLE
perf(executor): whole-program cow dispatch, parallel filter path collect

### DIFF
--- a/src/executor/expression/evaluator_bridge.rs
+++ b/src/executor/expression/evaluator_bridge.rs
@@ -2049,6 +2049,10 @@ impl<'a> CompiledEvaluator<'a> {
     /// without storing a per-row copy in the evaluator and without
     /// re-hashing the expression. Not for join mode (single row only).
     pub fn evaluate_program(&mut self, program: &SharedProgram, row: &Row) -> Result<Value> {
+        debug_assert!(
+            self.current_row2.is_none() && self.columns2.is_none(),
+            "evaluate_program does not support join mode"
+        );
         let mut ctx = ExecuteContext::new(row);
         if !self.params.is_empty() {
             ctx = ctx.with_params(&self.params);

--- a/src/executor/expression/program.rs
+++ b/src/executor/expression/program.rs
@@ -57,6 +57,11 @@ pub struct Program {
     /// Whether this program contains subqueries
     has_subqueries: bool,
 
+    /// Whether every op is handled by ExprVM::execute_cow, so the
+    /// borrowed interpreter never bails mid-program into a full owned
+    /// re-execution
+    cow_supported: bool,
+
     /// Source expression string (for debugging)
     #[cfg(debug_assertions)]
     source: Option<String>,
@@ -83,12 +88,15 @@ impl Program {
             )
         });
 
+        let cow_supported = Self::compute_cow_supported(&ops);
+
         Self {
             ops,
             max_stack_depth,
             needs_outer_context,
             needs_second_row,
             has_subqueries,
+            cow_supported,
             #[cfg(debug_assertions)]
             source: None,
         }
@@ -111,12 +119,15 @@ impl Program {
             )
         });
 
+        let cow_supported = Self::compute_cow_supported(&ops);
+
         Self {
             ops,
             max_stack_depth,
             needs_outer_context,
             needs_second_row,
             has_subqueries,
+            cow_supported,
             #[cfg(debug_assertions)]
             source: None,
         }
@@ -360,7 +371,72 @@ impl Program {
         self.ops = Self::peephole_optimize(self.ops);
         // Recalculate metadata after optimization
         self.max_stack_depth = Self::compute_stack_depth(&self.ops);
+        self.cow_supported = Self::compute_cow_supported(&self.ops);
         self
+    }
+
+    /// Whether execute_cow handles every op of this program
+    #[inline]
+    pub fn cow_supported(&self) -> bool {
+        self.cow_supported
+    }
+
+    /// Mirrors the op set ExprVM::execute_cow handles; keep the two in
+    /// sync (drift only costs performance, the cow catch-all stays)
+    fn compute_cow_supported(ops: &[Op]) -> bool {
+        ops.iter().all(|op| {
+            matches!(
+                op,
+                Op::LoadColumn(_)
+                    | Op::LoadColumn2(_)
+                    | Op::LoadConst(_)
+                    | Op::LoadNull(_)
+                    | Op::LoadParam(_)
+                    | Op::LoadAggregateResult(_)
+                    | Op::Eq
+                    | Op::Ne
+                    | Op::Lt
+                    | Op::Le
+                    | Op::Gt
+                    | Op::Ge
+                    | Op::EqColumnConst(..)
+                    | Op::LtColumnConst(..)
+                    | Op::GtColumnConst(..)
+                    | Op::And(_)
+                    | Op::AndFinalize
+                    | Op::Or(_)
+                    | Op::OrFinalize
+                    | Op::Not
+                    | Op::IsNull
+                    | Op::IsNotNull
+                    | Op::Jump(_)
+                    | Op::JumpIfFalse(_)
+                    | Op::JumpIfTrue(_)
+                    | Op::JumpIfNull(_)
+                    | Op::JumpIfNotNull(_)
+                    | Op::PopJumpIfFalse(_)
+                    | Op::PopJumpIfTrue(_)
+                    | Op::Pop
+                    | Op::Nop
+                    | Op::Coalesce(_)
+                    | Op::NullIf
+                    | Op::Greatest(_)
+                    | Op::Least(_)
+                    | Op::Concat
+                    | Op::ConcatN(_)
+                    | Op::CaseStart
+                    | Op::CaseWhen(_)
+                    | Op::CaseThen(_)
+                    | Op::CaseElse
+                    | Op::CaseEnd
+                    | Op::CaseCompare
+                    | Op::CallScalar { .. }
+                    | Op::Return
+                    | Op::ReturnTrue
+                    | Op::ReturnFalse
+                    | Op::ReturnNull(_)
+            )
+        })
     }
 
     /// Peephole optimizer: fuse common instruction patterns into single ops

--- a/src/executor/expression/vm.rs
+++ b/src/executor/expression/vm.rs
@@ -2050,6 +2050,13 @@ impl ExprVM {
         program: &'a Program,
         ctx: &'a ExecuteContext<'a>,
     ) -> Result<Value> {
+        // A program with any op this loop does not handle goes straight
+        // to the owned VM, instead of bailing mid-program and paying the
+        // already-executed prefix twice
+        if !program.cow_supported() {
+            return self.execute(program, ctx);
+        }
+
         // Local stack with borrowed values - lifetime tied to this execution
         let mut stack: SmallVec<[StackValue<'a>; STACK_INLINE_CAPACITY]> = SmallVec::new();
 

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3056,13 +3056,12 @@ impl Executor {
                 }
 
                 // Normal path: collect all rows first (for ORDER BY, aggregation, etc.)
-                // With an identity projection the table hands back the
-                // materialized RowVec directly (with real row ids) instead
-                // of a per-row scanner drain
-                let identity_proj = column_idx_vec.len() == all_columns.len()
-                    && column_idx_vec.iter().enumerate().all(|(i, &c)| c == i);
-                let all_rows = if identity_proj {
-                    table.collect_all_rows(storage_expr.as_deref())?
+                // Without a storage filter there is no index opportunity,
+                // so the table hands back the materialized RowVec directly
+                // (with real row ids) instead of a per-row scanner drain.
+                // With one, scan() keeps its PK/index fast paths.
+                let all_rows = if storage_expr.is_none() {
+                    table.collect_all_rows(None)?
                 } else {
                     let mut scanner = table.scan(&column_idx_vec, storage_expr.as_deref())?;
                     let mut all_rows =

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3056,12 +3056,22 @@ impl Executor {
                 }
 
                 // Normal path: collect all rows first (for ORDER BY, aggregation, etc.)
-                // Now we create the scanner since we need all rows
-                let mut scanner = table.scan(&column_idx_vec, storage_expr.as_deref())?;
-                let mut all_rows = RowVec::new();
-                while scanner.next() {
-                    all_rows.push(scanner.take_row_with_id());
-                }
+                // With an identity projection the table hands back the
+                // materialized RowVec directly (with real row ids) instead
+                // of a per-row scanner drain
+                let identity_proj = column_idx_vec.len() == all_columns.len()
+                    && column_idx_vec.iter().enumerate().all(|(i, &c)| c == i);
+                let all_rows = if identity_proj {
+                    table.collect_all_rows(storage_expr.as_deref())?
+                } else {
+                    let mut scanner = table.scan(&column_idx_vec, storage_expr.as_deref())?;
+                    let mut all_rows =
+                        RowVec::with_capacity(scanner.estimated_count().unwrap_or(64));
+                    while scanner.next() {
+                        all_rows.push(scanner.take_row_with_id());
+                    }
+                    all_rows
+                };
 
                 // Apply parallel filtering if we have enough rows
                 // CRITICAL: Propagate errors with ? instead of silently swallowing them


### PR DESCRIPTION
Wave C3 of the executor perf campaign: the execute_cow bail and the parallel memory-filter drain.

## 1. execute_cow whole-program dispatch (vm.rs, program.rs)

The borrowed-value interpreter ran a program until the first op its loop does not handle (the fused `Ne/Ge/Le/IsNull/Like/InSet/Between` comparisons, arithmetic, `Dup`, `NativeFn1`...), then restarted the WHOLE program in the owned VM. Every cow-handled op before the bail point evaluated twice per row: `WHERE a = 1 AND b >= 2` paid the equality twice.

`Program` now precomputes a `cow_supported` flag at build time (mirroring the cow loop's op set), and `execute_cow` dispatches unsupported programs to the owned VM before touching the stack. The cow catch-all stays in place, so drift between the flag and the loop only costs performance, never correctness.

**Why not add the missing ops to the cow loop instead?** I tried that first and measured it: **6-10% SLOWER** on integer-heavy filters. The fused ColumnConst ops read the row directly and never borrow stack values, so the borrowed interpreter's per-op overhead buys nothing there; on main the bail at op 0 was effectively free because the owned VM is faster for those shapes. The dispatch flag keeps every shape on its faster interpreter.

## 2. Parallel memory-filter path double materialization (query.rs)

The no-LIMIT memory-filter path drained an already-materialized scanner row by row (two virtual calls per row) into a `RowVec::new()` with no capacity hint. The fix is gated on `storage_expr.is_none()`: with no storage filter there is no index opportunity, so `table.collect_all_rows` returns the RowVec directly; with a storage filter, `scan()` keeps its PK/index fast paths and the drain loop pre-sizes from `estimated_count`. (The adversarial round caught the first version of this gate: keying on identity projection instead of the filter dropped the MVCC PK/index lookup inside `scan()` and turned partial-pushdown point queries without LIMIT into full scans. Fixed; a 200K-row probe confirms the point shape is back to 1.1us/op.) Side note: the collect branch restores real row ids where the old drain produced id 0 for every row (`take_row_with_id` has no MVCCScanner override); the reviewer verified nothing on this SELECT-only path consumes the id.

## 3. C2 review carry-over

`evaluate_program` gets a `debug_assert` rejecting join-mode evaluators, converting the C2 adversarial reviewer's "comment-only contract" finding into a loud failure in debug builds.

## Numbers (selbench, alternating rounds vs main, 10K rows)

| bench | main | this PR |
|---|---|---|
| mem_filter_mixed (4 conjuncts, residual forces VM) | 345-355us | 316-330us (~7%) |
| parallel_memfilter_scan (no LIMIT, non-pushable WHERE) | 648-722us | 609-618us (6-15%) |
| mem_filter_eq_prefix / order_by_expr_sort | | slightly better, within noise band |

## Adversarial review round

No correctness refutation. The reviewer mechanically diffed the flag's allow-list against the cow loop's match arms (48 vs 48, identical) and compared all 48 shared op implementations line by line: semantically identical. One correction to this PR's own reasoning, worth recording: "bail programs always produced the owned result anyway" is false when short-circuit or CASE control flow skips the unsupported op on a given row; those rows previously got the cow result. Correctness therefore rests on the verified op-level parity, not on the bail argument. Two honest behavior notes from the round: (1) a non-deterministic scalar function in the prefix of a bailing program used to run twice per row and now runs once (a fix); (2) rows whose short-circuit skips the unsupported op used to stay in the borrowed interpreter and now pay owned-VM loads, while the opposite rows stop paying the double prefix; net is workload-dependent, program-wise the double evaluation is gone.

## Verification

- Both suites 4927/4927, differential oracle 9/9, fmt + clippy clean; 140 targeted tests by the reviewer on both backends.
- The dispatch flag changes which interpreter runs, never what it computes (op-level parity verified arm by arm).
