### PR TITLE
docs: refresh BENCHMARKS.md on current versions and one machine

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -10,6 +10,8 @@ Performance comparison between **Stoolap**, **SQLite**, and **DuckDB** using ide
 | Iterations | 500 (point queries), 250 (medium), 50 (heavy) |
 | Mode | In-memory |
 | Platform | Apple Silicon |
+| Sampling | best of 10 runs per engine, measured back to back |
+| Measured | 2026-09-02, `main` at 2526f538 |
 | SQLite | rusqlite v0.40.2 |
 | DuckDB | duckdb v1.10501.0 |
 
@@ -267,4 +269,4 @@ cargo build --release --example benchmark --example benchmark_sqlite --example b
 
 ---
 
-*Benchmarks performed on Apple Silicon, in-memory mode, best of 10 runs. Results are point-in-time for v0.4.0; re-run on your hardware and workload for current numbers.*
+*Benchmarks performed on Apple Silicon, in-memory mode, best of 10 runs, all three engines measured back to back on one idle machine. Results are point-in-time for `main` at 2526f538, which is after the v0.4.0 release, not the release itself; re-run on your hardware and workload for current numbers.*

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -10,8 +10,8 @@ Performance comparison between **Stoolap**, **SQLite**, and **DuckDB** using ide
 | Iterations | 500 (point queries), 250 (medium), 50 (heavy) |
 | Mode | In-memory |
 | Platform | Apple Silicon |
-| SQLite | rusqlite v0.32.1 |
-| DuckDB | duckdb v1.4.3 |
+| SQLite | rusqlite v0.40.2 |
+| DuckDB | duckdb v1.10501.0 |
 
 ## Overall Score
 
@@ -30,19 +30,17 @@ Performance comparison between **Stoolap**, **SQLite**, and **DuckDB** using ide
 
 | Operation | Stoolap (us) | SQLite (us) | DuckDB (us) | Best |
 |-----------|-------------|-------------|-------------|------|
-| SELECT by ID | **0.12** | 0.21 | 145.55 | Stoolap |
-| SELECT by index (exact) | **3.81** | 28.02 | 288.70 | Stoolap |
-| SELECT by index (range) | **29.80** | 285.62 | 428.24 | Stoolap |
-| SELECT complex | **111.88** | 534.21 | 184.68 | Stoolap |
-| SELECT * (full scan) | **87.00** | 515.21 | 707.14 | Stoolap |
-| UPDATE by ID | **0.54** | 0.61 | 146.14 | Stoolap |
-| UPDATE complex | **59.01** | 443.73 | 209.77 | Stoolap |
-| INSERT single | **1.14** | 1.62 | 194.26 | Stoolap |
-| DELETE by ID | **0.65** | 1.32 | 152.34 | Stoolap |
-| DELETE complex | **2.90** | 380.14 | 197.44 | Stoolap |
-| Aggregation (GROUP BY) | **48.81** | 1403.39 | 104.32 | Stoolap |
-
-**Basic Operations Score: Stoolap 11, SQLite 0, DuckDB 0**
+| SELECT by ID | **0.13** | 0.21 | 72.54 | Stoolap |
+| SELECT by index (exact) | **3.27** | 27.44 | 1283.59 | Stoolap |
+| SELECT by index (range) | **27.20** | 249.63 | 314.86 | Stoolap |
+| SELECT complex | **102.42** | 482.93 | 170.17 | Stoolap |
+| SELECT * (full scan) | **84.70** | 485.73 | 622.47 | Stoolap |
+| UPDATE by ID | 0.60 | **0.55** | 86.91 | SQLite |
+| UPDATE complex | **56.61** | 394.35 | 145.22 | Stoolap |
+| INSERT single | **0.82** | 1.40 | 150.74 | Stoolap |
+| DELETE by ID | **0.69** | 1.18 | 99.71 | Stoolap |
+| DELETE complex | **2.29** | 345.08 | 116.55 | Stoolap |
+| Aggregation (GROUP BY) | **43.73** | 1154.25 | 100.39 | Stoolap |
 
 ---
 
@@ -50,21 +48,19 @@ Performance comparison between **Stoolap**, **SQLite**, and **DuckDB** using ide
 
 | Operation | Stoolap (us) | SQLite (us) | DuckDB (us) | Best |
 |-----------|-------------|-------------|-------------|------|
