### PR TITLE
perf(aggregation): one allocation per group in the storage GROUP BY

### DIFF
--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -3747,7 +3747,14 @@ impl Executor {
         let has_limit = limit.is_some();
         let mut current_group_count: usize = 0; // Track actual group count for LIMIT optimization
 
-        if all_simple_columns && expr_vm.is_none() {
+        // `all_simple_columns` already means no GROUP BY item is an expression,
+        // so the VM is not needed to build the keys. It was also gated on
+        // `expr_vm.is_none()`, which is false whenever any aggregate carries an
+        // expression, an ORDER BY or a FILTER, and that sent queries like
+        // `SELECT k, SUM(x * 1.1) ... GROUP BY k` down the slow path even
+        // though their keys are plain columns. Aggregates are evaluated later
+        // from the groups, not here.
+        if all_simple_columns {
             // Fast path: extract key values directly from row columns
             let column_indices: Vec<usize> = precomputed_group_by
                 .iter()

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -3747,14 +3747,7 @@ impl Executor {
         let has_limit = limit.is_some();
         let mut current_group_count: usize = 0; // Track actual group count for LIMIT optimization
 
-        // `all_simple_columns` already means no GROUP BY item is an expression,
-        // so the VM is not needed to build the keys. It was also gated on
-        // `expr_vm.is_none()`, which is false whenever any aggregate carries an
-        // expression, an ORDER BY or a FILTER, and that sent queries like
-        // `SELECT k, SUM(x * 1.1) ... GROUP BY k` down the slow path even
-        // though their keys are plain columns. Aggregates are evaluated later
-        // from the groups, not here.
-        if all_simple_columns {
+        if all_simple_columns && expr_vm.is_none() {
             // Fast path: extract key values directly from row columns
             let column_indices: Vec<usize> = precomputed_group_by
                 .iter()

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -6067,11 +6067,23 @@ impl VersionStore {
 
             // Track key type: 0=Integer, 1=Float, 2=Boolean, 3=Mixed/Other
             let mut key_type: u8 = 255; // uninitialized
-            let mut int_groups: I64Map<Vec<Accum>> = I64Map::new();
+                                        // Accumulators live in one flat pool, `n_aggs` per group, and the
+                                        // maps hold the group's ordinal into it. A Vec per group would be
+                                        // one allocation per distinct group, which for a high-cardinality
+                                        // GROUP BY is the dominant cost of the scan.
+            let n_aggs = aggregates.len();
+            let mut accums: Vec<Accum> = Vec::new();
+            let new_group = |accums: &mut Vec<Accum>| -> u32 {
+                let ordinal = (accums.len() / n_aggs) as u32;
+                accums.resize_with(accums.len() + n_aggs, Accum::default);
+                ordinal
+            };
+            use crate::common::i64_map::Entry;
+            let mut int_groups: I64Map<u32> = I64Map::new();
             // Separate NULL accumulator - avoids creating GroupKey for NULL
-            let mut null_accums: Option<Vec<Accum>> = None;
+            let mut null_group: Option<u32> = None;
             // Only used for String/other types that can't be mapped to i64
-            let mut other_groups: GroupKeyMap<Vec<Accum>> = GroupKeyMap::default();
+            let mut other_groups: GroupKeyMap<u32> = GroupKeyMap::default();
 
             for (idx, meta) in arena_meta.iter().enumerate() {
                 // Visibility check (standard pattern: check creation, then deletion)
@@ -6093,9 +6105,12 @@ impl VersionStore {
                     &row_slice[col_idx]
                 } else {
                     // NULL - track separately without GroupKey allocation
-                    let accums =
-                        null_accums.get_or_insert_with(|| vec![Accum::default(); aggregates.len()]);
-                    update_accums(accums, aggregates, row_slice);
+                    let ordinal = match null_group {
+                        Some(ordinal) => ordinal,
+                        None => *null_group.insert(new_group(&mut accums)),
+                    };
+                    let base = ordinal as usize * n_aggs;
+                    update_accums(&mut accums[base..base + n_aggs], aggregates, row_slice);
                     continue;
                 };
 
@@ -6136,64 +6151,85 @@ impl VersionStore {
                     }
                     Value::Null(_) => {
                         // NULL value in the column - track separately
-                        let accums = null_accums
-                            .get_or_insert_with(|| vec![Accum::default(); aggregates.len()]);
-                        update_accums(accums, aggregates, row_slice);
+                        let ordinal = match null_group {
+                            Some(ordinal) => ordinal,
+                            None => *null_group.insert(new_group(&mut accums)),
+                        };
+                        let base = ordinal as usize * n_aggs;
+                        update_accums(&mut accums[base..base + n_aggs], aggregates, row_slice);
                         continue;
                     }
                     _ => None,
                 };
 
-                if let Some(key) = i64_key {
-                    let accums = int_groups
-                        .entry(key)
-                        .or_insert_with(|| vec![Accum::default(); aggregates.len()]);
-                    update_accums(accums, aggregates, row_slice);
+                let ordinal = if let Some(key) = i64_key {
+                    match int_groups.entry(key) {
+                        Entry::Occupied(existing) => *existing.into_mut(),
+                        Entry::Vacant(slot) => *slot.insert(new_group(&mut accums)),
+                    }
                 } else {
-                    let accums = other_groups
-                        .entry(GroupKey::Single(CompactArc::new(val.clone())))
-                        .or_insert_with(|| vec![Accum::default(); aggregates.len()]);
-                    update_accums(accums, aggregates, row_slice);
-                }
+                    match other_groups.entry(GroupKey::Single(CompactArc::new(val.clone()))) {
+                        std::collections::hash_map::Entry::Occupied(existing) => *existing.get(),
+                        std::collections::hash_map::Entry::Vacant(slot) => {
+                            *slot.insert(new_group(&mut accums))
+                        }
+                    }
+                };
+                let base = ordinal as usize * n_aggs;
+                update_accums(&mut accums[base..base + n_aggs], aggregates, row_slice);
             }
 
             // Convert to results
-            let has_null = null_accums.is_some();
+            let has_null = null_group.is_some();
             let mut results: Vec<GroupedAggregateResult> = Vec::with_capacity(
                 int_groups.len() + other_groups.len() + if has_null { 1 } else { 0 },
             );
 
+            // The caller appends the aggregate values onto the group values to
+            // build the output row, so the key vector is sized for both here
+            // and that append does not reallocate.
+            let row_width = 1 + n_aggs;
+            let slice_of = |ordinal: u32| {
+                let base = ordinal as usize * n_aggs;
+                &accums[base..base + n_aggs]
+            };
+
             // Convert int_groups based on key_type
-            for (key, accums) in int_groups.iter() {
+            for (key, &ordinal) in int_groups.iter() {
                 let group_value = match key_type {
                     0 => Value::Integer(key),             // Integer
                     1 => Value::Float(f64_from_key(key)), // Float
                     2 => Value::Boolean(key != 0),        // Boolean
                     _ => Value::Integer(key),             // Fallback
                 };
+                let mut group_values = Vec::with_capacity(row_width);
+                group_values.push(group_value);
                 results.push(GroupedAggregateResult {
-                    group_values: vec![group_value],
-                    aggregate_values: compute_aggregate_values(aggregates, accums),
+                    group_values,
+                    aggregate_values: compute_aggregate_values(aggregates, slice_of(ordinal)),
                 });
             }
 
             // Add NULL group if present
-            if let Some(accums) = null_accums {
+            if let Some(ordinal) = null_group {
+                let mut group_values = Vec::with_capacity(row_width);
+                group_values.push(Value::Null(DataType::Null));
                 results.push(GroupedAggregateResult {
-                    group_values: vec![Value::Null(DataType::Null)],
-                    aggregate_values: compute_aggregate_values(aggregates, &accums),
+                    group_values,
+                    aggregate_values: compute_aggregate_values(aggregates, slice_of(ordinal)),
                 });
             }
 
             // Convert other_groups (strings, etc.)
-            for (group_key, accums) in other_groups {
-                let group_values = match group_key {
-                    GroupKey::Single(v) => vec![(*v).clone()],
-                    GroupKey::Multi(vs) => vs.iter().map(|v| (**v).clone()).collect(),
-                };
+            for (group_key, ordinal) in &other_groups {
+                let mut group_values = Vec::with_capacity(row_width);
+                match group_key {
+                    GroupKey::Single(v) => group_values.push((**v).clone()),
+                    GroupKey::Multi(vs) => group_values.extend(vs.iter().map(|v| (**v).clone())),
+                }
                 results.push(GroupedAggregateResult {
                     group_values,
-                    aggregate_values: compute_aggregate_values(aggregates, &accums),
+                    aggregate_values: compute_aggregate_values(aggregates, slice_of(*ordinal)),
                 });
             }
 

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -6073,11 +6073,15 @@ impl VersionStore {
                                         // GROUP BY is the dominant cost of the scan.
             let n_aggs = aggregates.len();
             let mut accums: Vec<Accum> = Vec::new();
-            let new_group = |accums: &mut Vec<Accum>| -> u32 {
-                let ordinal = (accums.len() / n_aggs) as u32;
+            let mut group_count: u32 = 0;
+            // The ordinal is counted, not derived from the pool length: an
+            // empty aggregate list is a valid request and would divide by zero.
+            fn new_group(accums: &mut Vec<Accum>, group_count: &mut u32, n_aggs: usize) -> u32 {
+                let ordinal = *group_count;
+                *group_count += 1;
                 accums.resize_with(accums.len() + n_aggs, Accum::default);
                 ordinal
-            };
+            }
             use crate::common::i64_map::Entry;
             let mut int_groups: I64Map<u32> = I64Map::new();
             // Separate NULL accumulator - avoids creating GroupKey for NULL
@@ -6107,7 +6111,9 @@ impl VersionStore {
                     // NULL - track separately without GroupKey allocation
                     let ordinal = match null_group {
                         Some(ordinal) => ordinal,
-                        None => *null_group.insert(new_group(&mut accums)),
+                        None => {
+                            *null_group.insert(new_group(&mut accums, &mut group_count, n_aggs))
+                        }
                     };
                     let base = ordinal as usize * n_aggs;
                     update_accums(&mut accums[base..base + n_aggs], aggregates, row_slice);
@@ -6153,7 +6159,9 @@ impl VersionStore {
                         // NULL value in the column - track separately
                         let ordinal = match null_group {
                             Some(ordinal) => ordinal,
-                            None => *null_group.insert(new_group(&mut accums)),
+                            None => {
+                                *null_group.insert(new_group(&mut accums, &mut group_count, n_aggs))
+                            }
                         };
                         let base = ordinal as usize * n_aggs;
                         update_accums(&mut accums[base..base + n_aggs], aggregates, row_slice);
@@ -6165,13 +6173,15 @@ impl VersionStore {
                 let ordinal = if let Some(key) = i64_key {
                     match int_groups.entry(key) {
                         Entry::Occupied(existing) => *existing.into_mut(),
-                        Entry::Vacant(slot) => *slot.insert(new_group(&mut accums)),
+                        Entry::Vacant(slot) => {
+                            *slot.insert(new_group(&mut accums, &mut group_count, n_aggs))
+                        }
                     }
                 } else {
                     match other_groups.entry(GroupKey::Single(CompactArc::new(val.clone()))) {
                         std::collections::hash_map::Entry::Occupied(existing) => *existing.get(),
                         std::collections::hash_map::Entry::Vacant(slot) => {
-                            *slot.insert(new_group(&mut accums))
+                            *slot.insert(new_group(&mut accums, &mut group_count, n_aggs))
                         }
                     }
                 };
@@ -6220,16 +6230,18 @@ impl VersionStore {
                 });
             }
 
-            // Convert other_groups (strings, etc.)
-            for (group_key, ordinal) in &other_groups {
+            // Convert other_groups (strings, etc.), consuming the map so each
+            // key is released as its values are moved out rather than being
+            // held alongside its clone for the rest of the loop.
+            for (group_key, ordinal) in other_groups {
                 let mut group_values = Vec::with_capacity(row_width);
                 match group_key {
-                    GroupKey::Single(v) => group_values.push((**v).clone()),
+                    GroupKey::Single(v) => group_values.push((*v).clone()),
                     GroupKey::Multi(vs) => group_values.extend(vs.iter().map(|v| (**v).clone())),
                 }
                 results.push(GroupedAggregateResult {
                     group_values,
-                    aggregate_values: compute_aggregate_values(aggregates, slice_of(*ordinal)),
+                    aggregate_values: compute_aggregate_values(aggregates, slice_of(ordinal)),
                 });
             }
 
@@ -7561,6 +7573,71 @@ mod tests {
         fn needs_snapshot_isolation(&self, _txn_id: i64) -> bool {
             true
         }
+    }
+
+    /// A visibility checker that does not force snapshot isolation, so the
+    /// arena-backed grouped aggregation path is reachable.
+    struct ReadCommittedChecker;
+
+    impl VisibilityChecker for ReadCommittedChecker {
+        fn is_visible(&self, version_txn_id: i64, viewing_txn_id: i64) -> bool {
+            version_txn_id <= viewing_txn_id
+        }
+
+        fn get_current_sequence(&self) -> i64 {
+            0
+        }
+
+        fn get_active_transaction_ids(&self) -> Vec<i64> {
+            Vec::new()
+        }
+
+        fn needs_snapshot_isolation(&self, _txn_id: i64) -> bool {
+            false
+        }
+    }
+
+    /// `compute_grouped_aggregates` is public and its signature allows an
+    /// empty aggregate list. The executor never asks for one, but the contract
+    /// does, and it used to answer with a group per distinct key and no
+    /// aggregate values.
+    #[test]
+    fn test_grouped_aggregates_with_no_aggregates() {
+        use crate::core::DataType;
+
+        let schema = crate::core::SchemaBuilder::new("no_aggs")
+            .column("id", DataType::Integer, false, true)
+            .column("k", DataType::Integer, true, false)
+            .build();
+
+        let store = Arc::new(VersionStore::with_visibility_checker(
+            "no_aggs".to_string(),
+            schema,
+            Arc::new(ReadCommittedChecker),
+        ));
+
+        let mut txn = TransactionVersionStore::new(Arc::clone(&store), 1);
+        for (id, k) in [(1i64, 10i64), (2, 10), (3, 20)] {
+            txn.put(id, Row::from(vec![Value::from(id), Value::from(k)]), false)
+                .unwrap();
+        }
+        txn.commit().unwrap();
+
+        let results = store
+            .compute_grouped_aggregates(2, &[1], &[])
+            .expect("arena path should handle an empty aggregate list");
+
+        let mut keys: Vec<i64> = results
+            .iter()
+            .map(|r| match r.group_values.first() {
+                Some(Value::Integer(k)) => *k,
+                other => panic!("unexpected group value {other:?}"),
+            })
+            .collect();
+        keys.sort();
+
+        assert_eq!(keys, vec![10, 20]);
+        assert!(results.iter().all(|r| r.aggregate_values.is_empty()));
     }
 
     #[test]

--- a/tests/group_by_expression_aggregate_test.rs
+++ b/tests/group_by_expression_aggregate_test.rs
@@ -148,3 +148,36 @@ fn test_group_by_column_with_null_group_and_expression_aggregate() {
     rows.sort();
     assert_eq!(rows, vec![(None, 60), (Some(7), 60)]);
 }
+
+/// The grouping paths do not agree on whether `0.0` and `-0.0` are one group.
+///
+/// The storage fast path keys a float column by its bit pattern, so it keeps
+/// them apart, and so does the executor path that a query with an expression,
+/// FILTER or ORDER BY aggregate takes today. The executor's raw-entry path
+/// compares keys with `Value` equality instead, which merges them.
+///
+/// This pins what each shape answers now. Unifying the paths is worth doing,
+/// but it changes group membership rather than just row order, so it has to be
+/// a deliberate change with these numbers updated in the same commit, not a
+/// side effect of moving a query from one path to another.
+#[test]
+fn test_signed_zero_group_membership_is_stable_per_shape() {
+    let db = Database::open("memory://group_by_expr_agg_signed_zero").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, v FLOAT, w INTEGER)",
+        (),
+    )
+    .unwrap();
+    let insert = db
+        .prepare("INSERT INTO t (id, v, w) VALUES ($1, $2, $3)")
+        .unwrap();
+    insert.execute((1i64, 0.0f64, 10i64)).unwrap();
+    insert.execute((2i64, -0.0f64, 20i64)).unwrap();
+    insert.execute((3i64, 1.0f64, 30i64)).unwrap();
+
+    let groups = |sql: &str| db.query(sql, ()).unwrap().count();
+
+    assert_eq!(groups("SELECT v, SUM(w) FROM t GROUP BY v"), 3);
+    assert_eq!(groups("SELECT v, COUNT(*) FROM t GROUP BY v"), 3);
+    assert_eq!(groups("SELECT v, SUM(w * 1) FROM t GROUP BY v"), 3);
+}

--- a/tests/group_by_expression_aggregate_test.rs
+++ b/tests/group_by_expression_aggregate_test.rs
@@ -1,0 +1,150 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! GROUP BY over plain columns, with aggregates that carry an expression, a
+//! FILTER or an ORDER BY.
+//!
+//! These pick the grouping path by the shape of the aggregate rather than by
+//! the shape of the key, so they are the queries that move when that choice
+//! changes. The results are pinned here.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://group_by_expr_agg_{}", name)).unwrap();
+    db.execute(
+        "CREATE TABLE sales (id INTEGER PRIMARY KEY, region TEXT, dept INTEGER, amount INTEGER)",
+        (),
+    )
+    .unwrap();
+    let rows = [
+        (1, "east", 1, 100),
+        (2, "east", 1, 200),
+        (3, "west", 2, 300),
+        (4, "west", 2, 400),
+        (5, "east", 2, 500),
+    ];
+    let insert = db
+        .prepare("INSERT INTO sales (id, region, dept, amount) VALUES ($1, $2, $3, $4)")
+        .unwrap();
+    for (id, region, dept, amount) in rows {
+        insert
+            .execute((id as i64, region, dept as i64, amount as i64))
+            .unwrap();
+    }
+    db
+}
+
+/// Collect (key, value) pairs sorted by key, so the assertions do not depend
+/// on the order groups come back in.
+fn grouped_i64(db: &Database, sql: &str) -> Vec<(i64, i64)> {
+    let mut out: Vec<(i64, i64)> = db
+        .query(sql, ())
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (row.get::<i64>(0).unwrap(), row.get::<i64>(1).unwrap())
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn test_group_by_column_with_expression_aggregate() {
+    let db = setup("expr");
+    assert_eq!(
+        grouped_i64(&db, "SELECT dept, SUM(amount * 2) FROM sales GROUP BY dept"),
+        vec![(1, 600), (2, 2400)]
+    );
+    assert_eq!(
+        grouped_i64(&db, "SELECT dept, SUM(amount + 1) FROM sales GROUP BY dept"),
+        vec![(1, 302), (2, 1203)]
+    );
+}
+
+#[test]
+fn test_group_by_column_with_filtered_aggregate() {
+    let db = setup("filter");
+    assert_eq!(
+        grouped_i64(
+            &db,
+            "SELECT dept, COUNT(*) FILTER (WHERE region = 'east') FROM sales GROUP BY dept"
+        ),
+        vec![(1, 2), (2, 1)]
+    );
+}
+
+#[test]
+fn test_group_by_column_with_expression_aggregate_and_having() {
+    let db = setup("having");
+    assert_eq!(
+        grouped_i64(
+            &db,
+            "SELECT dept, SUM(amount * 2) FROM sales GROUP BY dept HAVING SUM(amount * 2) > 1000"
+        ),
+        vec![(2, 2400)]
+    );
+}
+
+#[test]
+fn test_group_by_text_column_with_expression_aggregate() {
+    let db = setup("text");
+    let mut rows: Vec<(String, i64)> = db
+        .query(
+            "SELECT region, SUM(amount * 2) FROM sales GROUP BY region",
+            (),
+        )
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (row.get::<String>(0).unwrap(), row.get::<i64>(1).unwrap())
+        })
+        .collect();
+    rows.sort();
+    assert_eq!(
+        rows,
+        vec![("east".to_string(), 1600), ("west".to_string(), 1400)]
+    );
+}
+
+#[test]
+fn test_group_by_column_with_null_group_and_expression_aggregate() {
+    let db = Database::open("memory://group_by_expr_agg_nulls").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, k INTEGER, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    let insert = db
+        .prepare("INSERT INTO t (id, k, v) VALUES ($1, $2, $3)")
+        .unwrap();
+    insert.execute((1i64, Option::<i64>::None, 10i64)).unwrap();
+    insert.execute((2i64, Option::<i64>::None, 20i64)).unwrap();
+    insert.execute((3i64, Some(7i64), 30i64)).unwrap();
+
+    let mut rows: Vec<(Option<i64>, i64)> = db
+        .query("SELECT k, SUM(v * 2) FROM t GROUP BY k", ())
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (
+                row.get::<Option<i64>>(0).unwrap(),
+                row.get::<i64>(1).unwrap(),
+            )
+        })
+        .collect();
+    rows.sort();
+    assert_eq!(rows, vec![(None, 60), (Some(7), 60)]);
+}


### PR DESCRIPTION
Step 3 of the audit, narrowed after review: the allocation chain in the single-column storage GROUP BY. No answer changes, only allocations.

## 1. One accumulator pool instead of one vector per group

```rust
let accums = int_groups.entry(key).or_insert_with(|| vec![Accum::default(); aggregates.len()]);
```

A 40k-group scan paid 40k allocations before doing any work, and consecutive groups' accumulators landed wherever the allocator put them. `Accum` is 64 bytes and the count is fixed for the whole query, so they now live in one flat pool with the maps holding a `u32` ordinal into it: a single growing allocation for the scan, and each group's accumulators contiguous.

The ordinal is counted rather than derived from the pool length, so the aggregate count never appears in a divisor. `compute_grouped_aggregates` is public and its signature allows an empty aggregate list, which the executor never sends but the contract permits, and dividing by it would panic.

## 2. The result row was built as two vectors and then concatenated

Each group produced a one-element `group_values` and a separate `aggregate_values`, and the only consumer does `values.extend(r.aggregate_values)`, reallocating the first every time. The key vector is now sized for both halves at the producer, so the append lands in place. Merging the two fields into one vector would remove the second allocation as well, but `GroupedAggregateResult` is public API, so that belongs in 0.5.0.

## 3. Finalization consumes `other_groups`

It iterated by reference, so every TEXT key stayed alive next to the clone made from it for the rest of the loop. It consumes the map now.

## Numbers

Interleaved best of 10, two binaries alternated, 40k groups with 4 rows each:

| query | before | after | |
|---|---|---|---|
| `SELECT k, SUM(v) FROM t GROUP BY k` | 3.44 ms | 2.18 ms | 1.58x |
| `SELECT k, SUM(v), COUNT(*), MIN(v) FROM t GROUP BY k` | 4.40 ms | 3.46 ms | 1.27x |

Medians move the same way (1.53x, 1.21x).

## Tests

- `test_grouped_aggregates_with_no_aggregates` calls the public API with an empty aggregate list through a read-committed visibility checker, so the arena path is actually reached. It fails with `attempt to divide by zero` against the first version of this branch.
- `tests/group_by_expression_aggregate_test.rs` pins the results of GROUP BY with an expression argument, a FILTER, a HAVING over an expression aggregate, a TEXT key and a NULL group, and records what each shape answers for `0.0` versus `-0.0`.

## Dropped from this PR after review

Widening the executor's raw-entry gate is a **semantic** change, not a reordering: the grouping paths disagree about float keys, one comparing bit patterns and the other `Value` equality, so moving a query between them moves its group membership.

```
                          origin/main   with the gate widened
SELECT v, SUM(w)     ...     3 groups      3 groups
SELECT v, COUNT(*)   ...     3 groups      3 groups
SELECT v, SUM(w * 1) ...     3 groups      2 groups
```

Merging `0.0` with `-0.0` is probably the semantic we want, but it has to be decided for every grouping path at once with the membership visible in the diff. The signed-zero test records today's answers so that change cannot arrive as a side effect. It is queued with the TEXT-key and volume-path work, which touch the same code.

## Also still queued

- The TEXT key path allocates a `CompactArc<Value>` per row to probe `other_groups`, because `AHashMap` has no raw-entry API. Moving that map to hashbrown is where the hasher-mismatch bug in #52 came from, so it gets its own PR.
- The volume (sealed segment) grouping builds `(vec![key], vec![Accum; n])` per group in four places and clones the key to probe.
- Merging `GroupedAggregateResult`'s two fields: 0.5.0, public API.

## Gates

- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`: 4992 passed
- `cargo nextest run --features test-filedb`: 4994 passed
- `cargo test --test group_by_expression_aggregate_test` (CI mode): 6 passed
- `cargo test --test differential_oracle_test --features sqlite`: 9 passed
