### PR TITLE
perf(aggregation): raw-entry grouping, clone-free distinct tracking

### DIFF
--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -2468,8 +2468,13 @@ impl Executor {
 
         for (_, row) in rows {
             // OPTIMIZATION: Hash directly from row references (no clone for hashing)
-            // FxHasher has zero initialization cost unlike AHash
+            // FxHasher has zero initialization cost unlike AHash.
+            // The manual hash MUST equal the map hasher's hash_one(&Vec<Value>),
+            // which length-prefixes the slice: on resize hashbrown rehashes
+            // every entry with the map's own hasher, and a mismatch scatters
+            // the table and splits groups
             let mut hasher = FxHasher::default();
+            hasher.write_usize(group_by_indices.len());
             for &idx in &group_by_indices {
                 if let Some(value) = row.get(idx) {
                     value.hash(&mut hasher);
@@ -3645,13 +3650,18 @@ impl Executor {
             // against borrowed row values, clone key Values only when a
             // new group is actually inserted (same pattern as
             // try_fast_aggregation above)
-            let mut keyed_groups: hashbrown::HashMap<Vec<Value>, Vec<usize>> =
-                hashbrown::HashMap::with_capacity(64);
+            // The map hasher and the manual hash must agree exactly
+            // (hash_one(&Vec<Value>) length-prefixes the slice): hashbrown
+            // rehashes with the map's own hasher on resize
+            type FxBuild = BuildHasherDefault<FxHasher>;
+            let mut keyed_groups: hashbrown::HashMap<Vec<Value>, Vec<usize>, FxBuild> =
+                hashbrown::HashMap::with_capacity_and_hasher(64, FxBuild::default());
             let num_cols = column_indices.len();
             let mut group_count: usize = 0;
 
             for (row_idx, (_, row)) in rows.iter().enumerate() {
                 let mut hasher = FxHasher::default();
+                hasher.write_usize(num_cols);
                 for &idx in &column_indices {
                     match row.get(idx) {
                         Some(value) => value.hash(&mut hasher),

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -31,7 +31,7 @@ use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 // SmallVec removed - Vec is faster due to spilled() check overhead in hot loops
 
 use crate::common::{CompactArc, CompactVec, I64Map, StringMap};
-use crate::core::{Result, Row, RowVec, Value, ValueMap};
+use crate::core::{Result, Row, RowVec, Value};
 use crate::functions::aggregate::CompiledAggregate;
 use crate::functions::AggregateFunction;
 use crate::parser::ast::*;
@@ -544,58 +544,71 @@ impl Executor {
             // No hidden aggregates - move data directly (no clone)
             self.apply_post_aggregation_expressions(stmt, ctx, having_columns, having_rows)?
         } else {
-            // Hidden aggregates exist - need to clone to preserve original for later use
+            // Hidden aggregates exist: extract only the needed columns
+            // up front, then move the aggregated rows instead of cloning
+            // the whole result set
             let having_col_index_map = build_column_index_map(&having_columns);
-            let (mut cols, mut rows) = self.apply_post_aggregation_expressions(
-                stmt,
-                ctx,
-                having_columns.clone(),
-                having_rows.clone(),
-            )?;
+            let by_index: Vec<(String, Vec<Value>)> = hidden_aggs
+                .iter()
+                .map(|(agg_idx, agg)| {
+                    let having_idx = group_by_count + agg_idx;
+                    let values = having_rows
+                        .iter()
+                        .map(|(_, row)| {
+                            row.get(having_idx)
+                                .cloned()
+                                .unwrap_or_else(Value::null_unknown)
+                        })
+                        .collect();
+                    (agg.get_column_name(), values)
+                })
+                .collect();
+            // Name-based fallback buffers (aggregate deduplicated but
+            // still marked hidden)
+            let by_name: Vec<(String, Vec<Value>)> = hidden_aggs
+                .iter()
+                .filter_map(|(_, agg)| {
+                    let col_name = agg.get_column_name();
+                    having_col_index_map
+                        .get(&col_name.to_lowercase())
+                        .map(|&idx| {
+                            let values = having_rows
+                                .iter()
+                                .map(|(_, row)| {
+                                    row.get(idx).cloned().unwrap_or_else(Value::null_unknown)
+                                })
+                                .collect();
+                            (col_name, values)
+                        })
+                })
+                .collect();
+
+            let (mut cols, mut rows) =
+                self.apply_post_aggregation_expressions(stmt, ctx, having_columns, having_rows)?;
 
             // Append hidden aggregates to the result for ORDER BY to use
-            for (agg_idx, agg) in &hidden_aggs {
-                // Get the column name for this aggregate
-                let col_name = agg.get_column_name();
-                cols.push(col_name.clone());
-
-                // Find the index in having_columns (group_by_count + aggregate index)
-                let having_idx = group_by_count + agg_idx;
-
-                // Append the value from each row
+            for (col_name, values) in by_index {
+                cols.push(col_name);
                 for (row_idx, (_, row)) in rows.iter_mut().enumerate() {
-                    if let Some((_, having_row)) = having_rows.get(row_idx) {
-                        if let Some(val) = having_row.get(having_idx) {
-                            row.push(val.clone());
-                        } else {
-                            row.push(Value::null_unknown());
-                        }
-                    } else {
-                        row.push(Value::null_unknown());
-                    }
+                    row.push(
+                        values
+                            .get(row_idx)
+                            .cloned()
+                            .unwrap_or_else(Value::null_unknown),
+                    );
                 }
             }
-
-            // Also try to find by column name in case index doesn't match
-            // (This handles cases where aggregate was deduplicated but still marked hidden)
-            for (_, agg) in &hidden_aggs {
-                let col_name = agg.get_column_name();
-                let col_lower = col_name.to_lowercase();
-                if let Some(&idx) = having_col_index_map.get(&col_lower) {
-                    // Only add if not already added by index
-                    if !cols.iter().any(|c| c.eq_ignore_ascii_case(&col_name)) {
-                        cols.push(col_name);
-                        for (row_idx, (_, row)) in rows.iter_mut().enumerate() {
-                            if let Some((_, having_row)) = having_rows.get(row_idx) {
-                                if let Some(val) = having_row.get(idx) {
-                                    row.push(val.clone());
-                                } else {
-                                    row.push(Value::null_unknown());
-                                }
-                            } else {
-                                row.push(Value::null_unknown());
-                            }
-                        }
+            for (col_name, values) in by_name {
+                // Only add if not already added by index
+                if !cols.iter().any(|c| c.eq_ignore_ascii_case(&col_name)) {
+                    cols.push(col_name);
+                    for (row_idx, (_, row)) in rows.iter_mut().enumerate() {
+                        row.push(
+                            values
+                                .get(row_idx)
+                                .cloned()
+                                .unwrap_or_else(Value::null_unknown),
+                        );
                     }
                 }
             }
@@ -3628,152 +3641,58 @@ impl Executor {
                 })
                 .collect();
 
-            // OPTIMIZATION: Single-column GROUP BY uses direct hash map (no Vec<Value> overhead)
-            if column_indices.len() == 1 {
-                let col_idx = column_indices[0];
-                // Use ValueMap for Value keys (HashDoS resistant with AHash)
-                let mut single_col_groups: ValueMap<Vec<usize>> = ValueMap::default();
+            // One raw-entry loop for any column count: hash and compare
+            // against borrowed row values, clone key Values only when a
+            // new group is actually inserted (same pattern as
+            // try_fast_aggregation above)
+            let mut keyed_groups: hashbrown::HashMap<Vec<Value>, Vec<usize>> =
+                hashbrown::HashMap::with_capacity(64);
+            let num_cols = column_indices.len();
+            let mut group_count: usize = 0;
 
-                for (row_idx, (_, row)) in rows.iter().enumerate() {
-                    let key_value = row
-                        .get(col_idx)
-                        .cloned()
-                        .unwrap_or_else(Value::null_unknown);
-
-                    // Early termination: skip rows that would create new groups beyond the limit
-                    if has_limit
-                        && single_col_groups.len() >= group_limit
-                        && !single_col_groups.contains_key(&key_value)
-                    {
-                        continue;
+            for (row_idx, (_, row)) in rows.iter().enumerate() {
+                let mut hasher = FxHasher::default();
+                for &idx in &column_indices {
+                    match row.get(idx) {
+                        Some(value) => value.hash(&mut hasher),
+                        None => Value::null_unknown().hash(&mut hasher),
                     }
-
-                    // Use entry API with proper Value equality
-                    single_col_groups
-                        .entry(key_value)
-                        .or_default()
-                        .push(row_idx);
                 }
+                let hash = hasher.finish();
 
-                // Convert to GroupEntry format for downstream processing
-                for (key_value, row_indices) in single_col_groups {
-                    groups
-                        .entry(0) // Use dummy hash, we'll flatten anyway
-                        .or_default()
-                        .push(GroupEntry {
-                            key_values: vec![key_value],
-                            row_indices,
-                        });
-                }
-            } else if column_indices.len() == 2 {
-                // OPTIMIZATION: 2-column GROUP BY uses tuple keys instead of Vec<Value>
-                // Tuples are 30% faster than Vec per CLAUDE.md (no heap allocation)
-                let col_idx0 = column_indices[0];
-                let col_idx1 = column_indices[1];
-                // AHash for HashDoS resistance (user-controlled GROUP BY keys)
-                let mut two_col_groups: ahash::AHashMap<(Value, Value), Vec<usize>> =
-                    ahash::AHashMap::default();
-
-                for (row_idx, (_, row)) in rows.iter().enumerate() {
-                    let key = (
-                        row.get(col_idx0)
-                            .cloned()
-                            .unwrap_or_else(Value::null_unknown),
-                        row.get(col_idx1)
-                            .cloned()
-                            .unwrap_or_else(Value::null_unknown),
-                    );
-
-                    // Early termination: skip rows that would create new groups beyond the limit
-                    if has_limit
-                        && two_col_groups.len() >= group_limit
-                        && !two_col_groups.contains_key(&key)
-                    {
-                        continue;
+                let entry = keyed_groups.raw_entry_mut().from_hash(hash, |stored| {
+                    stored.len() == num_cols
+                        && stored.iter().zip(column_indices.iter()).all(|(s, &idx)| {
+                            match row.get(idx) {
+                                Some(rv) => s == rv,
+                                None => matches!(s, Value::Null(_)),
+                            }
+                        })
+                });
+                match entry {
+                    RawEntryMut::Occupied(mut occupied) => occupied.get_mut().push(row_idx),
+                    RawEntryMut::Vacant(vacant) => {
+                        // Early termination: skip rows that would create
+                        // new groups beyond the limit
+                        if has_limit && group_count >= group_limit {
+                            continue;
+                        }
+                        group_count += 1;
+                        let key: Vec<Value> = column_indices
+                            .iter()
+                            .map(|&idx| row.get(idx).cloned().unwrap_or_else(Value::null_unknown))
+                            .collect();
+                        vacant.insert_hashed_nocheck(hash, key, vec![row_idx]);
                     }
-
-                    two_col_groups.entry(key).or_default().push(row_idx);
                 }
+            }
 
-                // Convert to GroupEntry format for downstream processing
-                for ((v0, v1), row_indices) in two_col_groups {
-                    groups
-                        .entry(0) // Use dummy hash, we'll flatten anyway
-                        .or_default()
-                        .push(GroupEntry {
-                            key_values: vec![v0, v1],
-                            row_indices,
-                        });
-                }
-            } else if column_indices.len() == 3 {
-                // OPTIMIZATION: 3-column GROUP BY uses tuple keys (no Vec heap allocation)
-                let col_idx0 = column_indices[0];
-                let col_idx1 = column_indices[1];
-                let col_idx2 = column_indices[2];
-                let mut three_col_groups: ahash::AHashMap<(Value, Value, Value), Vec<usize>> =
-                    ahash::AHashMap::default();
-
-                for (row_idx, (_, row)) in rows.iter().enumerate() {
-                    let key = (
-                        row.get(col_idx0)
-                            .cloned()
-                            .unwrap_or_else(Value::null_unknown),
-                        row.get(col_idx1)
-                            .cloned()
-                            .unwrap_or_else(Value::null_unknown),
-                        row.get(col_idx2)
-                            .cloned()
-                            .unwrap_or_else(Value::null_unknown),
-                    );
-
-                    // Early termination: skip rows that would create new groups beyond the limit
-                    if has_limit
-                        && three_col_groups.len() >= group_limit
-                        && !three_col_groups.contains_key(&key)
-                    {
-                        continue;
-                    }
-
-                    three_col_groups.entry(key).or_default().push(row_idx);
-                }
-
-                for ((v0, v1, v2), row_indices) in three_col_groups {
-                    groups.entry(0).or_default().push(GroupEntry {
-                        key_values: vec![v0, v1, v2],
-                        row_indices,
-                    });
-                }
-            } else {
-                // 4+ columns: use AHashMap<Vec<Value>> directly (no collision handling needed)
-                let mut multi_col_groups: ahash::AHashMap<Vec<Value>, Vec<usize>> =
-                    ahash::AHashMap::default();
-
-                for (row_idx, (_, row)) in rows.iter().enumerate() {
-                    key_buffer.clear();
-                    for &idx in &column_indices {
-                        key_buffer.push(row.get(idx).cloned().unwrap_or_else(Value::null_unknown));
-                    }
-
-                    // Early termination: skip rows that would create new groups beyond the limit
-                    if has_limit
-                        && multi_col_groups.len() >= group_limit
-                        && !multi_col_groups.contains_key(&key_buffer)
-                    {
-                        continue;
-                    }
-
-                    multi_col_groups
-                        .entry(key_buffer.clone())
-                        .or_default()
-                        .push(row_idx);
-                }
-
-                for (key_values, row_indices) in multi_col_groups {
-                    groups.entry(0).or_default().push(GroupEntry {
-                        key_values,
-                        row_indices,
-                    });
-                }
+            // Convert to GroupEntry format for downstream processing
+            for (key_values, row_indices) in keyed_groups {
+                groups.entry(0).or_default().push(GroupEntry {
+                    key_values,
+                    row_indices,
+                });
             }
         } else {
             // Slow path: need to evaluate expressions, use buffer

--- a/src/functions/aggregate/mod.rs
+++ b/src/functions/aggregate/mod.rs
@@ -112,6 +112,11 @@ impl DistinctTracker {
     /// Note: Caller must ensure value is not NULL before calling
     #[inline]
     pub fn check_and_add(&mut self, value: &Value) -> bool {
+        // Membership first: duplicates (the common case) then pay no
+        // clone; the extra lookup happens only once per distinct value
+        if self.seen.contains(value) {
+            return false;
+        }
         self.seen.insert(value.clone())
     }
 
@@ -121,7 +126,7 @@ impl DistinctTracker {
         if value.is_null() {
             return false;
         }
-        self.seen.insert(value.clone())
+        self.check_and_add(value)
     }
 
     /// Get the count of distinct values

--- a/src/functions/aggregate/mod.rs
+++ b/src/functions/aggregate/mod.rs
@@ -61,7 +61,7 @@ pub use statistics::{
 pub use string_agg::{GroupConcatFunction, StringAggFunction};
 pub use sum::SumFunction;
 
-use crate::core::{Value, ValueSet};
+use crate::core::Value;
 use std::cmp::Ordering;
 
 /// Compare two Values for ordering (used by FIRST/LAST with ORDER BY).
@@ -100,11 +100,12 @@ fn compare_values_for_sort(a: &Value, b: &Value) -> Ordering {
 
 /// Helper struct for tracking distinct values
 ///
-/// Uses ValueSet directly instead of converting to strings,
-/// avoiding allocation overhead for each value.
+/// Uses a seeded hashbrown set so membership and insert share one
+/// lookup, avoiding both the clone-per-duplicate of a plain insert
+/// and the double hash of contains-then-insert.
 #[derive(Default, Debug)]
 pub struct DistinctTracker {
-    seen: ValueSet,
+    seen: hashbrown::HashSet<Value, ahash::RandomState>,
 }
 
 impl DistinctTracker {
@@ -112,12 +113,11 @@ impl DistinctTracker {
     /// Note: Caller must ensure value is not NULL before calling
     #[inline]
     pub fn check_and_add(&mut self, value: &Value) -> bool {
-        // Membership first: duplicates (the common case) then pay no
-        // clone; the extra lookup happens only once per distinct value
-        if self.seen.contains(value) {
-            return false;
-        }
-        self.seen.insert(value.clone())
+        // One hash, one probe: the closure clones only when the value
+        // is actually new
+        let before = self.seen.len();
+        self.seen.get_or_insert_with(value, |v| v.clone());
+        self.seen.len() > before
     }
 
     /// Check if a value has been seen before, with null handling (returns true if new)

--- a/tests/group_by_resize_test.rs
+++ b/tests/group_by_resize_test.rs
@@ -1,0 +1,86 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! GROUP BY across hash-map resize boundaries: manual raw-entry hashes
+//! must match the map's own hasher exactly, or the resize rehash
+//! scatters entries and duplicate groups appear.
+
+use stoolap::Database;
+
+#[test]
+fn group_by_distinct_survives_map_resize() {
+    let db = Database::open("memory://gb_resize_slow").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, k INTEGER, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    let mut tx = db.begin().unwrap();
+    let mut id = 0i64;
+    // 200 distinct keys, each with two distinct v values
+    for round in 0..2i64 {
+        for k in 0..200i64 {
+            tx.execute("INSERT INTO t VALUES ($1, $2, $3)", (id, k, round))
+                .unwrap();
+            id += 1;
+        }
+    }
+    tx.commit().unwrap();
+
+    // COUNT(DISTINCT) forces the general grouping path
+    let rows = db
+        .query("SELECT k, COUNT(DISTINCT v) FROM t GROUP BY k", ())
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 200, "groups split across a map resize");
+    for r in &rows {
+        let c: i64 = r.get(1).unwrap();
+        assert_eq!(c, 2, "a group lost rows to a duplicate entry");
+    }
+}
+
+#[test]
+fn multi_column_group_by_survives_map_resize() {
+    let db = Database::open("memory://gb_resize_fast").unwrap();
+    db.execute(
+        "CREATE TABLE t2 (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    let mut tx = db.begin().unwrap();
+    let mut id = 0i64;
+    // 500 distinct (a, b) pairs inserted twice
+    for round in 0..2i64 {
+        let _ = round;
+        for p in 0..500i64 {
+            tx.execute("INSERT INTO t2 VALUES ($1, $2, $3)", (id, p / 25, p % 25))
+                .unwrap();
+            id += 1;
+        }
+    }
+    tx.commit().unwrap();
+
+    // Simple aggregate keeps this on the multi-column fast path
+    let rows = db
+        .query("SELECT a, b, COUNT(*) FROM t2 GROUP BY a, b", ())
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 500, "groups split across a map resize");
+    for r in &rows {
+        let c: i64 = r.get(2).unwrap();
+        assert_eq!(c, 2, "a group lost rows to a duplicate entry");
+    }
+}


### PR DESCRIPTION
Wave F1 of the executor perf campaign: aggregation per-row costs.

## Changes

1. **One raw-entry loop for slow-path grouping** (aggregation.rs): the all-simple-columns slow path (taken whenever any aggregate carries DISTINCT / FILTER / expression arguments) had four per-column-count branches, each cloning every group-key Value per input row (the 4+ column branch allocated a whole `Vec<Value>` per row), plus a `contains_key` + `entry` double hash per row when a LIMIT was pushed down. All four branches are now one hashbrown `raw_entry_mut` loop mirroring the fast path's existing pattern at line ~2466: hash borrowed row values, compare stored keys against row references, clone only on vacant insert. About 150 lines down to 50.
2. **DistinctTracker checks membership before cloning** (functions/aggregate/mod.rs): `check_and_add` cloned the Value per accumulated row and let `insert` discard the owned key on duplicates; `COUNT(DISTINCT status)` over 1M rows with 5 values built ~1M throwaway clones. One fix covers COUNT/SUM/AVG DISTINCT in both the dynamic and compiled aggregate paths.
3. **Hidden aggregates extract columns, not rows** (aggregation.rs): `ORDER BY SUM(x)` with `SUM(x)` not in SELECT cloned the entire aggregated result (`having_columns.clone(), having_rows.clone()`) to read back one column per hidden aggregate afterwards. The needed columns now extract into per-column buffers in one pass and the rows move, matching the non-hidden branch.

## Numbers (selbench, two alternating rounds vs main, 10K rows / 20 text groups)

| bench | main | this PR |
|---|---|---|
| group_by_distinct_slow (`COUNT(DISTINCT age) GROUP BY city`) | 451-527us | 387-390us (**1.16-1.36x**) |
| count_distinct_text / group_by_hidden_agg | | within noise on these shapes |

Honest scoping: the tracker win needs heavier text values than the 20-char bench strings (clone is an Arc bump there), and the hidden-aggregate win scales with group count (invisible at 20 groups). Both changes strictly remove work; the measured headline is the grouping rewrite.

## Adversarial review round (273b0729)

Two Sev-1 hash-consistency bugs, both fixed with red-first resize-crossing tests (`group_by_resize_test`):

- **Introduced (first commit)**: the raw-entry map's default hasher disagreed with the manual FxHasher hashes; hashbrown rehashes with the map's own hasher on resize, so >112 groups split (113 keys -> 226 rows). Map is Fx-built now and the manual hash length-prefixes exactly like `hash_one(&Vec<Value>)`.
- **Pre-existing on main**: `try_fast_aggregation`'s multi-column path had the mirror bug (Fx map, manual hash missing the slice length prefix): multi-column GROUP BY split past initial capacity — 500 (a,b) groups inserted twice returned 1000 rows with COUNT(*)=1, proven on the merge base. Same fix, so this PR also repairs a live wrong-results bug on main.

Neither was CI-visible: no existing test drove >112 groups through these paths. Sign-off note: the rewrite trades the old AHash (HashDoS-hardened) group maps for deterministic FxHash, following the existing try_fast_aggregation precedent; flag if you want seeded hashing back.

## Deferred (own PRs)

- ROLLUP/CUBE re-groups the full input once per grouping set (algorithm change: group once on the finest set, derive coarser sets).
- Derived-table streaming aggregation handles only Text keys; Integer keys re-execute the whole subquery and materialize (needs the I64Map branch mirrored).

## Verification

- Both suites 4944/4944, differential oracle 9/9, fmt + clippy clean.
- Semantic parity: the raw-entry comparator uses the same Value equality the old maps used (their Hash/Eq were Value's own), the limit check moved from pre-entry to the vacant arm with identical outcomes, and the hidden-aggregate buffers reproduce the old `having_rows.get(row_idx)` positional semantics including the out-of-range NULL fill.