-| INNER JOIN | 20.35 | **14.86** | 607.20 | SQLite |
-| LEFT JOIN + GROUP BY | **51.61** | 55.69 | 1269.40 | Stoolap |
-| Scalar subquery | **9.08** | 399.10 | 257.12 | Stoolap |
-| IN subquery | **110.94** | 1838.79 | 853.94 | Stoolap |
-| EXISTS subquery | **3.06** | 38.42 | 928.06 | Stoolap |
-| CTE + JOIN | **38.54** | 74.16 | 859.53 | Stoolap |
-| Window ROW_NUMBER | **260.10** | 1781.90 | 690.83 | Stoolap |
-| Window ROW_NUMBER (PK) | **5.98** | 21.36 | 419.10 | Stoolap |
-| Window PARTITION BY | **7.56** | 64.81 | 1162.16 | Stoolap |
-| UNION ALL | **5.48** | 6.24 | 173.19 | Stoolap |
-| CASE expression | 5.25 | **5.10** | 247.54 | SQLite |
-| Complex JOIN+GROUP+HAVING | **51.00** | 93.20 | 2233.32 | Stoolap |
-| Batch INSERT (100 rows) | 77.94 | **74.93** | 14920.25 | SQLite |
-
-**Advanced Operations Score: Stoolap 10, SQLite 3, DuckDB 0**
+| INNER JOIN | 20.61 | **13.67** | 352.72 | SQLite |
+| LEFT JOIN + GROUP BY | **45.47** | 54.18 | 1404.65 | Stoolap |
+| Scalar subquery | **8.49** | 332.67 | 255.46 | Stoolap |
+| IN subquery | **93.63** | 1630.64 | 624.48 | Stoolap |
+| EXISTS subquery | **2.60** | 30.25 | 977.45 | Stoolap |
+| CTE + JOIN | **31.53** | 65.19 | 1097.58 | Stoolap |
+| Window ROW_NUMBER | **240.48** | 1549.46 | 797.31 | Stoolap |
+| Window ROW_NUMBER (PK) | **5.91** | 17.97 | 481.57 | Stoolap |
+| Window PARTITION BY | **8.13** | 49.13 | 708.42 | Stoolap |
+| UNION ALL | **4.89** | 5.85 | 220.02 | Stoolap |
+| CASE expression | **4.29** | 4.39 | 225.71 | Stoolap |
+| Complex JOIN+GROUP+HAVING | **48.73** | 71.83 | 2174.61 | Stoolap |
+| Batch INSERT (100 rows) | **51.71** | 64.75 | 9153.49 | Stoolap |
 
 ---
 
@@ -72,37 +68,35 @@ Performance comparison between **Stoolap**, **SQLite**, and **DuckDB** using ide
 
 | Operation | Stoolap (us) | SQLite (us) | DuckDB (us) | Best |
 |-----------|-------------|-------------|-------------|------|
