### PR TITLE
fix(common): make CompactVec::reserve grow geometrically

### DIFF
--- a/src/common/compact_vec.rs
+++ b/src/common/compact_vec.rs
@@ -195,6 +195,10 @@ impl<T> CompactVec<T> {
     }
 
     /// Reserves capacity for at least `additional` more elements.
+    ///
+    /// Grows geometrically like `Vec::reserve`, so a sequence of small
+    /// reservations costs O(log n) reallocations rather than one per call.
+    /// Use [`CompactVec::reserve_exact`] when the final size is known.
     #[inline]
     pub fn reserve(&mut self, additional: usize) {
         // Unpack once
@@ -203,9 +207,20 @@ impl<T> CompactVec<T> {
         let required = len.saturating_add(additional);
 
         if required > cap {
-            // Calculate new capacity directly, avoid second capacity() call
-            let new_cap = required.min(u32::MAX as usize);
+            let new_cap = required.max(cap.saturating_mul(2)).min(u32::MAX as usize);
             self.realloc(new_cap);
+        }
+    }
+
+    /// Reserves capacity for exactly `additional` more elements.
+    #[inline]
+    pub fn reserve_exact(&mut self, additional: usize) {
+        let len = Self::unpack_len(self.len_cap) as usize;
+        let cap = Self::unpack_cap(self.len_cap) as usize;
+        let required = len.saturating_add(additional);
+
+        if required > cap {
+            self.realloc(required.min(u32::MAX as usize));
         }
     }
 
@@ -1452,6 +1467,32 @@ mod tests {
         // 0 and 1 are dropped with the vector, 2 was dropped above, 3 is leaked
         // by mem::forget. Nothing is dropped twice.
         assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 3);
+    }
+
+    /// Repeated small reservations must grow geometrically, not once per call.
+    #[test]
+    fn test_reserve_amortizes_and_reserve_exact_does_not() {
+        let mut v: CompactVec<u64> = CompactVec::new();
+        let mut reallocations = 0;
+        let mut last_cap = v.capacity();
+        for i in 0..1000u64 {
+            v.reserve(1);
+            v.push(i);
+            if v.capacity() != last_cap {
+                reallocations += 1;
+                last_cap = v.capacity();
+            }
+        }
+        assert!(
+            reallocations <= 12,
+            "reserve(1) x1000 reallocated {reallocations} times"
+        );
+
+        let mut e: CompactVec<u64> = CompactVec::new();
+        e.reserve_exact(37);
+        assert_eq!(e.capacity(), 37);
+        e.reserve_exact(10);
+        assert_eq!(e.capacity(), 37, "already has room, must not grow");
     }
 
     /// Test panic safety in Clone implementation


### PR DESCRIPTION
Small and contract-level. Item 7 of the audit was measured and mostly dropped; this is the one piece of it that is a real defect.

## `reserve` was `reserve_exact` under the wrong name

```rust
/// Reserves capacity for at least `additional` more elements.
pub fn reserve(&mut self, additional: usize) {
    ...
    if required > cap {
        let new_cap = required.min(u32::MAX as usize);   // exactly `required`
        self.realloc(new_cap);
    }
}
```

The comment promised "at least", the body delivered "exactly". So a caller that reserves as it goes pays a reallocation and a full copy on every call. The new test makes it concrete: `reserve(1)` then `push`, a thousand times, on the old body:

```
reserve(1) x1000 reallocated 1000 times
```

`reserve` now grows to `max(required, 2 * capacity)`, as `Vec::reserve` does, and `reserve_exact` is added for callers that know the final size. On the new body the same loop reallocates 11 times, and the test bounds it at 12.

Nothing in the tree hits the quadratic case today, because every caller sizes its buffer up front. The fix is so the next caller does not have to know that.

## What was measured and dropped

The rest of item 7 was a bulk `CompactVec::append` (one memcpy instead of moving elements one at a time) wired into the six owned-buffer `extend` sites in `row.rs`, plus an index nested loop change that clones only the projected columns of a shared row instead of every column. Both were built and measured, interleaved best of 8, 100k output rows, ten columns a side:

| query | before | after |
|---|---|---|
| hash join `SELECT *` | 12.14 ms | 12.10 ms |
| hash join, 2 of 20 columns | 14.86 ms | 15.30 ms |
| index nested loop `SELECT *` | 29.65 ms | 29.16 ms |
| index nested loop, 2 of 20 columns | 18.47 ms | 18.10 ms |

Parity throughout. The instruction-count argument in the audit was right, but the row copy is not where a join spends its time. Same call as the cow_btree node allocation: a change that cannot be measured does not ship.

## Gates

- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`: 4993 passed
- `cargo nextest run --features test-filedb`: 4995 passed
- `cargo test --test differential_oracle_test --features sqlite`: 9 passed
