### PR TITLE
fix(common): identify columns by content, guard retain and drain

### DIFF
--- a/src/common/compact_vec.rs
+++ b/src/common/compact_vec.rs
@@ -417,13 +417,18 @@ impl<T> CompactVec<T> {
                     }
                 }
                 guard.write_idx += 1;
+                guard.read_idx += 1;
             } else {
+                // Advance past the slot before dropping it: if `T::drop`
+                // panics, the guard must not count this element as untouched
+                // tail and hand the dropped value back to the vector.
+                let idx = guard.read_idx;
+                guard.read_idx += 1;
                 // SAFETY: the element is initialized and is not moved anywhere.
                 unsafe {
-                    ptr::drop_in_place(ptr.add(guard.read_idx));
+                    ptr::drop_in_place(ptr.add(idx));
                 }
             }
-            guard.read_idx += 1;
         }
     }
 
@@ -1053,13 +1058,19 @@ impl<'a, T> ExactSizeIterator for Drain<'a, T> {
 
 impl<'a, T> Drop for Drain<'a, T> {
     fn drop(&mut self) {
-        // Drop any remaining elements not yet consumed
-        while self.current < self.end {
-            // SAFETY: Elements [current..end] are initialized but not yet consumed.
+        let remaining = self.end - self.current;
+        if remaining > 0 {
+            let first = self.current;
+            self.current = self.end;
+            // Drop the rest as a slice: slice drop glue keeps dropping the
+            // remaining elements when one destructor panics, where an
+            // element-by-element loop would strand them. The vector no longer
+            // owns this range, so nothing else would ever free them.
+            // SAFETY: [first..end] are initialized and owned by this drain.
             unsafe {
-                ptr::drop_in_place(self.vec.ptr.as_ptr().add(self.current));
+                let start = self.vec.ptr.as_ptr().add(first);
+                ptr::drop_in_place(ptr::slice_from_raw_parts_mut(start, remaining));
             }
-            self.current += 1;
         }
         // The length was already lowered to `start` by `drain()`, so there is
         // nothing to restore here.
@@ -1317,6 +1328,86 @@ mod tests {
             DROP_COUNT.load(Ordering::SeqCst),
             5,
             "each of the 5 elements must be dropped exactly once"
+        );
+    }
+
+    /// A destructor that panics while `retain` is dropping a rejected element
+    /// must not hand that element back to the vector.
+    #[test]
+    fn test_retain_destructor_panic_does_not_double_drop() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+        static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+        static PANICKED: AtomicBool = AtomicBool::new(false);
+
+        struct PanicOnDrop(usize);
+
+        impl Drop for PanicOnDrop {
+            fn drop(&mut self) {
+                DROP_COUNT.fetch_add(1, Ordering::SeqCst);
+                // Panic once, so a second drop of the same slot is observable
+                // in the counter instead of aborting the process.
+                if self.0 == 2 && !PANICKED.swap(true, Ordering::SeqCst) {
+                    panic!("intentional panic in destructor");
+                }
+            }
+        }
+
+        DROP_COUNT.store(0, Ordering::SeqCst);
+        PANICKED.store(false, Ordering::SeqCst);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut vec: CompactVec<PanicOnDrop> = CompactVec::new();
+            for i in 0..5 {
+                vec.push(PanicOnDrop(i));
+            }
+            vec.retain(|item| item.0 != 2);
+        }));
+
+        assert!(result.is_err(), "the destructor panic must propagate");
+        assert_eq!(
+            DROP_COUNT.load(Ordering::SeqCst),
+            5,
+            "each of the 5 elements must be dropped exactly once"
+        );
+    }
+
+    /// A destructor that panics while a Drain is cleaning up must not strand
+    /// the elements behind it: the vector no longer owns them.
+    #[test]
+    fn test_drain_drop_finishes_after_destructor_panic() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+        static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+        static PANICKED: AtomicBool = AtomicBool::new(false);
+
+        struct PanicOnDrop(usize);
+
+        impl Drop for PanicOnDrop {
+            fn drop(&mut self) {
+                DROP_COUNT.fetch_add(1, Ordering::SeqCst);
+                if self.0 == 2 && !PANICKED.swap(true, Ordering::SeqCst) {
+                    panic!("intentional panic in destructor");
+                }
+            }
+        }
+
+        DROP_COUNT.store(0, Ordering::SeqCst);
+        PANICKED.store(false, Ordering::SeqCst);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut vec: CompactVec<PanicOnDrop> = CompactVec::new();
+            for i in 0..5 {
+                vec.push(PanicOnDrop(i));
+            }
+            drop(vec.drain(1..));
+        }));
+
+        assert!(result.is_err(), "the destructor panic must propagate");
+        assert_eq!(
+            DROP_COUNT.load(Ordering::SeqCst),
+            5,
+            "the drain must drop 1..5 and the vector must drop 0, none stranded"
         );
     }
 

