### PR TITLE
perf(window): O(n) PERCENT_RANK and CUME_DIST, hoisted constant arguments

### DIFF
--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -38,6 +38,9 @@ use std::cmp::Ordering;
 use crate::common::{CompactVec, StringMap};
 use crate::core::row_vec::RowVec;
 use crate::core::value::NULL_VALUE;
+
+/// Stack constant for COUNT(*) accumulation by reference
+const COUNT_ONE: Value = Value::Integer(1);
 use crate::core::{Error, Result, Row, Value};
 
 /// Type alias for partition keys - stack-allocated for common case (up to 4 columns)
@@ -587,7 +590,9 @@ impl Executor {
                                 .unwrap_or(NULL_VALUE);
                             ext_values.push(wf_value);
                         }
-                        let ext_row = Row::from_compact_vec(ext_values.clone());
+                        // Move the buffer into the row instead of cloning it; the
+                        // next iteration's extend refills a fresh one
+                        let ext_row = Row::from_compact_vec(std::mem::take(&mut ext_values));
 
                         if let Ok(ext_result_values) = eval.eval_all(&ext_row) {
                             for (eval_idx, (item_idx, _)) in ext_expr_items.iter().enumerate() {
@@ -814,7 +819,9 @@ impl Executor {
                                     .unwrap_or(NULL_VALUE);
                                 ext_values.push(wf_value);
                             }
-                            let ext_row = Row::from_compact_vec(ext_values.clone());
+                            // Move the buffer into the row instead of cloning it; the
+                            // next iteration's extend refills a fresh one
+                            let ext_row = Row::from_compact_vec(std::mem::take(&mut ext_values));
                             eval.eval(&ext_row)?
                         }
                     };
@@ -1025,7 +1032,9 @@ impl Executor {
                                     .unwrap_or(NULL_VALUE);
                                 ext_values.push(wf_value);
                             }
-                            let ext_row = Row::from_compact_vec(ext_values.clone());
+                            // Move the buffer into the row instead of cloning it; the
+                            // next iteration's extend refills a fresh one
+                            let ext_row = Row::from_compact_vec(std::mem::take(&mut ext_values));
                             eval.eval(&ext_row)?
                         }
                     };
