### PR TITLE
perf(join): reference comparators, shared NULL pads, leaner batch INL

### DIFF
--- a/src/executor/operators/hash_join.rs
+++ b/src/executor/operators/hash_join.rs
@@ -491,7 +491,9 @@ impl HashJoinOperator {
             JoinSide::Left => self.left_col_count,
             JoinSide::Right => self.right_col_count,
         };
-        let row = Row::from_values(vec![NULL_VALUE; count]);
+        // Shared storage: every later clone is an Arc bump, not a
+        // CompactVec allocation per unmatched row
+        let row = Row::from_values(vec![NULL_VALUE; count]).into_shared();
         self.cached_null_build = Some(row.clone());
         row
     }
@@ -507,7 +509,7 @@ impl HashJoinOperator {
             JoinSide::Left => self.right_col_count,
             JoinSide::Right => self.left_col_count,
         };
-        let row = Row::from_values(vec![NULL_VALUE; count]);
+        let row = Row::from_values(vec![NULL_VALUE; count]).into_shared();
         self.cached_null_probe = Some(row.clone());
         row
     }
@@ -604,8 +606,9 @@ impl Operator for HashJoinOperator {
             JoinSide::Right => &mut self.right,
         };
 
-        // Collect all build rows
-        let mut build_rows = Vec::new();
+        // Collect all build rows, pre-sized from the operator's estimate
+        // to avoid doubling reallocation on materialized inputs
+        let mut build_rows = Vec::with_capacity(build_op.estimated_rows().unwrap_or(0));
         while let Some(row_ref) = build_op.next()? {
             build_rows.push(row_ref.into_owned());
         }

