### PR TITLE
perf(cte): avoid pool checkout for the working-set placeholder

### DIFF
--- a/src/executor/cte.rs
+++ b/src/executor/cte.rs
@@ -456,7 +456,14 @@ impl Executor {
             }
             // Add current CTE with working rows; the working set is
             // rebuilt from new_rows below, so move it instead of cloning
-            temp_registry.store(cte_name, columns.clone(), std::mem::take(&mut working_rows));
+            // mem::replace with a pool-free empty vec: RowVec::default
+            // would check a buffer out of the thread-local pool just to
+            // serve as a throwaway placeholder
+            temp_registry.store(
+                cte_name,
+                columns.clone(),
+                std::mem::replace(&mut working_rows, RowVec::from_vec(Vec::new())),
+            );
 
             // Execute each recursive member
             let mut new_rows = RowVec::new();


### PR DESCRIPTION
Follow-up to #47: the adversarial-review P3 nit fix (fab84435) was pushed right after the merge, so it stayed on the branch. Cherry-picked onto main unchanged.

mem::take invoked RowVec::default, which pops the largest buffer from the thread-local row-vec pool just to serve as a throwaway placeholder per recursive iteration; mem::replace with a pool-free empty vec leaves the pool alone.

The tree is byte-identical to the already-gated perf/cte-share head: both suites 4927/4927, recursive tests 19/19, fmt + clippy clean.