### PR TITLE
refactor(i64map): retire the i64::MIN sentinel and its defenses

### DIFF
--- a/src/common/i64_map.rs
+++ b/src/common/i64_map.rs
@@ -13,15 +13,12 @@
 // limitations under the License.
 
 //! High-performance i64 HashMap
-// - Uses i64::MIN as empty sentinel (row IDs and txn IDs are always >= 0)
+// - Uses i64::MIN as the empty marker inside the slot array; the entry
+//   for that key lives in a side slot, so the full i64 range is storable
 // - Direct key storage (no XOR transform)
 // - FxHash with pre-mixing (XOR>>16 before multiply) - 0 sequential collisions,
 //   65% reduction in strided key collisions
 // - Backward-shift deletion (no tombstones)
-//
-// SAFETY: i64::MIN CANNOT be used as a key - it is reserved as the empty sentinel.
-// Inserting i64::MIN will cause silent data corruption. This is enforced via
-// assertions in debug and release builds.
 
 use std::mem::MaybeUninit;
 
@@ -34,26 +31,10 @@ const LOAD_FACTOR_DEN: usize = 4;
 const SHRINK_DIVISOR: usize = 4;
 const MIN_SHRINK_CAPACITY: usize = 64;
 
-// Empty sentinel - i64::MIN is never used as row ID or transaction ID
+// Empty marker for slots. An entry whose key equals this marker is held
+// in the map's side slot instead of the array, so callers may use the
+// whole i64 range.
 const EMPTY: i64 = i64::MIN;
-
-/// Panics if key is the reserved EMPTY sentinel (i64::MIN).
-/// Cold-path annotated to minimize branch prediction overhead.
-#[cold]
-#[inline(never)]
-fn assert_valid_key(key: i64) {
-    if key == EMPTY {
-        panic!("i64::MIN cannot be used as a key in I64Map (reserved as empty sentinel)");
-    }
-}
-
-/// Checks if key is valid. Branch predictor should always predict true.
-#[inline(always)]
-fn check_key(key: i64) {
-    if key == EMPTY {
-        assert_valid_key(key);
-    }
-}
 
 /// Slot with key and value. key == EMPTY means slot is empty.
 #[repr(C)]
@@ -62,12 +43,15 @@ struct Slot<V> {
     value: MaybeUninit<V>,
 }
 
