### PR TITLE
perf(cte): share recursive working-set rows across iterations

### DIFF
--- a/src/executor/cte.rs
+++ b/src/executor/cte.rs
@@ -425,12 +425,19 @@ impl Executor {
             anchor_columns
         };
 
-        let mut all_rows = Self::materialize_result(result)?;
+        let all_rows = Self::materialize_result(result)?;
 
         // If no anchor rows, return empty result
         if all_rows.is_empty() {
             return Ok((columns, all_rows));
         }
+
+        // Shared rows make every accumulator/working-set/registry copy
+        // an Arc bump instead of a deep row clone
+        let mut all_rows: RowVec = all_rows
+            .into_iter()
+            .map(|(id, row)| (id, row.into_shared()))
+            .collect();
 
         // Current working set (rows from previous iteration)
         let mut working_rows = all_rows.clone();
@@ -447,8 +454,9 @@ impl Executor {
             for (name, (cols, rows)) in cte_registry.iter() {
                 temp_registry.store_arc(name, cols.clone(), CompactArc::clone(rows));
             }
-            // Add current CTE with working rows
-            temp_registry.store(cte_name, columns.clone(), working_rows.clone());
+            // Add current CTE with working rows; the working set is
+            // rebuilt from new_rows below, so move it instead of cloning
+            temp_registry.store(cte_name, columns.clone(), std::mem::take(&mut working_rows));
 
             // Execute each recursive member
             let mut new_rows = RowVec::new();
@@ -468,10 +476,17 @@ impl Executor {
                 break;
             }
 
+            // Convert to Shared once: the accumulator extension and the
+            // next working set then share the same row data
+            let new_rows: RowVec = new_rows
+                .into_iter()
+                .map(|(id, row)| (id, row.into_shared()))
+                .collect();
+
             // Add new rows to total result, renumbering row IDs
             let base_id = all_rows.len() as i64;
-            for (i, (_, row)) in new_rows.clone().into_iter().enumerate() {
-                all_rows.push((base_id + i as i64, row));
+            for (i, (_, row)) in new_rows.iter().enumerate() {
+                all_rows.push((base_id + i as i64, row.clone()));
             }
 
             // New rows become the working set for next iteration


### PR DESCRIPTION
Wave D1 of the executor perf campaign: recursive CTE row sharing. Small diff (20 lines), measured story below.

## The change (cte.rs, recursive loop only)

Each recursive iteration paid three full row-set copies: `working_rows.clone()` into the temp registry, `new_rows.clone()` for the accumulator extension, and the recursive member's `FROM r` reference cloning the working set out of the registry again. Now:

- the working set **moves** into the temp registry (`mem::take`; it is rebuilt from `new_rows` right after),
- the anchor and each iteration's new rows convert to **Shared** storage once, so the accumulator extension and the per-iteration registry reference are Arc bumps per row.

**Recursive fan-out probe (40 iterations x 1000 rows with heap Text): 4.5-5.2ms -> 2.7-2.9ms (~1.6-1.8x).** CTE self-join shape at parity.

## What the audit expected vs what measurement showed

The audit's big-win #1 targeted the single-reference `WITH big AS (...) SELECT ... FROM big WHERE ... LIMIT n` shape (registry clone per reference + no LIMIT short-circuit). Tracing on current main shows that shape **never reaches the CTE registry**: no store, no `execute_query_on_cte_result` call; the planner inlines it. The registry engages only for join, multi-reference, and recursive shapes. So:

- No LIMIT short-circuit was added (the audited path is unreachable for the common shape; I wrote it, proved it dead by trace, removed it).
- Converting **all** stored CTE rows to Shared in `CteRegistry::store` was tried and measured: the CTE self-join shape regressed 5-8% (a per-row Arc allocation at store time with no payback for single-use rows, plus downstream copy-on-write). Reverted; the conversion lives only in the recursive path where the same rows are provably referenced multiple times.

## Verification

- Both suites 4927/4927, recursive_cte_test 19/19, differential oracle 9/9, fmt + clippy clean.
- Pure sharing change: row values are never mutated through the shared handles on this path (the accumulator and registry are read-only consumers; any downstream writer goes through Row's copy-on-write make_mut).