-| DISTINCT (no ORDER) | **4.81** | 104.38 | 235.97 | Stoolap |
-| DISTINCT + ORDER BY | **5.18** | 139.58 | 291.81 | Stoolap |
-| COUNT DISTINCT | **0.37** | 105.98 | 219.91 | Stoolap |
-| LIKE prefix (User_1%) | **4.25** | 9.49 | 173.02 | Stoolap |
-| LIKE contains (%50%) | **37.52** | 156.52 | 271.86 | Stoolap |
-| OR conditions (3 vals) | **3.43** | 14.54 | 207.08 | Stoolap |
-| IN list (7 values) | **2.47** | 14.52 | 1152.84 | Stoolap |
-| NOT IN subquery | **81.75** | 1898.21 | 965.60 | Stoolap |
-| NOT EXISTS subquery | **24.88** | 1729.58 | 1429.57 | Stoolap |
-| OFFSET pagination (5000) | **14.53** | 21.31 | 1222.62 | Stoolap |
-| Multi-col ORDER BY (3) | **144.68** | 416.71 | 361.35 | Stoolap |
-| Self JOIN (same age) | 13.76 | **10.71** | 396.87 | SQLite |
-| Multi window funcs (3) | **568.68** | 1803.93 | 760.23 | Stoolap |
-| Nested subquery (3 lvl) | **339.88** | 6397.42 | 850.91 | Stoolap |
-| Multi aggregates (6) | **125.83** | 842.98 | 306.48 | Stoolap |
-| COALESCE + IS NOT NULL | 4.30 | **2.84** | 90.97 | SQLite |
-| Expr in WHERE (funcs) | **5.53** | 15.05 | 236.50 | Stoolap |
-| Math expressions | **15.96** | 36.74 | 247.55 | Stoolap |
-| String concat (\|\|) | 7.13 | **5.60** | 253.41 | SQLite |
-| Large result (no LIMIT) | **244.04** | 486.65 | 348.78 | Stoolap |
-| Multiple CTEs (2) | 20.64 | **20.60** | 313.38 | SQLite |
-| Correlated in SELECT | **265.93** | 511.29 | 1283.17 | Stoolap |
-| BETWEEN (non-indexed) | **2.64** | 9.26 | 178.98 | Stoolap |
-| GROUP BY (2 columns) | **161.17** | 2259.41 | 320.48 | Stoolap |
-| CROSS JOIN (limited) | **95.77** | 1358.05 | 1458.25 | Stoolap |
-| Derived table (FROM sub) | 411.49 | 875.95 | **255.77** | DuckDB |
-| Window ROWS frame | **548.16** | 1881.15 | 2198.75 | Stoolap |
-| HAVING complex | **99.57** | 1420.61 | 114.47 | Stoolap |
-| Compare with subquery | **5.52** | 1424.07 | 293.51 | Stoolap |
-
-**Bottleneck Hunters Score: Stoolap 24, SQLite 4, DuckDB 1**
+| DISTINCT (no ORDER) | **4.40** | 97.75 | 258.64 | Stoolap |
+| DISTINCT + ORDER BY | **4.73** | 123.02 | 335.87 | Stoolap |
+| COUNT DISTINCT | **0.26** | 91.07 | 269.60 | Stoolap |
+| LIKE prefix (User_1%) | **3.51** | 8.19 | 253.31 | Stoolap |
+| LIKE contains (%50%) | **30.14** | 133.87 | 243.19 | Stoolap |
+| OR conditions (3 vals) | **2.92** | 12.68 | 207.39 | Stoolap |
+| IN list (7 values) | **2.05** | 12.50 | 8600.29 | Stoolap |
+| NOT IN subquery | **67.48** | 1693.86 | 621.88 | Stoolap |
+| NOT EXISTS subquery | **21.77** | 86.66 | 1042.73 | Stoolap |
+| OFFSET pagination (5000) | **11.62** | 21.24 | 542.62 | Stoolap |
+| Multi-col ORDER BY (3) | **141.29** | 360.62 | 344.13 | Stoolap |
+| Self JOIN (same age) | 12.65 | **9.43** | 419.84 | SQLite |
+| Multi window funcs (3) | **399.55** | 1579.36 | 828.94 | Stoolap |
+| Nested subquery (3 lvl) | **323.75** | 5585.09 | 967.97 | Stoolap |
+| Multi aggregates (6) | **114.25** | 760.42 | 355.11 | Stoolap |
+| COALESCE + IS NOT NULL | 3.68 | **2.94** | 82.59 | SQLite |
+| Expr in WHERE (funcs) | **5.41** | 14.06 | 324.14 | Stoolap |
+| Math expressions | 12.36 | **11.74** | 216.67 | SQLite |
+| String concat (\|\|) | 6.13 | **5.25** | 251.33 | SQLite |
+| Large result (no LIMIT) | **234.14** | 465.87 | 372.65 | Stoolap |
+| Multiple CTEs (2) | 20.12 | **17.41** | 312.59 | SQLite |
+| Correlated in SELECT | **251.33** | 523.02 | 1306.52 | Stoolap |
+| BETWEEN (non-indexed) | **3.00** | 8.90 | 171.87 | Stoolap |
+| GROUP BY (2 columns) | **140.68** | 2370.70 | 404.03 | Stoolap |
+| CROSS JOIN (limited) | **89.24** | 1462.06 | 332.74 | Stoolap |
+| Derived table (FROM sub) | 379.44 | 943.29 | **327.14** | DuckDB |
+| Window ROWS frame | **354.91** | 2109.35 | 2461.63 | Stoolap |
+| HAVING complex | **88.77** | 1492.41 | 94.98 | Stoolap |
+| Compare with subquery | **5.10** | 1642.36 | 250.43 | Stoolap |
 
 ---
 
