### PR TITLE
fix: close the remaining i64::MIN and unbounded-LIMIT panics

### DIFF
--- a/src/common/i64_map.rs
+++ b/src/common/i64_map.rs
@@ -895,6 +895,10 @@ pub struct I64Set {
     slots: Box<[i64]>,
     len: usize,
     mask: usize,
+    /// i64::MIN is the slot array's empty sentinel, so it is stored out
+    /// of band. Callers pass user data (join keys, IN lists), so the set
+    /// must accept the full i64 range instead of panicking.
+    has_min: bool,
 }
 
 impl Clone for I64Set {
@@ -943,17 +947,18 @@ impl I64Set {
             slots: slots.into_boxed_slice(),
             len: 0,
             mask: cap - 1,
+            has_min: false,
         }
     }
 
     #[inline(always)]
     pub fn len(&self) -> usize {
-        self.len
+        self.len + usize::from(self.has_min)
     }
 
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        self.len == 0
+        self.len == 0 && !self.has_min
     }
 
     #[inline(always)]
@@ -1008,7 +1013,11 @@ impl I64Set {
     /// Insert a value into the set. Returns true if the value was newly inserted.
     #[inline(always)]
     pub fn insert(&mut self, key: i64) -> bool {
-        check_key(key);
+        if key == EMPTY {
+            let inserted = !self.has_min;
+            self.has_min = true;
+            return inserted;
+        }
 
         if self.len * LOAD_FACTOR_DEN >= self.slots.len() * LOAD_FACTOR_NUM {
             self.grow();
@@ -1039,7 +1048,9 @@ impl I64Set {
 
     #[inline(always)]
     pub fn contains(&self, key: i64) -> bool {
-        check_key(key);
+        if key == EMPTY {
+            return self.has_min;
+        }
 
         let mask = self.mask;
         let mut idx = Self::hash(key) & mask;
@@ -1063,7 +1074,11 @@ impl I64Set {
 
     #[inline(always)]
     pub fn remove(&mut self, key: i64) -> bool {
-        check_key(key);
+        if key == EMPTY {
+            let removed = self.has_min;
+            self.has_min = false;
+            return removed;
+        }
 
         let mask = self.mask;
         let mut idx = Self::hash(key) & mask;
@@ -1206,6 +1221,7 @@ impl I64Set {
             *slot = EMPTY;
         }
         self.len = 0;
+        self.has_min = false;
     }
 
     #[inline]
@@ -1213,6 +1229,7 @@ impl I64Set {
         self.slots
             .iter()
             .filter_map(|&slot| if slot != EMPTY { Some(slot) } else { None })
+            .chain(if self.has_min { Some(EMPTY) } else { None })
     }
 
     /// Drains all values from the set, returning an iterator over them
@@ -1220,6 +1237,8 @@ impl I64Set {
     pub fn drain(&mut self) -> impl Iterator<Item = i64> + '_ {
         let len = self.len;
         self.len = 0;
+        let had_min = self.has_min;
+        self.has_min = false;
         self.slots
             .iter_mut()
             .filter_map(move |slot| {
@@ -1232,6 +1251,7 @@ impl I64Set {
                 }
             })
             .take(len)
+            .chain(if had_min { Some(EMPTY) } else { None })
     }
 }
 
@@ -1243,6 +1263,7 @@ impl IntoIterator for I64Set {
         I64SetIntoIter {
             slots: self.slots,
             pos: 0,
+            has_min: self.has_min,
         }
     }
 }
@@ -1251,6 +1272,7 @@ impl IntoIterator for I64Set {
 pub struct I64SetIntoIter {
     slots: Box<[i64]>,
     pos: usize,
+    has_min: bool,
 }
 
 impl Iterator for I64SetIntoIter {
@@ -1265,6 +1287,10 @@ impl Iterator for I64SetIntoIter {
             if slot != EMPTY {
                 return Some(slot);
             }
+        }
+        if self.has_min {
+            self.has_min = false;
+            return Some(EMPTY);
         }
         None
     }
@@ -1863,16 +1889,36 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "i64::MIN cannot be used as a key")]
-    fn test_i64set_min_panics_on_insert() {
+    fn test_i64set_handles_min_out_of_band() {
+        // I64Set stores i64::MIN beside the slot array, so callers can
+        // hand it user data without a sentinel dance
         let mut set = I64Set::new();
-        set.insert(i64::MIN);
-    }
+        assert!(!set.contains(i64::MIN));
+        assert!(set.insert(i64::MIN));
+        assert!(!set.insert(i64::MIN));
+        assert!(set.contains(i64::MIN));
+        assert_eq!(set.len(), 1);
+        assert!(!set.is_empty());
 
-    #[test]
-    #[should_panic(expected = "i64::MIN cannot be used as a key")]
-    fn test_i64set_min_panics_on_contains() {
-        let set = I64Set::new();
-        let _ = set.contains(i64::MIN);
+        set.insert(7);
+        set.insert(-3);
+        let mut collected: Vec<i64> = set.iter().collect();
+        collected.sort_unstable();
+        assert_eq!(collected, vec![i64::MIN, -3, 7]);
+        assert_eq!(set.len(), 3);
+
+        let mut drained: Vec<i64> = set.clone().into_iter().collect();
+        drained.sort_unstable();
+        assert_eq!(drained, vec![i64::MIN, -3, 7]);
+
+        assert!(set.remove(i64::MIN));
+        assert!(!set.remove(i64::MIN));
+        assert!(!set.contains(i64::MIN));
+        assert_eq!(set.len(), 2);
+
+        set.insert(i64::MIN);
+        set.clear();
+        assert!(set.is_empty());
+        assert!(!set.contains(i64::MIN));
     }
 }

--- a/src/common/i64_map.rs
+++ b/src/common/i64_map.rs
@@ -1297,7 +1297,14 @@ impl Iterator for I64SetIntoIter {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, Some(self.slots.len() - self.pos))
+        // The out-of-band sentinel is still pending after the slots are
+        // exhausted, so it counts toward the upper bound
+        // The out-of-band sentinel is still pending after the slots are
+        // exhausted, so it counts toward both bounds
+        (
+            usize::from(self.has_min),
+            Some(self.slots.len() - self.pos + usize::from(self.has_min)),
+        )
     }
 }
 
@@ -1886,6 +1893,29 @@ mod tests {
         for i in 0..10000i64 {
             assert!(set.contains(i * stride), "Missing key {}", i * stride);
         }
+    }
+
+    #[test]
+    fn test_i64set_into_iter_size_hint_covers_sentinel() {
+        // The buggy state is "slots exhausted, sentinel still pending",
+        // which occurs whenever the last occupied slot is the final one.
+        // Construct it directly so the assertion cannot depend on where
+        // the hash happened to place a key.
+        let mut set = I64Set::new();
+        set.insert(i64::MIN);
+        let mut iter = set.into_iter();
+        iter.pos = iter.slots.len();
+
+        let (lower, upper) = iter.size_hint();
+        assert_eq!(lower, 1, "a pending sentinel is a guaranteed item");
+        assert_eq!(
+            upper,
+            Some(1),
+            "upper bound must still admit the pending sentinel"
+        );
+        assert_eq!(iter.next(), Some(i64::MIN));
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert_eq!(iter.next(), None);
     }
 
     #[test]

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -2821,6 +2821,9 @@ impl Executor {
                 // Extract integer key directly - no clone, no hash
                 // Handle NULL values separately (they form their own group)
                 let key_opt = match row.get(col_idx) {
+                    // i64::MIN is I64Map's reserved empty sentinel: decline
+                    // the fast path and let the general grouping handle it
+                    Some(Value::Integer(i64::MIN)) => return Ok(None),
                     Some(Value::Integer(v)) => Some(*v),
                     Some(Value::Null(_)) => None, // NULL goes to null_group (inline pattern)
                     None => None,                 // Missing value treated as NULL

--- a/src/executor/cte.rs
+++ b/src/executor/cte.rs
@@ -2291,7 +2291,9 @@ impl Executor {
         // Execute and collect results with synthetic row IDs
         join_op.open()?;
         let mut row_id = 0i64;
-        let mut result_rows = RowVec::with_capacity(effective_limit.unwrap_or(1000) as usize);
+        // effective_limit is user-supplied and can be i64::MAX
+        let mut result_rows =
+            RowVec::with_capacity((effective_limit.unwrap_or(1000) as usize).min(4096));
         while let Some(row_ref) = join_op.next()? {
             result_rows.push((row_id, row_ref.into_owned()));
             row_id += 1;

--- a/src/executor/operators/index_nested_loop.rs
+++ b/src/executor/operators/index_nested_loop.rs
@@ -666,8 +666,13 @@ impl Operator for BatchIndexNestedLoopJoinOperator {
                 },
             }
 
-            // Map row IDs to outer row indices
+            // Map row IDs to outer row indices. i64::MIN is the row-id
+            // maps' reserved sentinel and no row can carry it, so such a
+            // probe simply matches nothing.
             for &row_id in &self.row_id_buffer {
+                if row_id == i64::MIN {
+                    continue;
+                }
                 key_to_outer_indices
                     .entry(row_id)
                     .or_default()

--- a/src/executor/result.rs
+++ b/src/executor/result.rs
@@ -1204,7 +1204,10 @@ impl TopNResult {
             }
         }
 
-        let mut heap: BinaryHeap<HeapRow<F>> = BinaryHeap::with_capacity(heap_capacity + 1);
+        // heap_capacity saturates at usize::MAX for an unbounded LIMIT, so
+        // cap the pre-allocation; the heap grows on demand anyway
+        let mut heap: BinaryHeap<HeapRow<F>> =
+            BinaryHeap::with_capacity(heap_capacity.saturating_add(1).min(4096));
 
         while inner.next() {
             let row = inner.take_row();

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -789,7 +789,9 @@ impl Executor {
         }
 
         // Process partitions one at a time, stopping when we have enough rows
-        let mut result_rows = RowVec::with_capacity(limit);
+        // A user-supplied limit can be i64::MAX; only pre-allocate up
+        // to the rows that can actually be produced
+        let mut result_rows = RowVec::with_capacity(limit.min(base_rows.len().max(16)));
         let mut result_row_id = 0i64;
 
         let partitions_vec: Vec<_> = partitions.into_iter().collect();
@@ -977,7 +979,10 @@ impl Executor {
         };
 
         // Process partitions one at a time, stopping when we have enough rows
-        let mut result_rows = RowVec::with_capacity(limit);
+        // Process partitions one at a time, stopping when we have enough
+        // rows. A user-supplied limit can be i64::MAX, so cap the
+        // pre-allocation; rows are fetched lazily per partition
+        let mut result_rows = RowVec::with_capacity(limit.min(4096));
         let mut result_row_id = 0i64;
 
         for partition_value in partition_values {

--- a/src/storage/expression/in_list.rs
+++ b/src/storage/expression/in_list.rs
@@ -34,8 +34,10 @@ use crate::core::{Result, Row, Schema, Value};
 enum HashedValues {
     /// Not yet computed
     None,
-    /// Integer hash set for O(1) lookup
-    Integers(I64Set),
+    /// Integer hash set for O(1) lookup. i64::MIN is the set's reserved
+    /// empty sentinel, so it is tracked out of band (same shape the PK
+    /// index uses)
+    Integers { set: I64Set, has_i64_min: bool },
     /// String hash set for O(1) lookup
     Strings(FxHashSet<String>),
     /// Boolean set (only 2 possible values)
@@ -151,9 +153,13 @@ impl InListExpr {
             Some("int") => {
                 // Check if all values are integers (or convertible floats)
                 let mut set = I64Set::new();
+                let mut has_i64_min = false;
                 let mut all_int = true;
                 for v in &self.values {
                     match v {
+                        Value::Integer(i64::MIN) => {
+                            has_i64_min = true;
+                        }
                         Value::Integer(i) => {
                             set.insert(*i);
                         }
@@ -163,7 +169,12 @@ impl InListExpr {
                         Value::Float(f)
                             if crate::executor::Executor::lossless_float_key(*f).is_some() =>
                         {
-                            set.insert(*f as i64);
+                            let key = *f as i64;
+                            if key == i64::MIN {
+                                has_i64_min = true;
+                            } else {
+                                set.insert(key);
+                            }
                         }
                         Value::Float(_) => {
                             all_int = false;
@@ -177,7 +188,7 @@ impl InListExpr {
                     }
                 }
                 if all_int {
-                    self.hashed = HashedValues::Integers(set);
+                    self.hashed = HashedValues::Integers { set, has_i64_min };
                 } else {
                     self.hashed = HashedValues::Mixed;
                 }
@@ -255,7 +266,13 @@ impl InListExpr {
     #[inline]
     fn check_integer(&self, val: i64) -> bool {
         match &self.hashed {
-            HashedValues::Integers(set) => set.contains(val),
+            HashedValues::Integers { set, has_i64_min } => {
+                if val == i64::MIN {
+                    *has_i64_min
+                } else {
+                    set.contains(val)
+                }
+            }
             _ => {
                 // Fallback to linear search. Float list values compare
                 // numerically first: as_int64 would truncate 5.5 to 5 and

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -1693,7 +1693,9 @@ impl MVCCTable {
             }
         }
 
-        let mut result = RowVec::with_capacity(limit);
+        // A user-supplied limit can be i64::MAX; only pre-allocate what
+        // can actually be returned
+        let mut result = RowVec::with_capacity(limit.min(4096));
         let mut count = 0;
 
         // Add global rows that don't have local overrides

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -189,9 +189,12 @@ impl MVCCTable {
             return None;
         }
 
-        // Get the integer value (PKs are always integers in our system)
+        // Get the integer value (PKs are always integers in our system).
+        // i64::MIN is the row-id maps' reserved empty sentinel, so no row
+        // can carry it: decline the fast path and let the scan return
+        // nothing rather than probing with the sentinel
         match value {
-            Value::Integer(i) => Some(*i),
+            Value::Integer(i) if *i != i64::MIN => Some(*i),
             _ => None,
         }
     }
@@ -1251,7 +1254,11 @@ impl MVCCTable {
         }
 
         // Fallback: If no primary key or not an integer, generate a synthetic row ID
-        self.version_store.get_next_auto_increment_id()
+        // Synthetic row id for non-integer primary keys; the caller
+        // rejects the exhausted case via prepare_insert
+        self.version_store
+            .try_next_auto_increment_id()
+            .unwrap_or(i64::MIN)
     }
 
     /// Finds the primary key column index
@@ -1317,7 +1324,15 @@ impl MVCCTable {
                 if value.is_null() {
                     if is_auto_increment {
                         // Generate new ID for NULL primary key
-                        let next_id = self.version_store.get_next_auto_increment_id();
+                        let next_id =
+                            self.version_store
+                                .try_next_auto_increment_id()
+                                .ok_or_else(|| {
+                                    Error::invalid_argument(format!(
+                                        "AUTO_INCREMENT counter exhausted for column '{}'",
+                                        pk_col.name
+                                    ))
+                                })?;
                         let _ = row.set(pk_idx, Value::Integer(next_id));
                     } else {
                         // Non-INTEGER PRIMARY KEY without AUTO_INCREMENT cannot be NULL
@@ -1347,9 +1362,14 @@ impl MVCCTable {
         // the reserved empty sentinel of the row-id maps, so it cannot
         // address a row. Report it instead of corrupting the map.
         if row_id == i64::MIN {
-            return Err(Error::internal(
-                "PRIMARY KEY value -9223372036854775808 is out of range (reserved)".to_string(),
-            ));
+            return Err(Error::invalid_argument(format!(
+                "PRIMARY KEY value {} is out of range (reserved) for column '{}'",
+                i64::MIN,
+                self.cached_schema
+                    .pk_column_index()
+                    .map(|i| self.cached_schema.columns[i].name.as_str())
+                    .unwrap_or("?"),
+            )));
         }
 
         // Check if row already exists in local versions

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -653,9 +653,24 @@ impl VersionStore {
         self.auto_increment_counter.load(Ordering::Acquire)
     }
 
-    /// Returns the next available auto-increment ID
-    pub fn get_next_auto_increment_id(&self) -> i64 {
-        self.auto_increment_counter.fetch_add(1, Ordering::AcqRel) + 1
+    /// Returns the next available auto-increment ID, or None when the
+    /// counter is exhausted. A plain fetch_add would overflow past
+    /// i64::MAX: a panic in debug, and in release a wrap to i64::MIN that
+    /// poisons every later id.
+    pub fn try_next_auto_increment_id(&self) -> Option<i64> {
+        let mut current = self.auto_increment_counter.load(Ordering::Acquire);
+        loop {
+            let next = current.checked_add(1)?;
+            match self.auto_increment_counter.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return Some(next),
+                Err(observed) => current = observed,
+            }
+        }
     }
 
     /// Sets the auto-increment counter to a specific value (only if current is lower)
@@ -2602,7 +2617,9 @@ impl VersionStore {
         };
 
         // Collect with early termination
-        let mut result = RowVec::with_capacity(limit);
+        // A user-supplied limit can be i64::MAX; only pre-allocate what
+        // the store could actually return
+        let mut result = RowVec::with_capacity(limit.min(4096));
         let mut skipped = 0usize;
 
         for (&row_id, chain) in versions.iter() {
@@ -3057,7 +3074,9 @@ impl VersionStore {
         };
 
         // Collect with early termination
-        let mut result = RowVec::with_capacity(limit);
+        // A user-supplied limit can be i64::MAX; only pre-allocate what
+        // the store could actually return
+        let mut result = RowVec::with_capacity(limit.min(4096));
 
         if ascending {
             for (&row_id, chain) in versions.range((start_bound, std::ops::Bound::Unbounded::<i64>))
@@ -3265,7 +3284,9 @@ impl VersionStore {
         let arena_data = arena_guard.data();
 
         // Collect with offset/limit and early termination
-        let mut result = RowVec::with_capacity(limit);
+        // A user-supplied limit can be i64::MAX; only pre-allocate what
+        // the store could actually return
+        let mut result = RowVec::with_capacity(limit.min(4096));
         let mut skipped = 0usize;
 
         for (&row_id, chain) in versions.iter() {
@@ -6087,7 +6108,13 @@ impl VersionStore {
                             key_type = 0;
                         }
                         if key_type == 0 {
-                            Some(*i)
+                            // i64::MIN is I64Map's empty sentinel - route to
+                            // other_groups, as the Float branch below does
+                            if *i == i64::MIN {
+                                None
+                            } else {
+                                Some(*i)
+                            }
                         } else {
                             None // Type mismatch → other_groups
                         }
@@ -6649,6 +6676,11 @@ impl TransactionVersionStore {
 
     /// Check if we have local changes for a row
     pub fn has_locally_seen(&self, row_id: i64) -> bool {
+        // The row-id maps reserve i64::MIN as their empty sentinel, so
+        // no row can carry it; answer without touching the map
+        if row_id == i64::MIN {
+            return false;
+        }
         self.local_versions
             .as_ref()
             .is_some_and(|lv| lv.contains_key(row_id))
@@ -6705,6 +6737,9 @@ impl TransactionVersionStore {
     /// Get the local version for a row (without checking parent)
     /// Returns the most recent version in the transaction's history
     pub fn get_local_version(&self, row_id: i64) -> Option<&RowVersion> {
+        if row_id == i64::MIN {
+            return None; // reserved sentinel: no row can carry it
+        }
         self.local_versions
             .as_ref()
             .and_then(|lv| lv.get(row_id))
@@ -6713,6 +6748,9 @@ impl TransactionVersionStore {
 
     /// Get a row, checking local versions first then parent store
     pub fn get(&self, row_id: i64) -> Option<Row> {
+        if row_id == i64::MIN {
+            return None; // reserved sentinel: no row can carry it
+        }
         // Check local versions first (get most recent)
         if let Some(lv) = self.local_versions.as_ref() {
             if let Some(versions) = lv.get(row_id) {
@@ -7542,8 +7580,8 @@ mod tests {
         let store = VersionStore::new("test_table".to_string(), test_schema());
 
         assert_eq!(store.get_current_auto_increment_value(), 0);
-        assert_eq!(store.get_next_auto_increment_id(), 1);
-        assert_eq!(store.get_next_auto_increment_id(), 2);
+        assert_eq!(store.try_next_auto_increment_id(), Some(1));
+        assert_eq!(store.try_next_auto_increment_id(), Some(2));
         assert_eq!(store.get_current_auto_increment_value(), 2);
     }
 

--- a/tests/panic_edges_test.rs
+++ b/tests/panic_edges_test.rs
@@ -314,3 +314,112 @@ fn auto_increment_exhaustion_reports_cleanly() {
     let c: i64 = db.query_one("SELECT COUNT(*) FROM t", ()).unwrap();
     assert_eq!(c, 1);
 }
+
+#[test]
+fn huge_limit_inside_transaction() {
+    // The local-changes path builds its own result buffer
+    let db = Database::open("memory://panic_limit_tx").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 1), (2, 2)", ())
+        .unwrap();
+
+    let mut tx = db.begin().unwrap();
+    tx.execute("INSERT INTO t VALUES (3, 3)", ()).unwrap();
+    let n = tx
+        .query("SELECT * FROM t LIMIT 9223372036854775807", ())
+        .unwrap()
+        .collect_vec()
+        .unwrap()
+        .len();
+    assert_eq!(n, 3);
+    tx.commit().unwrap();
+}
+
+#[test]
+fn huge_limit_with_cte_join() {
+    let db = Database::open("memory://panic_limit_cte").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 1..=20i64 {
+        tx.execute("INSERT INTO t VALUES ($1, $2)", (i, i)).unwrap();
+    }
+    tx.commit().unwrap();
+
+    let n = db
+        .query(
+            "WITH c AS (SELECT id, v FROM t WHERE v > 5) \
+             SELECT c.id FROM c JOIN t ON t.id = c.id LIMIT 9223372036854775807",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap()
+        .len();
+    assert_eq!(n, 15);
+}
+
+#[test]
+fn i64_min_join_key_against_pk() {
+    // A non-PK column may legally hold i64::MIN; joining it against a PK
+    // can never match, but it must not panic on the way there
+    let db = Database::open("memory://panic_join_sentinel").unwrap();
+    db.execute(
+        "CREATE TABLE outer_t (id INTEGER PRIMARY KEY, k INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE inner_t (id INTEGER PRIMARY KEY, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 1..=50i64 {
+        tx.execute("INSERT INTO inner_t VALUES ($1, $2)", (i, i * 2))
+            .unwrap();
+        tx.execute("INSERT INTO outer_t VALUES ($1, $2)", (i, i))
+            .unwrap();
+    }
+    tx.execute("INSERT INTO outer_t VALUES ($1, $2)", (100i64, i64::MIN))
+        .unwrap();
+    tx.commit().unwrap();
+
+    let c: i64 = db
+        .query_one(
+            "SELECT COUNT(*) FROM outer_t o JOIN inner_t i ON i.id = o.k",
+            (),
+        )
+        .unwrap();
+    assert_eq!(c, 50, "the sentinel key matches nothing");
+}
+
+#[test]
+fn i64_min_not_in_subquery_on_pk() {
+    let db = Database::open("memory://panic_not_in_sub").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE ex (id INTEGER PRIMARY KEY, k INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 1..=30i64 {
+        tx.execute("INSERT INTO t VALUES ($1, $2)", (i, i)).unwrap();
+    }
+    tx.execute("INSERT INTO ex VALUES (1, $1)", (i64::MIN,))
+        .unwrap();
+    tx.execute("INSERT INTO ex VALUES (2, 5)", ()).unwrap();
+    tx.commit().unwrap();
+
+    let c: i64 = db
+        .query_one(
+            "SELECT COUNT(*) FROM t WHERE id NOT IN (SELECT k FROM ex)",
+            (),
+        )
+        .unwrap();
+    assert_eq!(c, 29, "only id = 5 is excluded");
+    let n = db
+        .execute("DELETE FROM t WHERE id IN (SELECT k FROM ex)", ())
+        .unwrap();
+    assert_eq!(n, 1);
+}

--- a/tests/panic_edges_test.rs
+++ b/tests/panic_edges_test.rs
@@ -58,11 +58,14 @@ fn presorted_window_without_limit_does_not_overflow() {
         (),
     )
     .unwrap();
-    db.execute(
-        "INSERT INTO ps VALUES (1,30,1), (2,10,2), (3,20,3), (4,10,4)",
-        (),
-    )
-    .unwrap();
+    // More than 98 rows: in release the old code wrapped the batch size
+    // to 98 and silently truncated instead of panicking
+    let mut tx = db.begin().unwrap();
+    for i in 1..=200i64 {
+        tx.execute("INSERT INTO ps VALUES ($1, $2, $3)", (i, (i * 7) % 200, i))
+            .unwrap();
+    }
+    tx.commit().unwrap();
     db.execute("CREATE INDEX idx_psv ON ps(v)", ()).unwrap();
 
     let rows = db
@@ -73,7 +76,11 @@ fn presorted_window_without_limit_does_not_overflow() {
         .unwrap()
         .collect_vec()
         .unwrap();
-    assert_eq!(rows.len(), 4);
+    assert_eq!(
+        rows.len(),
+        200,
+        "every row must come back, not the wrapped 98"
+    );
 }
 
 #[cfg(feature = "test-filedb")]
@@ -84,12 +91,226 @@ fn i64_min_primary_key_rejected_on_persistent_tables() {
     let db = Database::open(&dsn).unwrap();
     db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
         .unwrap();
+    // Seal rows into cold segments first, so the rejected insert really
+    // crosses the segmented-table path
+    let mut tx = db.begin().unwrap();
+    for i in 1..=60i64 {
+        tx.execute("INSERT INTO t VALUES ($1, $2)", (i, i)).unwrap();
+    }
+    tx.commit().unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+
     let err = db
         .execute("INSERT INTO t VALUES ($1, $2)", (i64::MIN, 7i64))
         .expect_err("i64::MIN primary key must be rejected on file DBs too");
     assert!(err.to_string().contains("-9223372036854775808"));
-    db.execute("INSERT INTO t VALUES ($1, $2)", (1i64, 2i64))
+    db.execute("INSERT INTO t VALUES ($1, $2)", (1000i64, 2i64))
         .unwrap();
+    let c: i64 = db.query_one("SELECT COUNT(*) FROM t", ()).unwrap();
+    assert_eq!(c, 61);
+}
+
+#[test]
+fn i64_min_lookup_in_transaction_finds_nothing() {
+    // No row can carry the sentinel id, so every lookup shape must
+    // report "not found" instead of reaching the row-id map
+    let db = Database::open("memory://panic_i64min_lookup").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10)", ()).unwrap();
+
+    // Autocommit
+    let rows = db
+        .query("SELECT v FROM t WHERE id = $1", (i64::MIN,))
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert!(rows.is_empty());
+
+    // Inside a transaction with uncommitted changes to the same table
+    let mut tx = db.begin().unwrap();
+    tx.execute("INSERT INTO t VALUES (2, 20)", ()).unwrap();
+    let rows = tx
+        .query("SELECT v FROM t WHERE id = $1", (i64::MIN,))
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert!(rows.is_empty(), "sentinel lookup must not match a row");
+    let n = tx
+        .execute("UPDATE t SET v = 99 WHERE id = $1", (i64::MIN,))
+        .unwrap();
+    assert_eq!(n, 0);
+    let n = tx
+        .execute("DELETE FROM t WHERE id = $1", (i64::MIN,))
+        .unwrap();
+    assert_eq!(n, 0);
+    tx.commit().unwrap();
+
+    let c: i64 = db.query_one("SELECT COUNT(*) FROM t", ()).unwrap();
+    assert_eq!(c, 2);
+}
+
+#[cfg(feature = "test-filedb")]
+#[test]
+fn i64_min_lookup_on_persistent_table_finds_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let dsn = format!("file://{}", dir.path().display());
+    let db = Database::open(&dsn).unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 1..=50i64 {
+        tx.execute("INSERT INTO t VALUES ($1, $2)", (i, i * 2))
+            .unwrap();
+    }
+    tx.commit().unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+
+    // After sealing, the lookup crosses the cold-segment path too
+    let rows = db
+        .query("SELECT v FROM t WHERE id = $1", (i64::MIN,))
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert!(rows.is_empty());
+    let mut tx = db.begin().unwrap();
+    tx.execute("INSERT INTO t VALUES (100, 200)", ()).unwrap();
+    let rows = tx
+        .query("SELECT v FROM t WHERE id = $1", (i64::MIN,))
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert!(rows.is_empty());
+    tx.rollback().unwrap();
+}
+
+#[test]
+fn i64_min_in_list_is_matchable() {
+    let db = Database::open("memory://panic_i64min_in").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, $1)", (i64::MIN,))
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (2, 3)", ()).unwrap();
+
+    let c: i64 = db
+        .query_one(
+            "SELECT COUNT(*) FROM t WHERE v IN (-9223372036854775808)",
+            (),
+        )
+        .unwrap();
+    assert_eq!(c, 1);
+    let c: i64 = db
+        .query_one(
+            "SELECT COUNT(*) FROM t WHERE v IN (1, 2, -9223372036854775808)",
+            (),
+        )
+        .unwrap();
+    assert_eq!(c, 1);
+    let c: i64 = db
+        .query_one(
+            "SELECT COUNT(*) FROM t WHERE v NOT IN (-9223372036854775808)",
+            (),
+        )
+        .unwrap();
+    assert_eq!(c, 1);
+    // PK column IN-list takes the index probe path
+    let c: i64 = db
+        .query_one(
+            "SELECT COUNT(*) FROM t WHERE id IN (-9223372036854775808, 1)",
+            (),
+        )
+        .unwrap();
+    assert_eq!(c, 1);
+}
+
+#[test]
+fn i64_min_group_by_value() {
+    let db = Database::open("memory://panic_i64min_group").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, $1)", (i64::MIN,))
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (2, 3)", ()).unwrap();
+    db.execute("INSERT INTO t VALUES (3, $1)", (i64::MIN,))
+        .unwrap();
+
+    let rows = db
+        .query("SELECT v, COUNT(*) FROM t GROUP BY v ORDER BY v", ())
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+    let first: i64 = rows[0].get(0).unwrap();
+    let first_count: i64 = rows[0].get(1).unwrap();
+    assert_eq!(first, i64::MIN);
+    assert_eq!(first_count, 2);
+    let s: i64 = db
+        .query_one("SELECT SUM(id) FROM t GROUP BY v ORDER BY v LIMIT 1", ())
+        .unwrap();
+    assert_eq!(s, 4);
+}
+
+#[test]
+fn huge_limit_does_not_abort() {
+    let db = Database::open("memory://panic_huge_limit").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    for i in 1..=10i64 {
+        tx.execute("INSERT INTO t VALUES ($1, $2)", (i, i % 3))
+            .unwrap();
+    }
+    tx.commit().unwrap();
+
+    let n = db
+        .query("SELECT * FROM t LIMIT 9223372036854775807", ())
+        .unwrap()
+        .collect_vec()
+        .unwrap()
+        .len();
+    assert_eq!(n, 10);
+    let n = db
+        .query(
+            "SELECT id, ROW_NUMBER() OVER (PARTITION BY v) FROM t LIMIT 9223372036854775807",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap()
+        .len();
+    assert_eq!(n, 10);
+    let n = db
+        .query(
+            "SELECT id, ROW_NUMBER() OVER (ORDER BY v) FROM t ORDER BY id \
+             LIMIT 9223372036854775807 OFFSET 3",
+            (),
+        )
+        .unwrap()
+        .collect_vec()
+        .unwrap()
+        .len();
+    assert_eq!(n, 7);
+}
+
+#[test]
+fn auto_increment_exhaustion_reports_cleanly() {
+    let db = Database::open("memory://panic_autoinc").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO t VALUES (9223372036854775807, 1)", ())
+        .unwrap();
+    let err = db
+        .execute("INSERT INTO t (v) VALUES (2)", ())
+        .expect_err("exhausted auto-increment must report, not wrap");
+    assert!(
+        err.to_string().to_lowercase().contains("auto"),
+        "error should mention auto-increment, got: {err}"
+    );
+    // The id space must stay intact
     let c: i64 = db.query_one("SELECT COUNT(*) FROM t", ()).unwrap();
     assert_eq!(c, 1);
 }


### PR DESCRIPTION
Follow-up to #56. The adversarial round on that PR showed its framing was wrong: guarding INSERT closed one door of a class that stays open in four other places, all reachable from plain SQL. This closes the rest.

## Panics fixed (each with a red-first test)

1. **PK lookup of i64::MIN inside a transaction.** After the transaction had written any row, `SELECT/UPDATE/DELETE ... WHERE id = -9223372036854775808` panicked in `I64Map::get`. The PK fast path declines the sentinel, and the transaction-local accessors (`get`, `get_local_version`, `has_locally_seen`) answer "not found" without touching the map, so callers that bypass the fast path are safe too. Notably #56's error message made this worse in effect: a user told the value is rejected on INSERT would reasonably expect lookups to be handled.
2. **`IN (-9223372036854775808)`.** Building the hashed integer set inserted the sentinel. It is tracked out of band beside the set, the same shape `pk.rs` already uses. Covered for IN, NOT IN, mixed lists, and the PK index-probe path.
3. **`GROUP BY` over a non-PK INTEGER column holding i64::MIN.** Both grouping fast paths crashed. The storage path routes the sentinel to the generic group map (its Float branch already did exactly this), and the executor's single-column fast path declines so the general path handles it.
4. **Large but legal LIMIT.** `SELECT * FROM t LIMIT 9223372036854775807` aborted the process at `Vec::with_capacity`. Five capacity sites clamp now (three in the version store, two window paths, the TopN heap). Note the heap site is the cautionary one: it already used `saturating_add` and then handed the saturated value straight to `with_capacity`.
5. **AUTO_INCREMENT past i64::MAX.** `fetch_add` panicked in debug; in release it wrapped the counter to i64::MIN, so every later row got a negative id and #56's guard then reported a "primary key out of range" error for a statement that supplied no primary key. The counter is fallible now and reports exhaustion against the column name.

## Review notes also addressed

- The primary-key rejection is an `invalid_argument` naming the value and column, not `Error::internal`.
- The presorted-window test now uses 200 rows: in release the old arithmetic wrapped to a batch size of 98, so the 4-row fixture passed there and only covered the debug panic, not the silent truncation.
- The persistent tests seal cold segments (`PRAGMA CHECKPOINT`) before asserting, so they exercise the segmented path rather than the hot table.

## Still open (deliberately)

`src/storage/index/pk.rs` carries `has_i64_min` machinery documented as existing because `I64Set` reserves the sentinel, so that layer believes i64::MIN is a legal row id while `prepare_insert` rejects it. Resolving that contradiction (either tolerate the sentinel in the row-id maps or delete the dead flag) is a design call, not a panic fix.

## Verification

Both suites 4962/4964, differential oracle 9/9, CI-mode 9/9, fmt + clippy clean.