--- a/src/common/compact_vec.rs
+++ b/src/common/compact_vec.rs
@@ -360,32 +360,70 @@ impl<T> CompactVec<T> {
     where
         F: FnMut(&T) -> bool,
     {
-        let len = self.len();
-        let ptr = self.ptr.as_ptr();
-        let mut write_idx = 0;
+        let original_len = self.len();
 
-        for read_idx in 0..len {
-            // SAFETY: read_idx < len, so the element is valid and initialized.
-            // We either keep it (move to write_idx) or drop it.
-            unsafe {
-                let elem = &*ptr.add(read_idx);
-                if f(elem) {
-                    // Keep this element
-                    if write_idx != read_idx {
-                        // Move element from read_idx to write_idx
-                        ptr::copy_nonoverlapping(ptr.add(read_idx), ptr.add(write_idx), 1);
+        // The vector disowns its elements while they are being shifted; the
+        // guard hands back exactly the surviving ones, even if `f` panics.
+        // SAFETY: the guard below restores a correct length in every exit path.
+        unsafe {
+            self.set_len(0);
+        }
+
+        struct RetainGuard<'a, T> {
+            vec: &'a mut CompactVec<T>,
+            read_idx: usize,
+            write_idx: usize,
+            original_len: usize,
+        }
+
+        impl<T> Drop for RetainGuard<'_, T> {
+            fn drop(&mut self) {
+                let tail = self.original_len - self.read_idx;
+                if tail > 0 && self.write_idx != self.read_idx {
+                    // SAFETY: [read_idx..original_len] is still initialized and
+                    // write_idx < read_idx, so the move is backwards in place.
+                    unsafe {
+                        let ptr = self.vec.ptr.as_ptr();
+                        ptr::copy(ptr.add(self.read_idx), ptr.add(self.write_idx), tail);
                     }
-                    write_idx += 1;
-                } else {
-                    // Drop this element
-                    ptr::drop_in_place(ptr.add(read_idx));
+                }
+                // SAFETY: exactly write_idx + tail elements are initialized.
+                unsafe {
+                    self.vec.set_len(self.write_idx + tail);
                 }
             }
         }
 
-        // SAFETY: write_idx <= len, and exactly write_idx elements are initialized.
-        unsafe {
-            self.set_len(write_idx);
+        let mut guard = RetainGuard {
+            vec: self,
+            read_idx: 0,
+            write_idx: 0,
+            original_len,
+        };
+
+        while guard.read_idx < original_len {
+            let ptr = guard.vec.ptr.as_ptr();
+            // SAFETY: read_idx < original_len, so the element is initialized.
+            let keep = unsafe { f(&*ptr.add(guard.read_idx)) };
+            if keep {
+                if guard.write_idx != guard.read_idx {
+                    // SAFETY: write_idx < read_idx, so the two slots are distinct.
+                    unsafe {
+                        ptr::copy_nonoverlapping(
+                            ptr.add(guard.read_idx),
+                            ptr.add(guard.write_idx),
+                            1,
+                        );
+                    }
+                }
+                guard.write_idx += 1;
+            } else {
+                // SAFETY: the element is initialized and is not moved anywhere.
+                unsafe {
+                    ptr::drop_in_place(ptr.add(guard.read_idx));
+                }
+            }
+            guard.read_idx += 1;
         }
     }
 
@@ -590,9 +628,15 @@ impl<T> CompactVec<T> {
         let len = self.len();
         assert!(start <= len, "drain start index out of bounds");
 
+        // Shorten the vector before yielding anything: a Drain that is leaked
+        // after moving elements out must not leave them owned by the vector.
+        // SAFETY: start <= len, and [0..start] stays initialized.
+        unsafe {
+            self.set_len(start);
+        }
+
         Drain {
             vec: self,
-            start,
             current: start,
             end: len,
         }
@@ -975,7 +1019,6 @@ impl<T> From<CompactVec<T>> for Vec<T> {
 /// Removes elements from the vector as they are iterated.
 pub struct Drain<'a, T> {
     vec: &'a mut CompactVec<T>,
-    start: usize,
     current: usize,
     end: usize,
 }
@@ -1018,12 +1061,8 @@ impl<'a, T> Drop for Drain<'a, T> {
             }
             self.current += 1;
         }
-
-        // SAFETY: Elements [0..start] are still valid, elements [start..end] have
-        // been consumed or dropped, so we set len to start.
-        unsafe {
-            self.vec.set_len(self.start);
-        }
+        // The length was already lowered to `start` by `drain()`, so there is
+        // nothing to restore here.
     }
 }
 
@@ -1240,6 +1279,88 @@ mod tests {
 
         let cloned = vec.clone();
         assert_eq!(cloned[0], "hello");
+    }
+
+    /// A retain predicate that panics must not leave the vector holding
+    /// duplicated elements: every element is dropped exactly once.
+    #[test]
+    fn test_retain_panic_does_not_double_drop() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+        struct Tracked(usize);
+
+        impl Drop for Tracked {
+            fn drop(&mut self) {
+                DROP_COUNT.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        DROP_COUNT.store(0, Ordering::SeqCst);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut vec: CompactVec<Tracked> = CompactVec::new();
+            for i in 0..5 {
+                vec.push(Tracked(i));
+            }
+            vec.retain(|item| {
+                if item.0 == 3 {
+                    panic!("intentional panic in retain predicate");
+                }
+                item.0 != 2
+            });
+        }));
+
+        assert!(result.is_err(), "the predicate panic must propagate");
+        assert_eq!(
+            DROP_COUNT.load(Ordering::SeqCst),
+            5,
+            "each of the 5 elements must be dropped exactly once"
+        );
+    }
+
+    /// A partially consumed Drain that is forgotten must leave the vector at
+    /// the drain start, so the consumed elements are not dropped a second time.
+    #[test]
+    fn test_forgotten_drain_does_not_double_drop() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+        struct Tracked;
+
+        impl Drop for Tracked {
+            fn drop(&mut self) {
+                DROP_COUNT.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        DROP_COUNT.store(0, Ordering::SeqCst);
+
+        let mut vec: CompactVec<Tracked> = CompactVec::new();
+        for _ in 0..4 {
+            vec.push(Tracked);
+        }
+
+        let mut drain = vec.drain(2..);
+        let taken = drain.next();
+        assert!(taken.is_some());
+        drop(taken);
+        std::mem::forget(drain);
+
+        assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            vec.len(),
+            2,
+            "drain must lower the length before yielding elements"
+        );
+
+        drop(vec);
+
+        // 0 and 1 are dropped with the vector, 2 was dropped above, 3 is leaked
+        // by mem::forget. Nothing is dropped twice.
+        assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 3);
     }
 
     /// Test panic safety in Clone implementation

