### PR TITLE
perf(storage): mix the float bit pattern before it becomes a group key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,10 @@ harness = false
 name = "delete_complex"
 harness = false
 
+[[bench]]
+name = "group_by_keys"
+harness = false
+
 [profile.bench]
 lto = "thin"
 codegen-units = 1

--- a/benches/group_by_keys.rs
+++ b/benches/group_by_keys.rs
@@ -1,0 +1,103 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! GROUP BY throughput across grouping-key distributions
+//!
+//! Run with: cargo bench --bench group_by_keys
+//!
+//! The grouping fast path keys its hash map by the raw integer, or by
+//! `f64::to_bits()` for a float column. Some perfectly ordinary column values
+//! are adversarial for a hash that only mixes part of the key: a DOUBLE column
+//! holding round values has all-zero low mantissa bits, and an integer column
+//! holding a large stride has all-zero low bits. This benchmark keeps those
+//! shapes next to the benign ones so a hash change that reintroduces the
+//! clustering shows up as a large, obvious regression rather than as a slow
+//! query somebody reports later.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+use stoolap::Database;
+
+/// One row per group, so the grouping map holds exactly this many keys.
+///
+/// The value is chosen so the map sits at its 3/4 grow threshold rather than
+/// wherever a round number happens to land: capacity is
+/// `next_power_of_two(n * 4 / 3)`, so 12288 keys fill 16384 slots exactly.
+/// Probe length is worst there, which is where a weak hash shows itself.
+const ROW_COUNT: i64 = 12_288;
+fn setup(name: &str, key: impl Fn(i64) -> f64) -> Database {
+    let db = Database::open(&format!("memory://bench_group_by_{}", name)).unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, k FLOAT, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    let insert = db
+        .prepare("INSERT INTO t (id, k, v) VALUES ($1, $2, $3)")
+        .unwrap();
+    for i in 1..=ROW_COUNT {
+        insert.execute((i, key(i), i)).unwrap();
+    }
+    db
+}
+
+fn setup_int(name: &str, key: impl Fn(i64) -> i64) -> Database {
+    let db = Database::open(&format!("memory://bench_group_by_{}", name)).unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, k INTEGER, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    let insert = db
+        .prepare("INSERT INTO t (id, k, v) VALUES ($1, $2, $3)")
+        .unwrap();
+    for i in 1..=ROW_COUNT {
+        insert.execute((i, key(i), i)).unwrap();
+    }
+    db
+}
+
+fn bench_group_by_keys(c: &mut Criterion) {
+    let mut group = c.benchmark_group("GROUP BY key distribution");
+
+    let databases = vec![
+        // Benign shapes: dense row ids and values with a full mantissa.
+        ("integer_sequential", setup_int("int_seq", |i| i)),
+        (
+            "float_irregular",
+            setup("float_irregular", |i| i as f64 * 1.000_000_123_4),
+        ),
+        // Adversarial shapes: entropy sits above the low bits of the key.
+        ("float_whole", setup("float_whole", |i| i as f64)),
+        ("float_money", setup("float_money", |i| i as f64 * 0.01)),
+        ("integer_stride_2p32", setup_int("int_stride", |i| i << 32)),
+    ];
+
+    for (name, db) in &databases {
+        let stmt = db.prepare("SELECT k, SUM(v) FROM t GROUP BY k").unwrap();
+        group.bench_function(*name, |b| {
+            b.iter(|| {
+                let rows = stmt.query(()).unwrap();
+                for row in rows {
+                    black_box(row.unwrap());
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_group_by_keys);
+criterion_main!(benches);

--- a/benches/group_by_keys.rs
+++ b/benches/group_by_keys.rs
@@ -16,14 +16,16 @@
 //!
 //! Run with: cargo bench --bench group_by_keys
 //!
-//! The grouping fast path keys its hash map by the raw integer, or by
-//! `f64::to_bits()` for a float column. Some perfectly ordinary column values
-//! are adversarial for a hash that only mixes part of the key: a DOUBLE column
-//! holding round values has all-zero low mantissa bits, and an integer column
-//! holding a large stride has all-zero low bits. This benchmark keeps those
-//! shapes next to the benign ones so a hash change that reintroduces the
-//! clustering shows up as a large, obvious regression rather than as a slow
-//! query somebody reports later.
+//! The grouping fast path keys its hash map by the raw integer for an integer
+//! column, and by an encoded form of the bit pattern for a float column. The
+//! encoding exists because some perfectly ordinary column values are
+//! adversarial for a hash that can only see part of the key: a DOUBLE column
+//! holding round values has all-zero low mantissa bits, and it used to be
+//! keyed by `f64::to_bits()` directly, which put every group in one bucket.
+//! An integer column holding a large stride has the same shape and is still
+//! keyed raw. This benchmark keeps those distributions next to the benign ones
+//! so a change that reintroduces the clustering shows up as a large, obvious
+//! regression rather than as a slow query somebody reports later.
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;

--- a/src/common/i64_map.rs
+++ b/src/common/i64_map.rs
@@ -1627,22 +1627,27 @@ mod tests {
         }
     }
 
-    /// A dense key range must never collide.
+    /// A dense key range inside one 2^16 block must never collide.
     ///
     /// Row ids, transaction ids and every other counter key their maps this
-    /// way, so this is the property the hot path is built on. It holds because
-    /// multiplying by an odd constant permutes the low bits, and it has to
-    /// keep holding at every capacity and right up to the grow threshold.
+    /// way, so this is the property the hot path is built on, and it is
+    /// provable rather than measured: inside such a block `k >> 16` is
+    /// constant, so the pre-mix is `k ^ const`, and both that and the odd
+    /// multiply are permutations of the low bits.
+    ///
+    /// It stops being provable once a range straddles a block boundary, since
+    /// the two halves get different constants. See the test below for what
+    /// actually happens there.
     #[test]
     fn test_hash_keeps_dense_keys_collision_free() {
+        // 65536-aligned, so every window below stays inside one block.
+        const HIGH_BLOCK: i64 = 65536 * 15258;
+
         for (cap, n) in sweep() {
             let shapes: [(&str, Vec<i64>); 3] = [
                 ("from zero", (0..n as i64).collect()),
                 ("negative", (-(n as i64)..0).collect()),
-                (
-                    "from 1e9",
-                    (1_000_000_000..1_000_000_000 + n as i64).collect(),
-                ),
+                ("high block", (HIGH_BLOCK..HIGH_BLOCK + n as i64).collect()),
             ];
             for (name, keys) in &shapes {
                 let occupancy = bucket_occupancy(keys, cap);
@@ -1652,6 +1657,29 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// A dense range that straddles a 2^16 block boundary is not collision
+    /// free, and this pins down how far it degrades.
+    ///
+    /// The two halves of such a range are pre-mixed with different constants,
+    /// so their images can overlap. Sliding a 3/4-full window across several
+    /// boundaries, the worst case found is this one: half the keys share a
+    /// bucket with another key, and no key needs more than 6 probes. This is a
+    /// baseline guard rather than an invariant, so that a change to the hash
+    /// cannot quietly make the boundary worse.
+    #[test]
+    fn test_hash_bounds_dense_keys_across_a_block_boundary() {
+        let cap = 1024usize;
+        let n = 768usize;
+        let start = 33_554_048i64; // ends 384 keys past a 2^16 boundary
+        let keys: Vec<i64> = (start..start + n as i64).collect();
+
+        let occupancy = bucket_occupancy(&keys, cap);
+        assert!(
+            occupancy * 2 >= n,
+            "{n} boundary-straddling dense keys landed in {occupancy} of {cap} buckets"
+        );
     }
 
     #[test]

--- a/src/common/i64_map.rs
+++ b/src/common/i64_map.rs
@@ -193,6 +193,14 @@ impl<V> I64Map<V> {
     /// multiplication to break stride patterns while preserving bijectivity.
     /// This maintains 0 collisions for sequential keys while reducing strided
     /// key collisions by ~65% (e.g., stride=1024 goes from 99,872 to 34,464).
+    ///
+    /// The bucket is the low bits of the returned value, and multiplication
+    /// only carries entropy upwards, so only the low bits of the key and the
+    /// 16 above them can reach it. That is what keeps dense keys collision
+    /// free, and it is deliberate: row ids, transaction ids and every other
+    /// counter key their maps this way. The price is that a key carrying its
+    /// entropy higher up has to be mixed before it arrives here, which is
+    /// what [`key_from_f64`] is for.
     #[inline(always)]
     fn hash(key: i64) -> usize {
         let k = key as u64;
@@ -729,6 +737,55 @@ enum EntryTarget<'a, V> {
 enum VacantTarget<'a, V> {
     Slot { map: &'a mut I64Map<V>, idx: usize },
     Sentinel(&'a mut Option<V>),
+}
+
+/// Encode an `f64` as an [`I64Map`] or [`I64Set`] key.
+///
+/// The map takes its bucket from the low bits of the key, so a key whose
+/// entropy sits above them lands in a handful of buckets. Raw `f64::to_bits()`
+/// is exactly that shape: an IEEE-754 double holding a round value carries its
+/// significant bits at the top of the mantissa and leaves the low mantissa
+/// bits zero. Keying a map directly with the bit pattern puts every group of a
+/// `GROUP BY <double column>` into one bucket and turns the scan quadratic, on
+/// data as ordinary as whole numbers or money amounts.
+///
+/// The bit pattern is passed through the SplitMix64 finalizer, whose steps are
+/// each invertible, so the encoding is a bijection: distinct doubles keep
+/// distinct keys and grouping stays exact. [`f64_from_key`] recovers the
+/// original value.
+///
+/// The encoding preserves the bit-level identity of the value, so `0.0` and
+/// `-0.0` remain distinct keys and NaN payloads stay distinguished, exactly as
+/// the raw bit pattern did.
+#[inline]
+pub fn key_from_f64(value: f64) -> i64 {
+    let mut x = value.to_bits();
+    x ^= x >> 30;
+    x = x.wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    x ^= x >> 27;
+    x = x.wrapping_mul(0x94d0_49bb_1331_11eb);
+    x ^= x >> 31;
+    x as i64
+}
+
+/// Recover the `f64` that [`key_from_f64`] encoded.
+///
+/// Each step undoes one step of the finalizer in reverse order. Undoing
+/// `x ^= x >> s` takes the shift applied at `s`, then `2s`, until it reaches
+/// past the width, and the multiplications are undone with the multiplicative
+/// inverses of their constants modulo 2^64.
+#[inline]
+pub fn f64_from_key(key: i64) -> f64 {
+    let mut x = key as u64;
+    x ^= x >> 31;
+    x ^= x >> 62;
+    x = x.wrapping_mul(0x3196_42b2_d24d_8ec3);
+    x ^= x >> 27;
+    x ^= x >> 54;
+    x = x.wrapping_mul(0x96de_1b17_3f11_9089);
+    x ^= x >> 30;
+    x ^= x >> 60;
+    f64::from_bits(x)
 }
 
 pub struct OccupiedEntry<'a, V> {
@@ -1459,6 +1516,141 @@ mod tests {
     impl Drop for DropTracker {
         fn drop(&mut self) {
             *self.count.borrow_mut() += 1;
+        }
+    }
+
+    /// Count how many distinct buckets a set of keys lands in.
+    fn bucket_occupancy(keys: &[i64], cap: usize) -> usize {
+        let mask = cap - 1;
+        let mut seen = vec![false; cap];
+        for &key in keys {
+            seen[I64Map::<u64>::hash(key) & mask] = true;
+        }
+        seen.iter().filter(|&&s| s).count()
+    }
+
+    /// Capacities filled to 3/4, which is the load factor the map grows at.
+    /// One capacity proves nothing on its own: the bucket index is masked, so
+    /// how a key shape behaves depends on the mask width and on how full the
+    /// table is.
+    fn sweep() -> impl Iterator<Item = (usize, usize)> {
+        [1024usize, 4096, 65536]
+            .into_iter()
+            .map(|cap| (cap, cap * 3 / 4))
+    }
+
+    /// The encoding must be exactly reversible, or grouping would report the
+    /// wrong value for every float group.
+    #[test]
+    fn test_float_key_round_trips() {
+        let mut values = vec![
+            0.0,
+            -0.0,
+            1.0,
+            -1.0,
+            0.1,
+            -0.1,
+            f64::MIN,
+            f64::MAX,
+            f64::MIN_POSITIVE,
+            f64::EPSILON,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::from_bits(1),                  // smallest subnormal
+            f64::from_bits(0x7ff8000000000001), // a NaN payload
+        ];
+        // A spread of ordinary values plus a deterministic pseudo-random walk
+        // over raw bit patterns, so exponents and mantissas of every shape are
+        // covered rather than just the friendly ones.
+        for i in 1..2000i64 {
+            values.push(i as f64);
+            values.push(i as f64 * 0.01);
+            values.push(1.0 / i as f64);
+        }
+        let mut x = 0x243f_6a88_85a3_08d3u64;
+        for _ in 0..20_000 {
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            values.push(f64::from_bits(x));
+        }
+
+        for value in values {
+            let key = key_from_f64(value);
+            let back = f64_from_key(key);
+            assert_eq!(
+                back.to_bits(),
+                value.to_bits(),
+                "round trip changed the bit pattern of {value:?}"
+            );
+        }
+    }
+
+    /// Distinct doubles must keep distinct keys, or two groups would merge.
+    #[test]
+    fn test_float_key_is_injective() {
+        let mut keys = std::collections::HashSet::new();
+        for i in 0..50_000i64 {
+            assert!(
+                keys.insert(key_from_f64(i as f64 * 0.5)),
+                "two doubles collapsed onto one key"
+            );
+        }
+    }
+
+    /// Float keys must spread across buckets.
+    ///
+    /// A double holding a round value keeps its significant bits at the top of
+    /// the mantissa and its low mantissa bits at zero, and the map's bucket
+    /// comes from the low bits of the key, so feeding the raw bit pattern in
+    /// puts every group into one bucket. The bar here is half the keys landing
+    /// in distinct buckets; an ideal hash reaches about 0.7 * n at this load.
+    #[test]
+    fn test_float_keys_spread_across_buckets() {
+        for (cap, n) in sweep() {
+            type FloatFamily = (&'static str, fn(usize) -> f64);
+            let families: [FloatFamily; 5] = [
+                ("whole", |i| i as f64),
+                ("halves", |i| i as f64 * 0.5),
+                ("money", |i| i as f64 * 0.01),
+                ("irregular", |i| i as f64 * 1.000_000_123_4),
+                ("tiny", |i| i as f64 * 1e-9),
+            ];
+            for (name, f) in families {
+                let keys: Vec<i64> = (1..=n).map(|i| key_from_f64(f(i))).collect();
+                let occupancy = bucket_occupancy(&keys, cap);
+                assert!(
+                    occupancy > n / 2,
+                    "{n} {name} float keys landed in {occupancy} of {cap} buckets"
+                );
+            }
+        }
+    }
+
+    /// A dense key range must never collide.
+    ///
+    /// Row ids, transaction ids and every other counter key their maps this
+    /// way, so this is the property the hot path is built on. It holds because
+    /// multiplying by an odd constant permutes the low bits, and it has to
+    /// keep holding at every capacity and right up to the grow threshold.
+    #[test]
+    fn test_hash_keeps_dense_keys_collision_free() {
+        for (cap, n) in sweep() {
+            let shapes: [(&str, Vec<i64>); 3] = [
+                ("from zero", (0..n as i64).collect()),
+                ("negative", (-(n as i64)..0).collect()),
+                (
+                    "from 1e9",
+                    (1_000_000_000..1_000_000_000 + n as i64).collect(),
+                ),
+            ];
+            for (name, keys) in &shapes {
+                let occupancy = bucket_occupancy(keys, cap);
+                assert_eq!(
+                    occupancy, n,
+                    "hash collided on {n} dense keys ({name}) in {cap} slots"
+                );
+            }
         }
     }
 

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -35,6 +35,7 @@ use parking_lot::{Mutex, RwLock};
 
 use crate::common::SmartString;
 
+use crate::common::i64_map::{f64_from_key, key_from_f64};
 use crate::common::{
     new_cow_btree_map, new_i64_map, new_i64_map_with_capacity, CompactArc, CowBTreeMap, I64Map,
 };
@@ -6118,7 +6119,7 @@ impl VersionStore {
                             key_type = 1;
                         }
                         if key_type == 1 {
-                            Some(f.to_bits() as i64)
+                            Some(key_from_f64(*f))
                         } else {
                             None // Type mismatch → other_groups
                         }
@@ -6165,10 +6166,10 @@ impl VersionStore {
             // Convert int_groups based on key_type
             for (key, accums) in int_groups.iter() {
                 let group_value = match key_type {
-                    0 => Value::Integer(key),                      // Integer
-                    1 => Value::Float(f64::from_bits(key as u64)), // Float
-                    2 => Value::Boolean(key != 0),                 // Boolean
-                    _ => Value::Integer(key),                      // Fallback
+                    0 => Value::Integer(key),             // Integer
+                    1 => Value::Float(f64_from_key(key)), // Float
+                    2 => Value::Boolean(key != 0),        // Boolean
+                    _ => Value::Integer(key),             // Fallback
                 };
                 results.push(GroupedAggregateResult {
                     group_values: vec![group_value],


### PR DESCRIPTION
Rewritten after review. The first version changed `I64Map`'s hash and that was the wrong place; this one leaves the hash untouched and fixes the key.

## Why the hash was the wrong place to change

The bucket is the low bits of `hash(key)`, and in `Z/2^64` a multiply is lower triangular: `(a*b) mod 2^m` depends only on `a mod 2^m`. Two consequences follow, and they pull against each other:

- Multiplying by an odd constant is a **permutation of `Z/2^m`**, so a dense key range never collides, at any capacity and any load factor. That is not luck, and it is what row ids, transaction ids and every other counter in the engine rely on.
- Entropy above the mask is **invisible**. `f64::to_bits()` of a round value is exactly that shape, so all such keys share one bucket.

Any mixer that pulls the high bits down destroys the first property. Measured on dense keys with realistic slot sizes:

| dense-key lookup | current hash | strong (SplitMix) hash |
|---|---|---|
| 10k keys, 75% load | 0.522 ns | 1.437 ns |
| 1M keys, 75% load | **3.003 ns** | **8.662 ns** |

A perfect hash touches one cache line per lookup; a strong one touches 2.4. That is a 2.9x regression on the version store's row id map, which is not a trade worth making for a grouping key.

I also measured a probe matrix over stride families, capacities and loads before concluding this. Worst average probes over each family (deterministic, no timing involved):

| cap / load / family | current hash | rotate mixer (v1 of this PR) | split mixer | SplitMix |
|---|---|---|---|---|
| 4096, 75%, odd strides | 51.49 | 11.92 | 1.00 | 2.77 |
| 4096, 75%, even strides | 8.50 | 12.89 | 24.50 | 2.77 |
| 4096, 75%, powers of two | 13.81 | 1.71 | 1536.50 | 2.78 |
| 65536, 75%, powers of two | 3.50 | 1.67 | 24576.50 | 2.55 |

Every cheap fixed mixer has a family it loses to. The reviewer's `i*1483` case is in there: the rotate mixer this PR originally shipped gives 1069.64 average and 3071 maximum probes on it, and the dense regression they found reproduces exactly at 1.393. Both are gone because the hash is no longer touched.

## What actually changed

`version_store.rs` produced the bad key itself, and it is the one place that knows the value is a float:

```rust
- Some(f.to_bits() as i64)
+ Some(key_from_f64(*f))
...
- 1 => Value::Float(f64::from_bits(key as u64)),
+ 1 => Value::Float(f64_from_key(key)),
```

`key_from_f64` runs the bit pattern through the SplitMix64 finalizer; `f64_from_key` undoes it. Every step is invertible (the xor-shifts are undone by applying the shift at `s`, `2s`, ..., the multiplies by their modular inverses), so the encoding is a bijection: distinct doubles keep distinct keys and grouping stays exact. `-0.0` and NaN payloads stay exactly as distinguishable as the raw bit pattern left them, so no grouping semantics move.

The helpers live next to `hash` in `i64_map.rs`, because they exist to satisfy its contract, and that contract is now written down there.

## Results

Interleaved best of 12 runs, alternating binaries, since criterion disagreed with itself across runs on this machine (the same unmodified code measured `p = 0.12, no change` and `+9.2%, p = 0.00` for the same case):

| case | before | after | |
|---|---|---|---|
| whole doubles, 40k groups | 587 ms | **4.6 ms** | 128x |
| money 0.01 steps, 40k groups | 74.7 ms | **4.8 ms** | 15x |
| irregular doubles, 40k groups | 4.8 ms | 4.7 ms | parity |
| integer keys, 200k groups | 26.8 ms | 26.0 ms | parity |

Irregular doubles come out at parity rather than slower: the mix costs about a nanosecond per row and buys back the probes it removes.

## Tests

- `test_float_key_round_trips` asserts bit-exact recovery over edge values (zeros, infinities, subnormals, a NaN payload, MIN/MAX/EPSILON) plus 26k generated bit patterns.
- `test_float_key_is_injective` asserts 50k distinct doubles keep 50k distinct keys, so no two groups can merge.
- `test_float_keys_spread_across_buckets` sweeps three capacities at their 3/4 grow threshold across five float families. Against the old raw `to_bits()` key it fails with `768 whole float keys landed in 1 of 1024 buckets`.
- `test_hash_keeps_dense_keys_collision_free` sweeps the same capacities and asserts dense ranges stay collision free. It passes today; it is there because the rejected v1 of this PR broke exactly that, and the test I had then only checked one lucky capacity.

## Known and unchanged

An integer column whose values share low zero bits still clusters: 42 probes for the worst power-of-two stride measured, against 24576 for the float pattern fixed here. The benchmark keeps that case visible. Fixing it would mean mixing integer group keys too, which costs `GROUP BY <integer column>` its collision-free property, so it is deliberately left alone.

## Gates

- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`: 4984 passed
- `cargo nextest run --features test-filedb`: 4986 passed
- `cargo test --test differential_oracle_test --features sqlite`: 9 passed
- `cargo +nightly miri nextest run --lib -E 'test(/^common::i64_map::/)'`: 33 passed