@@ -110,9 +104,9 @@ Performance comparison between **Stoolap**, **SQLite**, and **DuckDB** using ide
 
 | Category | Stoolap Wins | SQLite Wins | DuckDB Wins |
 |----------|-------------|-------------|-------------|
-| Basic Operations | 11 | 0 | 0 |
-| Advanced Operations | 10 | 3 | 0 |
-| Bottleneck Hunters | 24 | 4 | 1 |
+| Basic Operations | 10 | 1 | 0 |
+| Advanced Operations | 12 | 1 | 0 |
+| Bottleneck Hunters | 23 | 5 | 1 |
 | **Total** | **45** | **7** | **1** |
 
 ---
@@ -121,21 +115,21 @@ Performance comparison between **Stoolap**, **SQLite**, and **DuckDB** using ide
 
 | Operation | Stoolap | SQLite | Speedup |
 |-----------|---------|--------|---------|
-| COUNT DISTINCT | 0.37 us | 105.98 us | **286x** |
-| Compare with subquery | 5.52 us | 1424.07 us | **258x** |
-| DELETE complex | 2.90 us | 380.14 us | **131x** |
-| NOT EXISTS subquery | 24.88 us | 1729.58 us | **70x** |
-| Scalar subquery | 9.08 us | 399.10 us | **44x** |
-| Aggregation (GROUP BY) | 48.81 us | 1403.39 us | **29x** |
-| DISTINCT + ORDER BY | 5.18 us | 139.58 us | **27x** |
-| NOT IN subquery | 81.75 us | 1898.21 us | **23x** |
-| DISTINCT (no ORDER) | 4.81 us | 104.38 us | **22x** |
-| Nested subquery (3 lvl) | 339.88 us | 6397.42 us | **19x** |
-| IN subquery | 110.94 us | 1838.79 us | **17x** |
-| CROSS JOIN (limited) | 95.77 us | 1358.05 us | **14x** |
-| GROUP BY (2 columns) | 161.17 us | 2259.41 us | **14x** |
-| HAVING complex | 99.57 us | 1420.61 us | **14x** |
-| EXISTS subquery | 3.06 us | 38.42 us | **13x** |
+| COUNT DISTINCT | 0.26 us | 91.07 us | **352x** |
+| Compare with subquery | 5.10 us | 1642.36 us | **322x** |
+| DELETE complex | 2.29 us | 345.08 us | **151x** |
+| Scalar subquery | 8.49 us | 332.67 us | **39x** |
+| Aggregation (GROUP BY) | 43.73 us | 1154.25 us | **26x** |
+| DISTINCT + ORDER BY | 4.73 us | 123.02 us | **26x** |
+| NOT IN subquery | 67.48 us | 1693.86 us | **25x** |
+| DISTINCT (no ORDER) | 4.40 us | 97.75 us | **22x** |
+| IN subquery | 93.63 us | 1630.64 us | **17x** |
+| Nested subquery (3 lvl) | 323.75 us | 5585.09 us | **17x** |
+| GROUP BY (2 columns) | 140.68 us | 2370.70 us | **17x** |
+| HAVING complex | 88.77 us | 1492.41 us | **17x** |
+| CROSS JOIN (limited) | 89.24 us | 1462.06 us | **16x** |
+| EXISTS subquery | 2.60 us | 30.25 us | **12x** |
+| SELECT by index (range) | 27.20 us | 249.63 us | **9x** |
 
 ---
 
@@ -143,29 +137,31 @@ Performance comparison between **Stoolap**, **SQLite**, and **DuckDB** using ide
 
 | Operation | Stoolap | DuckDB | Speedup |
 |-----------|---------|--------|---------|