--- a/src/executor/expression/evaluator_bridge.rs
+++ b/src/executor/expression/evaluator_bridge.rs
@@ -1406,9 +1406,6 @@ pub struct CompiledEvaluator<'a> {
     /// Column names for compilation context (Arc for zero-copy sharing)
     columns: CompactArc<Vec<String>>,
 
-    /// Cached Arc pointer for fast equality check (avoids Arc comparison)
-    columns_arc_id: usize,
-
     /// Second row columns (for joins)
     columns2: Option<Vec<String>>,
 
@@ -1456,7 +1453,6 @@ impl<'a> CompiledEvaluator<'a> {
         Self {
             function_registry,
             columns: CompactArc::new(Vec::new()),
-            columns_arc_id: 0,
             columns2: None,
             outer_columns: None,
             params: EMPTY_PARAMS.clone(),
@@ -1480,7 +1476,6 @@ impl<'a> CompiledEvaluator<'a> {
     /// Clear all state for reuse.
     pub fn clear(&mut self) {
         self.columns = CompactArc::new(Vec::new());
-        self.columns_arc_id = 0;
         self.columns2 = None;
         self.outer_columns = None;
         self.params = EMPTY_PARAMS.clone();
@@ -1555,20 +1550,16 @@ impl<'a> CompiledEvaluator<'a> {
 
     /// Initialize the column index mapping (call once before set_row_array)
     ///
-    /// Performance: This method caches the source slice pointer. When called
-    /// repeatedly with the same slice (e.g., same table schema), it skips
-    /// the expensive string cloning operation.
+    /// Performance: when the names are unchanged (e.g. the same table schema
+    /// across UPDATE/SELECT operations), the string cloning is skipped. The
+    /// comparison is by content: the caller's buffer is not retained, so its
+    /// address cannot stand in for its identity.
     pub fn init_columns(&mut self, columns: &[String]) {
-        // Fast path: if same slice by pointer and length, skip clone
-        // This handles the common case where init_columns is called repeatedly
-        // with the same table schema during UPDATE/SELECT operations
-        let new_source_id = columns.as_ptr() as usize;
-        if self.columns_arc_id == new_source_id && self.columns.len() == columns.len() {
+        if self.columns.as_slice() == columns {
             return;
         }
 
         self.columns = CompactArc::new(columns.to_vec());
-        self.columns_arc_id = new_source_id;
         // Clear local cache since compilation context changed
         self.local_cache.clear();
     }
@@ -1579,14 +1570,12 @@ impl<'a> CompiledEvaluator<'a> {
     /// such as from `Schema::column_names_arc()`. It avoids all string cloning.
     #[inline]
     pub fn init_columns_arc(&mut self, columns: CompactArc<Vec<String>>) {
-        // Use CompactArc pointer for identity check
-        let new_arc_id = CompactArc::as_ptr(&columns) as usize;
-        if self.columns_arc_id == new_arc_id {
+        // Both handles are alive here, so pointer equality is exact identity.
+        if CompactArc::ptr_eq(&self.columns, &columns) {
             return;
         }
 
         self.columns = columns;
-        self.columns_arc_id = new_arc_id;
         // Clear local cache since compilation context changed
         self.local_cache.clear();
     }
@@ -1630,7 +1619,6 @@ impl<'a> CompiledEvaluator<'a> {
     /// Initialize join columns
     pub fn init_join_columns(&mut self, left_columns: &[String], right_columns: &[String]) {
         self.columns = CompactArc::new(left_columns.to_vec());
-        self.columns_arc_id = 0; // Reset since we're creating a new CompactArc
         self.columns2 = Some(right_columns.to_vec());
         // Invalidate local cache since compilation context changed
         self.local_cache.clear();
@@ -2497,6 +2485,29 @@ mod tests {
         let mut eval = CompiledEvaluator::with_defaults();
         eval.init_columns(&["col1".to_string(), "col2".to_string()]);
         assert_eq!(eval.columns.len(), 2);
+    }
+
+    /// Column names are identified by content, not by the address of the
+    /// caller's buffer: a reused buffer holding different names must be picked
+    /// up rather than served from a stale copy.
+    #[test]
+    fn test_compiled_evaluator_init_columns_reused_buffer() {
+        let mut eval = CompiledEvaluator::with_defaults();
+        let mut names = vec!["a".to_string(), "b".to_string()];
+        eval.init_columns(&names);
+
+        // Same buffer address, same length, different names.
+        names[0] = "z".to_string();
+        eval.init_columns(&names);
+
+        assert_eq!(eval.columns.as_slice(), names.as_slice());
+
+        let row = Row::from(vec![Value::Integer(7), Value::Integer(9)]);
+        eval.set_row_array(&row);
+        assert_eq!(
+            eval.evaluate(&make_identifier("z")).unwrap(),
+            Value::Integer(7)
+        );
     }
 
     #[test]


### PR DESCRIPTION
First wave of the `src/common` audit: the three correctness findings. No performance work here, that comes in the following PRs.

## 1. `CompiledEvaluator` identified columns by a raw address (silent wrong results)

`columns_arc_id` was a single `usize` holding two different kinds of address:

- `init_columns(&[String])` stored `columns.as_ptr()`, the address of a **borrowed slice the evaluator does not retain** (it keeps a `to_vec()` copy). Once the caller's buffer is dropped, that address can be handed back by the allocator for something else.
- `init_columns_arc(CompactArc<Vec<String>>)` compared its `CompactArc` payload pointer against the same field, with no length guard.

A match on a recycled address returns early and leaves the **previous schema** installed. Column indices then resolve against the wrong table: wrong values, no error.

Fixed by comparing what actually identifies the columns:

- slice path: compare contents (`self.columns.as_slice() == columns`)
- Arc path: `CompactArc::ptr_eq`, where both handles are alive so pointer equality is exact identity and cannot ABA

The address cache is deleted. It was not paying for itself anyway: every production caller either creates a fresh evaluator (so the field is 0 and the fast path never hits) or calls `init_columns` once outside the row loop. On the hit path the content compare replaces N `String` allocations, so it can never be worse than the miss path it guards.

Red-first test (`test_compiled_evaluator_init_columns_reused_buffer`) reuses one buffer with different names, which keeps the address and the length identical. Before the fix:

```
assertion `left == right` failed
  left: ["a", "b"]
 right: ["z", "b"]
```

## 2. `CompactVec::retain` had no panic guard (double free)

The loop shifts kept elements down with `copy_nonoverlapping` and calls `set_len` only after it finishes. A predicate that panics leaves the length at its original value while the retained prefix has already been duplicated by the backshift, so those elements are dropped twice, and any element the `else` arm already dropped is dropped again.

`retain` now runs under an RAII guard that moves the untouched tail into place and restores an accurate length on every exit path, matching the shape of the existing guards in `Clone`, `extend` and `from_iter`.

Red-first test: 5 elements, predicate rejects one and panics on the next. Before the fix, 5 elements produced 6 drops.

Only `CompactVec<i64>` callers exist today (`storage/index/{hash,multi_column}.rs`), and `i64` has no drop glue, so this was not reachable in production. It is public API.

## 3. `CompactVec::drain` left the length untouched (double free under `mem::forget`)

`drain()` built the `Drain` without lowering `len`; only `Drain::drop` set it to `start`. `mem::forget` is safe code, so a partially consumed `Drain` that is forgotten leaves the vector owning elements that were already moved out.

`drain()` now shortens the vector before yielding anything, which is also what `std::vec::Drain` does. `Drain::start` became unnecessary and is removed.

Red-first test: drain from index 2 of a 4-element vector, consume one, `mem::forget` the drain. Before the fix `vec.len()` was still 4.

`drain` has no production callers today. Also public API.

## Not in scope

`I64Map::drain` and `I64Set::drain` are correct on `main` already (fixed in #58); the audit initially flagged them because the agent read a stale branch. The capacity they throw away is a real perf finding and is queued for a later PR.

## Gates

- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`: 4978 passed
- `cargo nextest run --features test-filedb`: 4980 passed
- `cargo test --test differential_oracle_test --features sqlite`: 9 passed
- `cargo +nightly miri nextest run --lib -E 'test(/^common::compact_vec::/)'`: 17 passed, which covers the new `retain` guard under Stacked Borrows