@@ -1964,7 +1973,6 @@ impl Executor {
         skip_sorting: bool,
     ) -> Result<(Vec<Value>, Vec<usize>)> {
         // Suppress unused variable warnings - these are needed for compute_lead_lag, compute_ntile, etc.
-        let _ = columns;
 
         // Empty fallback for when no precomputed values are provided
         let empty_order_by = ColumnarOrderByValues {
@@ -1990,7 +1998,10 @@ impl Executor {
         // MEMORY OPTIMIZATION: Compute rank info directly from ColumnarOrderByValues
         // instead of cloning ORDER BY values into a Vec<Value>
         // This uses rows_equal() for O(n) comparison without allocating order_values
-        let is_rank_function = matches!(wf_info.name.as_str(), "RANK" | "DENSE_RANK");
+        let is_rank_function = matches!(
+            wf_info.name.as_str(),
+            "RANK" | "DENSE_RANK" | "PERCENT_RANK"
+        );
         let is_rank = wf_info.name == "RANK";
         let rank_info = if is_rank_function && !order_by_values.is_empty() {
             Self::precompute_rank_info_columnar(&row_indices, order_by_values)
@@ -2009,22 +2020,59 @@ impl Executor {
             vec![partition_len; partition_len]
         };
 
+        // Hoist constant window-function arguments out of the row loop:
+        // offsets and bucket counts compile against no columns; LEAD/LAG's
+        // default compiles once here and evaluates per row below
+        let is_lead_lag = matches!(wf_info.name.as_str(), "LEAD" | "LAG");
+        let lead_lag_offset = if is_lead_lag && wf_info.arguments.len() > 1 {
+            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
+            match eval.eval_slice(&Row::new())? {
+                Value::Integer(n) => n as usize,
+                _ => 1,
+            }
+        } else {
+            1
+        };
+        let mut lead_lag_default_eval = if is_lead_lag && wf_info.arguments.len() > 2 {
+            Some(ExpressionEval::compile(&wf_info.arguments[2], columns)?.with_context(ctx))
+        } else {
+            None
+        };
+        let ntile_buckets = if wf_info.name == "NTILE" && !wf_info.arguments.is_empty() {
+            let mut eval = ExpressionEval::compile(&wf_info.arguments[0], &[])?.with_context(ctx);
+            match eval.eval_slice(&Row::new())? {
+                Value::Integer(n) if n > 0 => n as usize,
+                _ => 1,
+            }
+        } else {
+            1
+        };
+        let nth_value_n = if wf_info.name == "NTH_VALUE" && wf_info.arguments.len() > 1 {
+            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
+            match eval.eval_slice(&Row::new())? {
+                Value::Integer(n) if n > 0 => Some(n as usize),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
         for (i, &row_idx) in row_indices.iter().enumerate() {
             // Handle special functions
             let value = match wf_info.name.as_str() {
                 // MEMORY OPTIMIZATION: Access values directly from all_rows via indices
                 // instead of cloning into partition_values Vec
-                "LEAD" | "LAG" => self.compute_lead_lag_indexed(
-                    wf_info,
+                "LEAD" | "LAG" => Self::compute_lead_lag_indexed(
+                    wf_info.name == "LEAD",
+                    lead_lag_offset,
+                    &mut lead_lag_default_eval,
                     all_rows,
                     &row_indices,
                     arg_col_idx,
                     i,
                     &all_rows[row_idx].1,
-                    columns,
-                    ctx,
                 )?,
-                "NTILE" => self.compute_ntile(wf_info, row_indices.len(), i, ctx)?,
+                "NTILE" => Self::compute_ntile(ntile_buckets, row_indices.len(), i),
                 "RANK" | "DENSE_RANK" => Self::compute_rank_fast(is_rank, &rank_info, i),
                 "FIRST_VALUE" | "LAST_VALUE" | "NTH_VALUE" => {
                     // Compute frame bounds for navigation functions
@@ -2052,22 +2100,35 @@ impl Executor {
                             frame_start,
                             frame_end,
                         )?,
-                        "NTH_VALUE" => self.compute_nth_value_indexed(
-                            wf_info,
+                        "NTH_VALUE" => Self::compute_nth_value_indexed(
+                            nth_value_n,
                             all_rows,
                             &row_indices,
                             arg_col_idx,
                             frame_start,
                             frame_end,
-                            ctx,
-                        )?,
+                        ),
                         _ => unreachable!(),
                     }
                 }
                 "PERCENT_RANK" => {
-                    self.compute_percent_rank_columnar(order_by_values, &row_indices, i)?
+                    // (rank - 1) / (n - 1) with rank from the O(n) precompute
+                    if partition_len <= 1 {
+                        Value::Float(0.0)
+                    } else {
+                        let rank = rank_info.get(i).map(|&(gs, _)| gs + 1).unwrap_or(1);
+                        Value::Float((rank - 1) as f64 / (partition_len - 1) as f64)
+                    }
                 }
-                "CUME_DIST" => self.compute_cume_dist_columnar(order_by_values, &row_indices, i)?,
+                "CUME_DIST" => {
+                    // peer-group end / n from the O(n) precompute
+                    if partition_len == 0 {
+                        Value::Float(1.0)
+                    } else {
+                        let end = peer_group_ends.get(i).copied().unwrap_or(partition_len);
+                        Value::Float(end as f64 / partition_len as f64)
+                    }
+                }
                 _ => {
                     // ROW_NUMBER and other simple functions - no values needed
                     window_func.process(&[], &[], i)?
@@ -2097,8 +2158,6 @@ impl Executor {
         ctx: &ExecutionContext,
         results: &mut [Value],
     ) -> Result<()> {
-        let _ = columns;
-
         // Empty fallback for when no precomputed values are provided
         let empty_order_by = ColumnarOrderByValues {
             columns: vec![],
@@ -2121,7 +2180,10 @@ impl Executor {
         };
 
         // Compute rank info for RANK/DENSE_RANK
-        let is_rank_function = matches!(wf_info.name.as_str(), "RANK" | "DENSE_RANK");
+        let is_rank_function = matches!(
+            wf_info.name.as_str(),
+            "RANK" | "DENSE_RANK" | "PERCENT_RANK"
+        );
         let is_rank = wf_info.name == "RANK";
         let rank_info = if is_rank_function && !order_by_values.is_empty() {
             Self::precompute_rank_info_columnar(&row_indices, order_by_values)
@@ -2138,20 +2200,57 @@ impl Executor {
             vec![partition_len; partition_len]
         };
 
+        // Hoist constant window-function arguments out of the row loop:
+        // offsets and bucket counts compile against no columns; LEAD/LAG's
+        // default compiles once here and evaluates per row below
+        let is_lead_lag = matches!(wf_info.name.as_str(), "LEAD" | "LAG");
+        let lead_lag_offset = if is_lead_lag && wf_info.arguments.len() > 1 {
+            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
+            match eval.eval_slice(&Row::new())? {
+                Value::Integer(n) => n as usize,
+                _ => 1,
+            }
+        } else {
+            1
+        };
+        let mut lead_lag_default_eval = if is_lead_lag && wf_info.arguments.len() > 2 {
+            Some(ExpressionEval::compile(&wf_info.arguments[2], columns)?.with_context(ctx))
+        } else {
+            None
+        };
+        let ntile_buckets = if wf_info.name == "NTILE" && !wf_info.arguments.is_empty() {
+            let mut eval = ExpressionEval::compile(&wf_info.arguments[0], &[])?.with_context(ctx);
+            match eval.eval_slice(&Row::new())? {
+                Value::Integer(n) if n > 0 => n as usize,
+                _ => 1,
+            }
+        } else {
+            1
+        };
+        let nth_value_n = if wf_info.name == "NTH_VALUE" && wf_info.arguments.len() > 1 {
+            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
+            match eval.eval_slice(&Row::new())? {
+                Value::Integer(n) if n > 0 => Some(n as usize),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
         // Compute and write directly to results array
         for (i, &row_idx) in row_indices.iter().enumerate() {
             let value = match wf_info.name.as_str() {
-                "LEAD" | "LAG" => self.compute_lead_lag_indexed(
-                    wf_info,
+                "LEAD" | "LAG" => Self::compute_lead_lag_indexed(
+                    wf_info.name == "LEAD",
+                    lead_lag_offset,
+                    &mut lead_lag_default_eval,
                     all_rows,
                     &row_indices,
                     arg_col_idx,
                     i,
                     &all_rows[row_idx].1,
-                    columns,
-                    ctx,
                 )?,
-                "NTILE" => self.compute_ntile(wf_info, partition_len, i, ctx)?,
+                "NTILE" => Self::compute_ntile(ntile_buckets, partition_len, i),
                 "RANK" | "DENSE_RANK" => Self::compute_rank_fast(is_rank, &rank_info, i),
                 "FIRST_VALUE" | "LAST_VALUE" | "NTH_VALUE" => {
                     let peer_end = if i < peer_group_ends.len() {
@@ -2176,22 +2275,35 @@ impl Executor {
                             frame_start,
                             frame_end,
                         )?,
-                        "NTH_VALUE" => self.compute_nth_value_indexed(
-                            wf_info,
+                        "NTH_VALUE" => Self::compute_nth_value_indexed(
+                            nth_value_n,
                             all_rows,
                             &row_indices,
                             arg_col_idx,
                             frame_start,
                             frame_end,
-                            ctx,
-                        )?,
+                        ),
                         _ => unreachable!(),
                     }
                 }
                 "PERCENT_RANK" => {
-                    self.compute_percent_rank_columnar(order_by_values, &row_indices, i)?
+                    // (rank - 1) / (n - 1) with rank from the O(n) precompute
+                    if partition_len <= 1 {
+                        Value::Float(0.0)
+                    } else {
+                        let rank = rank_info.get(i).map(|&(gs, _)| gs + 1).unwrap_or(1);
+                        Value::Float((rank - 1) as f64 / (partition_len - 1) as f64)
+                    }
                 }
-                "CUME_DIST" => self.compute_cume_dist_columnar(order_by_values, &row_indices, i)?,
+                "CUME_DIST" => {
+                    // peer-group end / n from the O(n) precompute
+                    if partition_len == 0 {
+                        Value::Float(1.0)
+                    } else {
+                        let end = peer_group_ends.get(i).copied().unwrap_or(partition_len);
+                        Value::Float(end as f64 / partition_len as f64)
+                    }
+                }
                 _ => {
                     // ROW_NUMBER and other simple functions - no values needed
                     window_func.process(&[], &[], i)?
@@ -2222,8 +2334,6 @@ impl Executor {
         ctx: &ExecutionContext,
         results: &ParallelVec,
     ) -> Result<()> {
-        let _ = columns;
-
         // Empty fallback for when no precomputed values are provided
         let empty_order_by = ColumnarOrderByValues {
             columns: vec![],
@@ -2246,7 +2356,10 @@ impl Executor {
         };
 
         // Compute rank info for RANK/DENSE_RANK
-        let is_rank_function = matches!(wf_info.name.as_str(), "RANK" | "DENSE_RANK");
+        let is_rank_function = matches!(
+            wf_info.name.as_str(),
+            "RANK" | "DENSE_RANK" | "PERCENT_RANK"
+        );
         let is_rank = wf_info.name == "RANK";
         let rank_info = if is_rank_function && !order_by_values.is_empty() {
             Self::precompute_rank_info_columnar(&row_indices, order_by_values)
@@ -2263,20 +2376,57 @@ impl Executor {
             vec![partition_len; partition_len]
         };
 
+        // Hoist constant window-function arguments out of the row loop:
+        // offsets and bucket counts compile against no columns; LEAD/LAG's
+        // default compiles once here and evaluates per row below
+        let is_lead_lag = matches!(wf_info.name.as_str(), "LEAD" | "LAG");
+        let lead_lag_offset = if is_lead_lag && wf_info.arguments.len() > 1 {
+            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
+            match eval.eval_slice(&Row::new())? {
+                Value::Integer(n) => n as usize,
+                _ => 1,
+            }
+        } else {
+            1
+        };
+        let mut lead_lag_default_eval = if is_lead_lag && wf_info.arguments.len() > 2 {
+            Some(ExpressionEval::compile(&wf_info.arguments[2], columns)?.with_context(ctx))
+        } else {
+            None
+        };
+        let ntile_buckets = if wf_info.name == "NTILE" && !wf_info.arguments.is_empty() {
+            let mut eval = ExpressionEval::compile(&wf_info.arguments[0], &[])?.with_context(ctx);
+            match eval.eval_slice(&Row::new())? {
+                Value::Integer(n) if n > 0 => n as usize,
+                _ => 1,
+            }
+        } else {
+            1
+        };
+        let nth_value_n = if wf_info.name == "NTH_VALUE" && wf_info.arguments.len() > 1 {
+            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
+            match eval.eval_slice(&Row::new())? {
+                Value::Integer(n) if n > 0 => Some(n as usize),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
         // Compute and write directly using ParallelVec
         for (i, &row_idx) in row_indices.iter().enumerate() {
             let value = match wf_info.name.as_str() {
-                "LEAD" | "LAG" => self.compute_lead_lag_indexed(
-                    wf_info,
+                "LEAD" | "LAG" => Self::compute_lead_lag_indexed(
+                    wf_info.name == "LEAD",
+                    lead_lag_offset,
+                    &mut lead_lag_default_eval,
                     all_rows,
                     &row_indices,
                     arg_col_idx,
                     i,
                     &all_rows[row_idx].1,
-                    columns,
-                    ctx,
                 )?,
-                "NTILE" => self.compute_ntile(wf_info, partition_len, i, ctx)?,
+                "NTILE" => Self::compute_ntile(ntile_buckets, partition_len, i),
                 "RANK" | "DENSE_RANK" => Self::compute_rank_fast(is_rank, &rank_info, i),
                 "FIRST_VALUE" | "LAST_VALUE" | "NTH_VALUE" => {
                     let peer_end = if i < peer_group_ends.len() {
@@ -2301,22 +2451,35 @@ impl Executor {
                             frame_start,
                             frame_end,
                         )?,
-                        "NTH_VALUE" => self.compute_nth_value_indexed(
-                            wf_info,
+                        "NTH_VALUE" => Self::compute_nth_value_indexed(
+                            nth_value_n,
                             all_rows,
                             &row_indices,
                             arg_col_idx,
                             frame_start,
                             frame_end,
-                            ctx,
-                        )?,
+                        ),
                         _ => unreachable!(),
                     }
                 }
                 "PERCENT_RANK" => {
-                    self.compute_percent_rank_columnar(order_by_values, &row_indices, i)?
+                    // (rank - 1) / (n - 1) with rank from the O(n) precompute
+                    if partition_len <= 1 {
+                        Value::Float(0.0)
+                    } else {
+                        let rank = rank_info.get(i).map(|&(gs, _)| gs + 1).unwrap_or(1);
+                        Value::Float((rank - 1) as f64 / (partition_len - 1) as f64)
+                    }
                 }
-                "CUME_DIST" => self.compute_cume_dist_columnar(order_by_values, &row_indices, i)?,
+                "CUME_DIST" => {
+                    // peer-group end / n from the O(n) precompute
+                    if partition_len == 0 {
+                        Value::Float(1.0)
+                    } else {
+                        let end = peer_group_ends.get(i).copied().unwrap_or(partition_len);
+                        Value::Float(end as f64 / partition_len as f64)
+                    }
+                }
                 _ => {
                     // ROW_NUMBER and other simple functions - no values needed
                     window_func.process(&[], &[], i)?
@@ -2388,41 +2551,29 @@ impl Executor {
         ends
     }
 
-    /// Compute LEAD or LAG using index-based access (no cloning)
+    /// Compute LEAD or LAG using index-based access (no cloning).
+    /// The offset is pre-resolved and the default expression pre-compiled
+    /// by the caller; the default still evaluates per row because it can
+    /// reference row columns.
     #[allow(clippy::too_many_arguments)]
     fn compute_lead_lag_indexed(
-        &self,
-        wf_info: &WindowFunctionInfo,
+        is_lead: bool,
+        offset: usize,
+        default_eval: &mut Option<ExpressionEval>,
         all_rows: &[(i64, Row)],
         sorted_indices: &[usize],
         arg_col_idx: Option<usize>,
         current_pos: usize,
         current_row_data: &Row,
-        columns: &[String],
-        ctx: &ExecutionContext,
     ) -> Result<Value> {
-        // Get offset (default 1)
-        let offset = if wf_info.arguments.len() > 1 {
-            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
-            match eval.eval_slice(&Row::new())? {
-                Value::Integer(n) => n as usize,
-                _ => 1,
-            }
-        } else {
-            1
-        };
-
-        // Get default value - use current row context for column references
-        let default_value = if wf_info.arguments.len() > 2 {
-            let mut eval =
-                ExpressionEval::compile(&wf_info.arguments[2], columns)?.with_context(ctx);
-            eval.eval(current_row_data)?
-        } else {
-            Value::null_unknown()
+        // Evaluated unconditionally to preserve error semantics
+        let default_value = match default_eval {
+            Some(eval) => eval.eval(current_row_data)?,
+            None => Value::null_unknown(),
         };
 
         // Calculate target position in sorted order
-        let target_pos = if wf_info.name == "LEAD" {
+        let target_pos = if is_lead {
             current_pos.checked_add(offset)
         } else {
             // LAG
@@ -2495,133 +2646,44 @@ impl Executor {
         }
     }
 
-    /// Compute NTH_VALUE using index-based access (no cloning)
-    #[allow(clippy::too_many_arguments)]
+    /// Compute NTH_VALUE using index-based access (no cloning); n is
+    /// pre-resolved by the caller (None when absent or not a positive int)
     fn compute_nth_value_indexed(
-        &self,
-        wf_info: &WindowFunctionInfo,
+        n: Option<usize>,
         all_rows: &[(i64, Row)],
         sorted_indices: &[usize],
         arg_col_idx: Option<usize>,
         frame_start: usize,
         frame_end: usize,
-        ctx: &ExecutionContext,
-    ) -> Result<Value> {
+    ) -> Value {
         if frame_start >= frame_end {
-            return Ok(Value::null_unknown());
+            return Value::null_unknown();
         }
-
-        // Get n (1-indexed position) from second argument
-        let n = if wf_info.arguments.len() > 1 {
-            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
-            match eval.eval_slice(&Row::new())? {
-                Value::Integer(n) if n > 0 => n as usize,
-                _ => return Ok(Value::null_unknown()),
-            }
-        } else {
-            return Ok(Value::null_unknown());
+        let Some(n) = n else {
+            return Value::null_unknown();
         };
 
         // n is 1-indexed within the frame
         let frame_len = frame_end - frame_start;
         if n > frame_len {
-            return Ok(Value::null_unknown());
+            return Value::null_unknown();
         }
 
         let pos_in_frame = n - 1;
         let row_idx = sorted_indices[frame_start + pos_in_frame];
         if let Some(col_idx) = arg_col_idx {
-            Ok(all_rows[row_idx]
+            all_rows[row_idx]
                 .1
                 .get(col_idx)
                 .cloned()
-                .unwrap_or_else(Value::null_unknown))
+                .unwrap_or_else(Value::null_unknown)
         } else {
-            Ok(Value::null_unknown())
+            Value::null_unknown()
         }
     }
 
-    /// Compute PERCENT_RANK using ColumnarOrderByValues (no cloning)
-    /// PERCENT_RANK = (rank - 1) / (total_rows - 1)
-    fn compute_percent_rank_columnar(
-        &self,
-        order_by: &ColumnarOrderByValues,
-        sorted_indices: &[usize],
-        current_pos: usize,
-    ) -> Result<Value> {
-        let n = sorted_indices.len();
-        if n <= 1 {
-            return Ok(Value::Float(0.0));
-        }
-
-        // Find rank by counting how many preceding rows have different ORDER BY value
-        let mut rank = 1usize;
-        for i in 0..current_pos {
-            if i == 0 || !order_by.rows_equal(sorted_indices[i - 1], sorted_indices[i]) {
-                // New group - this row gets a new rank
-                if i < current_pos
-                    && !order_by.rows_equal(sorted_indices[i], sorted_indices[current_pos])
-                {
-                    rank = i + 1;
-                }
-            }
-        }
-        // Find actual rank of current row (position of first row with same ORDER BY value)
-        for i in 0..=current_pos {
-            if order_by.rows_equal(sorted_indices[i], sorted_indices[current_pos]) {
-                rank = i + 1;
-                break;
-            }
-        }
-
-        Ok(Value::Float((rank - 1) as f64 / (n - 1) as f64))
-    }
-
-    /// Compute CUME_DIST using ColumnarOrderByValues (no cloning)
-    /// CUME_DIST = (number of rows with value <= current) / total_rows
-    fn compute_cume_dist_columnar(
-        &self,
-        order_by: &ColumnarOrderByValues,
-        sorted_indices: &[usize],
-        current_pos: usize,
-    ) -> Result<Value> {
-        let n = sorted_indices.len();
-        if n == 0 {
-            return Ok(Value::Float(1.0));
-        }
-
-        // Find how many rows have ORDER BY value <= current (i.e., last row with same value)
-        let mut count = current_pos + 1;
-        for i in (current_pos + 1)..n {
-            if order_by.rows_equal(sorted_indices[current_pos], sorted_indices[i]) {
-                count = i + 1;
-            } else {
-                break;
-            }
-        }
-
-        Ok(Value::Float(count as f64 / n as f64))
-    }
-
-    /// Compute NTILE function
-    fn compute_ntile(
-        &self,
-        wf_info: &WindowFunctionInfo,
-        partition_size: usize,
-        current_row: usize,
-        ctx: &ExecutionContext,
-    ) -> Result<Value> {
-        // Get n (number of buckets)
-        let n = if !wf_info.arguments.is_empty() {
-            let mut eval = ExpressionEval::compile(&wf_info.arguments[0], &[])?.with_context(ctx);
-            match eval.eval_slice(&Row::new())? {
-                Value::Integer(n) if n > 0 => n as usize,
-                _ => 1,
-            }
-        } else {
-            1
-        };
-
+    /// Compute NTILE function; the bucket count is pre-resolved by the caller
+    fn compute_ntile(n: usize, partition_size: usize, current_row: usize) -> Value {
         // NTILE divides rows into n buckets as evenly as possible.
         // If partition_size doesn't divide evenly by n, the first (partition_size % n)
         // buckets get one extra row.
@@ -2635,7 +2697,7 @@ impl Executor {
 
         if n >= partition_size {
             // More buckets than rows - each row gets its own bucket
-            return Ok(Value::Integer((current_row + 1).min(n) as i64));
+            return Value::Integer((current_row + 1).min(n) as i64);
         }
 
         let base_size = partition_size / n;
@@ -2654,7 +2716,7 @@ impl Executor {
             remainder + row_in_smaller_section / base_size + 1
         };
 
-        Ok(Value::Integer(bucket as i64))
+        Value::Integer(bucket as i64)
     }
 
     /// Compute RANK or DENSE_RANK function using precomputed rank info.
@@ -3490,18 +3552,16 @@ impl Executor {
 
                         // Accumulate only the new values since prev_end
                         for j in prev_end..frame_end {
-                            let value = if let Some(col_idx) = arg_col_idx {
-                                rows[row_indices[j]]
-                                    .1
-                                    .get(col_idx)
-                                    .cloned()
-                                    .unwrap_or_else(Value::null_unknown)
+                            // Bind by reference: accumulate clones
+                            // internally only when it retains the value
+                            let value: &Value = if let Some(col_idx) = arg_col_idx {
+                                rows[row_indices[j]].1.get(col_idx).unwrap_or(&NULL_VALUE)
                             } else if has_expression_arg {
-                                expression_values[row_indices[j]].clone()
+                                &expression_values[row_indices[j]]
                             } else {
-                                Value::Integer(1)
+                                &COUNT_ONE
                             };
-                            agg_func.accumulate(&value, false);
+                            agg_func.accumulate(value, false);
                         }
                         if frame_end > prev_end {
                             prev_end = frame_end;
@@ -3728,20 +3788,18 @@ impl Executor {
 
                         // Accumulate values within the frame
                         for &idx in &row_indices[frame_start..frame_end] {
-                            let value = if let Some(col_idx) = arg_col_idx {
-                                rows[idx]
-                                    .1
-                                    .get(col_idx)
-                                    .cloned()
-                                    .unwrap_or_else(Value::null_unknown)
+                            // Bind by reference: accumulate clones
+                            // internally only when it retains the value
+                            let value: &Value = if let Some(col_idx) = arg_col_idx {
+                                rows[idx].1.get(col_idx).unwrap_or(&NULL_VALUE)
                             } else if has_expression_arg {
                                 // Expression argument (e.g., val * 2) - use pre-computed value
-                                expression_values[idx].clone()
+                                &expression_values[idx]
                             } else {
                                 // COUNT(*) counts all rows
-                                Value::Integer(1)
+                                &COUNT_ONE
                             };
-                            agg_func.accumulate(&value, wf_info.is_distinct);
+                            agg_func.accumulate(value, wf_info.is_distinct);
                         }
                         results[row_idx] = Some(agg_func.result());
                     }
@@ -3757,20 +3815,18 @@ impl Executor {
 
                 // Accumulate all values in the partition
                 for &row_idx in &row_indices {
-                    let value = if let Some(col_idx) = arg_col_idx {
-                        rows[row_idx]
-                            .1
-                            .get(col_idx)
-                            .cloned()
-                            .unwrap_or_else(Value::null_unknown)
+                    // Bind by reference: accumulate clones internally only
+                    // when it retains the value
+                    let value: &Value = if let Some(col_idx) = arg_col_idx {
+                        rows[row_idx].1.get(col_idx).unwrap_or(&NULL_VALUE)
                     } else if has_expression_arg {
                         // Expression argument (e.g., val * 2) - use pre-computed value
-                        expression_values[row_idx].clone()
+                        &expression_values[row_idx]
                     } else {
                         // COUNT(*) counts all rows
-                        Value::Integer(1)
+                        &COUNT_ONE
                     };
-                    agg_func.accumulate(&value, wf_info.is_distinct);
+                    agg_func.accumulate(value, wf_info.is_distinct);
                 }
                 let aggregate_result = agg_func.result();
 

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -41,11 +41,73 @@ use crate::core::value::NULL_VALUE;
 
 /// Stack constant for COUNT(*) accumulation by reference
 const COUNT_ONE: Value = Value::Integer(1);
+
+/// A window-function argument that cannot reference row columns:
+/// compiled once, evaluated once when deterministic and per call when
+/// volatile (RANDOM and friends keep their per-row behavior)
+struct ConstArg {
+    eval: ExpressionEval,
+    deterministic: bool,
+    cached: Option<Value>,
+}
+
+impl ConstArg {
+    fn compile(
+        expr: &Expression,
+        registry: &FunctionRegistry,
+        ctx: &ExecutionContext,
+    ) -> Result<Self> {
+        Ok(Self {
+            eval: ExpressionEval::compile(expr, &[])?.with_context(ctx),
+            deterministic: expr_is_deterministic(expr, registry),
+            cached: None,
+        })
+    }
+
+    fn value(&mut self) -> Result<Value> {
+        if self.deterministic {
+            if let Some(v) = &self.cached {
+                return Ok(v.clone());
+            }
+            let v = self.eval.eval_slice(&Row::new())?;
+            self.cached = Some(v.clone());
+            Ok(v)
+        } else {
+            self.eval.eval_slice(&Row::new())
+        }
+    }
+}
+
+/// Conservative determinism check: anything unrecognized counts as
+/// volatile and re-evaluates per row
+fn expr_is_deterministic(expr: &Expression, registry: &FunctionRegistry) -> bool {
+    match expr {
+        Expression::IntegerLiteral(_)
+        | Expression::FloatLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_) => true,
+        Expression::Prefix(prefix) => expr_is_deterministic(&prefix.right, registry),
+        Expression::Infix(infix) => {
+            expr_is_deterministic(&infix.left, registry)
+                && expr_is_deterministic(&infix.right, registry)
+        }
+        Expression::FunctionCall(func) => {
+            registry.is_deterministic(&func.function)
+                && func
+                    .arguments
+                    .iter()
+                    .all(|a| expr_is_deterministic(a, registry))
+        }
+        _ => false,
+    }
+}
 use crate::core::{Error, Result, Row, Value};
 
 /// Type alias for partition keys - stack-allocated for common case (up to 4 columns)
 type PartitionKey = SmallVec<[Value; 4]>;
 
+use crate::functions::registry::FunctionRegistry;
 use crate::functions::WindowFunction;
 use crate::parser::ast::*;
 use crate::storage::traits::{QueryResult, Table};
@@ -2027,42 +2089,43 @@ impl Executor {
             return Ok((Vec::new(), row_indices));
         }
 
-        // Hoist constant window-function arguments out of the row loop:
-        // offsets and bucket counts compile against no columns; LEAD/LAG's
-        // default compiles once here and evaluates per row below
+        // Compile constant window-function arguments once; deterministic
+        // ones also evaluate once (memoized) while volatile ones (RANDOM
+        // and friends) re-evaluate per row like the old per-row scheme.
+        // NTH_VALUE's n stays fully lazy behind the frame-emptiness check.
         let is_lead_lag = matches!(wf_info.name.as_str(), "LEAD" | "LAG");
-        let lead_lag_offset = if is_lead_lag && wf_info.arguments.len() > 1 {
-            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
-            match eval.eval_slice(&Row::new())? {
-                Value::Integer(n) => n as usize,
-                _ => 1,
-            }
+        let mut lead_lag_offset_arg = if is_lead_lag && wf_info.arguments.len() > 1 {
+            Some(ConstArg::compile(
+                &wf_info.arguments[1],
+                &self.function_registry,
+                ctx,
+            )?)
         } else {
-            1
+            None
         };
         let mut lead_lag_default_eval = if is_lead_lag && wf_info.arguments.len() > 2 {
             Some(ExpressionEval::compile(&wf_info.arguments[2], columns)?.with_context(ctx))
         } else {
             None
         };
-        let ntile_buckets = if wf_info.name == "NTILE" && !wf_info.arguments.is_empty() {
-            let mut eval = ExpressionEval::compile(&wf_info.arguments[0], &[])?.with_context(ctx);
-            match eval.eval_slice(&Row::new())? {
-                Value::Integer(n) if n > 0 => n as usize,
-                _ => 1,
-            }
-        } else {
-            1
-        };
-        let nth_value_n = if wf_info.name == "NTH_VALUE" && wf_info.arguments.len() > 1 {
-            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
-            match eval.eval_slice(&Row::new())? {
-                Value::Integer(n) if n > 0 => Some(n as usize),
-                _ => None,
-            }
+        let mut ntile_arg = if wf_info.name == "NTILE" && !wf_info.arguments.is_empty() {
+            Some(ConstArg::compile(
+                &wf_info.arguments[0],
+                &self.function_registry,
+                ctx,
+            )?)
         } else {
             None
         };
+        let nth_n_expr = if wf_info.name == "NTH_VALUE" && wf_info.arguments.len() > 1 {
+            Some(&wf_info.arguments[1])
+        } else {
+            None
+        };
+        let nth_n_deterministic = nth_n_expr
+            .map(|e| expr_is_deterministic(e, &self.function_registry))
+            .unwrap_or(true);
+        let mut nth_n_memo: Option<Option<usize>> = None;
 
         for (i, &row_idx) in row_indices.iter().enumerate() {
             // Handle special functions
@@ -2071,7 +2134,13 @@ impl Executor {
                 // instead of cloning into partition_values Vec
                 "LEAD" | "LAG" => Self::compute_lead_lag_indexed(
                     wf_info.name == "LEAD",
-                    lead_lag_offset,
+                    match &mut lead_lag_offset_arg {
+                        Some(arg) => match arg.value()? {
+                            Value::Integer(n) => n as usize,
+                            _ => 1,
+                        },
+                        None => 1,
+                    },
                     &mut lead_lag_default_eval,
                     all_rows,
                     &row_indices,
@@ -2079,7 +2148,17 @@ impl Executor {
                     i,
                     &all_rows[row_idx].1,
                 )?,
-                "NTILE" => Self::compute_ntile(ntile_buckets, row_indices.len(), i),
+                "NTILE" => Self::compute_ntile(
+                    match &mut ntile_arg {
+                        Some(arg) => match arg.value()? {
+                            Value::Integer(n) if n > 0 => n as usize,
+                            _ => 1,
+                        },
+                        None => 1,
+                    },
+                    row_indices.len(),
+                    i,
+                ),
                 "RANK" | "DENSE_RANK" => Self::compute_rank_fast(is_rank, &rank_info, i),
                 "FIRST_VALUE" | "LAST_VALUE" | "NTH_VALUE" => {
                     // Compute frame bounds for navigation functions
@@ -2108,13 +2187,16 @@ impl Executor {
                             frame_end,
                         )?,
                         "NTH_VALUE" => Self::compute_nth_value_indexed(
-                            nth_value_n,
+                            nth_n_expr,
+                            &mut nth_n_memo,
+                            nth_n_deterministic,
                             all_rows,
                             &row_indices,
                             arg_col_idx,
                             frame_start,
                             frame_end,
-                        ),
+                            ctx,
+                        )?,
                         _ => unreachable!(),
                     }
                 }
@@ -2214,49 +2296,56 @@ impl Executor {
             return Ok(());
         }
 
-        // Hoist constant window-function arguments out of the row loop:
-        // offsets and bucket counts compile against no columns; LEAD/LAG's
-        // default compiles once here and evaluates per row below
+        // Compile constant window-function arguments once; deterministic
+        // ones also evaluate once (memoized) while volatile ones (RANDOM
+        // and friends) re-evaluate per row like the old per-row scheme.
+        // NTH_VALUE's n stays fully lazy behind the frame-emptiness check.
         let is_lead_lag = matches!(wf_info.name.as_str(), "LEAD" | "LAG");
-        let lead_lag_offset = if is_lead_lag && wf_info.arguments.len() > 1 {
-            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
-            match eval.eval_slice(&Row::new())? {
-                Value::Integer(n) => n as usize,
-                _ => 1,
-            }
+        let mut lead_lag_offset_arg = if is_lead_lag && wf_info.arguments.len() > 1 {
+            Some(ConstArg::compile(
+                &wf_info.arguments[1],
+                &self.function_registry,
+                ctx,
+            )?)
         } else {
-            1
+            None
         };
         let mut lead_lag_default_eval = if is_lead_lag && wf_info.arguments.len() > 2 {
             Some(ExpressionEval::compile(&wf_info.arguments[2], columns)?.with_context(ctx))
         } else {
             None
         };
-        let ntile_buckets = if wf_info.name == "NTILE" && !wf_info.arguments.is_empty() {
-            let mut eval = ExpressionEval::compile(&wf_info.arguments[0], &[])?.with_context(ctx);
-            match eval.eval_slice(&Row::new())? {
-                Value::Integer(n) if n > 0 => n as usize,
-                _ => 1,
-            }
-        } else {
-            1
-        };
-        let nth_value_n = if wf_info.name == "NTH_VALUE" && wf_info.arguments.len() > 1 {
-            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
-            match eval.eval_slice(&Row::new())? {
-                Value::Integer(n) if n > 0 => Some(n as usize),
-                _ => None,
-            }
+        let mut ntile_arg = if wf_info.name == "NTILE" && !wf_info.arguments.is_empty() {
+            Some(ConstArg::compile(
+                &wf_info.arguments[0],
+                &self.function_registry,
+                ctx,
+            )?)
         } else {
             None
         };
+        let nth_n_expr = if wf_info.name == "NTH_VALUE" && wf_info.arguments.len() > 1 {
+            Some(&wf_info.arguments[1])
+        } else {
+            None
+        };
+        let nth_n_deterministic = nth_n_expr
+            .map(|e| expr_is_deterministic(e, &self.function_registry))
+            .unwrap_or(true);
+        let mut nth_n_memo: Option<Option<usize>> = None;
 
         // Compute and write directly to results array
         for (i, &row_idx) in row_indices.iter().enumerate() {
             let value = match wf_info.name.as_str() {
                 "LEAD" | "LAG" => Self::compute_lead_lag_indexed(
                     wf_info.name == "LEAD",
-                    lead_lag_offset,
+                    match &mut lead_lag_offset_arg {
+                        Some(arg) => match arg.value()? {
+                            Value::Integer(n) => n as usize,
+                            _ => 1,
+                        },
+                        None => 1,
+                    },
                     &mut lead_lag_default_eval,
                     all_rows,
                     &row_indices,
@@ -2264,7 +2353,17 @@ impl Executor {
                     i,
                     &all_rows[row_idx].1,
                 )?,
-                "NTILE" => Self::compute_ntile(ntile_buckets, partition_len, i),
+                "NTILE" => Self::compute_ntile(
+                    match &mut ntile_arg {
+                        Some(arg) => match arg.value()? {
+                            Value::Integer(n) if n > 0 => n as usize,
+                            _ => 1,
+                        },
+                        None => 1,
+                    },
+                    partition_len,
+                    i,
+                ),
                 "RANK" | "DENSE_RANK" => Self::compute_rank_fast(is_rank, &rank_info, i),
                 "FIRST_VALUE" | "LAST_VALUE" | "NTH_VALUE" => {
                     let peer_end = if i < peer_group_ends.len() {
@@ -2290,13 +2389,16 @@ impl Executor {
                             frame_end,
                         )?,
                         "NTH_VALUE" => Self::compute_nth_value_indexed(
-                            nth_value_n,
+                            nth_n_expr,
+                            &mut nth_n_memo,
+                            nth_n_deterministic,
                             all_rows,
                             &row_indices,
                             arg_col_idx,
                             frame_start,
                             frame_end,
-                        ),
+                            ctx,
+                        )?,
                         _ => unreachable!(),
                     }
                 }
@@ -2397,49 +2499,56 @@ impl Executor {
             return Ok(());
         }
 
-        // Hoist constant window-function arguments out of the row loop:
-        // offsets and bucket counts compile against no columns; LEAD/LAG's
-        // default compiles once here and evaluates per row below
+        // Compile constant window-function arguments once; deterministic
+        // ones also evaluate once (memoized) while volatile ones (RANDOM
+        // and friends) re-evaluate per row like the old per-row scheme.
+        // NTH_VALUE's n stays fully lazy behind the frame-emptiness check.
         let is_lead_lag = matches!(wf_info.name.as_str(), "LEAD" | "LAG");
-        let lead_lag_offset = if is_lead_lag && wf_info.arguments.len() > 1 {
-            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
-            match eval.eval_slice(&Row::new())? {
-                Value::Integer(n) => n as usize,
-                _ => 1,
-            }
+        let mut lead_lag_offset_arg = if is_lead_lag && wf_info.arguments.len() > 1 {
+            Some(ConstArg::compile(
+                &wf_info.arguments[1],
+                &self.function_registry,
+                ctx,
+            )?)
         } else {
-            1
+            None
         };
         let mut lead_lag_default_eval = if is_lead_lag && wf_info.arguments.len() > 2 {
             Some(ExpressionEval::compile(&wf_info.arguments[2], columns)?.with_context(ctx))
         } else {
             None
         };
-        let ntile_buckets = if wf_info.name == "NTILE" && !wf_info.arguments.is_empty() {
-            let mut eval = ExpressionEval::compile(&wf_info.arguments[0], &[])?.with_context(ctx);
-            match eval.eval_slice(&Row::new())? {
-                Value::Integer(n) if n > 0 => n as usize,
-                _ => 1,
-            }
-        } else {
-            1
-        };
-        let nth_value_n = if wf_info.name == "NTH_VALUE" && wf_info.arguments.len() > 1 {
-            let mut eval = ExpressionEval::compile(&wf_info.arguments[1], &[])?.with_context(ctx);
-            match eval.eval_slice(&Row::new())? {
-                Value::Integer(n) if n > 0 => Some(n as usize),
-                _ => None,
-            }
+        let mut ntile_arg = if wf_info.name == "NTILE" && !wf_info.arguments.is_empty() {
+            Some(ConstArg::compile(
+                &wf_info.arguments[0],
+                &self.function_registry,
+                ctx,
+            )?)
         } else {
             None
         };
+        let nth_n_expr = if wf_info.name == "NTH_VALUE" && wf_info.arguments.len() > 1 {
+            Some(&wf_info.arguments[1])
+        } else {
+            None
+        };
+        let nth_n_deterministic = nth_n_expr
+            .map(|e| expr_is_deterministic(e, &self.function_registry))
+            .unwrap_or(true);
+        let mut nth_n_memo: Option<Option<usize>> = None;
 
         // Compute and write directly using ParallelVec
         for (i, &row_idx) in row_indices.iter().enumerate() {
             let value = match wf_info.name.as_str() {
                 "LEAD" | "LAG" => Self::compute_lead_lag_indexed(
                     wf_info.name == "LEAD",
-                    lead_lag_offset,
+                    match &mut lead_lag_offset_arg {
+                        Some(arg) => match arg.value()? {
+                            Value::Integer(n) => n as usize,
+                            _ => 1,
+                        },
+                        None => 1,
+                    },
                     &mut lead_lag_default_eval,
                     all_rows,
                     &row_indices,
@@ -2447,7 +2556,17 @@ impl Executor {
                     i,
                     &all_rows[row_idx].1,
                 )?,
-                "NTILE" => Self::compute_ntile(ntile_buckets, partition_len, i),
+                "NTILE" => Self::compute_ntile(
+                    match &mut ntile_arg {
+                        Some(arg) => match arg.value()? {
+                            Value::Integer(n) if n > 0 => n as usize,
+                            _ => 1,
+                        },
+                        None => 1,
+                    },
+                    partition_len,
+                    i,
+                ),
                 "RANK" | "DENSE_RANK" => Self::compute_rank_fast(is_rank, &rank_info, i),
                 "FIRST_VALUE" | "LAST_VALUE" | "NTH_VALUE" => {
                     let peer_end = if i < peer_group_ends.len() {
@@ -2473,13 +2592,16 @@ impl Executor {
                             frame_end,
                         )?,
                         "NTH_VALUE" => Self::compute_nth_value_indexed(
-                            nth_value_n,
+                            nth_n_expr,
+                            &mut nth_n_memo,
+                            nth_n_deterministic,
                             all_rows,
                             &row_indices,
                             arg_col_idx,
                             frame_start,
                             frame_end,
-                        ),
+                            ctx,
+                        )?,
                         _ => unreachable!(),
                     }
                 }
@@ -2667,32 +2789,60 @@ impl Executor {
         }
     }
 
-    /// Compute NTH_VALUE using index-based access (no cloning); n is
-    /// pre-resolved by the caller (None when absent or not a positive int)
+    /// Compute NTH_VALUE using index-based access (no cloning). The n
+    /// argument resolves only for non-empty frames, exactly like the old
+    /// per-row scheme: deterministic expressions memoize after the first
+    /// resolution, volatile ones re-evaluate per row.
+    #[allow(clippy::too_many_arguments)]
     fn compute_nth_value_indexed(
-        n: Option<usize>,
+        n_expr: Option<&Expression>,
+        n_memo: &mut Option<Option<usize>>,
+        n_deterministic: bool,
         all_rows: &[(i64, Row)],
         sorted_indices: &[usize],
         arg_col_idx: Option<usize>,
         frame_start: usize,
         frame_end: usize,
-    ) -> Value {
+        ctx: &ExecutionContext,
+    ) -> Result<Value> {
         if frame_start >= frame_end {
-            return Value::null_unknown();
+            return Ok(Value::null_unknown());
         }
+        let Some(expr) = n_expr else {
+            return Ok(Value::null_unknown());
+        };
+        let resolve = |expr: &Expression| -> Result<Option<usize>> {
+            let mut eval = ExpressionEval::compile(expr, &[])?.with_context(ctx);
+            Ok(match eval.eval_slice(&Row::new())? {
+                Value::Integer(n) if n > 0 => Some(n as usize),
+                _ => None,
+            })
+        };
+        let n = if n_deterministic {
+            match n_memo {
+                Some(resolved) => *resolved,
+                None => {
+                    let resolved = resolve(expr)?;
+                    *n_memo = Some(resolved);
+                    resolved
+                }
+            }
+        } else {
+            resolve(expr)?
+        };
         let Some(n) = n else {
-            return Value::null_unknown();
+            return Ok(Value::null_unknown());
         };
 
         // n is 1-indexed within the frame
         let frame_len = frame_end - frame_start;
         if n > frame_len {
-            return Value::null_unknown();
+            return Ok(Value::null_unknown());
         }
 
         let pos_in_frame = n - 1;
         let row_idx = sorted_indices[frame_start + pos_in_frame];
-        if let Some(col_idx) = arg_col_idx {
+        Ok(if let Some(col_idx) = arg_col_idx {
             all_rows[row_idx]
                 .1
                 .get(col_idx)
@@ -2700,7 +2850,7 @@ impl Executor {
                 .unwrap_or_else(Value::null_unknown)
         } else {
             Value::null_unknown()
-        }
+        })
     }
 
     /// Compute NTILE function; the bucket count is pre-resolved by the caller

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -2020,6 +2020,13 @@ impl Executor {
             vec![partition_len; partition_len]
         };
 
+        // Empty partition: nothing to compute, and the hoisted argument
+        // evaluation below must not run (an invalid constant argument
+        // never evaluated under the old per-row scheme)
+        if row_indices.is_empty() {
+            return Ok((Vec::new(), row_indices));
+        }
+
         // Hoist constant window-function arguments out of the row loop:
         // offsets and bucket counts compile against no columns; LEAD/LAG's
         // default compiles once here and evaluates per row below
@@ -2200,6 +2207,13 @@ impl Executor {
             vec![partition_len; partition_len]
         };
 
+        // Empty partition: nothing to compute, and the hoisted argument
+        // evaluation below must not run (an invalid constant argument
+        // never evaluated under the old per-row scheme)
+        if row_indices.is_empty() {
+            return Ok(());
+        }
+
         // Hoist constant window-function arguments out of the row loop:
         // offsets and bucket counts compile against no columns; LEAD/LAG's
         // default compiles once here and evaluates per row below
@@ -2375,6 +2389,13 @@ impl Executor {
         } else {
             vec![partition_len; partition_len]
         };
+
+        // Empty partition: nothing to compute, and the hoisted argument
+        // evaluation below must not run (an invalid constant argument
+        // never evaluated under the old per-row scheme)
+        if row_indices.is_empty() {
+            return Ok(());
+        }
 
         // Hoist constant window-function arguments out of the row loop:
         // offsets and bucket counts compile against no columns; LEAD/LAG's

--- a/tests/window_function_test.rs
+++ b/tests/window_function_test.rs
@@ -1004,3 +1004,33 @@ fn window_constant_args_on_empty_table() {
         assert_eq!(rows.len(), 0, "{sql}");
     }
 }
+
+#[test]
+fn nth_value_arg_not_evaluated_for_empty_frames() {
+    // The n argument must only evaluate when the frame is non-empty:
+    // a single-row partition with a 1-FOLLOWING frame has an empty
+    // frame, so an invalid argument stays unevaluated and the result
+    // is NULL
+    let db = stoolap::Database::open("memory://win_nth_lazy").unwrap();
+    db.execute(
+        "CREATE TABLE one_t (id INTEGER PRIMARY KEY, grp INTEGER, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO one_t VALUES (1, 10, 100)", ())
+        .unwrap();
+    let rows = db
+        .query(
+            "SELECT NTH_VALUE(v, grp) OVER (ORDER BY id ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING) FROM one_t",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    let val: Option<i64> = rows[0].get(0).unwrap();
+    assert_eq!(
+        val, None,
+        "empty frame must yield NULL without evaluating n"
+    );
+}

--- a/tests/window_function_test.rs
+++ b/tests/window_function_test.rs
@@ -983,3 +983,24 @@ fn test_multiple_windows_in_single_expression() {
     // ROW_NUMBER()=3 + SUM=60 = 63
     assert_eq!(rows[2], (30, 63));
 }
+
+#[test]
+fn window_constant_args_on_empty_table() {
+    // An invalid constant argument must not error when there are no
+    // rows to evaluate it against (the hoisted evaluation is skipped
+    // for empty partitions, matching the old per-row behavior)
+    let db = stoolap::Database::open("memory://win_empty_args").unwrap();
+    db.execute(
+        "CREATE TABLE empty_t (id INTEGER PRIMARY KEY, grp INTEGER, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    for sql in [
+        "SELECT LEAD(v, grp) OVER (ORDER BY id) FROM empty_t",
+        "SELECT NTILE(grp) OVER (ORDER BY id) FROM empty_t",
+        "SELECT NTH_VALUE(v, grp) OVER (ORDER BY id) FROM empty_t",
+    ] {
+        let rows = db.query(sql, ()).unwrap().collect_vec().unwrap();
+        assert_eq!(rows.len(), 0, "{sql}");
+    }
+}


### PR DESCRIPTION
Wave G1 of the executor perf campaign: window function costs.

## Changes

1. **PERCENT_RANK / CUME_DIST: O(n^2) -> O(n)** (window.rs, all three partition-compute variants). PERCENT_RANK rescanned every preceding row per row and CUME_DIST scanned forward through its peer group per row. Both now read the precomputes that already existed in the same callers: PERCENT_RANK = (rank-1)/(n-1) with rank from `precompute_rank_info_columnar` (its gate now includes PERCENT_RANK), CUME_DIST = `peer_group_ends[i]/n`. The two per-row scan helpers are deleted.
2. **Constant argument hoisting** for LEAD/LAG (offset), NTILE (bucket count), NTH_VALUE (n): these compiled `ExpressionEval` per row against empty columns. They resolve once before the row loop now. LAG/LEAD's default is different: it can reference row columns, so it compiles once and still **evaluates** per row, unconditionally, preserving the old error surface exactly.
3. **Accumulate by reference**: the three aggregate frame loops cloned every value (heap clone for Text) just to pass `&value`; they bind references now (static NULL + a `COUNT_ONE` const for `COUNT(*)`); `accumulate` clones internally only when it retains.
4. **Extended-row buffer moves** instead of double-cloning at the three expression-wrapping sites (`Row::from_compact_vec(std::mem::take(&mut ext_values))`).

## Numbers (selbench vs main, 10K rows)

| bench | main | this PR |
|---|---|---|
| window_percent_rank_10k (single partition) | **221.2ms** | **338us (~650x)** |
| window_lag_offset_10k (`LAG(v, 2, 0)`) | 1689us | 421us (**4.0x**) |
| window_max_text_10k (text agg over frames) | 605us | 567us (~7%) |
| window_row_number | 441us | 420us (~5%) |

## Adversarial review round (f34106c7)

No P1; a 4-battery differential oracle against main was byte-identical except two edge deltas:

- **Fixed**: hoisted constant-argument evaluation errored on empty tables where the per-row scheme vacuously succeeded; all three variants now early-return for empty partitions (red-first test).
- **Disclosed, kept**: PERCENT_RANK now always equals (RANK-1)/(n-1). Old and new provably coincide wherever the window sort groups equal values adjacently (every consistent comparator path); they differ only where the sort was already broken, and there the old value contradicted the engine's own RANK.
- **Filed pre-existing window sort bugs, now with repros**: integer sort fast path keys NULL and non-Integer values as i64::MAX (collides with real i64::MAX data), NaN treated Equal-vs-everything in mixed-type comparator, type drift past the 100-row sample, lossy `as f64` above 2^53.

## Deferred (G2)

- RANGE-offset frame bounds still scan the partition per row (binary search over the sorted keys + sliding accumulators for invertible aggregates); needs DESC-direction care.
- Partition map + sort are rebuilt once per window function sharing the same OVER clause; the cache mirrors order_by_cache but touches shared plumbing.
- Base-column materialization clones every value (signature change through five call sites).
- From the E1 review, still open: window ORDER BY ignores NULLS FIRST/LAST entirely, and the int/float sort fast paths use MAX sentinels that tie real MAX values with NULLs.

## Verification

- Both suites 4945/4945, differential oracle 9/9, window test batteries green, fmt + clippy clean.
- Parity notes: PERCENT_RANK's old "position of first row with equal ORDER BY value" is exactly rank_info's group_start + 1; CUME_DIST's forward peer scan is exactly the peer-group end; both no-ORDER-BY edge cases (all rows one peer group) produce 0.0 / 1.0 as before; the three compute variants received identical edits.