-| SELECT by ID | 0.12 us | 145.55 us | **1213x** |
-| EXISTS subquery | 3.06 us | 928.06 us | **303x** |
-| UPDATE by ID | 0.54 us | 146.14 us | **271x** |
-| DELETE by ID | 0.65 us | 152.34 us | **234x** |
-| Batch INSERT (100 rows) | 77.94 us | 14920.25 us | **191x** |
-| INSERT single | 1.14 us | 194.26 us | **170x** |
-| Window PARTITION BY | 7.56 us | 1162.16 us | **154x** |
-| OFFSET pagination (5000) | 14.53 us | 1222.62 us | **84x** |
-| SELECT by index (exact) | 3.81 us | 288.70 us | **76x** |
-| Window ROW_NUMBER (PK) | 5.98 us | 419.10 us | **70x** |
-| DELETE complex | 2.90 us | 197.44 us | **68x** |
-| NOT EXISTS subquery | 24.88 us | 1429.57 us | **57x** |
-| Compare with subquery | 5.52 us | 293.51 us | **53x** |
-| DISTINCT (no ORDER) | 4.81 us | 235.97 us | **49x** |
-| CASE expression | 5.25 us | 247.54 us | **47x** |
-| Complex JOIN+GROUP+HAVING | 51.00 us | 2233.32 us | **44x** |
-| UNION ALL | 5.48 us | 173.19 us | **32x** |
-| Scalar subquery | 9.08 us | 257.12 us | **28x** |
-| LEFT JOIN + GROUP BY | 51.61 us | 1269.40 us | **25x** |
-| NOT IN subquery | 81.75 us | 965.60 us | **12x** |
-| IN subquery | 110.94 us | 853.94 us | **7.7x** |
-| Nested subquery (3 lvl) | 339.88 us | 850.91 us | **2.5x** |
-| SELECT complex | 111.88 us | 184.68 us | **1.7x** |
+| IN list (7 values) | 2.05 us | 8600.29 us | **4193x** |
+| COUNT DISTINCT | 0.26 us | 269.60 us | **1041x** |
+| SELECT by ID | 0.13 us | 72.54 us | **545x** |
+| SELECT by index (exact) | 3.27 us | 1283.59 us | **392x** |
+| EXISTS subquery | 2.60 us | 977.45 us | **377x** |
+| INSERT single | 0.82 us | 150.74 us | **185x** |
+| Batch INSERT (100 rows) | 51.71 us | 9153.49 us | **177x** |
+| DELETE by ID | 0.69 us | 99.71 us | **144x** |
+| UPDATE by ID | 0.60 us | 86.91 us | **144x** |
+| Window PARTITION BY | 8.13 us | 708.42 us | **87x** |
+| Window ROW_NUMBER (PK) | 5.91 us | 481.57 us | **81x** |
+| LIKE prefix (User_1%) | 3.51 us | 253.31 us | **72x** |
+| OR conditions (3 vals) | 2.92 us | 207.39 us | **71x** |
+| DISTINCT + ORDER BY | 4.73 us | 335.87 us | **71x** |
+| Expr in WHERE (funcs) | 5.41 us | 324.14 us | **60x** |
+| DISTINCT (no ORDER) | 4.40 us | 258.64 us | **59x** |
+| BETWEEN (non-indexed) | 3.00 us | 171.87 us | **57x** |
+| CASE expression | 4.29 us | 225.71 us | **53x** |
+| DELETE complex | 2.29 us | 116.55 us | **51x** |
+| Compare with subquery | 5.10 us | 250.43 us | **49x** |
+| NOT EXISTS subquery | 21.77 us | 1042.73 us | **48x** |
+| OFFSET pagination (5000) | 11.62 us | 542.62 us | **47x** |
+| UNION ALL | 4.89 us | 220.02 us | **45x** |
+| Complex JOIN+GROUP+HAVING | 48.73 us | 2174.61 us | **45x** |
+| String concat (\|\|) | 6.13 us | 251.33 us | **41x** |
 
 ---
 
@@ -175,19 +171,19 @@ Performance comparison between **Stoolap**, **SQLite**, and **DuckDB** using ide
 
 | Operation | SQLite | Stoolap | Factor |
 |-----------|--------|---------|--------|
-| COALESCE | 2.84 us | 4.30 us | 1.5x |
-| INNER JOIN | 14.86 us | 20.35 us | 1.4x |
-| Self JOIN | 10.71 us | 13.76 us | 1.3x |
-| String concat | 5.60 us | 7.13 us | 1.3x |
-| Batch INSERT | 74.93 us | 77.94 us | 1.0x |
-| CASE expression | 5.10 us | 5.25 us | 1.0x |
-| Multiple CTEs (2) | 20.60 us | 20.64 us | 1.0x |
+| INNER JOIN | 13.67 us | 20.61 us | 1.5x |
+| Self JOIN (same age) | 9.43 us | 12.65 us | 1.3x |
+| COALESCE + IS NOT NULL | 2.94 us | 3.68 us | 1.3x |
+| String concat (\|\|) | 5.25 us | 6.13 us | 1.2x |
+| Multiple CTEs (2) | 17.41 us | 20.12 us | 1.2x |
+| UPDATE by ID | 0.55 us | 0.60 us | 1.1x |
+| Math expressions | 11.74 us | 12.36 us | 1.1x |
 
 ### DuckDB Advantages
 
 | Operation | DuckDB | Stoolap | Factor |
 |-----------|--------|---------|--------|
