### PR TITLE
perf(subquery): memoized IN set on cache hits; fix result-cache rollback poisoning

### DIFF
--- a/src/executor/context.rs
+++ b/src/executor/context.rs
@@ -111,8 +111,13 @@ pub fn cache_scalar_subquery(key: String, tables: SmallVec<[CompactArc<str>; 2]>
 // Stores (tables_referenced, result) for table-based invalidation.
 // LRU-bounded to prevent unbounded memory growth.
 
-/// Cached IN subquery entry: (tables_referenced for invalidation, result values)
-type InSubqueryCacheEntry = (SmallVec<[CompactArc<str>; 2]>, Vec<Value>);
+/// Cached IN subquery entry: (tables_referenced for invalidation, result
+/// values, lazily built shared hash set for single-column IN)
+type InSubqueryCacheEntry = (
+    SmallVec<[CompactArc<str>; 2]>,
+    Vec<Value>,
+    Option<CompactArc<crate::core::ValueSet>>,
+);
 
 thread_local! {
     static IN_SUBQUERY_CACHE: RefCell<LruCache<String, InSubqueryCacheEntry>> =
@@ -140,7 +145,7 @@ pub fn invalidate_in_subquery_cache_for_table(table_name: &str) {
         // Collect keys to remove (LruCache doesn't have retain)
         let keys_to_remove: Vec<String> = c
             .iter()
-            .filter(|(_, (tables, _))| tables.iter().any(|t| t.eq_ignore_ascii_case(table_name)))
+            .filter(|(_, (tables, _, _))| tables.iter().any(|t| t.eq_ignore_ascii_case(table_name)))
             .map(|(k, _)| k.clone())
             .collect();
         for key in keys_to_remove {
@@ -151,13 +156,27 @@ pub fn invalidate_in_subquery_cache_for_table(table_name: &str) {
 
 /// Get a cached IN subquery result by SQL string key.
 pub fn get_cached_in_subquery(key: &str) -> Option<Vec<Value>> {
-    IN_SUBQUERY_CACHE.with(|cache| cache.borrow_mut().get(key).map(|(_, v)| v.clone()))
+    IN_SUBQUERY_CACHE.with(|cache| cache.borrow_mut().get(key).map(|(_, v, _)| v.clone()))
+}
+
+/// Get a cached IN subquery result as a shared hash set, building and
+/// memoizing the set inside the entry on first request. Later hits are
+/// an Arc clone: no value clones, no set rebuild.
+pub fn get_cached_in_subquery_set(key: &str) -> Option<CompactArc<crate::core::ValueSet>> {
+    IN_SUBQUERY_CACHE.with(|cache| {
+        let mut c = cache.borrow_mut();
+        let entry = c.get_mut(key)?;
+        if entry.2.is_none() {
+            entry.2 = Some(CompactArc::new(entry.1.iter().cloned().collect()));
+        }
+        entry.2.clone()
+    })
 }
 
 /// Cache an IN subquery result with the tables it references.
 pub fn cache_in_subquery(key: String, tables: SmallVec<[CompactArc<str>; 2]>, values: Vec<Value>) {
     IN_SUBQUERY_CACHE.with(|cache| {
-        cache.borrow_mut().put(key, (tables, values));
+        cache.borrow_mut().put(key, (tables, values, None));
     });
 }
 

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -903,9 +903,17 @@ impl Executor {
             None
         };
 
-        // Execute the subquery to get values (with caching for non-correlated subqueries)
-        let cache_key = subquery.subquery.to_string();
-        let values = if let Some(cached) = get_cached_in_subquery(&cache_key) {
+        // Execute the subquery to get values (with caching for
+        // non-correlated subqueries). Inside an explicit transaction the
+        // cache is bypassed: a cached in-transaction view would survive
+        // ROLLBACK
+        let cache_key = if ctx.transaction_id().is_none() {
+            Some(subquery.subquery.to_string())
+        } else {
+            None
+        };
+        let cached = cache_key.as_deref().and_then(get_cached_in_subquery);
+        let values = if let Some(cached) = cached {
             cached
         } else {
             let subquery_ctx = ctx.with_incremented_query_depth();
@@ -927,11 +935,13 @@ impl Executor {
                 return Err(err);
             }
             // Cache for future use
-            cache_in_subquery(
-                cache_key,
-                extract_table_names_for_cache(&subquery.subquery),
-                values.clone(),
-            );
+            if let Some(key) = cache_key {
+                cache_in_subquery(
+                    key,
+                    extract_table_names_for_cache(&subquery.subquery),
+                    values.clone(),
+                );
+            }
             values
         };
 

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -222,7 +222,8 @@ impl Executor {
                         // A repeated non-correlated subquery reuses the
                         // memoized shared set from the cache entry
                         let is_non_correlated = ctx.outer_row().is_none()
-                            && !Self::is_subquery_correlated(&subquery.subquery);
+                            && !Self::is_subquery_correlated(&subquery.subquery)
+                            && ctx.transaction_id().is_none();
                         let cached_set = if is_non_correlated {
                             get_cached_in_subquery_set(&subquery.subquery.to_string())
                         } else {
@@ -512,19 +513,15 @@ impl Executor {
         // If there's no additional predicate, check if at least one row is visible
         // Note: Index may contain row_ids for deleted rows, so we must verify visibility
         if correlation.additional_predicate.is_none() {
-            // Count visible rows per batch instead of materializing rows
-            // that were only tested for emptiness and discarded
-            let row_counter = match get_cached_count_counter(&correlation.inner_table) {
-                Some(c) => c,
-                None => match self.get_or_create_row_counter(&correlation.inner_table) {
-                    Some(c) => c,
-                    None => return Ok(None), // Fall back if counter creation fails
-                },
+            let row_fetcher = match self.get_or_create_row_fetcher(&correlation.inner_table) {
+                Some(f) => f,
+                None => return Ok(None), // Fall back if fetcher creation fails
             };
             // Check batches until we find a visible row or exhaust all row_ids
             // We can't stop after first batch because deleted rows may precede visible ones
             for chunk in row_ids.chunks(VISIBILITY_CHECK_BATCH_SIZE) {
-                if row_counter(chunk) > 0 {
+                let visible = row_fetcher(chunk)?;
+                if !visible.is_empty() {
                     return Ok(Some(true)); // Found at least one visible row
                 }
             }
@@ -1715,8 +1712,10 @@ impl Executor {
         let is_non_correlated =
             ctx.outer_row().is_none() && !Self::is_subquery_correlated(subquery);
 
-        // For non-correlated subqueries, check cache first using SQL string as key
-        let cache_key = if is_non_correlated {
+        // For non-correlated subqueries, check cache first using SQL string
+        // as key; bypassed inside explicit transactions (see
+        // execute_in_subquery for the ROLLBACK rationale)
+        let cache_key = if is_non_correlated && ctx.transaction_id().is_none() {
             let key = subquery.to_string();
             if let Some(cached_value) = get_cached_scalar_subquery(&key) {
                 return Ok(cached_value);
@@ -1826,8 +1825,11 @@ impl Executor {
         let is_non_correlated =
             ctx.outer_row().is_none() && !Self::is_subquery_correlated(subquery);
 
-        // For non-correlated subqueries, check cache first using SQL string as key
-        let cache_key = if is_non_correlated {
+        // For non-correlated subqueries, check cache first using SQL string
+        // as key. Inside an explicit transaction the caches are bypassed
+        // entirely: an in-transaction execution sees uncommitted rows, and
+        // caching that view would survive a ROLLBACK
+        let cache_key = if is_non_correlated && ctx.transaction_id().is_none() {
             let key = subquery.to_string();
             if let Some(cached_values) = get_cached_in_subquery(&key) {
                 return Ok(cached_values);
@@ -3053,9 +3055,14 @@ impl Executor {
         let cache_key =
             compute_semi_join_cache_key(&info.inner_table, &info.inner_column, pred_hash);
 
-        // Check cache first - return Arc directly (no clone needed)
-        if let Some(cached) = get_cached_semi_join(cache_key) {
-            return Ok(cached);
+        // Check cache first - return Arc directly (no clone needed).
+        // Bypassed inside explicit transactions (a cached in-transaction
+        // view would survive ROLLBACK)
+        let cacheable = ctx.transaction_id().is_none();
+        if cacheable {
+            if let Some(cached) = get_cached_semi_join(cache_key) {
+                return Ok(cached);
+            }
         }
 
         // Build SELECT inner_column FROM inner_table WHERE non_correlated_predicates
@@ -3126,11 +3133,13 @@ impl Executor {
         let hash_set_arc = CompactArc::new(hash_set);
 
         // Cache for subsequent calls within this query (CompactArc clone is cheap)
-        cache_semi_join_arc(
-            cache_key,
-            &info.inner_table,
-            CompactArc::clone(&hash_set_arc),
-        );
+        if cacheable {
+            cache_semi_join_arc(
+                cache_key,
+                &info.inner_table,
+                CompactArc::clone(&hash_set_arc),
+            );
+        }
 
         Ok(hash_set_arc)
     }

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -37,8 +37,8 @@ use super::context::{
     get_cached_batch_aggregate, get_cached_batch_aggregate_info, get_cached_count_counter,
     get_cached_exists_correlation, get_cached_exists_fetcher, get_cached_exists_index,
     get_cached_exists_pred_key, get_cached_exists_predicate, get_cached_exists_schema,
-    get_cached_in_subquery, get_cached_scalar_subquery, get_cached_semi_join,
-    BatchAggregateLookupInfo, ExecutionContext, ExistsCorrelationInfo,
+    get_cached_in_subquery, get_cached_in_subquery_set, get_cached_scalar_subquery,
+    get_cached_semi_join, BatchAggregateLookupInfo, ExecutionContext, ExistsCorrelationInfo,
 };
 use super::expr_converter::convert_ast_to_storage_expr;
 use super::expression::compute_expression_hash;
@@ -218,17 +218,29 @@ impl Executor {
                             not: in_expr.not,
                         }));
                     } else {
-                        // Single-column IN - use InHashSet for O(1) lookups
-                        let values = self.execute_in_subquery(&subquery.subquery, ctx)?;
-
-                        // Collect into FxHashSet for O(1) membership testing (optimized for Value types with WyMix)
-                        let hash_set: ValueSet = values.into_iter().collect();
+                        // Single-column IN - use InHashSet for O(1) lookups.
+                        // A repeated non-correlated subquery reuses the
+                        // memoized shared set from the cache entry
+                        let is_non_correlated = ctx.outer_row().is_none()
+                            && !Self::is_subquery_correlated(&subquery.subquery);
+                        let cached_set = if is_non_correlated {
+                            get_cached_in_subquery_set(&subquery.subquery.to_string())
+                        } else {
+                            None
+                        };
+                        let values_arc = match cached_set {
+                            Some(arc) => arc,
+                            None => {
+                                let values = self.execute_in_subquery(&subquery.subquery, ctx)?;
+                                CompactArc::new(values.into_iter().collect::<ValueSet>())
+                            }
+                        };
 
                         // Use InHashSet with Arc for fast O(1) lookup per row
                         return Ok(Expression::InHashSet(InHashSetExpression {
                             token: in_expr.token.clone(),
                             column: Box::new(processed_left),
-                            values: CompactArc::new(hash_set),
+                            values: values_arc,
                             not: in_expr.not,
                         }));
                     }
@@ -500,15 +512,19 @@ impl Executor {
         // If there's no additional predicate, check if at least one row is visible
         // Note: Index may contain row_ids for deleted rows, so we must verify visibility
         if correlation.additional_predicate.is_none() {
-            let row_fetcher = match self.get_or_create_row_fetcher(&correlation.inner_table) {
-                Some(f) => f,
-                None => return Ok(None), // Fall back if fetcher creation fails
+            // Count visible rows per batch instead of materializing rows
+            // that were only tested for emptiness and discarded
+            let row_counter = match get_cached_count_counter(&correlation.inner_table) {
+                Some(c) => c,
+                None => match self.get_or_create_row_counter(&correlation.inner_table) {
+                    Some(c) => c,
+                    None => return Ok(None), // Fall back if counter creation fails
+                },
             };
             // Check batches until we find a visible row or exhaust all row_ids
             // We can't stop after first batch because deleted rows may precede visible ones
             for chunk in row_ids.chunks(VISIBILITY_CHECK_BATCH_SIZE) {
-                let visible = row_fetcher(chunk)?;
-                if !visible.is_empty() {
+                if row_counter(chunk) > 0 {
                     return Ok(Some(true)); // Found at least one visible row
                 }
             }

--- a/tests/in_subquery_cache_test.rs
+++ b/tests/in_subquery_cache_test.rs
@@ -70,3 +70,63 @@ fn in_subquery_set_survives_repeats_and_invalidation() {
         .unwrap();
     assert_eq!(c, 150);
 }
+
+#[test]
+fn subquery_caches_not_poisoned_by_rollback() {
+    let db = Database::open("memory://in_subq_rollback").unwrap();
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE inner_t (id INTEGER PRIMARY KEY, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..200i64 {
+        tx.execute("INSERT INTO users VALUES ($1, $2)", (i, i))
+            .unwrap();
+    }
+    for i in 0..50i64 {
+        tx.execute("INSERT INTO inner_t VALUES ($1, $2)", (i, i))
+            .unwrap();
+    }
+    tx.commit().unwrap();
+
+    let in_sql = "SELECT COUNT(*) FROM users WHERE id IN (SELECT id FROM inner_t WHERE v >= 0)";
+    let scalar_sql = "SELECT COUNT(*) FROM users WHERE id < (SELECT MAX(id) FROM inner_t)";
+
+    // Warm the caches in autocommit
+    let c: i64 = db.query_one(in_sql, ()).unwrap();
+    assert_eq!(c, 50);
+    let c: i64 = db.query_one(scalar_sql, ()).unwrap();
+    assert_eq!(c, 49);
+
+    // An uncommitted INSERT seen by an in-transaction query must not
+    // poison the cache after ROLLBACK
+    let mut tx = db.begin().unwrap();
+    tx.execute("INSERT INTO inner_t VALUES (100, 0)", ())
+        .unwrap();
+    let c: i64 = tx.query_one(in_sql, ()).unwrap();
+    assert_eq!(c, 51, "in-tx read sees own insert");
+    let c: i64 = tx.query_one(scalar_sql, ()).unwrap();
+    assert_eq!(c, 100, "in-tx scalar sees own insert");
+    tx.rollback().unwrap();
+
+    let c: i64 = db.query_one(in_sql, ()).unwrap();
+    assert_eq!(c, 50, "IN cache poisoned by rolled-back insert");
+    let c: i64 = db.query_one(scalar_sql, ()).unwrap();
+    assert_eq!(c, 49, "scalar cache poisoned by rolled-back insert");
+
+    // Same shape for the EXISTS semi-join cache
+    let exists_sql =
+        "SELECT COUNT(*) FROM users u WHERE EXISTS (SELECT 1 FROM inner_t i WHERE i.id = u.id AND i.v >= 0)";
+    let c: i64 = db.query_one(exists_sql, ()).unwrap();
+    assert_eq!(c, 50);
+    let mut tx = db.begin().unwrap();
+    tx.execute("DELETE FROM inner_t WHERE id = 0", ()).unwrap();
+    let c: i64 = tx.query_one(exists_sql, ()).unwrap();
+    assert_eq!(c, 49, "in-tx exists sees own delete");
+    tx.rollback().unwrap();
+    let c: i64 = db.query_one(exists_sql, ()).unwrap();
+    assert_eq!(c, 50, "semi-join cache poisoned by rolled-back delete");
+}

--- a/tests/in_subquery_cache_test.rs
+++ b/tests/in_subquery_cache_test.rs
@@ -1,0 +1,72 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The non-correlated IN-subquery cache memoizes a shared hash set per
+//! entry; DML on the inner table must invalidate both the values and
+//! the memoized set.
+
+use stoolap::Database;
+
+#[test]
+fn in_subquery_set_survives_repeats_and_invalidation() {
+    let db = Database::open("memory://in_subq_set_cache").unwrap();
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE inner_t (id INTEGER PRIMARY KEY, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..200i64 {
+        tx.execute("INSERT INTO users VALUES ($1, $2)", (i, i))
+            .unwrap();
+    }
+    for i in 0..50i64 {
+        tx.execute("INSERT INTO inner_t VALUES ($1, $2)", (i, i))
+            .unwrap();
+    }
+    tx.commit().unwrap();
+
+    let stmt = db
+        .prepare("SELECT COUNT(*) FROM users WHERE id IN (SELECT id FROM inner_t WHERE v >= 0)")
+        .unwrap();
+    // First run populates the cache, repeats use the memoized set
+    for _ in 0..3 {
+        let c: i64 = stmt.query_one(()).unwrap();
+        assert_eq!(c, 50);
+    }
+
+    // INSERT into the inner table must invalidate the cached set
+    db.execute("INSERT INTO inner_t VALUES (100, 0)", ())
+        .unwrap();
+    let c: i64 = stmt.query_one(()).unwrap();
+    assert_eq!(c, 51);
+    let c: i64 = stmt.query_one(()).unwrap();
+    assert_eq!(c, 51);
+
+    // DELETE must invalidate as well
+    db.execute("DELETE FROM inner_t WHERE id = 0", ()).unwrap();
+    let c: i64 = stmt.query_one(()).unwrap();
+    assert_eq!(c, 50);
+
+    // NOT IN goes through the same shared set
+    let c: i64 = db
+        .query_one(
+            "SELECT COUNT(*) FROM users WHERE id NOT IN (SELECT id FROM inner_t WHERE v >= 0)",
+            (),
+        )
+        .unwrap();
+    assert_eq!(c, 150);
+}

--- a/tests/in_subquery_cache_test.rs
+++ b/tests/in_subquery_cache_test.rs
@@ -130,3 +130,44 @@ fn subquery_caches_not_poisoned_by_rollback() {
     let c: i64 = db.query_one(exists_sql, ()).unwrap();
     assert_eq!(c, 50, "semi-join cache poisoned by rolled-back delete");
 }
+
+#[test]
+fn in_index_fast_path_not_poisoned_by_rollback() {
+    let db = Database::open("memory://in_subq_idx_rollback").unwrap();
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE inner_t (id INTEGER PRIMARY KEY, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..200i64 {
+        tx.execute("INSERT INTO users VALUES ($1, $2)", (i, i))
+            .unwrap();
+    }
+    for i in 0..50i64 {
+        tx.execute("INSERT INTO inner_t VALUES ($1, $2)", (i, i))
+            .unwrap();
+    }
+    tx.commit().unwrap();
+
+    // No aggregation: routes through the PK/index IN fast path
+    let sql = "SELECT id FROM users WHERE id IN (SELECT id FROM inner_t WHERE v >= 0)";
+    let rows = db.query(sql, ()).unwrap().collect_vec().unwrap();
+    assert_eq!(rows.len(), 50);
+
+    let mut tx = db.begin().unwrap();
+    tx.execute("INSERT INTO inner_t VALUES (100, 0)", ())
+        .unwrap();
+    let rows = tx.query(sql, ()).unwrap().collect_vec().unwrap();
+    assert_eq!(rows.len(), 51, "in-tx read sees own insert");
+    tx.rollback().unwrap();
+
+    let rows = db.query(sql, ()).unwrap().collect_vec().unwrap();
+    assert_eq!(
+        rows.len(),
+        50,
+        "index fast-path cache poisoned by rolled-back insert"
+    );
+}


### PR DESCRIPTION
Wave D2 of the executor perf campaign: subquery cache costs. Two items, two honest deferrals.

## 1. Memoized IN-subquery hash set (context.rs, subquery.rs)

The non-correlated IN-subquery cache stored `Vec<Value>`; every hit cloned the entire vector (`get_cached_in_subquery`), and the InHashSet consumer then rebuilt a `ValueSet` plus a fresh `CompactArc` per statement. The cache entry now carries a lazily built `CompactArc<ValueSet>`: the first set-request after (re)population builds it once inside the entry, and every later hit is an Arc bump. The `Vec` stays for the callers that genuinely need values (index probing, multi-column IN).

**Repeated IN-subquery statement, 2000 values: 224-227us -> 200-201us (~12%).**

Staleness: DML invalidation pops the whole cache entry and repopulation always writes `(tables, values, None)`, so the memoized set can never outlive its values. New test `in_subquery_cache_test` pins repeat + INSERT/DELETE invalidation + NOT IN, and runs under CI-mode `cargo test` too.

## 2. EXISTS row_counter: tried, reverted by the adversarial round

The no-additional-predicate EXISTS path was switched to the COUNT twin's visibility row counter, but the reviewer showed the counter's cold fallback guards on `has_committed_row` while the fetcher guards on actual visibility: during a concurrent commit of a sealed-row UPDATE/DELETE this widens an existing race into a wrong-EXISTS window. The hot-path bench was flat (~630us both sides), so the fetcher stays. The guard divergence itself exists on main's COUNT path today; follow-up filed.

## 3. Pre-existing P1 fixed in-round: result-cache rollback poisoning

`BEGIN; INSERT; SELECT ... IN (subquery); ROLLBACK` cached the uncommitted view in the IN/scalar/semi-join caches, and ROLLBACK never invalidated, so later autocommit queries returned rolled-back data until unrelated DML. All three caches now bypass read and write inside explicit transactions (`ctx.transaction_id()` gate). Red-first test pins insert and delete rollbacks across all three cache shapes.

## Deferred, with reasons

- **`to_string()` cache keys -> dual hash** (scalar/IN subquery caches): needs a full-fidelity `SelectStatement` hasher where any missed field is a silent cache collision = wrong results. Deserves its own PR with a collision-discrimination test, same as the #36/#39 rounds.
- **Audit big-win #10 (uncorrelated subquery under correlated outer re-executes per row)**: the audit's own verifier flagged the proposed gate as unsound — `is_subquery_correlated` ignores unqualified identifiers by design, but the compiler resolves them against the outer row (`resolve_outer_column` fallback), so gating on it alone could cache a de-facto correlated subquery. Needs a schema-aware resolvability check; design-first item.

## Verification

- Both suites 4929/4929 (new tests included), differential oracle 9/9, fmt + clippy clean; rebased on #48.

