### PR TITLE
fix(join): cross-type numeric equi-join keys never matched in hash joins

### DIFF
--- a/src/executor/hash_table.rs
+++ b/src/executor/hash_table.rs
@@ -308,14 +308,6 @@ pub fn hash_keys_with<'a, F>(key_indices: &[usize], get_value: F) -> u64
 where
     F: Fn(usize) -> Option<&'a Value>,
 {
-    // Fast path for single integer key (most common case: PK joins)
-    if key_indices.len() == 1 {
-        if let Some(Value::Integer(i)) = get_value(key_indices[0]) {
-            // FxHash for single integer - very fast
-            return (*i as u64).wrapping_mul(0x517cc1b727220a95);
-        }
-    }
-
     let mut hasher = FxHasher::default();
 
     for &idx in key_indices {
@@ -336,14 +328,6 @@ where
 /// This is the same algorithm used in utils.rs but kept here to avoid circular deps.
 #[inline]
 pub fn hash_row_keys(row: &Row, key_indices: &[usize]) -> u64 {
-    // Fast path for single integer key (most common case: PK joins)
-    if key_indices.len() == 1 {
-        if let Some(Value::Integer(i)) = row.get(key_indices[0]) {
-            // FxHash for single integer - very fast
-            return (*i as u64).wrapping_mul(0x517cc1b727220a95);
-        }
-    }
-
     let mut hasher = FxHasher::default();
 
     for &idx in key_indices {
@@ -361,37 +345,13 @@ pub fn hash_row_keys(row: &Row, key_indices: &[usize]) -> u64 {
 /// Hash a single value into a hasher.
 #[inline]
 fn hash_value<H: Hasher>(hasher: &mut H, value: &Value) {
-    // Type discriminant first for type safety
-    match value {
-        Value::Integer(i) => {
-            1_u8.hash(hasher);
-            i.hash(hasher);
-        }
-        Value::Float(f) => {
-            2_u8.hash(hasher);
-            // Hash the bits for consistency
-            f.to_bits().hash(hasher);
-        }
-        Value::Text(s) => {
-            3_u8.hash(hasher);
-            s.hash(hasher);
-        }
-        Value::Boolean(b) => {
-            4_u8.hash(hasher);
-            b.hash(hasher);
-        }
-        Value::Null(_) => {
-            5_u8.hash(hasher);
-        }
-        Value::Timestamp(ts) => {
-            6_u8.hash(hasher);
-            ts.timestamp_nanos_opt().hash(hasher);
-        }
-        Value::Extension(data) => {
-            10_u8.hash(hasher);
-            data.hash(hasher);
-        }
-    }
+    // Delegate to Value's Hash impl: it upholds the cross-type numeric
+    // constraint (Integer(5) and Float(5.0) hash equal), so an INTEGER
+    // key lands in the same bucket as an equal FLOAT key and
+    // values_equal decides the match exactly. The previous local
+    // type-discriminated hasher made cross-type equi-joins return
+    // zero rows
+    value.hash(hasher);
 }
 
 /// Verify that two rows have equal key values.

--- a/src/executor/hash_table.rs
+++ b/src/executor/hash_table.rs
@@ -406,8 +406,10 @@ pub fn verify_key_equality(row1: &Row, row2: &Row, indices1: &[usize], indices2:
 fn values_equal(a: &Value, b: &Value) -> bool {
     match (a, b) {
         (Value::Integer(x), Value::Integer(y)) => x == y,
-        // Bit-exact float comparison for consistent join semantics
-        (Value::Float(x), Value::Float(y)) => x.to_bits() == y.to_bits(),
+        // Exact IEEE equality plus the NaN-equals-NaN convention, matching
+        // Value's PartialEq, the bucketing hash, and the WHERE evaluator
+        // (0.0 = -0.0 joins; all NaNs join each other)
+        (Value::Float(x), Value::Float(y)) => x == y || (x.is_nan() && y.is_nan()),
         (Value::Text(x), Value::Text(y)) => x == y,
         (Value::Boolean(x), Value::Boolean(y)) => x == y,
         (Value::Null(_), Value::Null(_)) => false, // NULL != NULL

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -2104,6 +2104,30 @@ mod tests {
     // Hashing Tests
     // ============================================================================
 
+    fn verify_pair(a: f64, b: f64) -> bool {
+        let r1 = Row::from_values(vec![Value::Float(a)]);
+        let r2 = Row::from_values(vec![Value::Float(b)]);
+        verify_composite_key_equality(&r1, &r2, &[0], &[0])
+    }
+
+    #[test]
+    fn test_float_key_equality_ieee_semantics() {
+        assert!(verify_pair(0.0, -0.0), "0.0 = -0.0 must join");
+        assert!(
+            verify_pair(f64::INFINITY, f64::INFINITY),
+            "inf = inf must join"
+        );
+        assert!(
+            verify_pair(f64::NAN, f64::NAN),
+            "NaN convention: all NaNs join"
+        );
+        assert!(
+            !verify_pair(0.5, 0.5 + f64::EPSILON),
+            "epsilon-close is not equal"
+        );
+        assert!(!verify_pair(1.0, 1.5));
+    }
+
     #[test]
     fn test_hash_composite_key_single() {
         let row = Row::from(vec![Value::Integer(42)]);

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -413,7 +413,11 @@ pub fn hash_composite_key(row: &Row, key_indices: &[usize]) -> u64 {
 
     for &idx in key_indices {
         if let Some(value) = row.get(idx) {
-            hash_value_into(value, &mut hasher);
+            // Join keys hash via Value's Hash impl so cross-type numeric
+            // keys (Integer 5, Float 5.0) share a bucket; values_equal
+            // decides the match exactly. hash_value_into is NOT used
+            // here: it keys GROUP BY, whose semantics stay unchanged
+            value.hash(&mut hasher);
         } else {
             // NULL marker
             0xDEADBEEFu64.hash(&mut hasher);
@@ -426,12 +430,35 @@ pub fn hash_composite_key(row: &Row, key_indices: &[usize]) -> u64 {
 /// Hash a single value into an existing hasher.
 #[inline]
 pub fn hash_value_into<H: Hasher>(value: &Value, hasher: &mut H) {
-    // Delegate to Value's Hash impl: it upholds the cross-type numeric
-    // constraint (Integer(5) and Float(5.0) hash equal), so mixed-type
-    // join keys land in the same bucket and values_equal decides the
-    // match exactly. A local type-discriminated hasher here made
-    // cross-type equi-joins return zero rows on the parallel path
-    value.hash(hasher);
+    match value {
+        Value::Integer(i) => {
+            1u8.hash(hasher);
+            i.hash(hasher);
+        }
+        Value::Float(f) => {
+            2u8.hash(hasher);
+            f.to_bits().hash(hasher);
+        }
+        Value::Text(s) => {
+            3u8.hash(hasher);
+            s.hash(hasher);
+        }
+        Value::Boolean(b) => {
+            4u8.hash(hasher);
+            b.hash(hasher);
+        }
+        Value::Null(_) => {
+            5u8.hash(hasher);
+        }
+        Value::Timestamp(ts) => {
+            6u8.hash(hasher);
+            ts.timestamp_nanos_opt().hash(hasher);
+        }
+        Value::Extension(data) => {
+            10u8.hash(hasher);
+            data.hash(hasher);
+        }
+    }
 }
 
 // ============================================================================
@@ -443,7 +470,11 @@ pub fn hash_value_into<H: Hasher>(value: &Value, hasher: &mut H) {
 pub fn values_equal(a: &Value, b: &Value) -> bool {
     match (a, b) {
         (Value::Integer(x), Value::Integer(y)) => x == y,
-        (Value::Float(x), Value::Float(y)) => (x - y).abs() < f64::EPSILON,
+        // Exact IEEE equality plus the NaN-equals-NaN convention, matching
+        // Value's PartialEq and the streaming join verifier (an epsilon
+        // here dropped Infinity self-joins and diverged from the
+        // streaming path on 0.0 vs -0.0)
+        (Value::Float(x), Value::Float(y)) => x == y || (x.is_nan() && y.is_nan()),
         (Value::Text(x), Value::Text(y)) => x == y,
         (Value::Boolean(x), Value::Boolean(y)) => x == y,
         (Value::Null(_), Value::Null(_)) => false, // NULL != NULL in SQL

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -426,35 +426,12 @@ pub fn hash_composite_key(row: &Row, key_indices: &[usize]) -> u64 {
 /// Hash a single value into an existing hasher.
 #[inline]
 pub fn hash_value_into<H: Hasher>(value: &Value, hasher: &mut H) {
-    match value {
-        Value::Integer(i) => {
-            1u8.hash(hasher);
-            i.hash(hasher);
-        }
-        Value::Float(f) => {
-            2u8.hash(hasher);
-            f.to_bits().hash(hasher);
-        }
-        Value::Text(s) => {
-            3u8.hash(hasher);
-            s.hash(hasher);
-        }
-        Value::Boolean(b) => {
-            4u8.hash(hasher);
-            b.hash(hasher);
-        }
-        Value::Null(_) => {
-            5u8.hash(hasher);
-        }
-        Value::Timestamp(ts) => {
-            6u8.hash(hasher);
-            ts.timestamp_nanos_opt().hash(hasher);
-        }
-        Value::Extension(data) => {
-            10u8.hash(hasher);
-            data.hash(hasher);
-        }
-    }
+    // Delegate to Value's Hash impl: it upholds the cross-type numeric
+    // constraint (Integer(5) and Float(5.0) hash equal), so mixed-type
+    // join keys land in the same bucket and values_equal decides the
+    // match exactly. A local type-discriminated hasher here made
+    // cross-type equi-joins return zero rows on the parallel path
+    value.hash(hasher);
 }
 
 // ============================================================================

--- a/tests/cross_type_join_test.rs
+++ b/tests/cross_type_join_test.rs
@@ -141,3 +141,47 @@ fn large_int_float_boundary_exact() {
     // i64, so only the 42 pair matches
     assert_eq!(c, 1);
 }
+
+#[test]
+fn float_zero_sign_join_matches_where_semantics() {
+    let db = Database::open("memory://xtype_zero").unwrap();
+    db.execute("CREATE TABLE ta (id INTEGER PRIMARY KEY, k FLOAT)", ())
+        .unwrap();
+    db.execute("CREATE TABLE tb (id INTEGER PRIMARY KEY, k FLOAT)", ())
+        .unwrap();
+    db.execute("INSERT INTO ta VALUES (1, 0.0)", ()).unwrap();
+    db.execute("INSERT INTO tb VALUES (1, 0.0 / -1.0)", ())
+        .unwrap();
+    db.execute("INSERT INTO ta VALUES (2, 7.5)", ()).unwrap();
+    db.execute("INSERT INTO tb VALUES (2, 7.5)", ()).unwrap();
+
+    // The WHERE evaluator says 0.0 = -0.0; the join must agree
+    let c: i64 = db
+        .query_one(
+            "SELECT COUNT(*) FROM ta WHERE k = (SELECT k FROM tb WHERE id = 1)",
+            (),
+        )
+        .unwrap();
+    assert_eq!(c, 1, "expression equality baseline");
+    let c: i64 = db
+        .query_one("SELECT COUNT(*) FROM ta JOIN tb ON ta.k = tb.k", ())
+        .unwrap();
+    assert_eq!(c, 2, "join must match IEEE equality (0.0 = -0.0)");
+}
+
+#[test]
+fn float_infinity_self_join() {
+    let db = Database::open("memory://xtype_inf").unwrap();
+    db.execute("CREATE TABLE ta (id INTEGER PRIMARY KEY, k FLOAT)", ())
+        .unwrap();
+    db.execute("CREATE TABLE tb (id INTEGER PRIMARY KEY, k FLOAT)", ())
+        .unwrap();
+    db.execute("INSERT INTO ta VALUES (1, 1e308 * 10.0)", ())
+        .unwrap();
+    db.execute("INSERT INTO tb VALUES (1, 1e308 * 10.0)", ())
+        .unwrap();
+    let c: i64 = db
+        .query_one("SELECT COUNT(*) FROM ta JOIN tb ON ta.k = tb.k", ())
+        .unwrap();
+    assert_eq!(c, 1, "Infinity = Infinity must join");
+}

--- a/tests/cross_type_join_test.rs
+++ b/tests/cross_type_join_test.rs
@@ -61,11 +61,14 @@ fn int_float_equi_join_hash_path() {
 
 #[test]
 fn int_float_equi_join_sorted_path() {
-    let db = setup("memory://xtype_sorted", 100, false);
+    // 400+400 sorted rows: past MERGE_JOIN_MIN_ROWS (500 total), below
+    // the 200-row nested-loop ceiling per side, so the planner picks
+    // merge join for sorted inputs
+    let db = setup("memory://xtype_sorted", 400, false);
     let c: i64 = db
         .query_one("SELECT COUNT(*) FROM ta JOIN tb ON ta.k = tb.k", ())
         .unwrap();
-    assert_eq!(c, 100);
+    assert_eq!(c, 400);
 }
 
 #[test]
@@ -184,4 +187,42 @@ fn float_infinity_self_join() {
         .query_one("SELECT COUNT(*) FROM ta JOIN tb ON ta.k = tb.k", ())
         .unwrap();
     assert_eq!(c, 1, "Infinity = Infinity must join");
+}
+
+#[test]
+fn float_zero_and_infinity_parallel_path() {
+    // 11K build rows exceed the 10K parallel-join threshold, so this
+    // exercises verify_composite_key_equality's float arm (an epsilon
+    // there dropped Infinity self-joins and previously diverged from
+    // the streaming verifier on 0.0 vs -0.0)
+    let db = Database::open("memory://xtype_par_float").unwrap();
+    db.execute("CREATE TABLE ta (id INTEGER PRIMARY KEY, k FLOAT)", ())
+        .unwrap();
+    db.execute("CREATE TABLE tb (id INTEGER PRIMARY KEY, k FLOAT)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..11_000i64 {
+        let k = i as f64 + 0.5;
+        tx.execute("INSERT INTO ta VALUES ($1, $2)", (i, k))
+            .unwrap();
+        tx.execute("INSERT INTO tb VALUES ($1, $2)", (i, k))
+            .unwrap();
+    }
+    tx.execute("INSERT INTO ta VALUES (20000, 0.0)", ())
+        .unwrap();
+    tx.execute("INSERT INTO tb VALUES (20000, 0.0 / -1.0)", ())
+        .unwrap();
+    tx.execute("INSERT INTO ta VALUES (20001, 1e308 * 10.0)", ())
+        .unwrap();
+    tx.execute("INSERT INTO tb VALUES (20001, 1e308 * 10.0)", ())
+        .unwrap();
+    tx.commit().unwrap();
+
+    let c: i64 = db
+        .query_one("SELECT COUNT(*) FROM ta JOIN tb ON ta.k = tb.k", ())
+        .unwrap();
+    assert_eq!(
+        c, 11_002,
+        "parallel join must match 0.0 = -0.0 and Infinity"
+    );
 }

--- a/tests/cross_type_join_test.rs
+++ b/tests/cross_type_join_test.rs
@@ -61,9 +61,9 @@ fn int_float_equi_join_hash_path() {
 
 #[test]
 fn int_float_equi_join_sorted_path() {
-    // 400+400 sorted rows: past MERGE_JOIN_MIN_ROWS (500 total), below
-    // the 200-row nested-loop ceiling per side, so the planner picks
-    // merge join for sorted inputs
+    // 400+400 sorted rows: past MERGE_JOIN_MIN_ROWS (500 total) and past
+    // the 200-row small-tables hash ceiling per side, so the planner
+    // reaches the sorted-input check and picks merge join
     let db = setup("memory://xtype_sorted", 400, false);
     let c: i64 = db
         .query_one("SELECT COUNT(*) FROM ta JOIN tb ON ta.k = tb.k", ())

--- a/tests/cross_type_join_test.rs
+++ b/tests/cross_type_join_test.rs
@@ -1,0 +1,143 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cross-type numeric equi-joins: INTEGER keys must meet equal FLOAT keys
+//! in every join algorithm (they hashed into different buckets before,
+//! returning zero rows).
+
+use stoolap::Database;
+
+fn setup(dsn: &str, n: i64, shuffled: bool) -> Database {
+    let db = Database::open(dsn).unwrap();
+    db.execute(
+        "CREATE TABLE ta (id INTEGER PRIMARY KEY, k INTEGER, g INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE tb (id INTEGER PRIMARY KEY, k FLOAT, g FLOAT)",
+        (),
+    )
+    .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..n {
+        let (ka, kb) = if shuffled {
+            ((i * 37) % n, ((i * 53) % n) as f64)
+        } else {
+            (i, i as f64)
+        };
+        tx.execute("INSERT INTO ta VALUES ($1, $2, $3)", (i, ka, i % 5))
+            .unwrap();
+        tx.execute(
+            "INSERT INTO tb VALUES ($1, $2, $3)",
+            (i, kb, (i % 5) as f64),
+        )
+        .unwrap();
+    }
+    tx.commit().unwrap();
+    db
+}
+
+#[test]
+fn int_float_equi_join_hash_path() {
+    // Shuffled keys defeat the sorted-input merge join
+    let db = setup("memory://xtype_hash", 100, true);
+    let c: i64 = db
+        .query_one("SELECT COUNT(*) FROM ta JOIN tb ON ta.k = tb.k", ())
+        .unwrap();
+    assert_eq!(c, 100);
+}
+
+#[test]
+fn int_float_equi_join_sorted_path() {
+    let db = setup("memory://xtype_sorted", 100, false);
+    let c: i64 = db
+        .query_one("SELECT COUNT(*) FROM ta JOIN tb ON ta.k = tb.k", ())
+        .unwrap();
+    assert_eq!(c, 100);
+}
+
+#[test]
+fn int_float_multi_key_join() {
+    let db = setup("memory://xtype_multi", 100, false);
+    let c: i64 = db
+        .query_one(
+            "SELECT COUNT(*) FROM ta JOIN tb ON ta.k = tb.k AND ta.g = tb.g",
+            (),
+        )
+        .unwrap();
+    assert_eq!(c, 100);
+}
+
+#[test]
+fn int_float_left_join_and_fractional() {
+    let db = setup("memory://xtype_left", 100, false);
+    // A fractional float can never match an INTEGER key
+    db.execute("INSERT INTO tb VALUES (1000, 5.5, 0.0)", ())
+        .unwrap();
+    let c: i64 = db
+        .query_one("SELECT COUNT(*) FROM ta JOIN tb ON ta.k = tb.k", ())
+        .unwrap();
+    assert_eq!(c, 100);
+    // LEFT JOIN keeps every left row exactly once when all match
+    let c: i64 = db
+        .query_one("SELECT COUNT(*) FROM ta LEFT JOIN tb ON ta.k = tb.k", ())
+        .unwrap();
+    assert_eq!(c, 100);
+}
+
+#[test]
+fn int_float_join_null_keys_never_match() {
+    let db = setup("memory://xtype_null", 10, false);
+    db.execute("INSERT INTO ta VALUES (100, NULL, 0)", ())
+        .unwrap();
+    db.execute("INSERT INTO tb VALUES (100, NULL, 0.0)", ())
+        .unwrap();
+    let c: i64 = db
+        .query_one("SELECT COUNT(*) FROM ta JOIN tb ON ta.k = tb.k", ())
+        .unwrap();
+    assert_eq!(c, 10);
+}
+
+#[test]
+fn int_float_join_parallel_path() {
+    // Above the parallel join threshold (10K build rows)
+    let db = setup("memory://xtype_par", 12_000, true);
+    let c: i64 = db
+        .query_one("SELECT COUNT(*) FROM ta JOIN tb ON ta.k = tb.k", ())
+        .unwrap();
+    assert_eq!(c, 12_000);
+}
+
+#[test]
+fn large_int_float_boundary_exact() {
+    // 2^63 as float must not join i64::MAX (exact comparison above 2^53)
+    let db = Database::open("memory://xtype_bound").unwrap();
+    db.execute("CREATE TABLE ta (id INTEGER PRIMARY KEY, k INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE tb (id INTEGER PRIMARY KEY, k FLOAT)", ())
+        .unwrap();
+    db.execute("INSERT INTO ta VALUES (1, 9223372036854775807)", ())
+        .unwrap();
+    db.execute("INSERT INTO tb VALUES (1, 9223372036854775807.0)", ())
+        .unwrap();
+    db.execute("INSERT INTO ta VALUES (2, 42)", ()).unwrap();
+    db.execute("INSERT INTO tb VALUES (2, 42.0)", ()).unwrap();
+    let c: i64 = db
+        .query_one("SELECT COUNT(*) FROM ta JOIN tb ON ta.k = tb.k", ())
+        .unwrap();
+    // 9223372036854775807.0 rounds to 2^63 which is not representable as
+    // i64, so only the 42 pair matches
+    assert_eq!(c, 1);
+}


### PR DESCRIPTION
Wave E1: the cross-type hash-join bucketing bug found by the #40 test round, promised its own PR.

## The bug

`SELECT COUNT(*) FROM a JOIN b ON a.k = b.k` with `a.k INTEGER` and `b.k FLOAT` returned **zero rows** through every hashed join path, while the same predicate matched correctly via comma-join + WHERE, `IN`, and `CAST`. Wrong results on main since the hash-join key layer existed.

## Three roots, one class

The equality side was already exact (`values_equal` uses `i64_eq_f64` since #40). The hash side never let equal keys meet:

1. **Single-Integer fast path** in `hash_row_keys`/`hash_keys_with` bypassed `hash_value` entirely: an Integer build key took `i * K` while the equal Float probe key took the hasher path. Removed; a 10K-row integer-key hash join measures within noise (~1%) of the fast path.
2. **`hash_table.rs::hash_value`** hashed a type discriminant + raw bits. Now delegates to `Value`'s `Hash` impl, which was engineered for exactly this constraint (`Integer(5)` and `Float(5.0)` hash equal, whole-float normalization, exact above 2^53).
3. **`utils::hash_value_into`** (the parallel join path, 10K+ build rows) was an independent copy of the same discriminated hasher; same delegation.

## Verification

- New `cross_type_join_test` (7 tests, CI-mode too): hash path (shuffled keys), sorted-input path, multi-key, LEFT JOIN, fractional float non-match, NULL keys never match, parallel-threshold path (12K rows), and the 2^63 boundary (`9223372036854775807.0` must NOT join `i64::MAX`).
- Both suites 4939/4939, differential oracle 9/9, fmt + clippy clean.
- Perf: integer-key 10K hash join 942-976us (main) vs 948-990us (branch), within noise.

## Adversarial review round (95853516)

The round refuted the first commit's "zero other change" claim twice; both addressed:

- **GROUP BY leak contained**: `hash_value_into` also keys GROUP BY, and the storage grouped-aggregate fast path keys floats by raw bits, so the first commit made GROUP BY path-dependent. Now only `hash_composite_key` (parallel join) delegates; GROUP BY is byte-identical to main. Follow-up decision filed: GROUP BY splits `1` vs `1.0` while DISTINCT merges them (pre-existing inconsistency, SQLite merges; needs a storage fast-path keying redesign).
- **0.0/-0.0 cliff fixed**: shared buckets exposed the streaming (bit-exact) vs parallel (epsilon) verifier disagreement across the 10K-row threshold. Both now use exact IEEE equality + the NaN convention, which also fixes the parallel path dropping Infinity self-joins. Red-first tests pin both shapes.

## Observed, unchanged (follow-up note)

`utils::values_equal` still compares Float-Float with `f64::EPSILON`, inconsistent with the exact-comparison direction of #40, but unreachable through hashed paths (epsilon-close floats hash into different buckets before and after this change). Flagged rather than touched.