-| Derived table | 255.77 us | 411.49 us | 1.6x |
+| Derived table (FROM sub) | 327.14 us | 379.44 us | 1.2x |
 
 ---
 
@@ -208,22 +204,22 @@ Performance comparison between **Stoolap**, **SQLite**, and **DuckDB** using ide
 
 ```
 Stoolap Strengths:
-  Point Queries (ID):     ████████████████████  1213x vs DuckDB
-  Subquery Compare:       ████████████████████  258x vs SQLite
-  DISTINCT Operations:    ████████████████████  22-286x vs SQLite
-  Semi-joins (EXISTS):    ████████████████████  13-303x faster
-  Batch Inserts:          ████████████████████  191x vs DuckDB
-  Window (PARTITION BY):  ████████████████████  154x vs DuckDB
-  OFFSET Pagination:      ████████████████████  84x vs DuckDB
-  Complex DML:            ████████████████████  68-131x faster
-  Aggregations:           ████████████████████  29x vs SQLite
+  Point Queries (ID):     ████████████████████  545x vs DuckDB
+  Subquery Compare:       ████████████████████  322x vs SQLite
+  DISTINCT Operations:    ████████████████████  22-352x vs SQLite
+  Semi-joins (EXISTS):    ████████████████████  4-377x faster
+  Batch Inserts:          ████████████████████  177x vs DuckDB
+  Window (PARTITION BY):  ████████████████████  87x vs DuckDB
+  OFFSET Pagination:      ████████████████████  47x vs DuckDB
+  Complex DML:            ████████████████████  3-151x faster
+  Aggregations:           ████████████████████  26x vs SQLite
 
 SQLite Strengths:
-  Simple JOINs:           ████████              SQLite ~1.4x faster
-  Simple Expressions:     ██████                SQLite ~1.0-1.5x faster
+  Simple JOINs:           ████████              SQLite ~1.3-1.5x faster
+  Simple Expressions:     ██████                SQLite ~1.1-1.3x faster
 
 DuckDB Strengths:
-  Derived Tables:         ██████                DuckDB ~1.6x faster
+  Derived Tables:         ██████                DuckDB ~1.2x faster
 ```
 
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "56.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c26b57282a08ae92f727497805122fec964c6245cfa0e13f0e75452eaf3bc41f"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -173,23 +173,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "chrono",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-array"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -197,30 +197,34 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.16.1",
- "num",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
 dependencies = [
  "bytes",
  "half",
- "num",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "56.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed61d9d73eda8df9e3014843def37af3050b5080a9acbe108f045a316d5a0be"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
+ "arrow-ord",
  "arrow-schema",
  "arrow-select",
  "atoi",
@@ -229,27 +233,28 @@ dependencies = [
  "comfy-table",
  "half",
  "lexical-core",
- "num",
+ "num-traits",
  "ryu",
 ]
 
 [[package]]
 name = "arrow-data"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "half",
- "num",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-ord"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -260,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -273,32 +278,32 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -306,7 +311,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "memchr",
- "num",
+ "num-traits",
  "regex",
  "regex-syntax",
 ]
