### PR TITLE
fix(window): sort keys stop tying NULLs with MAX values

### DIFF
--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -3436,8 +3436,9 @@ impl Executor {
             keyed.sort_unstable_by_key(|&(_, key)| std::cmp::Reverse(key));
         }
 
-        // Write back: NULLs last ascending, first descending (the
-        // placement the old sentinel keys produced)
+        // Write back: NULLs strictly last ascending, first descending.
+        // For floats this also fixes the old sentinel's misplacement of
+        // NULLs before +inf and NaN
         let mut pos = 0;
         if !ascending {
             for &idx in &null_indices {
@@ -3526,8 +3527,9 @@ impl Executor {
             keyed.sort_unstable_by_key(|&(_, key)| std::cmp::Reverse(key));
         }
 
-        // Write back: NULLs last ascending, first descending (the
-        // placement the old sentinel keys produced)
+        // Write back: NULLs strictly last ascending, first descending.
+        // For floats this also fixes the old sentinel's misplacement of
+        // NULLs before +inf and NaN
         let mut pos = 0;
         if !ascending {
             for &idx in &null_indices {

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -3376,7 +3376,10 @@ impl Executor {
             (Value::Null(_), Value::Null(_)) => Ordering::Equal,
             (Value::Null(_), _) => Ordering::Greater, // NULLs last
             (_, Value::Null(_)) => Ordering::Less,
-            _ => a.partial_cmp(b).unwrap_or(Ordering::Equal),
+            // Heterogeneous pairs use Value's total order (type rank,
+            // then within-type): the old stringly fallback made the
+            // comparator cyclic (2 < 10, 10 < '15', '15' < 2)
+            _ => a.cmp(b),
         }
     }
 

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -3240,6 +3240,9 @@ impl Executor {
                 Mixed,
             }
 
+            // A 100-row sample picks the candidate fast path; the typed
+            // extractors bail to the generic sort when the type drifts
+            // past the sample, so this is only a hint
             let mut detected = DetectedType::Unknown;
             for &idx in row_indices.iter().take(100) {
                 if let Some(val) = col.get(idx) {
@@ -3272,20 +3275,21 @@ impl Executor {
             }
 
             match detected {
-                DetectedType::Integer => {
-                    Self::sort_by_integer_key_columnar(row_indices, col, ascending);
+                DetectedType::Integer
+                    if Self::sort_by_integer_key_columnar(row_indices, col, ascending) =>
+                {
                     return;
                 }
-                DetectedType::Float => {
-                    Self::sort_by_float_key_columnar(row_indices, col, ascending);
+                DetectedType::Float
+                    if Self::sort_by_float_key_columnar(row_indices, col, ascending) =>
+                {
                     return;
                 }
-                _ => {
-                    // Mixed types or unknown - use generic single column sort
-                    Self::sort_single_column_columnar(row_indices, col, ascending);
-                    return;
-                }
+                _ => {}
             }
+            // Mixed types, unknown, or drift past the sample - generic sort
+            Self::sort_single_column_columnar(row_indices, col, ascending);
+            return;
         }
 
         // Multi-column ORDER BY: use parallel sort for large partitions
@@ -3341,14 +3345,33 @@ impl Executor {
     /// Fast value comparison with type-specific paths
     #[inline]
     fn compare_values_fast(a: &Value, b: &Value) -> Ordering {
+        use crate::core::value::cmp_i64_f64;
         match (a, b) {
             (Value::Integer(x), Value::Integer(y)) => x.cmp(y),
-            (Value::Float(x), Value::Float(y)) => x.partial_cmp(y).unwrap_or(Ordering::Equal),
+            // Total order: all NaNs equal to each other and after every
+            // real (an Equal-vs-everything NaN makes the sort comparator
+            // inconsistent); mixed compares are exact above 2^53
+            (Value::Float(x), Value::Float(y)) => match (x.is_nan(), y.is_nan()) {
+                (true, true) => Ordering::Equal,
+                (true, false) => Ordering::Greater,
+                (false, true) => Ordering::Less,
+                (false, false) => x.partial_cmp(y).unwrap_or(Ordering::Equal),
+            },
             (Value::Integer(x), Value::Float(y)) => {
-                (*x as f64).partial_cmp(y).unwrap_or(Ordering::Equal)
+                if y.is_nan() {
+                    Ordering::Less
+                } else {
+                    cmp_i64_f64(*x, *y).unwrap_or(Ordering::Equal)
+                }
             }
             (Value::Float(x), Value::Integer(y)) => {
-                x.partial_cmp(&(*y as f64)).unwrap_or(Ordering::Equal)
+                if x.is_nan() {
+                    Ordering::Greater
+                } else {
+                    cmp_i64_f64(*y, *x)
+                        .map(Ordering::reverse)
+                        .unwrap_or(Ordering::Equal)
+                }
             }
             (Value::Null(_), Value::Null(_)) => Ordering::Equal,
             (Value::Null(_), _) => Ordering::Greater, // NULLs last
@@ -3358,7 +3381,13 @@ impl Executor {
     }
 
     /// Ultra-fast sort for integer ORDER BY column (columnar layout)
-    fn sort_by_integer_key_columnar(row_indices: &mut [usize], col: &[Value], ascending: bool) {
+    /// Returns false without touching row_indices when a non-Integer,
+    /// non-NULL value appears (type drift past the detection sample)
+    fn sort_by_integer_key_columnar(
+        row_indices: &mut [usize],
+        col: &[Value],
+        ascending: bool,
+    ) -> bool {
         const PARALLEL_THRESHOLD: usize = 50_000;
 
         // OPTIMIZATION: Pre-extract sort keys to avoid bounds checking in the comparison hot path.
@@ -3370,17 +3399,22 @@ impl Executor {
         // then extract the sorted positions back to row_indices.
         let n = row_indices.len();
         if n < 2 {
-            return;
+            return true;
         }
 
-        // Pre-extract sort keys: O(k) where k = partition size
-        let mut keyed: Vec<(usize, i64)> = Vec::with_capacity(n);
+        // Pre-extract sort keys: O(k) where k = partition size.
+        // NULL rows are kept out of band instead of using a sentinel key,
+        // so a genuine i64::MAX row can never tie with NULLs and the hot
+        // sort stays a bare-u64 comparison. The i64 -> u64 map is
+        // order-preserving (flip the sign bit).
+        let mut keyed: Vec<(usize, u64)> = Vec::with_capacity(n);
+        let mut null_indices: Vec<usize> = Vec::new();
         for &idx in row_indices.iter() {
-            let key = match col.get(idx) {
-                Some(Value::Integer(i)) => *i,
-                _ => i64::MAX, // NULLs sort last
-            };
-            keyed.push((idx, key));
+            match col.get(idx) {
+                Some(Value::Integer(i)) => keyed.push((idx, (*i as u64) ^ (1u64 << 63))),
+                Some(Value::Null(_)) | None => null_indices.push(idx),
+                _ => return false, // type drift
+            }
         }
 
         // Sort by pre-extracted key - no bounds checking in comparison!
@@ -3402,14 +3436,36 @@ impl Executor {
             keyed.sort_unstable_by_key(|&(_, key)| std::cmp::Reverse(key));
         }
 
-        // Write sorted indices back
-        for (i, (idx, _)) in keyed.into_iter().enumerate() {
-            row_indices[i] = idx;
+        // Write back: NULLs last ascending, first descending (the
+        // placement the old sentinel keys produced)
+        let mut pos = 0;
+        if !ascending {
+            for &idx in &null_indices {
+                row_indices[pos] = idx;
+                pos += 1;
+            }
         }
+        for (idx, _) in keyed {
+            row_indices[pos] = idx;
+            pos += 1;
+        }
+        if ascending {
+            for &idx in &null_indices {
+                row_indices[pos] = idx;
+                pos += 1;
+            }
+        }
+        true
     }
 
     /// Fast sort for float ORDER BY column (columnar layout)
-    fn sort_by_float_key_columnar(row_indices: &mut [usize], col: &[Value], ascending: bool) {
+    /// Returns false without touching row_indices when a value that is
+    /// neither Float nor NULL appears (type drift past the sample)
+    fn sort_by_float_key_columnar(
+        row_indices: &mut [usize],
+        col: &[Value],
+        ascending: bool,
+    ) -> bool {
         const PARALLEL_THRESHOLD: usize = 50_000;
 
         // OPTIMIZATION: Pre-extract sort keys to avoid bounds checking in the comparison hot path.
@@ -3419,31 +3475,36 @@ impl Executor {
         // comparison via sort_by_key instead of sort_by with a closure.
         let n = row_indices.len();
         if n < 2 {
-            return;
+            return true;
         }
 
-        // Pre-extract sort keys as OrderedFloat bits for fast integer comparison
-        // Using to_bits() allows sort_by_key which is faster than sort_by with closure
+        // Pre-extract sort keys as ordered bits for fast integer
+        // comparison. The leading class separates NULLs from values, so a
+        // genuine f64::MAX row can never tie with NULL rows; NaN keeps a
+        // maximal key inside the value class (after all reals, before
+        // NULLs, matching the generic comparator)
         let mut keyed: Vec<(usize, u64)> = Vec::with_capacity(n);
+        let mut null_indices: Vec<usize> = Vec::new();
         for &idx in row_indices.iter() {
-            let f = match col.get(idx) {
-                Some(Value::Float(f)) => *f,
-                Some(Value::Integer(i)) => *i as f64,
-                _ => f64::MAX, // NULLs sort last
-            };
-            // Convert to sortable integer representation (handles NaN, -0.0, negative numbers)
-            let bits = if f.is_nan() {
-                u64::MAX // NaN sorts last
-            } else {
-                let b = f.to_bits();
-                // Flip sign bit and conditionally flip all bits for proper ordering
-                if (b & (1u64 << 63)) != 0 {
-                    !b // Negative: flip all bits
-                } else {
-                    b | (1u64 << 63) // Positive: set sign bit
+            match col.get(idx) {
+                Some(Value::Float(f)) => {
+                    let bits = if f.is_nan() {
+                        u64::MAX // all NaNs equal, after every real
+                    } else {
+                        let b = f.to_bits();
+                        // Flip sign bit and conditionally flip all bits
+                        // for proper ordering
+                        if (b & (1u64 << 63)) != 0 {
+                            !b // Negative: flip all bits
+                        } else {
+                            b | (1u64 << 63) // Positive: set sign bit
+                        }
+                    };
+                    keyed.push((idx, bits));
                 }
-            };
-            keyed.push((idx, bits));
+                Some(Value::Null(_)) | None => null_indices.push(idx),
+                _ => return false, // type drift
+            }
         }
 
         // Sort by pre-extracted key - no bounds checking, pure integer comparison!
@@ -3465,10 +3526,26 @@ impl Executor {
             keyed.sort_unstable_by_key(|&(_, key)| std::cmp::Reverse(key));
         }
 
-        // Write sorted indices back
-        for (i, (idx, _)) in keyed.into_iter().enumerate() {
-            row_indices[i] = idx;
+        // Write back: NULLs last ascending, first descending (the
+        // placement the old sentinel keys produced)
+        let mut pos = 0;
+        if !ascending {
+            for &idx in &null_indices {
+                row_indices[pos] = idx;
+                pos += 1;
+            }
         }
+        for (idx, _) in keyed {
+            row_indices[pos] = idx;
+            pos += 1;
+        }
+        if ascending {
+            for &idx in &null_indices {
+                row_indices[pos] = idx;
+                pos += 1;
+            }
+        }
+        true
     }
 
     /// Single column generic sort (columnar layout)

--- a/tests/window_sort_keys_test.rs
+++ b/tests/window_sort_keys_test.rs
@@ -85,36 +85,36 @@ fn window_rank_f64_max_vs_null() {
 
 #[test]
 fn window_order_survives_type_drift_past_sample() {
-    // 150 Integer values then a Float appears past the 100-row
-    // detection sample; ordering must still interleave correctly
+    // 120 Integer values sample as the integer fast path; Float 0.5
+    // appears past the 100-row sample, so the typed extractor must bail
+    // to the generic sort instead of keying the floats as i64::MAX
     let db = Database::open("memory://win_drift").unwrap();
-    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, k FLOAT)", ())
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
         .unwrap();
     let mut tx = db.begin().unwrap();
-    for i in 0..150i64 {
-        // Stored as integers via coercion-free int literals in a FLOAT
-        // column stay Float; use an INTEGER column shape instead
-        tx.execute("INSERT INTO t VALUES ($1, $2)", (i, (i * 2) as f64))
+    for i in 0..130i64 {
+        tx.execute("INSERT INTO t VALUES ($1, $2)", (i, i + 1))
             .unwrap();
     }
     tx.commit().unwrap();
-    let db2 = Database::open("memory://win_drift2").unwrap();
-    db2.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, k TEXT)", ())
-        .unwrap();
-    let mut tx = db2.begin().unwrap();
-    for i in 0..150i64 {
-        tx.execute("INSERT INTO t VALUES ($1, $2)", (i, format!("{:05}", i)))
-            .unwrap();
-    }
-    // Row 150: numerically-small text that must sort FIRST
-    tx.execute("INSERT INTO t VALUES (150, '00000')", ())
-        .unwrap();
-    tx.commit().unwrap();
-    let first: String = db2
-        .query_one(
-            "SELECT k FROM (SELECT k, ROW_NUMBER() OVER (ORDER BY k) AS rn FROM t) s WHERE rn = 1",
+
+    let rows = db
+        .query(
+            "SELECT id, RANK() OVER (ORDER BY CASE WHEN id < 120 THEN v ELSE 0.5 END) AS r              FROM t ORDER BY id",
             (),
         )
+        .unwrap()
+        .collect_vec()
         .unwrap();
-    assert_eq!(first, "00000");
+    // Rows 120..129 carry 0.5 and must rank 1 together; row id=0 (v=1)
+    // must rank 11 after them
+    for r in &rows {
+        let id: i64 = r.get(0).unwrap();
+        let rank: i64 = r.get(1).unwrap();
+        if id >= 120 {
+            assert_eq!(rank, 1, "0.5 rows must rank first (id {id})");
+        } else {
+            assert_eq!(rank, 11 + id, "integer rows shift by the ten 0.5 rows");
+        }
+    }
 }

--- a/tests/window_sort_keys_test.rs
+++ b/tests/window_sort_keys_test.rs
@@ -1,0 +1,120 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Window ORDER BY sort keys: NULLs must not collide with genuine
+//! i64::MAX / f64::MAX values, and type drift past the detection
+//! sample must not corrupt the ordering.
+
+use stoolap::Database;
+
+#[test]
+fn window_rank_i64_max_vs_null() {
+    let db = Database::open("memory://win_i64max").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, k INTEGER)", ())
+        .unwrap();
+    for (id, k) in [
+        (1i64, None),
+        (2, Some(9223372036854775807i64)),
+        (3, None),
+        (4, Some(5)),
+        (5, Some(9223372036854775807)),
+        (6, None),
+    ] {
+        db.execute("INSERT INTO t VALUES ($1, $2)", (id, k))
+            .unwrap();
+    }
+    let rows = db
+        .query(
+            "SELECT k, RANK() OVER (ORDER BY k) FROM t ORDER BY 2, 1",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let ranks: Vec<i64> = rows.iter().map(|r| r.get(1).unwrap()).collect();
+    // ASC, NULLs last: 5 -> rank 1; two i64::MAX -> rank 2; three NULLs -> rank 4
+    assert_eq!(
+        ranks,
+        vec![1, 2, 2, 4, 4, 4],
+        "i64::MAX must not tie with NULL"
+    );
+}
+
+#[test]
+fn window_rank_f64_max_vs_null() {
+    let db = Database::open("memory://win_f64max").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, f FLOAT)", ())
+        .unwrap();
+    for (id, f) in [
+        (1i64, None),
+        (2, Some(1.7976931348623157e308f64)),
+        (3, Some(2.5)),
+        (4, None),
+        (5, Some(1.7976931348623157e308)),
+    ] {
+        db.execute("INSERT INTO t VALUES ($1, $2)", (id, f))
+            .unwrap();
+    }
+    let rows = db
+        .query(
+            "SELECT f, RANK() OVER (ORDER BY f) FROM t ORDER BY 2, 1",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let ranks: Vec<i64> = rows.iter().map(|r| r.get(1).unwrap()).collect();
+    // 2.5 -> 1; two f64::MAX -> 2; two NULLs -> 4
+    assert_eq!(
+        ranks,
+        vec![1, 2, 2, 4, 4],
+        "f64::MAX must not tie with NULL"
+    );
+}
+
+#[test]
+fn window_order_survives_type_drift_past_sample() {
+    // 150 Integer values then a Float appears past the 100-row
+    // detection sample; ordering must still interleave correctly
+    let db = Database::open("memory://win_drift").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, k FLOAT)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..150i64 {
+        // Stored as integers via coercion-free int literals in a FLOAT
+        // column stay Float; use an INTEGER column shape instead
+        tx.execute("INSERT INTO t VALUES ($1, $2)", (i, (i * 2) as f64))
+            .unwrap();
+    }
+    tx.commit().unwrap();
+    let db2 = Database::open("memory://win_drift2").unwrap();
+    db2.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, k TEXT)", ())
+        .unwrap();
+    let mut tx = db2.begin().unwrap();
+    for i in 0..150i64 {
+        tx.execute("INSERT INTO t VALUES ($1, $2)", (i, format!("{:05}", i)))
+            .unwrap();
+    }
+    // Row 150: numerically-small text that must sort FIRST
+    tx.execute("INSERT INTO t VALUES (150, '00000')", ())
+        .unwrap();
+    tx.commit().unwrap();
+    let first: String = db2
+        .query_one(
+            "SELECT k FROM (SELECT k, ROW_NUMBER() OVER (ORDER BY k) AS rn FROM t) s WHERE rn = 1",
+            (),
+        )
+        .unwrap();
+    assert_eq!(first, "00000");
+}

--- a/tests/window_sort_keys_test.rs
+++ b/tests/window_sort_keys_test.rs
@@ -118,3 +118,39 @@ fn window_order_survives_type_drift_past_sample() {
         }
     }
 }
+
+#[test]
+fn window_order_mixed_numeric_text_total_order() {
+    // A CASE producing Integer and Text values routes to the generic
+    // comparator; the old fallback compared cross-type pairs stringly
+    // (2 < 10, 10 < '15', but '15' < 2), a cyclic comparator. The
+    // fallback now uses Value's total order: numerics before text.
+    let db = Database::open("memory://win_mixed_total").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 0..150i64 {
+        tx.execute("INSERT INTO t VALUES ($1)", (i,)).unwrap();
+    }
+    tx.commit().unwrap();
+
+    let rows = db
+        .query(
+            "SELECT id % 3, RANK() OVER (ORDER BY CASE WHEN id % 3 = 0 THEN 2 \
+             WHEN id % 3 = 1 THEN 10 ELSE '15' END) AS r FROM t ORDER BY 1, 2",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    for r in &rows {
+        let bucket: i64 = r.get(0).unwrap();
+        let rank: i64 = r.get(1).unwrap();
+        let expected = match bucket {
+            0 => 1,   // Integer 2: first block of 50
+            1 => 51,  // Integer 10: second block
+            _ => 101, // Text '15': after every numeric
+        };
+        assert_eq!(rank, expected, "bucket {bucket} landed out of order");
+    }
+}


### PR DESCRIPTION
G2-correctness: the three window ORDER BY sort bugs the #53 adversarial round reproduced.

## Fixes (window.rs, all with red-first RANK tests)

1. **NULL vs MAX sentinel collision.** The integer/float sort fast paths keyed NULLs as `i64::MAX` / `f64::MAX`, so real MAX values tied with NULLs: `ORDER BY k` over `(NULL, i64::MAX, NULL, 5, i64::MAX, NULL)` produced RANK 1..6 instead of `[1, 2, 2, 4, 4, 4]`. NULL indices now stay **out of band** and are written after the values ascending / before them descending (exactly the placement the old sentinels produced), while the value sort keeps its bare-u64 keys, so the hot comparison is unchanged.
2. **Type drift past the detection sample.** A value of a different type appearing after the 100-row sample got the sentinel key and corrupted the ordering. The sample is a hint now; the typed extractors return false on the first non-matching value and the generic sort takes over.
3. **Comparator total order.** `compare_values_fast` mapped NaN to Equal-vs-everything (an inconsistent comparator handed to sort_unstable) and compared Integer vs Float through a lossy `as f64`. NaNs now compare equal to each other and after every real (matching the float key path and the NULLS-after-reals convention), and mixed numeric compares use the exact `cmp_i64_f64`.

## Perf

Value-class sorting is unchanged (bare u64 keys, no tuple): benches with no NULL keys measure at parity with main within the noise band. The out-of-band NULL block skips sorting NULL peers entirely.

## Verification

- Both suites 4949/4949, differential oracle 9/9, CI-mode 3/3, fmt + clippy clean.
- New `window_sort_keys_test`: i64::MAX-vs-NULL RANK, f64::MAX-vs-NULL RANK, and ordering integrity when the type drifts past the sample.
