### PR TITLE
perf(window): share the partition map and sort across one OVER clause

### DIFF
--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -394,9 +394,13 @@ impl Executor {
 
         // OPTIMIZATION: LIMIT pushdown for PARTITION BY queries
         // Only safe when there is no top-level ORDER BY (otherwise the sort must see all
-        // rows before LIMIT can be applied) and when all window functions share the same
-        // PARTITION BY so one partition map can serve them all.
-        if stmt.order_by.is_empty() && stmt.offset.is_none() {
+        // rows before LIMIT can be applied), when all window functions share the same
+        // PARTITION BY so one partition map can serve them all, and when no OVER clause
+        // is volatile (RANDOM and friends must draw per window function).
+        let all_over_clauses_shareable = window_functions
+            .iter()
+            .all(|wf| self.over_clause_is_shareable(wf));
+        if all_over_clauses_shareable && stmt.order_by.is_empty() && stmt.offset.is_none() {
             if let Some(limit_expr) = &stmt.limit {
                 let has_partition_by = window_functions
                     .iter()
@@ -4342,6 +4346,7 @@ impl Executor {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
     use crate::storage::mvcc::engine::MVCCEngine;
     use std::sync::Arc;

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -78,15 +78,20 @@ impl ConstArg {
     }
 }
 
-/// Conservative determinism check: anything unrecognized counts as
-/// volatile and re-evaluates per row
+/// Conservative determinism check: does this expression yield the same
+/// value every time it is evaluated against the same row? Column
+/// references and bound parameters qualify; RANDOM and friends do not,
+/// and anything unrecognized counts as volatile.
 fn expr_is_deterministic(expr: &Expression, registry: &FunctionRegistry) -> bool {
     match expr {
         Expression::IntegerLiteral(_)
         | Expression::FloatLiteral(_)
         | Expression::StringLiteral(_)
         | Expression::BooleanLiteral(_)
-        | Expression::NullLiteral(_) => true,
+        | Expression::NullLiteral(_)
+        | Expression::Identifier(_)
+        | Expression::QualifiedIdentifier(_)
+        | Expression::Parameter(_) => true,
         Expression::Prefix(prefix) => expr_is_deterministic(&prefix.right, registry),
         Expression::Infix(infix) => {
             expr_is_deterministic(&infix.left, registry)
@@ -111,14 +116,16 @@ type PartitionKey = SmallVec<[Value; 4]>;
 /// shared across window functions with the same OVER clause
 type SharedSortedPartitions = std::sync::Arc<Vec<Vec<usize>>>;
 
-/// Structural identity of an ORDER BY clause: per item the expression
-/// hash plus its direction and NULLS placement. Hashes (not rendered
-/// SQL) because Display drops positional parameter indices and cannot
-/// escape separators.
-type OrderByKey = SmallVec<[(u64, bool, Option<bool>); 2]>;
+/// Identity of one ORDER BY item: expression hash, rendered expression,
+/// direction and NULLS placement. The hash alone is not identity (two
+/// expressions can collide), and rendered SQL alone is not either
+/// (Display drops positional parameter indices), so a cache hit
+/// requires both to match.
+type OrderByItemKey = (u64, String, bool, Option<bool>);
+type OrderByKey = SmallVec<[OrderByItemKey; 2]>;
 
-/// Structural identity of a whole OVER clause
-type OverClauseKey = (SmallVec<[u64; 2]>, OrderByKey);
+/// Identity of a whole OVER clause: partition items then ORDER BY items
+type OverClauseKey = (SmallVec<[(u64, String); 2]>, OrderByKey);
 
 use crate::functions::registry::FunctionRegistry;
 use crate::functions::WindowFunction;
@@ -1757,9 +1764,12 @@ impl Executor {
         order_by_values: Option<&ColumnarOrderByValues>,
         partition_cache: &mut Vec<(OverClauseKey, SharedSortedPartitions)>,
     ) -> Result<SharedSortedPartitions> {
+        let shareable = self.over_clause_is_shareable(wf_info);
         let key = Self::over_clause_cache_key(wf_info);
-        if let Some((_, cached)) = partition_cache.iter().find(|(k, _)| k == &key) {
-            return Ok(std::sync::Arc::clone(cached));
+        if shareable {
+            if let Some((_, cached)) = partition_cache.iter().find(|(k, _)| k == &key) {
+                return Ok(std::sync::Arc::clone(cached));
+            }
         }
 
         let mut partition_vec: Vec<Vec<usize>> = if wf_info.partition_by_exprs.is_empty() {
@@ -1783,7 +1793,9 @@ impl Executor {
         }
 
         let shared: SharedSortedPartitions = std::sync::Arc::new(partition_vec);
-        partition_cache.push((key, std::sync::Arc::clone(&shared)));
+        if shareable {
+            partition_cache.push((key, std::sync::Arc::clone(&shared)));
+        }
         Ok(shared)
     }
 
@@ -1793,9 +1805,22 @@ impl Executor {
         let partition = wf
             .partition_by_exprs
             .iter()
-            .map(compute_expression_hash)
+            .map(|e| (compute_expression_hash(e), e.to_string()))
             .collect();
         (partition, Self::order_by_cache_key(&wf.order_by))
+    }
+
+    /// Window functions whose OVER clause contains a volatile expression
+    /// (RANDOM, UUID, NOW, ...) must not share partitions: each function
+    /// evaluates its own draw
+    fn over_clause_is_shareable(&self, wf: &WindowFunctionInfo) -> bool {
+        wf.partition_by_exprs
+            .iter()
+            .all(|e| expr_is_deterministic(e, &self.function_registry))
+            && wf
+                .order_by
+                .iter()
+                .all(|ob| expr_is_deterministic(&ob.expression, &self.function_registry))
     }
 
     /// Structural identity of an ORDER BY clause. Rendered SQL cannot
@@ -1809,6 +1834,7 @@ impl Executor {
             .map(|ob| {
                 (
                     compute_expression_hash(&ob.expression),
+                    ob.expression.to_string(),
                     ob.ascending,
                     ob.nulls_first,
                 )
@@ -1821,21 +1847,20 @@ impl Executor {
     /// different partition scheme, because the streaming path builds only one
     /// partition map and computes per-partition subsets.
     fn all_partitions_match(window_functions: &[WindowFunctionInfo]) -> bool {
-        use std::fmt::Write;
-        let mut canonical: Option<String> = None;
+        let mut canonical: Option<SmallVec<[(u64, String); 2]>> = None;
         for wf in window_functions {
             // A global (unpartitioned) window must see all rows, so
             // per-partition streaming is unsafe.
             if wf.partition_by_exprs.is_empty() {
                 return false;
             }
-            let mut key = String::with_capacity(64);
-            for (i, expr) in wf.partition_by_exprs.iter().enumerate() {
-                if i > 0 {
-                    key.push(',');
-                }
-                let _ = write!(key, "{}", expr);
-            }
+            // Same identity the partition cache uses: hash plus rendered
+            // form, per item, so parameters and separators cannot merge
+            let key: SmallVec<[(u64, String); 2]> = wf
+                .partition_by_exprs
+                .iter()
+                .map(|e| (compute_expression_hash(e), e.to_string()))
+                .collect();
             match &canonical {
                 None => canonical = Some(key),
                 Some(c) if c != &key => return false,

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -107,6 +107,10 @@ use crate::core::{Error, Result, Row, Value};
 /// Type alias for partition keys - stack-allocated for common case (up to 4 columns)
 type PartitionKey = SmallVec<[Value; 4]>;
 
+/// Partitions of row indices, each already sorted by its ORDER BY,
+/// shared across window functions with the same OVER clause
+type SharedSortedPartitions = std::sync::Arc<Vec<Vec<usize>>>;
+
 use crate::functions::registry::FunctionRegistry;
 use crate::functions::WindowFunction;
 use crate::parser::ast::*;
@@ -451,6 +455,9 @@ impl Executor {
         }
 
         let mut window_value_map: StringMap<Vec<Value>> = StringMap::new();
+        // Sorted partitions shared across window functions with the same
+        // OVER clause (K functions pay one map build and one sort)
+        let mut partition_cache: Vec<(String, SharedSortedPartitions)> = Vec::new();
         for wf in &window_functions {
             let window_values = self.compute_window_function(
                 wf,
@@ -461,6 +468,7 @@ impl Executor {
                 pre_sorted.as_ref(),
                 pre_grouped.as_ref(),
                 &order_by_cache,
+                &mut partition_cache,
             )?;
             window_value_map.insert(wf.column_name.to_lowercase(), window_values);
         }
@@ -737,6 +745,7 @@ impl Executor {
 
         // Precompute aggregate window functions once over all rows (not per partition)
         let mut precomputed_agg: StringMap<Vec<Value>> = StringMap::new();
+        let mut streaming_partition_cache: Vec<(String, SharedSortedPartitions)> = Vec::new();
         for (wf, _, is_agg) in &resolved_wfs {
             if *is_agg {
                 let cache_key = Self::order_by_cache_key(&wf.order_by);
@@ -752,6 +761,7 @@ impl Executor {
                     ctx,
                     None,
                     precomputed_order_by,
+                    &mut streaming_partition_cache,
                 )?;
                 precomputed_agg.insert(wf.column_name.to_lowercase(), agg_results);
             }
@@ -988,6 +998,9 @@ impl Executor {
             // Values are stored keyed by local position within row_indices.
             let row_indices: Vec<usize> = (0..partition_rows.len()).collect();
             let mut window_value_map: StringMap<Vec<Value>> = StringMap::new();
+            // Per-partition rows: the shared cache would key on the OVER
+            // clause while indices differ per partition, so keep it local
+            let mut lazy_partition_cache: Vec<(String, SharedSortedPartitions)> = Vec::new();
 
             for (wf, win_func_opt, is_agg) in &resolved_wfs {
                 let cache_key = Self::order_by_cache_key(&wf.order_by);
@@ -1005,6 +1018,7 @@ impl Executor {
                         ctx,
                         None,
                         precomputed_order_by,
+                        &mut lazy_partition_cache,
                     )?;
                     // agg_results is already indexed by local row index
                     window_value_map.insert(wf.column_name.to_lowercase(), agg_results);
@@ -1721,6 +1735,67 @@ impl Executor {
     /// Create a cache key for ORDER BY expressions using their string representation.
     /// This enables semantic comparison (ignoring token positions) for ORDER BY clause deduplication.
     #[inline]
+    /// Resolve the sorted partitions for a window function's OVER clause,
+    /// sharing the partition map build and the per-partition sort across
+    /// window functions with identical PARTITION BY and ORDER BY
+    #[allow(clippy::too_many_arguments)]
+    fn shared_sorted_partitions(
+        &self,
+        wf_info: &WindowFunctionInfo,
+        rows: &[(i64, Row)],
+        columns: &[String],
+        col_index_map: &StringMap<usize>,
+        ctx: &ExecutionContext,
+        pre_grouped: Option<&WindowPreGroupedState>,
+        order_by_values: Option<&ColumnarOrderByValues>,
+        partition_cache: &mut Vec<(String, SharedSortedPartitions)>,
+    ) -> Result<SharedSortedPartitions> {
+        let key = Self::over_clause_cache_key(wf_info);
+        if let Some((_, cached)) = partition_cache.iter().find(|(k, _)| k == &key) {
+            return Ok(std::sync::Arc::clone(cached));
+        }
+
+        let mut partition_vec: Vec<Vec<usize>> = if wf_info.partition_by_exprs.is_empty() {
+            vec![(0..rows.len()).collect()]
+        } else if let Some(pg) = pre_grouped.filter(|pg| {
+            wf_info.partition_by.len() == 1
+                && wf_info.partition_by.len() == wf_info.partition_by_exprs.len()
+                && wf_info.partition_by[0].to_lowercase() == pg.partition_column
+        }) {
+            pg.partition_map.values().cloned().collect()
+        } else {
+            Self::build_partition_map(wf_info, rows, columns, col_index_map, ctx)?
+                .into_values()
+                .collect()
+        };
+
+        if let Some(order_by) = order_by_values.filter(|v| !v.is_empty()) {
+            for indices in partition_vec.iter_mut() {
+                Self::sort_by_order_values(indices, order_by);
+            }
+        }
+
+        let shared: SharedSortedPartitions = std::sync::Arc::new(partition_vec);
+        partition_cache.push((key, std::sync::Arc::clone(&shared)));
+        Ok(shared)
+    }
+
+    /// Semantic cache key for a (PARTITION BY, ORDER BY) pair; window
+    /// functions sharing both reuse one partition map and one sort
+    fn over_clause_cache_key(wf: &WindowFunctionInfo) -> String {
+        use std::fmt::Write;
+        let mut key = String::with_capacity(96);
+        for (i, expr) in wf.partition_by_exprs.iter().enumerate() {
+            if i > 0 {
+                key.push(',');
+            }
+            let _ = write!(key, "{}", expr);
+        }
+        key.push('\x1f');
+        key.push_str(&Self::order_by_cache_key(&wf.order_by));
+        key
+    }
+
     fn order_by_cache_key(order_by: &[OrderByExpression]) -> String {
         use std::fmt::Write;
         let mut key = String::with_capacity(64);
@@ -1843,6 +1918,7 @@ impl Executor {
     /// pre_grouped: Optional pre-grouped partitions from index (avoids hash-based grouping)
     /// order_by_cache: Precomputed ORDER BY values cache (keyed by semantic string representation)
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     fn compute_window_function(
         &self,
         wf_info: &WindowFunctionInfo,
@@ -1853,6 +1929,7 @@ impl Executor {
         pre_sorted: Option<&WindowPreSortedState>,
         pre_grouped: Option<&WindowPreGroupedState>,
         order_by_cache: &[(String, ColumnarOrderByValues)],
+        partition_cache: &mut Vec<(String, SharedSortedPartitions)>,
     ) -> Result<Vec<Value>> {
         // Check if this is an aggregate function used as window function
         let is_aggregate = self.function_registry.is_aggregate(&wf_info.name);
@@ -1873,6 +1950,7 @@ impl Executor {
                 ctx,
                 pre_sorted,
                 cached_order_by,
+                partition_cache,
             );
         }
 
@@ -1895,17 +1973,30 @@ impl Executor {
             None
         };
 
-        // If there's no partitioning, treat all rows as one partition
+        // Resolve partitions once per distinct OVER clause: the map build
+        // and the per-partition sort are shared across window functions
+        let partitions = self.shared_sorted_partitions(
+            wf_info,
+            rows,
+            columns,
+            col_index_map,
+            ctx,
+            pre_grouped,
+            precomputed_order_by,
+            partition_cache,
+        )?;
+
+        // If there's no partitioning, all rows form one partition
         if wf_info.partition_by_exprs.is_empty() {
             // Pre-allocate results array and use direct-writing variant
             let mut results: Vec<Value> = vec![NULL_VALUE; rows.len()];
-            let row_indices: Vec<usize> = (0..rows.len()).collect();
 
             self.compute_window_for_partition_direct(
                 &*window_func,
                 wf_info,
                 rows,
-                row_indices,
+                partitions[0].clone(),
+                true,
                 precomputed_order_by,
                 columns,
                 col_index_map,
@@ -1915,21 +2006,6 @@ impl Executor {
 
             return Ok(results);
         }
-
-        // Group rows by partition key
-        // OPTIMIZATION: Use pre-grouped partitions from index if available (avoids O(n) hashing)
-        // Only valid when this WF partitions by the exact same single simple column that
-        // the planner used to build the pre-grouped map.
-        let partitions: FxHashMap<PartitionKey, Vec<usize>> = if let Some(pg) =
-            pre_grouped.filter(|pg| {
-                wf_info.partition_by.len() == 1
-                    && wf_info.partition_by.len() == wf_info.partition_by_exprs.len()
-                    && wf_info.partition_by[0].to_lowercase() == pg.partition_column
-            }) {
-            pg.partition_map.clone()
-        } else {
-            Self::build_partition_map(wf_info, rows, columns, col_index_map, ctx)?
-        };
 
         // Compute window function for each partition
         // Use parallel execution for large number of partitions
@@ -1946,43 +2022,40 @@ impl Executor {
             let mut results: Vec<Value> = vec![NULL_VALUE; rows.len()];
             let parallel_results = ParallelVec::new(&mut results);
 
-            let partitions_vec: Vec<_> = partitions.into_iter().collect();
             #[cfg(feature = "parallel")]
-            let iter_result =
-                partitions_vec
-                    .par_iter()
-                    .try_for_each(|(_key, row_indices)| -> Result<()> {
-                        // Direct writing: each partition writes to its own indices
-                        self.compute_window_for_partition_parallel(
-                            &*window_func,
-                            wf_info,
-                            rows,
-                            row_indices.clone(),
-                            precomputed_order_by,
-                            columns,
-                            col_index_map,
-                            ctx,
-                            &parallel_results,
-                        )
-                    });
+            let iter_result = partitions
+                .par_iter()
+                .try_for_each(|row_indices| -> Result<()> {
+                    // Direct writing: each partition writes to its own indices
+                    self.compute_window_for_partition_parallel(
+                        &*window_func,
+                        wf_info,
+                        rows,
+                        row_indices.clone(),
+                        true,
+                        precomputed_order_by,
+                        columns,
+                        col_index_map,
+                        ctx,
+                        &parallel_results,
+                    )
+                });
             #[cfg(not(feature = "parallel"))]
-            let iter_result =
-                partitions_vec
-                    .iter()
-                    .try_for_each(|(_key, row_indices)| -> Result<()> {
-                        // Direct writing: each partition writes to its own indices
-                        self.compute_window_for_partition_parallel(
-                            &*window_func,
-                            wf_info,
-                            rows,
-                            row_indices.clone(),
-                            precomputed_order_by,
-                            columns,
-                            col_index_map,
-                            ctx,
-                            &parallel_results,
-                        )
-                    });
+            let iter_result = partitions.iter().try_for_each(|row_indices| -> Result<()> {
+                // Direct writing: each partition writes to its own indices
+                self.compute_window_for_partition_parallel(
+                    &*window_func,
+                    wf_info,
+                    rows,
+                    row_indices.clone(),
+                    true,
+                    precomputed_order_by,
+                    columns,
+                    col_index_map,
+                    ctx,
+                    &parallel_results,
+                )
+            });
             iter_result?;
 
             // ParallelVec is done, results are written in place
@@ -1993,13 +2066,14 @@ impl Executor {
             // creating per-partition Vec<Value> and then mapping back
             let mut results: Vec<Value> = vec![NULL_VALUE; rows.len()];
 
-            for (_key, row_indices) in partitions {
+            for row_indices in partitions.iter() {
                 // MEMORY OPTIMIZATION: Direct writing variant - writes to results in-place
                 self.compute_window_for_partition_direct(
                     &*window_func,
                     wf_info,
                     rows,
-                    row_indices,
+                    row_indices.clone(),
+                    true,
                     precomputed_order_by,
                     columns,
                     col_index_map,
@@ -2241,6 +2315,7 @@ impl Executor {
         wf_info: &WindowFunctionInfo,
         all_rows: &[(i64, Row)],
         mut row_indices: Vec<usize>,
+        already_sorted: bool,
         precomputed_order_by: Option<&ColumnarOrderByValues>,
         columns: &[String],
         col_index_map: &StringMap<usize>,
@@ -2255,8 +2330,9 @@ impl Executor {
         };
         let order_by_values = precomputed_order_by.unwrap_or(&empty_order_by);
 
-        // Sort partition by ORDER BY if specified
-        if !wf_info.order_by.is_empty() && !order_by_values.is_empty() {
+        // Sort partition by ORDER BY if specified (the shared-partition
+        // cache hands in pre-sorted indices)
+        if !already_sorted && !wf_info.order_by.is_empty() && !order_by_values.is_empty() {
             Self::sort_by_order_values(&mut row_indices, order_by_values);
         }
 
@@ -2444,6 +2520,7 @@ impl Executor {
         wf_info: &WindowFunctionInfo,
         all_rows: &[(i64, Row)],
         mut row_indices: Vec<usize>,
+        already_sorted: bool,
         precomputed_order_by: Option<&ColumnarOrderByValues>,
         columns: &[String],
         col_index_map: &StringMap<usize>,
@@ -2458,8 +2535,9 @@ impl Executor {
         };
         let order_by_values = precomputed_order_by.unwrap_or(&empty_order_by);
 
-        // Sort partition by ORDER BY if specified
-        if !wf_info.order_by.is_empty() && !order_by_values.is_empty() {
+        // Sort partition by ORDER BY if specified (the shared-partition
+        // cache hands in pre-sorted indices)
+        if !already_sorted && !wf_info.order_by.is_empty() && !order_by_values.is_empty() {
             Self::sort_by_order_values(&mut row_indices, order_by_values);
         }
 
@@ -3587,6 +3665,7 @@ impl Executor {
     /// Compute aggregate function as window function (SUM, COUNT, AVG, MIN, MAX)
     /// cached_order_by: Optional precomputed ORDER BY values from cache to avoid redundant computation
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     fn compute_aggregate_window_function(
         &self,
         wf_info: &WindowFunctionInfo,
@@ -3596,6 +3675,7 @@ impl Executor {
         ctx: &ExecutionContext,
         pre_sorted: Option<&WindowPreSortedState>,
         cached_order_by: Option<&ColumnarOrderByValues>,
+        partition_cache: &mut Vec<(String, SharedSortedPartitions)>,
     ) -> Result<Vec<Value>> {
         // Check if this is COUNT(*) - Star expression means count all rows
         let is_count_star =
@@ -3634,27 +3714,41 @@ impl Executor {
         };
         let order_by_values: &ColumnarOrderByValues = cached_order_by.unwrap_or(&empty_order_by);
 
-        // Group rows by partition key
-        let partitions = Self::build_partition_map(wf_info, rows, columns, col_index_map, ctx)?;
-
         // Check if we can skip sorting (index optimization)
         // Only applies when there's no PARTITION BY (single partition)
         let skip_sorting =
             wf_info.partition_by_exprs.is_empty() && self.check_rows_presorted(wf_info, pre_sorted);
+
+        // Resolve partitions once per distinct OVER clause (map build and
+        // per-partition sort shared across window functions). The
+        // presorted-by-index path keeps unsorted indices, so it bypasses
+        // the shared cache
+        let partitions: Vec<Vec<usize>> = if skip_sorting {
+            Self::build_partition_map(wf_info, rows, columns, col_index_map, ctx)?
+                .into_values()
+                .collect()
+        } else {
+            let shared = self.shared_sorted_partitions(
+                wf_info,
+                rows,
+                columns,
+                col_index_map,
+                ctx,
+                None,
+                cached_order_by,
+                partition_cache,
+            )?;
+            shared.iter().cloned().collect()
+        };
 
         // Compute aggregate for each partition
         // OPTIMIZATION: Use Option<Value> with vec![None; n] - None is just a discriminant
         // (no data to clone), much faster than vec![NULL_VALUE; n] which clones ~32 byte Values
         let mut results: Vec<Option<Value>> = vec![None; rows.len()];
 
-        for (_key, mut row_indices) in partitions {
-            // Sort partition by ORDER BY if specified (skip if pre-sorted)
+        for row_indices in partitions {
+            // Partitions from the shared cache arrive pre-sorted
             if !wf_info.order_by.is_empty() {
-                // Only sort if not already pre-sorted by index
-                if !skip_sorting {
-                    Self::sort_by_order_values(&mut row_indices, order_by_values);
-                }
-
                 // With ORDER BY, compute aggregate with frame specification
                 // Default frame is UNBOUNDED PRECEDING to CURRENT ROW if no explicit frame
                 let partition_len = row_indices.len();

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -111,13 +111,22 @@ type PartitionKey = SmallVec<[Value; 4]>;
 /// shared across window functions with the same OVER clause
 type SharedSortedPartitions = std::sync::Arc<Vec<Vec<usize>>>;
 
+/// Structural identity of an ORDER BY clause: per item the expression
+/// hash plus its direction and NULLS placement. Hashes (not rendered
+/// SQL) because Display drops positional parameter indices and cannot
+/// escape separators.
+type OrderByKey = SmallVec<[(u64, bool, Option<bool>); 2]>;
+
+/// Structural identity of a whole OVER clause
+type OverClauseKey = (SmallVec<[u64; 2]>, OrderByKey);
+
 use crate::functions::registry::FunctionRegistry;
 use crate::functions::WindowFunction;
 use crate::parser::ast::*;
 use crate::storage::traits::{QueryResult, Table};
 
 use super::context::ExecutionContext;
-use super::expression::{ExpressionEval, MultiExpressionEval};
+use super::expression::{compute_expression_hash, ExpressionEval, MultiExpressionEval};
 use super::result::{ColumnarResult, ExecutorResult};
 use super::utils::build_column_index_map;
 use super::Executor;
@@ -434,7 +443,7 @@ impl Executor {
         // NOTE: We use string representation for semantic comparison because PartialEq on expressions
         // compares token positions, making structurally identical expressions from different window
         // functions appear different.
-        let mut order_by_cache: Vec<(String, ColumnarOrderByValues)> = Vec::new();
+        let mut order_by_cache: Vec<(OrderByKey, ColumnarOrderByValues)> = Vec::new();
         for wf in &window_functions {
             if !wf.order_by.is_empty() {
                 // Create a semantic key from the ORDER BY expressions (ignores token positions)
@@ -457,7 +466,7 @@ impl Executor {
         let mut window_value_map: StringMap<Vec<Value>> = StringMap::new();
         // Sorted partitions shared across window functions with the same
         // OVER clause (K functions pay one map build and one sort)
-        let mut partition_cache: Vec<(String, SharedSortedPartitions)> = Vec::new();
+        let mut partition_cache: Vec<(OverClauseKey, SharedSortedPartitions)> = Vec::new();
         for wf in &window_functions {
             let window_values = self.compute_window_function(
                 wf,
@@ -711,7 +720,7 @@ impl Executor {
             select_items.iter().map(|i| i.output_name.clone()).collect();
 
         // Precompute ORDER BY values once for each unique ORDER BY clause
-        let mut order_by_cache: Vec<(String, ColumnarOrderByValues)> = Vec::new();
+        let mut order_by_cache: Vec<(OrderByKey, ColumnarOrderByValues)> = Vec::new();
         for wf in window_functions {
             if !wf.order_by.is_empty() {
                 let cache_key = Self::order_by_cache_key(&wf.order_by);
@@ -745,7 +754,8 @@ impl Executor {
 
         // Precompute aggregate window functions once over all rows (not per partition)
         let mut precomputed_agg: StringMap<Vec<Value>> = StringMap::new();
-        let mut streaming_partition_cache: Vec<(String, SharedSortedPartitions)> = Vec::new();
+        let mut streaming_partition_cache: Vec<(OverClauseKey, SharedSortedPartitions)> =
+            Vec::new();
         for (wf, _, is_agg) in &resolved_wfs {
             if *is_agg {
                 let cache_key = Self::order_by_cache_key(&wf.order_by);
@@ -976,7 +986,7 @@ impl Executor {
             }
 
             // Precompute ORDER BY values for each unique ORDER BY clause
-            let mut order_by_cache: Vec<(String, ColumnarOrderByValues)> = Vec::new();
+            let mut order_by_cache: Vec<(OrderByKey, ColumnarOrderByValues)> = Vec::new();
             for wf in &window_functions {
                 if !wf.order_by.is_empty() {
                     let cache_key = Self::order_by_cache_key(&wf.order_by);
@@ -1000,7 +1010,7 @@ impl Executor {
             let mut window_value_map: StringMap<Vec<Value>> = StringMap::new();
             // Per-partition rows: the shared cache would key on the OVER
             // clause while indices differ per partition, so keep it local
-            let mut lazy_partition_cache: Vec<(String, SharedSortedPartitions)> = Vec::new();
+            let mut lazy_partition_cache: Vec<(OverClauseKey, SharedSortedPartitions)> = Vec::new();
 
             for (wf, win_func_opt, is_agg) in &resolved_wfs {
                 let cache_key = Self::order_by_cache_key(&wf.order_by);
@@ -1732,9 +1742,6 @@ impl Executor {
         })
     }
 
-    /// Create a cache key for ORDER BY expressions using their string representation.
-    /// This enables semantic comparison (ignoring token positions) for ORDER BY clause deduplication.
-    #[inline]
     /// Resolve the sorted partitions for a window function's OVER clause,
     /// sharing the partition map build and the per-partition sort across
     /// window functions with identical PARTITION BY and ORDER BY
@@ -1748,7 +1755,7 @@ impl Executor {
         ctx: &ExecutionContext,
         pre_grouped: Option<&WindowPreGroupedState>,
         order_by_values: Option<&ColumnarOrderByValues>,
-        partition_cache: &mut Vec<(String, SharedSortedPartitions)>,
+        partition_cache: &mut Vec<(OverClauseKey, SharedSortedPartitions)>,
     ) -> Result<SharedSortedPartitions> {
         let key = Self::over_clause_cache_key(wf_info);
         if let Some((_, cached)) = partition_cache.iter().find(|(k, _)| k == &key) {
@@ -1780,33 +1787,33 @@ impl Executor {
         Ok(shared)
     }
 
-    /// Semantic cache key for a (PARTITION BY, ORDER BY) pair; window
+    /// Structural cache key for a (PARTITION BY, ORDER BY) pair; window
     /// functions sharing both reuse one partition map and one sort
-    fn over_clause_cache_key(wf: &WindowFunctionInfo) -> String {
-        use std::fmt::Write;
-        let mut key = String::with_capacity(96);
-        for (i, expr) in wf.partition_by_exprs.iter().enumerate() {
-            if i > 0 {
-                key.push(',');
-            }
-            let _ = write!(key, "{}", expr);
-        }
-        key.push('\x1f');
-        key.push_str(&Self::order_by_cache_key(&wf.order_by));
-        key
+    fn over_clause_cache_key(wf: &WindowFunctionInfo) -> OverClauseKey {
+        let partition = wf
+            .partition_by_exprs
+            .iter()
+            .map(compute_expression_hash)
+            .collect();
+        (partition, Self::order_by_cache_key(&wf.order_by))
     }
 
-    fn order_by_cache_key(order_by: &[OrderByExpression]) -> String {
-        use std::fmt::Write;
-        let mut key = String::with_capacity(64);
-        for (i, ob) in order_by.iter().enumerate() {
-            if i > 0 {
-                key.push(',');
-            }
-            // Use Display trait to get semantic string representation
-            let _ = write!(key, "{}", ob);
-        }
-        key
+    /// Structural identity of an ORDER BY clause. Rendered SQL cannot
+    /// serve here: Display prints bare positional parameters as "?"
+    /// without their index, so two clauses binding different values
+    /// would share a cache entry.
+    #[inline]
+    fn order_by_cache_key(order_by: &[OrderByExpression]) -> OrderByKey {
+        order_by
+            .iter()
+            .map(|ob| {
+                (
+                    compute_expression_hash(&ob.expression),
+                    ob.ascending,
+                    ob.nulls_first,
+                )
+            })
+            .collect()
     }
 
     /// Check that ALL window functions share the exact same PARTITION BY clause.
@@ -1918,7 +1925,6 @@ impl Executor {
     /// pre_grouped: Optional pre-grouped partitions from index (avoids hash-based grouping)
     /// order_by_cache: Precomputed ORDER BY values cache (keyed by semantic string representation)
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::too_many_arguments)]
     fn compute_window_function(
         &self,
         wf_info: &WindowFunctionInfo,
@@ -1928,8 +1934,8 @@ impl Executor {
         ctx: &ExecutionContext,
         pre_sorted: Option<&WindowPreSortedState>,
         pre_grouped: Option<&WindowPreGroupedState>,
-        order_by_cache: &[(String, ColumnarOrderByValues)],
-        partition_cache: &mut Vec<(String, SharedSortedPartitions)>,
+        order_by_cache: &[(OrderByKey, ColumnarOrderByValues)],
+        partition_cache: &mut Vec<(OverClauseKey, SharedSortedPartitions)>,
     ) -> Result<Vec<Value>> {
         // Check if this is an aggregate function used as window function
         let is_aggregate = self.function_registry.is_aggregate(&wf_info.name);
@@ -3665,7 +3671,6 @@ impl Executor {
     /// Compute aggregate function as window function (SUM, COUNT, AVG, MIN, MAX)
     /// cached_order_by: Optional precomputed ORDER BY values from cache to avoid redundant computation
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::too_many_arguments)]
     fn compute_aggregate_window_function(
         &self,
         wf_info: &WindowFunctionInfo,
@@ -3675,7 +3680,7 @@ impl Executor {
         ctx: &ExecutionContext,
         pre_sorted: Option<&WindowPreSortedState>,
         cached_order_by: Option<&ColumnarOrderByValues>,
-        partition_cache: &mut Vec<(String, SharedSortedPartitions)>,
+        partition_cache: &mut Vec<(OverClauseKey, SharedSortedPartitions)>,
     ) -> Result<Vec<Value>> {
         // Check if this is COUNT(*) - Star expression means count all rows
         let is_count_star =
@@ -3723,12 +3728,18 @@ impl Executor {
         // per-partition sort shared across window functions). The
         // presorted-by-index path keeps unsorted indices, so it bypasses
         // the shared cache
-        let partitions: Vec<Vec<usize>> = if skip_sorting {
-            Self::build_partition_map(wf_info, rows, columns, col_index_map, ctx)?
-                .into_values()
-                .collect()
+        let owned_partitions: Option<Vec<Vec<usize>>> = if skip_sorting {
+            Some(
+                Self::build_partition_map(wf_info, rows, columns, col_index_map, ctx)?
+                    .into_values()
+                    .collect(),
+            )
         } else {
-            let shared = self.shared_sorted_partitions(
+            None
+        };
+        let shared_partitions = match &owned_partitions {
+            Some(_) => None,
+            None => Some(self.shared_sorted_partitions(
                 wf_info,
                 rows,
                 columns,
@@ -3737,8 +3748,13 @@ impl Executor {
                 None,
                 cached_order_by,
                 partition_cache,
-            )?;
-            shared.iter().cloned().collect()
+            )?),
+        };
+        // Borrow the shared entry instead of cloning the index vectors
+        let partitions: &[Vec<usize>] = match (&owned_partitions, &shared_partitions) {
+            (Some(owned), _) => owned,
+            (None, Some(shared)) => shared,
+            (None, None) => &[],
         };
 
         // Compute aggregate for each partition
@@ -3746,7 +3762,8 @@ impl Executor {
         // (no data to clone), much faster than vec![NULL_VALUE; n] which clones ~32 byte Values
         let mut results: Vec<Option<Value>> = vec![None; rows.len()];
 
-        for row_indices in partitions {
+        for row_indices in partitions.iter() {
+            let row_indices = row_indices.as_slice();
             // Partitions from the shared cache arrive pre-sorted
             if !wf_info.order_by.is_empty() {
                 // With ORDER BY, compute aggregate with frame specification
@@ -4161,7 +4178,7 @@ impl Executor {
                     })?;
 
                 // Accumulate all values in the partition
-                for &row_idx in &row_indices {
+                for &row_idx in row_indices {
                     // Bind by reference: accumulate clones internally only
                     // when it retains the value
                     let value: &Value = if let Some(col_idx) = arg_col_idx {
@@ -4178,7 +4195,7 @@ impl Executor {
                 let aggregate_result = agg_func.result();
 
                 // Assign the same aggregate result to all rows in the partition
-                for &row_idx in &row_indices {
+                for &row_idx in row_indices {
                     results[row_idx] = Some(aggregate_result.clone());
                 }
             }

--- a/tests/window_over_key_test.rs
+++ b/tests/window_over_key_test.rs
@@ -1,0 +1,85 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Window functions sharing partition work must only share it when the
+//! OVER clauses are genuinely identical.
+
+use stoolap::Database;
+
+#[test]
+fn positional_parameters_do_not_share_partitions() {
+    let db = Database::open("memory://win_key_param").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    for i in 1..=6i64 {
+        db.execute("INSERT INTO t VALUES ($1, $2)", (i, i)).unwrap();
+    }
+    // Two OVER clauses differing only in a bound parameter value
+    let rows = db
+        .query(
+            "SELECT id, \
+             ROW_NUMBER() OVER (PARTITION BY v % ? ORDER BY v) AS a, \
+             ROW_NUMBER() OVER (PARTITION BY v % ? ORDER BY v) AS b \
+             FROM t ORDER BY id",
+            (2i64, 3i64),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let a: Vec<i64> = rows.iter().map(|r| r.get(1).unwrap()).collect();
+    let b: Vec<i64> = rows.iter().map(|r| r.get(2).unwrap()).collect();
+    assert_eq!(a, vec![1, 1, 2, 2, 3, 3], "v % 2 partitions");
+    assert_eq!(b, vec![1, 1, 1, 2, 2, 2], "v % 3 partitions");
+}
+
+#[test]
+fn quoted_comma_identifier_does_not_collide_with_two_columns() {
+    let db = Database::open("memory://win_key_comma").unwrap();
+    db.execute(
+        "CREATE TABLE qc (id INTEGER PRIMARY KEY, \"a,b\" INTEGER, a INTEGER, b INTEGER, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    for (id, ab, a, b, v) in [
+        (1i64, 1i64, 1i64, 1i64, 10i64),
+        (2, 1, 1, 2, 20),
+        (3, 2, 2, 1, 30),
+        (4, 2, 2, 2, 40),
+    ] {
+        db.execute(
+            "INSERT INTO qc VALUES ($1, $2, $3, $4, $5)",
+            (id, ab, a, b, v),
+        )
+        .unwrap();
+    }
+    let rows = db
+        .query(
+            "SELECT v, \
+             ROW_NUMBER() OVER (PARTITION BY \"a,b\" ORDER BY v) AS k1, \
+             ROW_NUMBER() OVER (PARTITION BY a, b ORDER BY v) AS k2 \
+             FROM qc ORDER BY v",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let k1: Vec<i64> = rows.iter().map(|r| r.get(1).unwrap()).collect();
+    let k2: Vec<i64> = rows.iter().map(|r| r.get(2).unwrap()).collect();
+    assert_eq!(k1, vec![1, 2, 1, 2], "partition by the quoted column");
+    assert_eq!(
+        k2,
+        vec![1, 1, 1, 1],
+        "each (a, b) pair is its own partition"
+    );
+}

--- a/tests/window_over_key_test.rs
+++ b/tests/window_over_key_test.rs
@@ -83,3 +83,60 @@ fn quoted_comma_identifier_does_not_collide_with_two_columns() {
         "each (a, b) pair is its own partition"
     );
 }
+
+#[test]
+fn hash_colliding_partition_expressions_stay_separate() {
+    // Two different literals whose expression hashes collide must not
+    // share a partition map: the cache must verify structural identity,
+    // not just the hash
+    let db = Database::open("memory://win_key_collide").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    for i in 1..=4i64 {
+        db.execute("INSERT INTO t VALUES ($1)", (i,)).unwrap();
+    }
+    let rows = db
+        .query(
+            "SELECT id, \
+             ROW_NUMBER() OVER (PARTITION BY id = -9223372036854775808 ORDER BY id) AS a, \
+             ROW_NUMBER() OVER (PARTITION BY id = -1.9149084435936727e80 ORDER BY id) AS b \
+             FROM t ORDER BY id",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let a: Vec<i64> = rows.iter().map(|r| r.get(1).unwrap()).collect();
+    let b: Vec<i64> = rows.iter().map(|r| r.get(2).unwrap()).collect();
+    assert_eq!(a, vec![1, 2, 3, 4], "no row matches the integer literal");
+    assert_eq!(b, vec![1, 2, 3, 4], "no row matches the float literal");
+}
+
+#[test]
+fn volatile_partition_expressions_are_not_shared() {
+    // PARTITION BY RANDOM() must be evaluated per window function; a
+    // shared partition map would force both columns to agree
+    let db = Database::open("memory://win_key_volatile").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 1..=200i64 {
+        tx.execute("INSERT INTO t VALUES ($1)", (i,)).unwrap();
+    }
+    tx.commit().unwrap();
+    let rows = db
+        .query(
+            "SELECT ROW_NUMBER() OVER (PARTITION BY RANDOM() < 0.5 ORDER BY id) AS a, \
+             ROW_NUMBER() OVER (PARTITION BY RANDOM() < 0.5 ORDER BY id) AS b \
+             FROM t ORDER BY id",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let a: Vec<i64> = rows.iter().map(|r| r.get(0).unwrap()).collect();
+    let b: Vec<i64> = rows.iter().map(|r| r.get(1).unwrap()).collect();
+    // Two independent random partitionings of 200 rows agreeing on every
+    // row has probability ~2^-200
+    assert_ne!(a, b, "volatile partitions must not share a cached map");
+}

--- a/tests/window_over_key_test.rs
+++ b/tests/window_over_key_test.rs
@@ -88,18 +88,21 @@ fn quoted_comma_identifier_does_not_collide_with_two_columns() {
 fn hash_colliding_partition_expressions_stay_separate() {
     // Two different literals whose expression hashes collide must not
     // share a partition map: the cache must verify structural identity,
-    // not just the hash
+    // not just the hash. The i64::MIN row satisfies the integer
+    // predicate and no float predicate, so a shared map is visible.
     let db = Database::open("memory://win_key_collide").unwrap();
-    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", ())
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
         .unwrap();
-    for i in 1..=4i64 {
-        db.execute("INSERT INTO t VALUES ($1)", (i,)).unwrap();
+    db.execute("INSERT INTO t VALUES ($1, $2)", (1i64, i64::MIN))
+        .unwrap();
+    for i in 2..=5i64 {
+        db.execute("INSERT INTO t VALUES ($1, $2)", (i, i)).unwrap();
     }
     let rows = db
         .query(
             "SELECT id, \
-             ROW_NUMBER() OVER (PARTITION BY id = -9223372036854775808 ORDER BY id) AS a, \
-             ROW_NUMBER() OVER (PARTITION BY id = -1.9149084435936727e80 ORDER BY id) AS b \
+             ROW_NUMBER() OVER (PARTITION BY v = -9223372036854775808 ORDER BY id) AS a, \
+             ROW_NUMBER() OVER (PARTITION BY v = -1.9149084435936727e80 ORDER BY id) AS b \
              FROM t ORDER BY id",
             (),
         )
@@ -108,8 +111,12 @@ fn hash_colliding_partition_expressions_stay_separate() {
         .unwrap();
     let a: Vec<i64> = rows.iter().map(|r| r.get(1).unwrap()).collect();
     let b: Vec<i64> = rows.iter().map(|r| r.get(2).unwrap()).collect();
-    assert_eq!(a, vec![1, 2, 3, 4], "no row matches the integer literal");
-    assert_eq!(b, vec![1, 2, 3, 4], "no row matches the float literal");
+    assert_eq!(
+        a,
+        vec![1, 1, 2, 3, 4],
+        "integer predicate splits i64::MIN off"
+    );
+    assert_eq!(b, vec![1, 2, 3, 4, 5], "float predicate matches nothing");
 }
 
 #[test]
@@ -139,4 +146,31 @@ fn volatile_partition_expressions_are_not_shared() {
     // Two independent random partitionings of 200 rows agreeing on every
     // row has probability ~2^-200
     assert_ne!(a, b, "volatile partitions must not share a cached map");
+}
+
+#[test]
+fn volatile_partitions_not_shared_under_limit() {
+    // The LIMIT streaming path builds one partition map for all window
+    // functions; volatile OVER clauses must keep it off that path
+    let db = Database::open("memory://win_key_volatile_limit").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 1..=200i64 {
+        tx.execute("INSERT INTO t VALUES ($1)", (i,)).unwrap();
+    }
+    tx.commit().unwrap();
+    let rows = db
+        .query(
+            "SELECT ROW_NUMBER() OVER (PARTITION BY RANDOM() < 0.5 ORDER BY id) AS a, \
+             ROW_NUMBER() OVER (PARTITION BY RANDOM() < 0.5 ORDER BY id) AS b \
+             FROM t LIMIT 150",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    let a: Vec<i64> = rows.iter().map(|r| r.get(0).unwrap()).collect();
+    let b: Vec<i64> = rows.iter().map(|r| r.get(1).unwrap()).collect();
+    assert_ne!(a, b, "volatile partitions must not share under LIMIT");
 }


### PR DESCRIPTION
Wave G2 of the executor perf campaign: share partition work across window functions.

## Change

Each window function called `build_partition_map` itself and then sorted every partition by its ORDER BY, so `SELECT ROW_NUMBER() OVER w, RANK() OVER w, SUM(x) OVER w, LAG(x) OVER w` paid four hash-grouping passes over all rows and four full sets of partition sorts.

Partitions now resolve **once per distinct OVER clause**: `shared_sorted_partitions` builds the map (or reuses the planner's pre-grouped map), sorts each partition once, and stores an `Arc<Vec<Vec<usize>>>` in a per-statement cache keyed by a semantic `(PARTITION BY, ORDER BY)` string. The three per-partition compute variants take an `already_sorted` flag so they skip the redundant sort. The aggregate window path uses the same cache.

## Numbers (selbench vs main, 10K rows / 80 partitions)

| bench | main | this PR |
|---|---|---|
| window_shared_over_x4 (4 functions, one OVER) | 1421-1541us | 889-927us (**1.60-1.66x**) |
| percent_rank / lag / max_text / row_number (single function) | | parity |

## Scoping

- The **presorted-by-index** aggregate path still builds its own map: the shared entry is sorted by definition, and that path exists precisely to avoid sorting.
- The **streaming-LIMIT** and **lazy-partition** paths keep local caches: their row indices are partition-local, so a statement-wide cache would key identical OVER clauses onto different index spaces.
- Partition *iteration order* changes from HashMap order to the collected Vec order. Both are arbitrary and no window result depends on it (each partition writes only to its own row indices).

## Verification

- Both suites 4950/4950, window batteries (function/advanced/coverage/sort-keys) 92/92, differential oracle 9/9, fmt + clippy clean.