@@ -1099,7 +1104,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1124,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.4.4"
+version = "1.10501.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8685352ce688883098b61a361e86e87df66fc8c444f4a2411e884c16d5243a65"
+checksum = "f13bc6d6487032fc2825a62ef8b4924b2378a2eb3166e132e5f3141ae9dd633f"
 dependencies = [
  "arrow",
  "cast",
@@ -1239,7 +1244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1725,9 +1730,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.12",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1752,12 +1754,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.9.1"
+name = "hashbrown"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "hashbrown 0.14.5",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1767,6 +1769,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2258,9 +2269,9 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.4.4"
+version = "1.10501.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78bacb8933586cee3b550c39b610d314f9b7a48701ac7a914a046165a4ad8da"
+checksum = "12096c1694924782b3fe21e790630b77bacb4fcb7ad9d7ee0fec626f985bf248"
 dependencies = [
  "cc",
  "flate2",
@@ -2302,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2555,21 +2566,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2598,28 +2595,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -3004,7 +2979,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3337,17 +3312,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.32.1"
+name = "rsqlite-vfs"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.9.1",
+ "hashlink 0.12.1",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -3394,7 +3380,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3720,6 +3706,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "sqllogictest"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3966,7 +3964,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4674,7 +4672,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,8 +85,8 @@ roaring = "0.11"  # Compressed bitmap indexes (used by Lucene, Druid, Spark)
 lru = "0.16"  # O(1) LRU cache for compiled expression programs
 
 # Optional benchmark dependencies (for comparison benchmarks)
-rusqlite = { version = "0.32", features = ["bundled"], optional = true }
-duckdb = { version = "1.4.3", features = ["bundled"], optional = true }
+rusqlite = { version = "0.40", features = ["bundled"], optional = true }
+duckdb = { version = "1.10501", features = ["bundled"], optional = true }
 
 # Optional ANN benchmark dependencies (download + decompress datasets)
 ureq = { version = "2", optional = true }


### PR DESCRIPTION
Every number in the file is a fresh best-of-10, all three engines measured back to back on one idle machine with the same harness. The old numbers were from 2026-04-01, 56 commits ago, against rusqlite 0.32.1 and duckdb 1.4.3.

## Versions

- rusqlite 0.32.1 -> **0.40.2** (latest)
- duckdb 1.4.3 -> **1.10501.0**

duckdb 1.10505.0 is newer still, but it requires `comfy-table ~7.1` against our `^7.2`, so it does not resolve. 1.10501.0 is the newest that does.

## Headline: unchanged

46 wins / 7 losses against SQLite, 52 / 1 against DuckDB, exactly as before.

## Four operations changed hands

| operation | verdict | us, before -> after | rival, before -> after |
|---|---|---|---|
| CASE expression | **won** | 5.25 -> 4.29 | SQLite 5.10 -> 4.39 |
| Batch INSERT (100 rows) | **won** | 77.94 -> 51.71 | SQLite 74.93 -> 64.75 |
| UPDATE by ID | lost | 0.54 -> 0.60 | SQLite 0.61 -> 0.55 |
| Math expressions | lost | 15.96 -> 12.36 | SQLite 36.74 -> **11.74** |

Math expressions is worth reading closely: we got 1.29x faster and still lost it, because the SQLite bundled with rusqlite 0.40 is 3.13x faster there than the one in 0.32.

## How to read the deltas

SQLite improved by **1.13x at the median** between the two recordings without a line of our code changing, and DuckDB by 1.03x. Our column improved by 1.10x. So most of the movement in our numbers is the machine and the newer rivals, not our work. The file cannot express that, which is why it is here.

The comparisons that do isolate our work are the same-machine ones:

| operation | before | after | |
|---|---|---|---|
| Window ROWS frame | 548.16 | 354.91 | 1.54x |
| Batch INSERT (100 rows) | 77.94 | 51.71 | 1.51x |
| COUNT DISTINCT | 0.37 | 0.26 | 1.43x |
| Multi window funcs (3) | 568.68 | 399.55 | 1.42x |
| INSERT single | 1.14 | 0.82 | 1.40x |

## Six operations are slower than the old file

BETWEEN (non-indexed) 0.88x, UPDATE by ID 0.89x, SELECT by ID 0.90x, Window PARTITION BY 0.93x, DELETE by ID 0.94x, INNER JOIN 0.99x.

Four of those are sub-microsecond point operations, and the harness measures them over 500 iterations, a window of about 300 microseconds, which cannot resolve a difference of this size. I checked the two largest against the actual v0.4.0 binary built and run on this machine:

- **Window PARTITION BY**: v0.4.0 8.505 us, current main 8.171 us. Main is faster; the 7.56 in the old file is not reproducible here.
- **UPDATE by ID**: measured over 50,000 iterations instead of 500, six commits spanning v0.4.0 to main all land within 2-5% of each other with no trend (v0.4.0 best 0.5777, main best 0.5784).

So those two are the harness, not the engine. The other four are inside the same noise band.

## Suggested follow-up

`ITERATIONS = 500` for point queries makes `bench-compare.py` unable to resolve 5-10% differences on the fastest operations, which is exactly where the engine is most sensitive. Raising it for the point-query group would make the tool's 3% threshold mean something. Happy to do it as a separate PR.