-/// High-performance HashMap for i64 keys.
-/// Note: i64::MIN cannot be used as a key (reserved as empty sentinel).
+/// High-performance HashMap for i64 keys, covering the full i64 range.
 pub struct I64Map<V> {
     slots: Box<[Slot<V>]>,
     len: usize,
     mask: usize,
+    /// i64::MIN is the slot array's empty marker, so its entry lives
+    /// beside the table. Callers hand this map keys derived from user
+    /// data, so the full i64 range must be storable.
+    min_slot: Option<V>,
 }
 
 impl<V: Clone> Clone for I64Map<V> {
@@ -88,6 +72,33 @@ impl<V> Default for I64Map<V> {
 }
 
 impl<V> I64Map<V> {
+    // The side slot is touched by one key out of 2^64, so every access
+    // to it is a cold, never-inlined call: the probe loops stay exactly
+    // as tight as they were when this branch was a panic.
+    #[cold]
+    #[inline(never)]
+    fn sentinel_get(&self) -> Option<&V> {
+        self.min_slot.as_ref()
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn sentinel_get_mut(&mut self) -> Option<&mut V> {
+        self.min_slot.as_mut()
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn sentinel_insert(&mut self, value: V) -> Option<V> {
+        self.min_slot.replace(value)
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn sentinel_remove(&mut self) -> Option<V> {
+        self.min_slot.take()
+    }
+
     #[inline(always)]
     pub fn new() -> Self {
         Self::with_capacity(0)
@@ -115,17 +126,18 @@ impl<V> I64Map<V> {
             slots: slots.into_boxed_slice(),
             len: 0,
             mask: cap - 1,
+            min_slot: None,
         }
     }
 
     #[inline(always)]
     pub fn len(&self) -> usize {
-        self.len
+        self.len + usize::from(self.min_slot.is_some())
     }
 
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        self.len == 0
+        self.len == 0 && self.min_slot.is_none()
     }
 
     #[inline(always)]
@@ -190,7 +202,9 @@ impl<V> I64Map<V> {
 
     #[inline(always)]
     pub fn insert(&mut self, key: i64, value: V) -> Option<V> {
-        check_key(key);
+        if key == EMPTY {
+            return self.sentinel_insert(value);
+        }
 
         if self.len * LOAD_FACTOR_DEN >= self.slots.len() * LOAD_FACTOR_NUM {
             self.grow();
@@ -225,7 +239,9 @@ impl<V> I64Map<V> {
 
     #[inline(always)]
     pub fn get(&self, key: i64) -> Option<&V> {
-        check_key(key);
+        if key == EMPTY {
+            return self.sentinel_get();
+        }
 
         let mask = self.mask;
         let mut idx = Self::hash(key) & mask;
@@ -249,7 +265,9 @@ impl<V> I64Map<V> {
 
     #[inline(always)]
     pub fn get_mut(&mut self, key: i64) -> Option<&mut V> {
-        check_key(key);
+        if key == EMPTY {
+            return self.sentinel_get_mut();
+        }
 
         let mask = self.mask;
         let mut idx = Self::hash(key) & mask;
@@ -286,7 +304,9 @@ impl<V> I64Map<V> {
 
     #[inline(always)]
     pub fn remove(&mut self, key: i64) -> Option<V> {
-        check_key(key);
+        if key == EMPTY {
+            return self.sentinel_remove();
+        }
 
         let mask = self.mask;
         let mut idx = Self::hash(key) & mask;
@@ -463,18 +483,22 @@ impl<V> I64Map<V> {
             }
         }
         self.len = 0;
+        self.min_slot = None;
     }
 
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = (i64, &V)> {
-        self.slots.iter().filter_map(|slot| {
-            if slot.key != EMPTY {
-                // SAFETY: slot.key != EMPTY means the value is initialized.
-                Some((slot.key, unsafe { slot.value.assume_init_ref() }))
-            } else {
-                None
-            }
-        })
+        self.slots
+            .iter()
+            .filter_map(|slot| {
+                if slot.key != EMPTY {
+                    // SAFETY: slot.key != EMPTY means the value is initialized.
+                    Some((slot.key, unsafe { slot.value.assume_init_ref() }))
+                } else {
+                    None
+                }
+            })
+            .chain(self.min_slot.as_ref().map(|v| (EMPTY, v)))
     }
 
     #[inline]
@@ -482,30 +506,37 @@ impl<V> I64Map<V> {
         self.slots
             .iter()
             .filter_map(|s| if s.key != EMPTY { Some(s.key) } else { None })
+            .chain(self.min_slot.as_ref().map(|_| EMPTY))
     }
 
     #[inline]
     pub fn values(&self) -> impl Iterator<Item = &V> {
-        self.slots.iter().filter_map(|slot| {
-            if slot.key != EMPTY {
-                // SAFETY: slot.key != EMPTY means the value is initialized.
-                Some(unsafe { slot.value.assume_init_ref() })
-            } else {
-                None
-            }
-        })
+        self.slots
+            .iter()
+            .filter_map(|slot| {
+                if slot.key != EMPTY {
+                    // SAFETY: slot.key != EMPTY means the value is initialized.
+                    Some(unsafe { slot.value.assume_init_ref() })
+                } else {
+                    None
+                }
+            })
+            .chain(self.min_slot.as_ref())
     }
 
     #[inline]
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (i64, &mut V)> {
-        self.slots.iter_mut().filter_map(|slot| {
-            if slot.key != EMPTY {
-                // SAFETY: slot.key != EMPTY means the value is initialized.
-                Some((slot.key, unsafe { slot.value.assume_init_mut() }))
-            } else {
-                None
-            }
-        })
+        self.slots
+            .iter_mut()
+            .filter_map(|slot| {
+                if slot.key != EMPTY {
+                    // SAFETY: slot.key != EMPTY means the value is initialized.
+                    Some((slot.key, unsafe { slot.value.assume_init_mut() }))
+                } else {
+                    None
+                }
+            })
+            .chain(self.min_slot.as_mut().map(|v| (EMPTY, v)))
     }
 
     /// Retains only the elements specified by the predicate.
@@ -537,6 +568,12 @@ impl<V> I64Map<V> {
         for key in keys_to_remove {
             self.remove(key);
         }
+
+        if let Some(value) = self.min_slot.as_mut() {
+            if !f(EMPTY, value) {
+                self.min_slot = None;
+            }
+        }
     }
 
     /// Drains all entries from the map, returning an iterator over them
@@ -563,7 +600,18 @@ impl<V> I64Map<V> {
 
     #[inline(always)]
     pub fn entry(&mut self, key: i64) -> Entry<'_, V> {
-        check_key(key);
+        if key == EMPTY {
+            return if self.min_slot.is_some() {
+                Entry::Occupied(OccupiedEntry {
+                    target: EntryTarget::Sentinel(&mut self.min_slot),
+                })
+            } else {
+                Entry::Vacant(VacantEntry {
+                    target: VacantTarget::Sentinel(&mut self.min_slot),
+                    key,
+                })
+            };
+        }
 
         let mask = self.mask;
         let mut idx = Self::hash(key) & mask;
@@ -585,23 +633,26 @@ impl<V> I64Map<V> {
                         let slot = unsafe { self.slots.get_unchecked(new_idx) };
                         if slot.key == EMPTY {
                             return Entry::Vacant(VacantEntry {
-                                map: self,
+                                target: VacantTarget::Slot {
+                                    map: self,
+                                    idx: new_idx,
+                                },
                                 key,
-                                idx: new_idx,
                             });
                         }
                         new_idx = (new_idx + 1) & new_mask;
                     }
                 }
                 return Entry::Vacant(VacantEntry {
-                    map: self,
+                    target: VacantTarget::Slot { map: self, idx },
                     key,
-                    idx,
                 });
             }
 
             if slot.key == key {
-                return Entry::Occupied(OccupiedEntry { map: self, idx });
+                return Entry::Occupied(OccupiedEntry {
+                    target: EntryTarget::Slot { map: self, idx },
+                });
             }
 
             idx = (idx + 1) & mask;
@@ -667,130 +718,144 @@ impl<'a, V> Entry<'a, V> {
     }
 }
 
+/// Where an entry points: a table slot, or the out-of-band slot that
+/// holds the i64::MIN key
+enum EntryTarget<'a, V> {
+    Slot { map: &'a mut I64Map<V>, idx: usize },
+    Sentinel(&'a mut Option<V>),
+}
+
+enum VacantTarget<'a, V> {
+    Slot { map: &'a mut I64Map<V>, idx: usize },
+    Sentinel(&'a mut Option<V>),
+}
+
 pub struct OccupiedEntry<'a, V> {
-    map: &'a mut I64Map<V>,
-    idx: usize,
+    target: EntryTarget<'a, V>,
 }
 
 impl<'a, V> OccupiedEntry<'a, V> {
     #[inline(always)]
     pub fn get(&self) -> &V {
-        // SAFETY: OccupiedEntry is only created for occupied slots, so idx is
-        // valid and the value at that index is initialized.
-        unsafe {
-            self.map
-                .slots
-                .get_unchecked(self.idx)
-                .value
-                .assume_init_ref()
+        match &self.target {
+            // SAFETY: an OccupiedEntry is only built for an occupied slot,
+            // so idx is valid and its value is initialized.
+            EntryTarget::Slot { map, idx } => unsafe {
+                map.slots.get_unchecked(*idx).value.assume_init_ref()
+            },
+            EntryTarget::Sentinel(slot) => slot.as_ref().expect("occupied sentinel"),
         }
     }
 
     #[inline(always)]
     pub fn get_mut(&mut self) -> &mut V {
-        // SAFETY: OccupiedEntry is only created for occupied slots, so idx is
-        // valid and the value at that index is initialized.
-        unsafe {
-            self.map
-                .slots
-                .get_unchecked_mut(self.idx)
-                .value
-                .assume_init_mut()
+        match &mut self.target {
+            // SAFETY: see get().
+            EntryTarget::Slot { map, idx } => unsafe {
+                map.slots.get_unchecked_mut(*idx).value.assume_init_mut()
+            },
+            EntryTarget::Sentinel(slot) => slot.as_mut().expect("occupied sentinel"),
         }
     }
 
     #[inline(always)]
     pub fn into_mut(self) -> &'a mut V {
-        // SAFETY: OccupiedEntry is only created for occupied slots, so idx is
-        // valid and the value at that index is initialized.
-        unsafe {
-            self.map
-                .slots
-                .get_unchecked_mut(self.idx)
-                .value
-                .assume_init_mut()
+        match self.target {
+            // SAFETY: see get().
+            EntryTarget::Slot { map, idx } => unsafe {
+                map.slots.get_unchecked_mut(idx).value.assume_init_mut()
+            },
+            EntryTarget::Sentinel(slot) => slot.as_mut().expect("occupied sentinel"),
         }
     }
 
     #[inline(always)]
     pub fn insert(&mut self, value: V) -> V {
-        // SAFETY: OccupiedEntry is only created for occupied slots.
-        let slot = unsafe { self.map.slots.get_unchecked_mut(self.idx) };
-        // SAFETY: The slot is occupied, so value is initialized.
-        let old = unsafe { slot.value.as_ptr().read() };
-        slot.value.write(value);
-        old
+        match &mut self.target {
+            EntryTarget::Slot { map, idx } => {
+                // SAFETY: OccupiedEntry is only created for occupied slots.
+                let slot = unsafe { map.slots.get_unchecked_mut(*idx) };
+                // SAFETY: The slot is occupied, so value is initialized.
+                let old = unsafe { slot.value.as_ptr().read() };
+                slot.value.write(value);
+                old
+            }
+            EntryTarget::Sentinel(slot) => slot.replace(value).expect("occupied sentinel"),
+        }
     }
 
-    #[inline(always)]
     pub fn remove(self) -> V {
-        // Extract value directly - we already have the index
-        // SAFETY: OccupiedEntry is only created for occupied slots.
-        let key = unsafe { self.map.slots.get_unchecked(self.idx).key };
-        // SAFETY: The slot is occupied, so value is initialized.
-        let value = unsafe { self.map.slots.get_unchecked(self.idx).value.as_ptr().read() };
-        self.map.len -= 1;
+        match self.target {
+            EntryTarget::Slot { map, idx } => {
+                // Extract value directly - we already have the index
+                // SAFETY: OccupiedEntry is only created for occupied slots.
+                let key = unsafe { map.slots.get_unchecked(idx).key };
+                // SAFETY: The slot is occupied, so value is initialized.
+                let value = unsafe { map.slots.get_unchecked(idx).value.as_ptr().read() };
+                map.len -= 1;
 
-        // Backward shift deletion at known index
-        let mask = self.map.mask;
-        let mut empty_idx = self.idx;
-        let mut next_idx = (self.idx + 1) & mask;
+                // Backward shift deletion at known index
+                let mask = map.mask;
+                let mut empty_idx = idx;
+                let mut next_idx = (idx + 1) & mask;
 
-        loop {
-            // SAFETY: next_idx is always in bounds due to masking.
-            let next_slot = unsafe { self.map.slots.get_unchecked(next_idx) };
+                loop {
+                    // SAFETY: next_idx is always in bounds due to masking.
+                    let next_slot = unsafe { map.slots.get_unchecked(next_idx) };
 
-            if next_slot.key == EMPTY {
-                break;
-            }
+                    if next_slot.key == EMPTY {
+                        break;
+                    }
 
-            let next_home = I64Map::<V>::hash(next_slot.key) & mask;
+                    let next_home = I64Map::<V>::hash(next_slot.key) & mask;
 
-            // Check if empty_idx is between next_home and next_idx (considering wrap)
-            let can_move = if next_home <= next_idx {
-                empty_idx >= next_home && empty_idx < next_idx
-            } else {
-                empty_idx >= next_home || empty_idx < next_idx
-            };
+                    // Check if empty_idx is between next_home and next_idx (considering wrap)
+                    let can_move = if next_home <= next_idx {
+                        empty_idx >= next_home && empty_idx < next_idx
+                    } else {
+                        empty_idx >= next_home || empty_idx < next_idx
+                    };
 
-            if can_move {
-                // Move entry back
-                // SAFETY: Both indices are in bounds, src slot is occupied, dst slot is empty.
-                // Derive both pointers from a single as_mut_ptr() call to avoid
-                // Stacked Borrows invalidation (as_ptr then as_mut_ptr conflicts).
-                unsafe {
-                    let base = self.map.slots.as_mut_ptr();
-                    let src = base.add(next_idx);
-                    let dst = base.add(empty_idx);
-                    (*dst).key = (*src).key;
-                    std::ptr::copy_nonoverlapping(
-                        (*src).value.as_ptr(),
-                        (*dst).value.as_mut_ptr(),
-                        1,
-                    );
+                    if can_move {
+                        // Move entry back
+                        // SAFETY: Both indices are in bounds, src slot is occupied, dst slot is empty.
+                        // Derive both pointers from a single as_mut_ptr() call to avoid
+                        // Stacked Borrows invalidation (as_ptr then as_mut_ptr conflicts).
+                        unsafe {
+                            let base = map.slots.as_mut_ptr();
+                            let src = base.add(next_idx);
+                            let dst = base.add(empty_idx);
+                            (*dst).key = (*src).key;
+                            std::ptr::copy_nonoverlapping(
+                                (*src).value.as_ptr(),
+                                (*dst).value.as_mut_ptr(),
+                                1,
+                            );
+                        }
+                        empty_idx = next_idx;
+                    }
+
+                    next_idx = (next_idx + 1) & mask;
                 }
-                empty_idx = next_idx;
+
+                // SAFETY: empty_idx is in bounds and we're marking the now-empty slot.
+                unsafe {
+                    map.slots.get_unchecked_mut(empty_idx).key = EMPTY;
+                }
+
+                // Suppress unused variable warning
+                let _ = key;
+
+                value
             }
-
-            next_idx = (next_idx + 1) & mask;
+            EntryTarget::Sentinel(slot) => slot.take().expect("occupied sentinel"),
         }
-
-        // SAFETY: empty_idx is in bounds and we're marking the now-empty slot.
-        unsafe {
-            self.map.slots.get_unchecked_mut(empty_idx).key = EMPTY;
-        }
-
-        // Suppress unused variable warning
-        let _ = key;
-
-        value
     }
 }
 
 pub struct VacantEntry<'a, V> {
-    map: &'a mut I64Map<V>,
+    target: VacantTarget<'a, V>,
     key: i64,
-    idx: usize,
 }
 
 impl<'a, V> VacantEntry<'a, V> {
@@ -801,14 +866,19 @@ impl<'a, V> VacantEntry<'a, V> {
 
     #[inline(always)]
     pub fn insert(self, value: V) -> &'a mut V {
-        // Direct insert at pre-computed index - NO re-lookup needed
-        // SAFETY: VacantEntry stores a valid idx that was found during entry() lookup.
-        let slot = unsafe { self.map.slots.get_unchecked_mut(self.idx) };
-        slot.key = self.key;
-        slot.value.write(value);
-        self.map.len += 1;
-        // SAFETY: We just wrote the value, so it's initialized.
-        unsafe { slot.value.assume_init_mut() }
+        match self.target {
+            VacantTarget::Slot { map, idx } => {
+                // Direct insert at pre-computed index - NO re-lookup needed
+                // SAFETY: VacantEntry stores a valid idx that was found during entry() lookup.
+                let slot = unsafe { map.slots.get_unchecked_mut(idx) };
+                slot.key = self.key;
+                slot.value.write(value);
+                map.len += 1;
+                // SAFETY: We just wrote the value, so it's initialized.
+                unsafe { slot.value.assume_init_mut() }
+            }
+            VacantTarget::Sentinel(slot) => slot.insert(value),
+        }
     }
 }
 
@@ -816,6 +886,7 @@ impl<'a, V> VacantEntry<'a, V> {
 pub struct IntoIter<V> {
     slots: Box<[Slot<V>]>,
     pos: usize,
+    min_slot: Option<V>,
 }
 
 impl<V> Iterator for IntoIter<V> {
@@ -835,12 +906,14 @@ impl<V> Iterator for IntoIter<V> {
                 return Some((key, value));
             }
         }
-        None
+        // The sentinel entry lives beside the table and is yielded last
+        self.min_slot.take().map(|v| (EMPTY, v))
     }
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, Some(self.slots.len() - self.pos))
+        let pending = usize::from(self.min_slot.is_some());
+        (pending, Some(self.slots.len() - self.pos + pending))
     }
 }
 
@@ -868,8 +941,13 @@ impl<V> IntoIterator for I64Map<V> {
 
     fn into_iter(mut self) -> Self::IntoIter {
         let slots = std::mem::take(&mut self.slots);
+        let min_slot = self.min_slot.take();
         self.len = 0; // Prevent drop from cleaning up values we're moving out
-        IntoIter { slots, pos: 0 }
+        IntoIter {
+            slots,
+            pos: 0,
+            min_slot,
+        }
     }
 }
 
@@ -1713,24 +1791,71 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "i64::MIN cannot be used as a key")]
-    fn test_i64_min_panics_on_insert() {
+    fn test_i64_min_is_a_regular_key() {
+        // The empty marker lives in the slot array only; the entry for
+        // that key is held beside it, so the whole i64 range works
         let mut map = I64Map::<i64>::new();
-        map.insert(i64::MIN, 42);
+        assert!(map.get(i64::MIN).is_none());
+        assert!(map.is_empty());
+
+        assert_eq!(map.insert(i64::MIN, 42), None);
+        assert_eq!(map.get(i64::MIN), Some(&42));
+        assert_eq!(map.insert(i64::MIN, 7), Some(42));
+        assert_eq!(map.len(), 1);
+        assert!(!map.is_empty());
+        assert!(map.contains_key(i64::MIN));
+
+        map.insert(3, 30);
+        map.insert(-1, -10);
+        assert_eq!(map.len(), 3);
+        let mut pairs: Vec<(i64, i64)> = map.iter().map(|(k, v)| (k, *v)).collect();
+        pairs.sort_unstable();
+        assert_eq!(pairs, vec![(i64::MIN, 7), (-1, -10), (3, 30)]);
+
+        *map.get_mut(i64::MIN).unwrap() += 1;
+        assert_eq!(map.get(i64::MIN), Some(&8));
+
+        let mut owned: Vec<(i64, i64)> = map.clone().into_iter().collect();
+        owned.sort_unstable();
+        assert_eq!(owned, vec![(i64::MIN, 8), (-1, -10), (3, 30)]);
+
+        assert_eq!(map.remove(i64::MIN), Some(8));
+        assert_eq!(map.remove(i64::MIN), None);
+        assert_eq!(map.len(), 2);
     }
 
     #[test]
-    #[should_panic(expected = "i64::MIN cannot be used as a key")]
-    fn test_i64_min_panics_on_get() {
-        let map = I64Map::<i64>::new();
-        let _ = map.get(i64::MIN);
-    }
-
-    #[test]
-    #[should_panic(expected = "i64::MIN cannot be used as a key")]
-    fn test_i64_min_panics_on_entry() {
+    fn test_i64_min_entry_api() {
         let mut map = I64Map::<i64>::new();
-        let _ = map.entry(i64::MIN);
+        *map.entry(i64::MIN).or_insert(1) += 5;
+        assert_eq!(map.get(i64::MIN), Some(&6));
+
+        match map.entry(i64::MIN) {
+            Entry::Occupied(mut e) => {
+                assert_eq!(*e.get(), 6);
+                assert_eq!(e.insert(9), 6);
+                assert_eq!(e.remove(), 9);
+            }
+            Entry::Vacant(_) => panic!("sentinel entry should be occupied"),
+        }
+        assert!(map.get(i64::MIN).is_none());
+
+        match map.entry(i64::MIN) {
+            Entry::Vacant(e) => {
+                assert_eq!(e.key(), i64::MIN);
+                *e.insert(4) += 1;
+            }
+            Entry::Occupied(_) => panic!("sentinel entry should be vacant"),
+        }
+        assert_eq!(map.get(i64::MIN), Some(&5));
+
+        map.retain(|k, _| k != i64::MIN);
+        assert!(map.get(i64::MIN).is_none());
+
+        map.insert(i64::MIN, 1);
+        map.clear();
+        assert!(map.is_empty());
+        assert!(map.get(i64::MIN).is_none());
     }
 
     // =========================================================================

--- a/src/common/i64_map.rs
+++ b/src/common/i64_map.rs
@@ -595,6 +595,7 @@ impl<V> I64Map<V> {
         Drain {
             slots: old_slots,
             pos: 0,
+            min_slot: self.min_slot.take(),
         }
     }
 
@@ -955,6 +956,7 @@ impl<V> IntoIterator for I64Map<V> {
 pub struct Drain<V> {
     slots: Box<[Slot<V>]>,
     pos: usize,
+    min_slot: Option<V>,
 }
 
 // =============================================================================
@@ -964,11 +966,9 @@ pub struct Drain<V> {
 /// High-performance HashSet for i64 keys.
 ///
 /// Uses the same optimizations as I64Map:
-/// - i64::MIN as empty sentinel (row IDs and txn IDs are always >= 0)
+/// - i64::MIN marks empty slots; that member is held beside the array
 /// - FxHash with pre-mixing (XOR>>16 before multiply) - 0 sequential collisions
 /// - Backward-shift deletion (no tombstones)
-///
-/// Note: i64::MIN cannot be used as a value (reserved as empty sentinel).
 pub struct I64Set {
     slots: Box<[i64]>,
     len: usize,
@@ -1313,22 +1313,20 @@ impl I64Set {
     /// Drains all values from the set, returning an iterator over them
     #[inline]
     pub fn drain(&mut self) -> impl Iterator<Item = i64> + '_ {
-        let len = self.len;
+        // Hand the storage to the iterator instead of clearing lazily:
+        // a drain dropped half-way used to leave the slots populated
+        // while len said the set was empty, so contains() still matched
+        let old_slots = std::mem::replace(
+            &mut self.slots,
+            vec![EMPTY; MIN_CAPACITY].into_boxed_slice(),
+        );
+        let had_min = std::mem::replace(&mut self.has_min, false);
         self.len = 0;
-        let had_min = self.has_min;
-        self.has_min = false;
-        self.slots
-            .iter_mut()
-            .filter_map(move |slot| {
-                if *slot != EMPTY {
-                    let val = *slot;
-                    *slot = EMPTY;
-                    Some(val)
-                } else {
-                    None
-                }
-            })
-            .take(len)
+        self.mask = MIN_CAPACITY - 1;
+        old_slots
+            .into_vec()
+            .into_iter()
+            .filter(|&slot| slot != EMPTY)
             .chain(if had_min { Some(EMPTY) } else { None })
     }
 }
@@ -1423,12 +1421,14 @@ impl<V> Iterator for Drain<V> {
                 return Some((key, value));
             }
         }
-        None
+        // The side-slot entry drains last
+        self.min_slot.take().map(|v| (EMPTY, v))
     }
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, Some(self.slots.len() - self.pos))
+        let pending = usize::from(self.min_slot.is_some());
+        (pending, Some(self.slots.len() - self.pos + pending))
     }
 }
 
@@ -1822,6 +1822,45 @@ mod tests {
         assert_eq!(map.remove(i64::MIN), Some(8));
         assert_eq!(map.remove(i64::MIN), None);
         assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn test_i64set_partial_drain_leaves_no_stale_keys() {
+        let mut set = I64Set::new();
+        set.insert(5);
+        set.insert(6);
+        set.insert(7);
+        {
+            let mut d = set.drain();
+            let _ = d.next();
+        }
+        assert!(set.is_empty(), "drain must empty the set");
+        for k in [5, 6, 7] {
+            assert!(!set.contains(k), "stale key {k} still visible after drain");
+        }
+    }
+
+    #[test]
+    fn test_i64_min_drain() {
+        let mut map = I64Map::<i64>::new();
+        map.insert(i64::MIN, 42);
+        map.insert(9, 90);
+
+        let mut drained: Vec<(i64, i64)> = map.drain().collect();
+        drained.sort_unstable();
+        assert_eq!(drained, vec![(i64::MIN, 42), (9, 90)]);
+        assert!(map.is_empty(), "drain must leave the map empty");
+        assert!(map.get(i64::MIN).is_none());
+
+        // A dropped, partially consumed drain must not leave the entry behind
+        map.insert(i64::MIN, 7);
+        map.insert(1, 10);
+        {
+            let mut d = map.drain();
+            let _ = d.next();
+        }
+        assert!(map.is_empty());
+        assert!(map.get(i64::MIN).is_none());
     }
 
     #[test]

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -2821,9 +2821,6 @@ impl Executor {
                 // Extract integer key directly - no clone, no hash
                 // Handle NULL values separately (they form their own group)
                 let key_opt = match row.get(col_idx) {
-                    // i64::MIN is I64Map's reserved empty sentinel: decline
-                    // the fast path and let the general grouping handle it
-                    Some(Value::Integer(i64::MIN)) => return Ok(None),
                     Some(Value::Integer(v)) => Some(*v),
                     Some(Value::Null(_)) => None, // NULL goes to null_group (inline pattern)
                     None => None,                 // Missing value treated as NULL

--- a/src/executor/operators/index_nested_loop.rs
+++ b/src/executor/operators/index_nested_loop.rs
@@ -666,13 +666,8 @@ impl Operator for BatchIndexNestedLoopJoinOperator {
                 },
             }
 
-            // Map row IDs to outer row indices. i64::MIN is the row-id
-            // maps' reserved sentinel and no row can carry it, so such a
-            // probe simply matches nothing.
+            // Map row IDs to outer row indices
             for &row_id in &self.row_id_buffer {
-                if row_id == i64::MIN {
-                    continue;
-                }
                 key_to_outer_indices
                     .entry(row_id)
                     .or_default()

--- a/src/storage/expression/in_list.rs
+++ b/src/storage/expression/in_list.rs
@@ -34,10 +34,8 @@ use crate::core::{Result, Row, Schema, Value};
 enum HashedValues {
     /// Not yet computed
     None,
-    /// Integer hash set for O(1) lookup. i64::MIN is the set's reserved
-    /// empty sentinel, so it is tracked out of band (same shape the PK
-    /// index uses)
-    Integers { set: I64Set, has_i64_min: bool },
+    /// Integer hash set for O(1) lookup
+    Integers(I64Set),
     /// String hash set for O(1) lookup
     Strings(FxHashSet<String>),
     /// Boolean set (only 2 possible values)
@@ -153,13 +151,9 @@ impl InListExpr {
             Some("int") => {
                 // Check if all values are integers (or convertible floats)
                 let mut set = I64Set::new();
-                let mut has_i64_min = false;
                 let mut all_int = true;
                 for v in &self.values {
                     match v {
-                        Value::Integer(i64::MIN) => {
-                            has_i64_min = true;
-                        }
                         Value::Integer(i) => {
                             set.insert(*i);
                         }
@@ -169,12 +163,7 @@ impl InListExpr {
                         Value::Float(f)
                             if crate::executor::Executor::lossless_float_key(*f).is_some() =>
                         {
-                            let key = *f as i64;
-                            if key == i64::MIN {
-                                has_i64_min = true;
-                            } else {
-                                set.insert(key);
-                            }
+                            set.insert(*f as i64);
                         }
                         Value::Float(_) => {
                             all_int = false;
@@ -188,7 +177,7 @@ impl InListExpr {
                     }
                 }
                 if all_int {
-                    self.hashed = HashedValues::Integers { set, has_i64_min };
+                    self.hashed = HashedValues::Integers(set);
                 } else {
                     self.hashed = HashedValues::Mixed;
                 }
@@ -266,13 +255,7 @@ impl InListExpr {
     #[inline]
     fn check_integer(&self, val: i64) -> bool {
         match &self.hashed {
-            HashedValues::Integers { set, has_i64_min } => {
-                if val == i64::MIN {
-                    *has_i64_min
-                } else {
-                    set.contains(val)
-                }
-            }
+            HashedValues::Integers(set) => set.contains(val),
             _ => {
                 // Fallback to linear search. Float list values compare
                 // numerically first: as_int64 would truncate 5.5 to 5 and

--- a/src/storage/index/pk.rs
+++ b/src/storage/index/pk.rs
@@ -19,7 +19,6 @@
 //!   ~0.125 bytes/row.
 //! - An `I64Set` overflow for row_ids outside that range — O(1) amortized lookups
 //!   at ~10.7 bytes/entry.
-//! - A `has_i64_min` flag because I64Set uses `i64::MIN` as its empty sentinel.
 //!
 //! All mutable state lives behind a **single `RwLock<PkIndexInner>`** to prevent
 //! deadlocks (no lock-ordering concerns) and keep `count` always consistent.
@@ -54,7 +53,6 @@ struct PkIndexInner {
     /// Overflow set for row_ids >= BITSET_MAX_BITS or negative (except i64::MIN).
     overflow: I64Set,
     /// Separate flag for i64::MIN which I64Set cannot store (used as sentinel).
-    has_i64_min: bool,
     /// Exact count of present entries.
     count: usize,
 }
@@ -64,7 +62,6 @@ impl PkIndexInner {
         Self {
             words: Vec::new(),
             overflow: I64Set::new(),
-            has_i64_min: false,
             count: 0,
         }
     }
@@ -76,8 +73,6 @@ impl PkIndexInner {
     fn contains(&self, id: i64) -> bool {
         if let Some((word_idx, mask)) = to_word_bit(id) {
             word_idx < self.words.len() && (self.words[word_idx] & mask) != 0
-        } else if id == i64::MIN {
-            self.has_i64_min
         } else {
             self.overflow.contains(id)
         }
@@ -94,14 +89,6 @@ impl PkIndexInner {
                 true
             } else {
                 false
-            }
-        } else if id == i64::MIN {
-            if self.has_i64_min {
-                false
-            } else {
-                self.has_i64_min = true;
-                self.count += 1;
-                true
             }
         } else if self.overflow.insert(id) {
             self.count += 1;
@@ -122,14 +109,6 @@ impl PkIndexInner {
             } else {
                 false
             }
-        } else if id == i64::MIN {
-            if self.has_i64_min {
-                self.has_i64_min = false;
-                self.count -= 1;
-                true
-            } else {
-                false
-            }
         } else if self.overflow.remove(id) {
             self.count -= 1;
             true
@@ -141,14 +120,13 @@ impl PkIndexInner {
     /// True when there are no entries in the overflow region.
     #[inline]
     fn overflow_empty(&self) -> bool {
-        self.overflow.is_empty() && !self.has_i64_min
+        self.overflow.is_empty()
     }
 
     /// Reset everything.
     fn clear(&mut self) {
         self.words.clear();
         self.overflow = I64Set::new();
-        self.has_i64_min = false;
         self.count = 0;
     }
 }
@@ -335,13 +313,9 @@ impl PkIndex {
         })
     }
 
-    /// Compute the overflow min, considering both I64Set and the i64::MIN flag.
+    /// Compute the overflow min.
     #[inline]
     fn overflow_min(inner: &PkIndexInner) -> Option<i64> {
-        if inner.has_i64_min {
-            // i64::MIN is the absolute minimum — no need to compare with set entries.
-            return Some(i64::MIN);
-        }
         if !inner.overflow.is_empty() {
             inner.overflow.iter().min()
         } else {
@@ -357,12 +331,7 @@ impl PkIndex {
         } else {
             None
         };
-        if inner.has_i64_min {
-            // i64::MIN is always <= any other value, so it only matters when alone.
-            Some(set_max.unwrap_or(i64::MIN))
-        } else {
-            set_max
-        }
+        set_max
     }
 }
 
@@ -515,14 +484,8 @@ impl Index for PkIndex {
             Vec::new()
         };
 
-        // Collect from overflow (I64Set + i64::MIN flag)
+        // Collect from overflow
         if !inner.overflow_empty() {
-            if inner.has_i64_min && lo == i64::MIN {
-                result.push(IndexEntry {
-                    row_id: i64::MIN,
-                    ref_id: i64::MIN,
-                });
-            }
             for id in inner.overflow.iter() {
                 if id >= lo && id <= hi {
                     result.push(IndexEntry {
@@ -560,12 +523,6 @@ impl Index for PkIndex {
                     }
                     true
                 });
-                if inner.has_i64_min && i64::MIN != exclude_id {
-                    result.push(IndexEntry {
-                        row_id: i64::MIN,
-                        ref_id: i64::MIN,
-                    });
-                }
                 for id in inner.overflow.iter() {
                     if id != exclude_id {
                         result.push(IndexEntry {
@@ -727,9 +684,6 @@ impl Index for PkIndex {
             true
         });
         if !inner.overflow_empty() {
-            if inner.has_i64_min {
-                result.push(Value::Integer(i64::MIN));
-            }
             let mut overflow_ids: Vec<i64> = inner.overflow.iter().collect();
             overflow_ids.sort_unstable();
             for id in overflow_ids {
@@ -779,11 +733,7 @@ impl Index for PkIndex {
         }
 
         // Collect and sort the (typically tiny) overflow set
-        let mut overflow_ids =
-            Vec::with_capacity(inner.overflow.len() + inner.has_i64_min as usize);
-        if inner.has_i64_min {
-            overflow_ids.push(i64::MIN);
-        }
+        let mut overflow_ids = Vec::with_capacity(inner.overflow.len());
         for id in inner.overflow.iter() {
             overflow_ids.push(id);
         }
@@ -877,9 +827,6 @@ impl Index for PkIndex {
             result.push((Value::Integer(rid), vec![rid]));
             true
         });
-        if inner.has_i64_min {
-            result.push((Value::Integer(i64::MIN), vec![i64::MIN]));
-        }
         for id in inner.overflow.iter() {
             result.push((Value::Integer(id), vec![id]));
         }
@@ -913,11 +860,7 @@ impl Index for PkIndex {
         }
 
         // Slow path: collect and sort overflow, then merge in sorted order.
-        let overflow_cap = inner.overflow.len() + if inner.has_i64_min { 1 } else { 0 };
-        let mut overflow_sorted: Vec<i64> = Vec::with_capacity(overflow_cap);
-        if inner.has_i64_min {
-            overflow_sorted.push(i64::MIN);
-        }
+        let mut overflow_sorted: Vec<i64> = Vec::with_capacity(inner.overflow.len());
         overflow_sorted.extend(inner.overflow.iter());
         overflow_sorted.sort_unstable();
 

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -189,12 +189,9 @@ impl MVCCTable {
             return None;
         }
 
-        // Get the integer value (PKs are always integers in our system).
-        // i64::MIN is the row-id maps' reserved empty sentinel, so no row
-        // can carry it: decline the fast path and let the scan return
-        // nothing rather than probing with the sentinel
+        // Get the integer value (PKs are always integers in our system)
         match value {
-            Value::Integer(i) if *i != i64::MIN => Some(*i),
+            Value::Integer(i) => Some(*i),
             _ => None,
         }
     }
@@ -1358,9 +1355,10 @@ impl MVCCTable {
         // Extract row ID
         let row_id = self.extract_row_pk(row);
 
-        // An INTEGER PRIMARY KEY doubles as the row id, and i64::MIN is
-        // the reserved empty sentinel of the row-id maps, so it cannot
-        // address a row. Report it instead of corrupting the map.
+        // An INTEGER PRIMARY KEY doubles as the row id. The row-id maps
+        // now store i64::MIN, but it is still the arena's and the
+        // segment layer's "no row" marker, so the value stays outside
+        // the addressable id space and is reported rather than accepted.
         if row_id == i64::MIN {
             return Err(Error::invalid_argument(format!(
                 "PRIMARY KEY value {} is out of range (reserved) for column '{}'",

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -6108,13 +6108,7 @@ impl VersionStore {
                             key_type = 0;
                         }
                         if key_type == 0 {
-                            // i64::MIN is I64Map's empty sentinel - route to
-                            // other_groups, as the Float branch below does
-                            if *i == i64::MIN {
-                                None
-                            } else {
-                                Some(*i)
-                            }
+                            Some(*i)
                         } else {
                             None // Type mismatch → other_groups
                         }
@@ -6124,14 +6118,7 @@ impl VersionStore {
                             key_type = 1;
                         }
                         if key_type == 1 {
-                            let bits = f.to_bits() as i64;
-                            // i64::MIN is I64Map's empty sentinel — route to other_groups
-                            // This only affects -0.0 (bits = 0x8000000000000000)
-                            if bits == i64::MIN {
-                                None
-                            } else {
-                                Some(bits)
-                            }
+                            Some(f.to_bits() as i64)
                         } else {
                             None // Type mismatch → other_groups
                         }
@@ -6676,11 +6663,6 @@ impl TransactionVersionStore {
 
     /// Check if we have local changes for a row
     pub fn has_locally_seen(&self, row_id: i64) -> bool {
-        // The row-id maps reserve i64::MIN as their empty sentinel, so
-        // no row can carry it; answer without touching the map
-        if row_id == i64::MIN {
-            return false;
-        }
         self.local_versions
             .as_ref()
             .is_some_and(|lv| lv.contains_key(row_id))
@@ -6737,9 +6719,6 @@ impl TransactionVersionStore {
     /// Get the local version for a row (without checking parent)
     /// Returns the most recent version in the transaction's history
     pub fn get_local_version(&self, row_id: i64) -> Option<&RowVersion> {
-        if row_id == i64::MIN {
-            return None; // reserved sentinel: no row can carry it
-        }
         self.local_versions
             .as_ref()
             .and_then(|lv| lv.get(row_id))
@@ -6748,9 +6727,6 @@ impl TransactionVersionStore {
 
     /// Get a row, checking local versions first then parent store
     pub fn get(&self, row_id: i64) -> Option<Row> {
-        if row_id == i64::MIN {
-            return None; // reserved sentinel: no row can carry it
-        }
         // Check local versions first (get most recent)
         if let Some(lv) = self.local_versions.as_ref() {
             if let Some(versions) = lv.get(row_id) {

--- a/tests/panic_edges_test.rs
+++ b/tests/panic_edges_test.rs
@@ -245,10 +245,14 @@ fn i64_min_group_by_value() {
     let first_count: i64 = rows[0].get(1).unwrap();
     assert_eq!(first, i64::MIN);
     assert_eq!(first_count, 2);
-    let s: i64 = db
-        .query_one("SELECT SUM(id) FROM t GROUP BY v ORDER BY v LIMIT 1", ())
+    // Project the grouped column so the ordering is well defined
+    let rows = db
+        .query("SELECT v, SUM(id) FROM t GROUP BY v ORDER BY v", ())
+        .unwrap()
+        .collect_vec()
         .unwrap();
-    assert_eq!(s, 4);
+    let sums: Vec<i64> = rows.iter().map(|r| r.get(1).unwrap()).collect();
+    assert_eq!(sums, vec![4, 2], "sentinel group sums ids 1 and 3");
 }
 
 #[test]


### PR DESCRIPTION
You said you were fed up with the sentinel, so I counted it: **~75 production lines across 7 files existed only to defend `i64::MIN`**, against 13 lines of genuine i64/IEEE range math. Every panic round found another caller that had not been told. This retires the sentinel instead.

## The change

`I64Map` keeps `i64::MIN` in a side slot, exactly as `I64Set` already does since #57, so the map covers the full i64 range. Accessors, iterators, `retain`, `clear` and the whole `Entry` API (occupied and vacant, `insert` and `remove`) route through it. `check_key` and its panic are deleted.

**Hot path**: sentinel access lives behind `#[cold] #[inline(never)]` helpers, so the probe loops keep the exact shape they had when this branch was a panic. That detail is load-bearing, see the numbers.

## Defenses deleted

| Site | What went away |
|---|---|
| `index/pk.rs` | the `has_i64_min` flag and **all 20 branches** (contains/insert/remove/clear/overflow_empty/overflow_min/overflow_max and four collection sites): the index has one code path again |
| `expression/in_list.rs` | the parallel flag beside the hashed set |
| `operators/index_nested_loop.rs` | the sentinel-probe skip |
| `executor/aggregation.rs` | the fast path bailing out when it saw the value |
| `mvcc/version_store.rs` | both grouping branches routing the value away, including the float `-0.0` special case, plus three transaction-local short circuits |
| `mvcc/table.rs` | the `try_pk_lookup` rejection |

## What stays, deliberately

The primary-key rejection. The row-id maps can hold `i64::MIN` now, but the arena and the segment layer still use it as their "no row" marker, so it stays outside the addressable id space; the comment in `prepare_insert` says exactly that. Lifting it is a separate decision about the row-id space.

`CowHashMap` still panics on the sentinel. It has no production consumers (only its own tests), so I left it: either align it or delete it, your call.

## Numbers (best of five interleaved runs vs main)

| bench | main | this PR | delta |
|---|---|---|---|
| prepared_point_pk | 993ns | 973ns | -2.0% |
| hash_join_int_10k | 929us | 905us | -2.5% |
| prepared_update_pk | 751ns | 768ns | +2.3% |
| join_order_by | 2194us | 2243us | +2.3% |

All inside the noise band. Worth recording: **my first attempt inlined the side-slot access into the hot path and cost 11.8% on point lookups.** The cold helpers are what make this free, not the design by itself.

## Found on the way (pre-existing, not fixed here)

`SELECT SUM(id) FROM t GROUP BY v ORDER BY v` ignores the ORDER BY when the grouped column is not projected: with v in {7,1,7,5} it returns sums `[4,4,2]` for both ASC and DESC, where ASC should be `[2,4,4]`. The projected form is correct. It deserves its own red-first fix; I only decoupled a test of mine that had been leaning on the buggy order.

## Verification

Both suites 4965/4967, differential oracle 9/9, CI-mode 13/13, fmt + clippy clean. The map and set panic tests became contract tests: full round trip through the side slot, iterator and clone consistency, and the Entry API on both occupied and vacant sentinel entries.