--- a/src/executor/operators/index_nested_loop.rs
+++ b/src/executor/operators/index_nested_loop.rs
@@ -298,7 +298,13 @@ impl IndexNestedLoopJoinOperator {
             IndexLookupStrategy::PrimaryKey => {
                 match key_value {
                     Value::Integer(id) => self.row_id_buffer.push(*id),
-                    Value::Float(f) => self.row_id_buffer.push(*f as i64),
+                    // Only a losslessly integral float can equal a PK;
+                    // truncation would join 5.5 against row 5
+                    Value::Float(f) => {
+                        if let Some(id) = crate::executor::Executor::lossless_float_key(*f) {
+                            self.row_id_buffer.push(id);
+                        }
+                    }
                     _ => {} // Non-numeric PK values can't match
                 }
             }

--- a/src/executor/operators/index_nested_loop.rs
+++ b/src/executor/operators/index_nested_loop.rs
@@ -31,6 +31,7 @@ use crate::executor::expression::JoinFilter;
 use crate::executor::operator::{ColumnInfo, Operator, RowRef};
 use crate::storage::expression::ConstBoolExpr;
 use crate::storage::traits::{Index, Table};
+use smallvec::SmallVec;
 
 use super::hash_join::JoinType;
 
@@ -619,7 +620,9 @@ impl Operator for BatchIndexNestedLoopJoinOperator {
         // Step 1: Collect all outer rows and their join keys
         let mut outer_rows: Vec<Row> = Vec::new();
         let mut row_id_set: I64Set = I64Set::new();
-        let mut key_to_outer_indices: I64Map<Vec<usize>> = I64Map::new();
+        // SmallVec keeps the common unique-key case inline (no heap Vec
+        // per distinct row id)
+        let mut key_to_outer_indices: I64Map<SmallVec<[usize; 2]>> = I64Map::new();
 
         while let Some(row_ref) = self.outer.next()? {
             let outer_row = row_ref.into_owned();
@@ -646,7 +649,13 @@ impl Operator for BatchIndexNestedLoopJoinOperator {
                 }
                 IndexLookupStrategy::PrimaryKey => match &key_value {
                     Value::Integer(id) => self.row_id_buffer.push(*id),
-                    Value::Float(f) => self.row_id_buffer.push(*f as i64),
+                    // Only a losslessly integral float can equal a PK;
+                    // truncation would join 5.5 against row 5
+                    Value::Float(f) => {
+                        if let Some(id) = crate::executor::Executor::lossless_float_key(*f) {
+                            self.row_id_buffer.push(id);
+                        }
+                    }
                     _ => {}
                 },
             }
@@ -674,17 +683,13 @@ impl Operator for BatchIndexNestedLoopJoinOperator {
             .inner_table
             .fetch_rows_by_ids(&all_row_ids, &true_expr)?;
 
-        // Build inner row map by row_id
-        let mut inner_by_id: I64Map<Row> = I64Map::with_capacity(inner_rows_batch.len());
-        for (row_id, row) in inner_rows_batch {
-            inner_by_id.insert(row_id, row);
-        }
-
-        // Step 3: Build results by matching outer rows with inner rows
+        // Step 3: Build results by matching outer rows with inner rows.
+        // Row ids are already deduplicated, so the fetched batch is
+        // iterated directly (the old I64Map was built only to iterate)
         let mut matched_outers: Vec<bool> = vec![false; outer_rows.len()];
 
-        for (row_id, inner_row) in inner_by_id.iter() {
-            if let Some(outer_indices) = key_to_outer_indices.get(row_id) {
+        for (row_id, inner_row) in inner_rows_batch.iter() {
+            if let Some(outer_indices) = key_to_outer_indices.get(*row_id) {
                 for &outer_idx in outer_indices {
                     let outer_row = &outer_rows[outer_idx];
 

--- a/src/executor/operators/merge_join.rs
+++ b/src/executor/operators/merge_join.rs
@@ -23,7 +23,7 @@
 use std::cmp::Ordering;
 
 use crate::core::value::NULL_VALUE;
-use crate::core::{Result, Row, Value};
+use crate::core::{Result, Row};
 use crate::executor::operator::{ColumnInfo, Operator, RowRef};
 use crate::executor::utils::compare_values;
 
@@ -73,8 +73,8 @@ pub struct MergeJoinOperator {
     unmatched_right_idx: usize,
 
     // Cached null rows for OUTER joins (avoid repeated allocation)
-    cached_null_left: Vec<Value>,
-    cached_null_right: Vec<Value>,
+    cached_null_left: Row,
+    cached_null_right: Row,
 
     // State
     opened: bool,
@@ -136,8 +136,8 @@ impl MergeJoinOperator {
             right_matched: Vec::new(),
             returning_unmatched_right: false,
             unmatched_right_idx: 0,
-            cached_null_left: Vec::new(),  // Initialized in open()
-            cached_null_right: Vec::new(), // Initialized in open()
+            cached_null_left: Row::new(),  // Initialized in open()
+            cached_null_right: Row::new(), // Initialized in open()
             opened: false,
         }
     }
@@ -149,21 +149,17 @@ impl MergeJoinOperator {
             .iter()
             .zip(self.right_key_indices.iter())
         {
-            let lv = left.get(*li).cloned().unwrap_or(NULL_VALUE);
-            let rv = right.get(*ri).cloned().unwrap_or(NULL_VALUE);
+            // Compare by reference; a missing index counts as NULL
+            let lv = left.get(*li).filter(|v| !v.is_null());
+            let rv = right.get(*ri).filter(|v| !v.is_null());
 
             // NULL comparison: NULLs sort last
-            if lv.is_null() && rv.is_null() {
-                continue;
-            }
-            if lv.is_null() {
-                return Ordering::Greater;
-            }
-            if rv.is_null() {
-                return Ordering::Less;
-            }
-
-            let cmp = compare_values(&lv, &rv);
+            let cmp = match (lv, rv) {
+                (None, None) => continue,
+                (None, Some(_)) => return Ordering::Greater,
+                (Some(_), None) => return Ordering::Less,
+                (Some(l), Some(r)) => compare_values(l, r),
+            };
             if cmp != Ordering::Equal {
                 return cmp;
             }
@@ -181,20 +177,16 @@ impl MergeJoinOperator {
     /// Compare two rows from the same side on their keys.
     fn compare_same_side(&self, row1: &Row, row2: &Row, key_indices: &[usize]) -> Ordering {
         for &idx in key_indices {
-            let v1 = row1.get(idx).cloned().unwrap_or(NULL_VALUE);
-            let v2 = row2.get(idx).cloned().unwrap_or(NULL_VALUE);
+            // Compare by reference; a missing index counts as NULL
+            let v1 = row1.get(idx).filter(|v| !v.is_null());
+            let v2 = row2.get(idx).filter(|v| !v.is_null());
 
-            if v1.is_null() && v2.is_null() {
-                continue;
-            }
-            if v1.is_null() {
-                return Ordering::Greater;
-            }
-            if v2.is_null() {
-                return Ordering::Less;
-            }
-
-            let cmp = compare_values(&v1, &v2);
+            let cmp = match (v1, v2) {
+                (None, None) => continue,
+                (None, Some(_)) => return Ordering::Greater,
+                (Some(_), None) => return Ordering::Less,
+                (Some(a), Some(b)) => compare_values(a, b),
+            };
             if cmp != Ordering::Equal {
                 return cmp;
             }
@@ -205,13 +197,14 @@ impl MergeJoinOperator {
     /// Create a NULL row for the left side (uses cached values).
     #[inline]
     fn null_left_row(&self) -> Row {
-        Row::from_values(self.cached_null_left.clone())
+        // Shared storage: clone is an Arc bump
+        self.cached_null_left.clone()
     }
 
     /// Create a NULL row for the right side (uses cached values).
     #[inline]
     fn null_right_row(&self) -> Row {
-        Row::from_values(self.cached_null_right.clone())
+        self.cached_null_right.clone()
     }
 
     /// Combine left and right rows into output row.
@@ -233,8 +226,10 @@ impl Operator for MergeJoinOperator {
             self.join_type,
             JoinType::Left | JoinType::Right | JoinType::Full
         ) {
-            self.cached_null_left = vec![NULL_VALUE; self.left_col_count];
-            self.cached_null_right = vec![NULL_VALUE; self.right_col_count];
+            self.cached_null_left =
+                Row::from_values(vec![NULL_VALUE; self.left_col_count]).into_shared();
+            self.cached_null_right =
+                Row::from_values(vec![NULL_VALUE; self.right_col_count]).into_shared();
         }
 
         // Materialize left
@@ -467,6 +462,7 @@ impl Operator for MergeJoinOperator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::Value;
     use crate::executor::operator::MaterializedOperator;
 
     fn make_rows(data: Vec<Vec<i64>>) -> Vec<Row> {

--- a/src/executor/operators/nested_loop_join.rs
+++ b/src/executor/operators/nested_loop_join.rs
@@ -23,7 +23,7 @@
 //! Despite its higher complexity, it supports all join conditions and types.
 
 use crate::core::value::NULL_VALUE;
-use crate::core::{Result, Row, Value};
+use crate::core::{Result, Row};
 use crate::executor::expression::JoinFilter;
 use crate::executor::operator::{ColumnInfo, Operator, RowRef};
 use crate::functions::registry::global_registry;
@@ -68,8 +68,8 @@ pub struct NestedLoopJoinOperator {
     unmatched_right_idx: usize,
 
     // Cached null rows for OUTER joins (avoid repeated allocation)
-    cached_null_right: Vec<Value>,
-    cached_null_left: Vec<Value>,
+    cached_null_right: Row,
+    cached_null_left: Row,
 
     // State tracking
     opened: bool,
@@ -114,8 +114,8 @@ impl NestedLoopJoinOperator {
             right_matched: Vec::new(),
             returning_unmatched_right: false,
             unmatched_right_idx: 0,
-            cached_null_right: Vec::new(), // Initialized in open()
-            cached_null_left: Vec::new(),  // Initialized in open()
+            cached_null_right: Row::new(), // Initialized in open()
+            cached_null_left: Row::new(),  // Initialized in open()
             opened: false,
             left_exhausted: false,
         }
@@ -124,13 +124,13 @@ impl NestedLoopJoinOperator {
     /// Create a NULL row for the left side (uses cached values).
     #[inline]
     fn null_left_row(&self) -> Row {
-        Row::from_values(self.cached_null_left.clone())
+        self.cached_null_left.clone()
     }
 
     /// Create a NULL row for the right side (uses cached values).
     #[inline]
     fn null_right_row(&self) -> Row {
-        Row::from_values(self.cached_null_right.clone())
+        self.cached_null_right.clone()
     }
 
     /// Combine left and right rows into output row.
@@ -169,8 +169,10 @@ impl Operator for NestedLoopJoinOperator {
             self.join_type,
             JoinType::Left | JoinType::Right | JoinType::Full
         ) {
-            self.cached_null_right = vec![NULL_VALUE; self.right_col_count];
-            self.cached_null_left = vec![NULL_VALUE; self.left_col_count];
+            self.cached_null_right =
+                Row::from_values(vec![NULL_VALUE; self.right_col_count]).into_shared();
+            self.cached_null_left =
+                Row::from_values(vec![NULL_VALUE; self.left_col_count]).into_shared();
         }
 
         // Build column names for filter compilation
@@ -353,6 +355,7 @@ impl Operator for NestedLoopJoinOperator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::Value;
     use crate::executor::operator::MaterializedOperator;
     use crate::parser::ast::{Identifier, InfixExpression};
     use crate::parser::token::{Position, Token, TokenType};

--- a/tests/cross_type_join_test.rs
+++ b/tests/cross_type_join_test.rs
@@ -226,3 +226,54 @@ fn float_zero_and_infinity_parallel_path() {
         "parallel join must match 0.0 = -0.0 and Infinity"
     );
 }
+
+#[test]
+fn float_key_pk_inl_join_no_truncation() {
+    let db = Database::open("memory://xtype_inl_pk").unwrap();
+    db.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE readings (rid INTEGER PRIMARY KEY, val FLOAT)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO items VALUES (0, 'zero'), (5, 'five'), (9223372036854775807, 'max')",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO readings VALUES (1, 5.5), (2, 5.0), (3, 1e19)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO readings VALUES (4, $1)", (f64::NAN,))
+        .unwrap();
+
+    // Batch INL (no LIMIT): only 5.0 = 5 matches; 5.5 must not truncate
+    // to row 5, 1e19 must not saturate to i64::MAX, NaN must not probe 0
+    let rows = db
+        .query(
+            "SELECT r.rid FROM readings r JOIN items i ON r.val = i.id",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 1, "batch INL truncated a float key");
+    let rid: i64 = rows[0].get(0).unwrap();
+    assert_eq!(rid, 2);
+
+    // Streaming INL (LIMIT): same single match
+    let rows = db
+        .query(
+            "SELECT r.rid FROM readings r JOIN items i ON r.val = i.id LIMIT 10",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 1, "streaming INL truncated a float key");
+    let rid: i64 = rows[0].get(0).unwrap();
+    assert_eq!(rid, 2);
+}


### PR DESCRIPTION
Wave E2 of the executor perf campaign: per-row and per-comparison join costs.

## Changes

1. **Merge join comparators compare by reference** (merge_join.rs): both key Values were cloned per key column per comparison across the whole merge (O(N+M) comparisons), purely to default out-of-range indices to NULL; a match on `(left.get(li), right.get(ri))` handles that without cloning. NULLs-sort-last semantics preserved exactly.
2. **Shared NULL-pad caches** (hash_join.rs, merge_join.rs, nested_loop_join.rs): the cached NULL rows were Owned, so every unmatched OUTER-join row paid a CompactVec allocation + NULL memcpy despite the cache comment saying otherwise. The caches convert to Shared storage once; each clone is an Arc bump.
3. **Batch INL cleanup** (index_nested_loop.rs): the `I64Map<Row>` built from the fetched inner batch was iterated exactly once and never keyed into — deleted, the batch iterates directly (ids already deduplicated). `key_to_outer_indices` stores `SmallVec<[usize; 2]>`, keeping the common unique-key PK-FK case inline instead of allocating a one-element heap Vec per distinct row id.
4. **Lossless float PK keys in BOTH INL operators — a reproduced wrong-results fix.** The adversarial round constructed a reaching shape (the PK INL planner gate has no outer-column type check and the residual filter never carries the join equality): pre-PR, `ON r.val = i.id` with FLOAT `val` joined `5.5` to PK row 5, `1e19` to the `i64::MAX` row, and `NaN` to row 0. The batch operator was guarded in the first commit; the streaming (LIMIT-path) twin carried the identical truncating line and is guarded in the review round. Red-first test `float_key_pk_inl_join_no_truncation` pins both paths.
5. **Hash join build collection pre-sizes** from `estimated_rows()`.

## Numbers (selbench, two alternating rounds vs main)

| bench | main | this PR |
|---|---|---|
| left_join_sparse (10K left, sparse right, NULL pads) | 541-556us | 426-451us (**1.23-1.27x**) |
| merge_join_sorted_5k | 381-407us | 331-353us (**1.15x**) |
| join_order_by (batch INL, 10K) | 2070-2177us | 1866-2014us (~8-10%) |
| hash_join_int_10k | flat | flat (prealloc marginal) |

## Deferred (operator API changes, next join wave)

- Residual filters evaluate only after full composite materialization (join_executor.rs:913); needs RowRef-reading filters or a scratch-row protocol.
- `MaterializedOperator::from_arc` deep-clones genuinely shared Arc row sets (semantic-cache hits); needs an Arc-serving operator.

## Verification

- Both suites 4942/4942, differential oracle 9/9, fmt + clippy clean.
- No semantic changes intended: comparator NULL ordering preserved arm for arm, Shared NULL rows materialize identically through combine (established by the D1 round's Row API audit), INL result construction unchanged apart from iteration source.

