### PR TITLE
perf(mvcc): stop reserving 10,000 arena slots for every table

### DIFF
--- a/src/storage/mvcc/arena.rs
+++ b/src/storage/mvcc/arena.rs
@@ -82,14 +82,20 @@ pub struct RowArena {
 }
 
 impl RowArena {
-    /// Create a new arena
-    /// Note: Pre-allocate 10,000 slots to avoid reallocation during bulk inserts.
-    /// Vec doubling during growth can cause peak memory spikes.
+    /// Create a new arena.
+    ///
+    /// Nothing is reserved up front. Reserving 10,000 slots cost every table
+    /// 320 KB before it held a row (80 KB of pointers plus 240 KB of metadata),
+    /// which a schema with many small tables pays over and over, and it bought
+    /// very little: growing a Vec by doubling copies about 2n elements in total
+    /// whatever it starts from, so a 10,000 slot head start only saves copying
+    /// the first 10,000, and the expensive doublings at the end happen either
+    /// way. A caller that knows the size should use [`RowArena::with_capacity`].
     pub fn new() -> Self {
         Self {
             inner: RwLock::new(ArenaInner {
-                data: Vec::with_capacity(10_000),
-                meta: Vec::with_capacity(10_000),
+                data: Vec::new(),
+                meta: Vec::new(),
             }),
             free_list: Mutex::new(Vec::new()),
         }
@@ -359,13 +365,13 @@ impl RowArena {
         }
     }
 
-    /// Drop all data and recreate with default capacity.
+    /// Drop all data and release the memory.
     /// This releases all memory immediately (O(1) memory release)
     /// unlike clear_batch which only clears slots but retains Vec capacity.
     pub fn clear_all(&self) {
         let mut inner = self.inner.write();
-        inner.data = Vec::with_capacity(10_000);
-        inner.meta = Vec::with_capacity(10_000);
+        inner.data = Vec::new();
+        inner.meta = Vec::new();
         self.free_list.lock().clear();
     }
 

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -534,7 +534,6 @@ impl VersionStore {
         checker: Option<Arc<TransactionRegistry>>,
         expected_rows: usize,
     ) -> Self {
-        let _ = expected_rows;
         let versions = new_cow_btree_map();
 
         Self {
@@ -546,7 +545,7 @@ impl VersionStore {
             auto_increment_counter: AtomicI64::new(0),
             uncommitted_writes: RwLock::new(new_i64_map()),
             visibility_checker: checker,
-            arena: RowArena::new(),
+            arena: RowArena::with_capacity(expected_rows),
             zone_maps: RwLock::new(None),
             max_version_history: 10, // Default: keep up to 10 previous versions
             committed_row_count: AtomicUsize::new(0),
@@ -562,7 +561,6 @@ impl VersionStore {
         checker: Option<Arc<dyn VisibilityChecker>>,
         expected_rows: usize,
     ) -> Self {
-        let _ = expected_rows;
         let versions = new_cow_btree_map();
 
         Self {
@@ -574,7 +572,7 @@ impl VersionStore {
             auto_increment_counter: AtomicI64::new(0),
             uncommitted_writes: RwLock::new(new_i64_map()),
             visibility_checker: checker,
-            arena: RowArena::new(),
+            arena: RowArena::with_capacity(expected_rows),
             zone_maps: RwLock::new(None),
             max_version_history: 10,
             committed_row_count: AtomicUsize::new(0),


### PR DESCRIPTION
## What it was

`RowArena::new` reserved 10,000 rows up front:

```rust
data: Vec::with_capacity(10_000),   // 10_000 * 8  =  80 KB of Arc pointers
meta: Vec::with_capacity(10_000),   // 10_000 * 24 = 240 KB of metadata
```

so every table cost 320 KB of committed memory before holding a row. `clear_all` restored the same reservation, and `VersionStore::with_capacity` took an `expected_rows` hint, discarded it with `let _ = expected_rows;`, and built the same fixed-size arena anyway.

## Why the reservation did not earn its keep

The comment justified it as avoiding reallocation during bulk inserts. Growing a `Vec` by doubling copies about `2n` elements in total whatever it starts from, so a 10,000 slot head start only saves copying the first 10,000 elements, about 320 KB of memcpy over the whole load, while the expensive doublings near the end happen either way.

Measured, 200k row bulk insert, best of 8 interleaved runs:

| | before | after |
|---|---|---|
| best | 101.53 ms | 101.45 ms |
| median | 107.00 ms | 106.97 ms |

Parity, as the arithmetic says it must be.

## What it does change

Tables holding one row each, maximum resident set size:

| tables | before | after |
|---|---|---|
| 200 | 21.6 MB | 14.8 MB |
| 1000 | 62.4 MB | **28.5 MB** |

About 34 KB per table of resident memory. Resident is smaller than the 320 KB reserved because most of those pages were never touched, so the committed-memory saving is the full 320 KB per table.

`VersionStore::with_capacity` now passes its hint to `RowArena::with_capacity`, so the constructor does what its name and doc comment say. It has no production caller today, which is part of why the discarded parameter went unnoticed.

## Tests

No new test: this changes a capacity, not behaviour, and the suite exercises arena insert, delete, reuse and `clear_all` throughout. A test asserting a starting capacity would only pin the number I am removing.

## Gates

- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`: 4992 passed
- `cargo nextest run --features test-filedb`: 4994 passed
- `cargo test --test differential_oracle_test --features sqlite`: 9 passed
