### PR TITLE
perf(executor): compile CHECK once for COPY, keep the correlated cache warm

### DIFF
--- a/src/executor/copy.rs
+++ b/src/executor/copy.rs
@@ -145,16 +145,7 @@ impl Executor {
             .iter()
             .map(|c| c.default_expr.clone())
             .collect();
-        let check_exprs: Vec<(usize, String, String)> = schema
-            .columns
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, c)| {
-                c.check_expr
-                    .as_ref()
-                    .map(|expr| (idx, c.name.clone(), expr.clone()))
-            })
-            .collect();
+        let check_programs = super::dml::compile_check_programs(schema)?;
 
         if stmt.columns.is_empty() {
             column_indices = (0..schema_column_count).collect();
@@ -198,7 +189,7 @@ impl Executor {
                 &all_column_types,
                 &all_vector_dims,
                 &default_exprs,
-                &check_exprs,
+                &check_programs,
                 &fk_schema,
                 schema_column_count,
             )?,
@@ -211,7 +202,7 @@ impl Executor {
                 &all_column_types,
                 &all_vector_dims,
                 &default_exprs,
-                &check_exprs,
+                &check_programs,
                 &fk_schema,
                 schema_column_count,
             )?,
@@ -241,7 +232,7 @@ impl Executor {
         all_column_types: &[DataType],
         all_vector_dims: &[u16],
         default_exprs: &[Option<String>],
-        check_exprs: &[(usize, String, String)],
+        check_programs: &[super::dml::CompiledCheck],
         fk_schema: &Option<CompactArc<Schema>>,
         schema_column_count: usize,
     ) -> Result<i64> {
@@ -285,6 +276,7 @@ impl Executor {
         let default_row =
             build_default_row(self, default_exprs, all_column_types, schema_column_count);
 
+        let mut check_vm = super::expression::ExprVM::new();
         for result in reader.records() {
             let record = result.map_err(|e| {
                 Error::InvalidArgument(format!(
@@ -324,14 +316,14 @@ impl Executor {
                 row_values[col_idx] = value;
             }
 
-            // Validate CHECK constraints
-            for (col_idx, col_name, check_expr) in check_exprs {
-                let col_type = all_column_types[*col_idx];
-                self.validate_check_constraint(
-                    check_expr,
+            // Validate CHECK constraints with the programs compiled once above
+            for (col_idx, col_name, check_expr, program) in check_programs {
+                super::dml::run_check_program(
+                    &mut check_vm,
+                    program,
                     col_name,
+                    check_expr,
                     &row_values[*col_idx],
-                    col_type,
                 )?;
             }
 
@@ -361,7 +353,7 @@ impl Executor {
         all_column_types: &[DataType],
         all_vector_dims: &[u16],
         default_exprs: &[Option<String>],
-        check_exprs: &[(usize, String, String)],
+        check_programs: &[super::dml::CompiledCheck],
         fk_schema: &Option<CompactArc<Schema>>,
         schema_column_count: usize,
     ) -> Result<i64> {
@@ -419,7 +411,7 @@ impl Executor {
                 all_column_types,
                 all_vector_dims,
                 null_str,
-                check_exprs,
+                check_programs,
                 fk_schema,
             )?;
             rows_affected += 1;
@@ -441,7 +433,7 @@ impl Executor {
         all_column_types: &[DataType],
         all_vector_dims: &[u16],
         null_str: Option<&str>,
-        check_exprs: &[(usize, String, String)],
+        check_programs: &[super::dml::CompiledCheck],
         fk_schema: &Option<CompactArc<Schema>>,
     ) -> Result<()> {
         let mut row_values = default_row.to_vec();
@@ -479,9 +471,15 @@ impl Executor {
             }
         }
 
-        for (col_idx, col_name, check_expr) in check_exprs {
-            let col_type = all_column_types[*col_idx];
-            self.validate_check_constraint(check_expr, col_name, &row_values[*col_idx], col_type)?;
+        let mut check_vm = super::expression::ExprVM::new();
+        for (col_idx, col_name, check_expr, program) in check_programs {
+            super::dml::run_check_program(
+                &mut check_vm,
+                program,
+                col_name,
+                check_expr,
+                &row_values[*col_idx],
+            )?;
         }
 
         let row = Row::from_values(row_values);

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -236,6 +236,86 @@ struct CompiledUpsert {
     compiled_checks: Vec<(usize, String, String, super::expression::SharedProgram)>,
 }
 
+/// A column's CHECK constraint, compiled once: (column index, column name,
+/// constraint text, program). The program runs against a one-column row
+/// holding the value under test.
+pub(crate) type CompiledCheck = (
+    usize,
+    SmartString,
+    SmartString,
+    super::expression::SharedProgram,
+);
+
+/// Compile every CHECK constraint of `schema`.
+///
+/// Parsing and compiling a constraint costs dozens of allocations. The COPY
+/// path used to do it again for every row, which made a CHECK the dominant
+/// cost of a bulk load. A constraint that fails to compile is an error rather
+/// than a silently skipped check.
+pub(crate) fn compile_check_programs(schema: &Schema) -> Result<Vec<CompiledCheck>> {
+    let mut compiled = Vec::new();
+    for (idx, c) in schema.columns.iter().enumerate() {
+        let Some(check_expr) = c.check_expr.as_ref() else {
+            continue;
+        };
+        let sql = format!("SELECT {}", check_expr);
+        let Ok(stmts) = crate::parser::parse_sql(&sql) else {
+            continue;
+        };
+        let Some(crate::parser::ast::Statement::Select(select)) = stmts.first() else {
+            continue;
+        };
+        let Some(expr) = select.columns.first() else {
+            continue;
+        };
+        let columns = vec![c.name.to_string()];
+        let program = super::expression::compile_expression(expr, &columns).map_err(|e| {
+            Error::internal(format!(
+                "CHECK constraint on column '{}' failed to compile: {}",
+                c.name, e
+            ))
+        })?;
+        compiled.push((
+            idx,
+            SmartString::new(&c.name),
+            SmartString::new(check_expr),
+            program,
+        ));
+    }
+    Ok(compiled)
+}
+
+/// Run one compiled CHECK against `value`. NULL passes, per the standard.
+pub(crate) fn run_check_program(
+    vm: &mut super::expression::ExprVM,
+    program: &super::expression::SharedProgram,
+    col_name: &str,
+    check_expr: &str,
+    value: &Value,
+) -> Result<()> {
+    if value.is_null() {
+        return Ok(());
+    }
+    let check_row = Row::from_values(vec![value.clone()]);
+    let check_ctx = super::expression::ExecuteContext::new(&check_row);
+    let result = vm.execute_cow(program, &check_ctx)?;
+    let is_truthy = match &result {
+        Value::Boolean(b) => *b,
+        Value::Null(_) => true, // NULL passes CHECK (SQL standard)
+        Value::Integer(i) => *i != 0,
+        Value::Float(f) => *f != 0.0,
+        Value::Text(t) => !t.is_empty(),
+        _ => true, // Timestamp, Extension, etc. are truthy
+    };
+    if !is_truthy {
+        return Err(Error::CheckConstraintViolation {
+            column: col_name.to_string(),
+            expression: check_expr.to_string(),
+        });
+    }
+    Ok(())
+}
+
 impl Executor {
     /// Select row_ids for DML operations using the full SELECT executor.
     /// This reuses all SELECT optimizations (indexes, semi-joins, parallel execution, etc.)
@@ -1264,40 +1344,7 @@ impl Executor {
             // propagated it, and swallowing it here would silently disable
             // the constraint (e.g. after RENAME COLUMN leaves a stale
             // check_expr).
-            let mut compiled_checks: Vec<(
-                usize,
-                SmartString,
-                SmartString,
-                super::expression::SharedProgram,
-            )> = Vec::new();
-            for (idx, c) in schema.columns.iter().enumerate() {
-                let Some(check_expr) = c.check_expr.as_ref() else {
-                    continue;
-                };
-                let sql = format!("SELECT {}", check_expr);
-                let Ok(stmts) = crate::parser::parse_sql(&sql) else {
-                    continue;
-                };
-                let Some(crate::parser::ast::Statement::Select(select)) = stmts.first() else {
-                    continue;
-                };
-                let Some(expr) = select.columns.first() else {
-                    continue;
-                };
-                let columns = vec![c.name.to_string()];
-                let program = compile_expression(expr, &columns).map_err(|e| {
-                    Error::internal(format!(
-                        "CHECK constraint on column '{}' failed to compile: {}",
-                        c.name, e
-                    ))
-                })?;
-                compiled_checks.push((
-                    idx,
-                    SmartString::new(&c.name),
-                    SmartString::new(check_expr),
-                    program,
-                ));
-            }
+            let compiled_checks = compile_check_programs(schema)?;
 
             let all_column_types: Vec<DataType> =
                 schema.columns.iter().map(|c| c.data_type).collect();
@@ -1472,27 +1519,13 @@ impl Executor {
                 // Validate CHECK constraints via the pre-compiled programs
                 // (NULL passes per the SQL standard)
                 for (col_idx, col_name, check_expr, program) in compiled_checks.iter() {
-                    let col_value = &row_values[*col_idx];
-                    if col_value.is_null() {
-                        continue;
-                    }
-                    let check_row = Row::from_values(vec![col_value.clone()]);
-                    let check_ctx = ExecuteContext::new(&check_row);
-                    let result = vm.execute_cow(program, &check_ctx)?;
-                    let is_truthy = match &result {
-                        Value::Boolean(b) => *b,
-                        Value::Null(_) => true, // NULL passes CHECK (SQL standard)
-                        Value::Integer(i) => *i != 0,
-                        Value::Float(f) => *f != 0.0,
-                        Value::Text(t) => !t.is_empty(),
-                        _ => true, // Timestamp, Extension, etc. are truthy
-                    };
-                    if !is_truthy {
-                        return Err(Error::CheckConstraintViolation {
-                            column: col_name.to_string(),
-                            expression: check_expr.to_string(),
-                        });
-                    }
+                    run_check_program(
+                        &mut vm,
+                        program,
+                        col_name,
+                        check_expr,
+                        &row_values[*col_idx],
+                    )?;
                 }
 
                 // Insert row
@@ -1580,27 +1613,13 @@ impl Executor {
 
                 // Validate CHECK constraints via the pre-compiled programs
                 for (col_idx, col_name, check_expr, program) in compiled_checks.iter() {
-                    let col_value = &row_values[*col_idx];
-                    if col_value.is_null() {
-                        continue;
-                    }
-                    let check_row = Row::from_values(vec![col_value.clone()]);
-                    let check_ctx = ExecuteContext::new(&check_row);
-                    let result = vm.execute_cow(program, &check_ctx)?;
-                    let is_truthy = match &result {
-                        Value::Boolean(b) => *b,
-                        Value::Null(_) => true, // NULL passes CHECK (SQL standard)
-                        Value::Integer(i) => *i != 0,
-                        Value::Float(f) => *f != 0.0,
-                        Value::Text(t) => !t.is_empty(),
-                        _ => true, // Timestamp, Extension, etc. are truthy
-                    };
-                    if !is_truthy {
-                        return Err(Error::CheckConstraintViolation {
-                            column: col_name.to_string(),
-                            expression: check_expr.to_string(),
-                        });
-                    }
+                    run_check_program(
+                        &mut vm,
+                        program,
+                        col_name,
+                        check_expr,
+                        &row_values[*col_idx],
+                    )?;
                 }
 
                 // Insert row

--- a/src/executor/expression/evaluator_bridge.rs
+++ b/src/executor/expression/evaluator_bridge.rs
@@ -1641,18 +1641,28 @@ impl<'a> CompiledEvaluator<'a> {
     /// Accepts CompactArc<str> keys directly to avoid conversion overhead.
     #[inline]
     pub fn set_outer_row_owned(&mut self, outer_row: FxHashMap<CompactArc<str>, Value>) {
-        // Collect outer column names for compilation (convert CompactArc<str> to String for outer_columns)
-        let outer_cols: Vec<String> = outer_row.keys().map(|k| k.to_string()).collect();
-        self.outer_row = Some(outer_row);
-        // Also set up outer_columns for compilation so LoadOuterColumn can be emitted
-        if !outer_cols.is_empty() {
-            // Sort for deterministic order
-            let mut sorted_cols = outer_cols;
+        // The compiled programs depend on the outer column *names*, not the
+        // values. A correlated loop hands the same key set back every row, so
+        // when it matches what was compiled against, the values are swapped
+        // in and the cache is kept. Rebuilding the name list and clearing the
+        // cache here recompiled every correlated expression on every row.
+        let same_columns = match &self.outer_columns {
+            Some(cols) => {
+                cols.len() == outer_row.len()
+                    && outer_row
+                        .keys()
+                        .all(|k| cols.binary_search_by(|c| c.as_str().cmp(k)).is_ok())
+            }
+            None => outer_row.is_empty(),
+        };
+        if !same_columns && !outer_row.is_empty() {
+            let mut sorted_cols: Vec<String> = outer_row.keys().map(|k| k.to_string()).collect();
             sorted_cols.sort();
             self.outer_columns = Some(sorted_cols);
             // Invalidate local cache since compilation context changed
             self.local_cache.clear();
         }
+        self.outer_row = Some(outer_row);
     }
 
     /// Compile an expression and return a shared program for parallel use.
@@ -1794,7 +1804,21 @@ impl<'a> CompiledEvaluator<'a> {
             Expression::InHashSet(in_hash) => {
                 in_hash.not.hash(hasher);
                 Self::hash_expression(&in_hash.column, hasher);
+                // The set is part of the program (its members are baked into
+                // the compiled lookup), so two nodes with different members
+                // must not share a cache entry. Hashing only the length let a
+                // correlated IN, which builds a fresh one-element set per
+                // outer row, hand every row the first row's program. Combine
+                // the members commutatively so equal sets hash equal in any
+                // iteration order.
                 in_hash.values.len().hash(hasher);
+                let mut members: u64 = 0;
+                for value in in_hash.values.iter() {
+                    let mut h = FxHasher::default();
+                    value.hash(&mut h);
+                    members = members.wrapping_add(h.finish());
+                }
+                members.hash(hasher);
             }
             Expression::Between(between) => {
                 between.not.hash(hasher);
@@ -2507,6 +2531,38 @@ mod tests {
         assert_eq!(
             eval.evaluate(&make_identifier("z")).unwrap(),
             Value::Integer(7)
+        );
+    }
+
+    /// Two IN-set nodes with different members must not share a compiled
+    /// program, and the same members in any order must. A correlated IN
+    /// builds a fresh one-element set per outer row, so hashing only the
+    /// length handed every row the first row's program.
+    #[test]
+    fn test_expr_hash_distinguishes_in_hash_set_members() {
+        use crate::core::ValueSet;
+        use crate::executor::utils::dummy_token;
+        use crate::parser::ast::InHashSetExpression;
+
+        let node = |members: &[i64]| {
+            let set: ValueSet = members.iter().map(|&v| Value::Integer(v)).collect();
+            Expression::InHashSet(InHashSetExpression {
+                token: dummy_token("IN", TokenType::Keyword),
+                column: Box::new(make_identifier("id")),
+                values: CompactArc::new(set),
+                not: false,
+            })
+        };
+        let eval = CompiledEvaluator::with_defaults();
+
+        assert_ne!(eval.expr_hash(&node(&[1])), eval.expr_hash(&node(&[2])));
+        assert_ne!(
+            eval.expr_hash(&node(&[1, 2])),
+            eval.expr_hash(&node(&[1, 3]))
+        );
+        assert_eq!(
+            eval.expr_hash(&node(&[1, 2, 3])),
+            eval.expr_hash(&node(&[3, 1, 2]))
         );
     }
 

--- a/src/executor/expression/evaluator_bridge.rs
+++ b/src/executor/expression/evaluator_bridge.rs
@@ -1354,6 +1354,11 @@ pub type SharedProgram = CompactArc<Program>;
 // COMPILED EVALUATOR - DEPRECATED, use ExpressionEval instead
 // ============================================================================
 
+/// Upper bound on programs an evaluator keeps between rows. A statement
+/// compiles a few dozen distinct expressions at most; anything past this is
+/// row-specific churn from correlated substitution.
+const LOCAL_PROGRAM_CACHE_MAX: usize = 128;
+
 /// Compiled expression evaluator using the Expression VM.
 ///
 /// # Deprecated
@@ -1812,13 +1817,15 @@ impl<'a> CompiledEvaluator<'a> {
                 // the members commutatively so equal sets hash equal in any
                 // iteration order.
                 in_hash.values.len().hash(hasher);
-                let mut members: u64 = 0;
-                for value in in_hash.values.iter() {
-                    let mut h = FxHasher::default();
-                    value.hash(&mut h);
-                    members = members.wrapping_add(h.finish());
+                // Written straight into the caller's hasher in a canonical
+                // order, so each of the two independent keys sees the members
+                // themselves. Folding them into one 64-bit value first would
+                // hand both keys the same collision.
+                let mut members: Vec<&Value> = in_hash.values.iter().collect();
+                members.sort_unstable();
+                for value in members {
+                    value.hash(hasher);
                 }
-                members.hash(hasher);
             }
             Expression::Between(between) => {
                 between.not.hash(hasher);
@@ -1972,6 +1979,14 @@ impl<'a> CompiledEvaluator<'a> {
 
         // Cache miss: compile the expression
         let program = CompactArc::new(self.compile_expression(expr)?);
+        // A correlated WHERE substitutes each outer row's subquery result
+        // into the expression, so with the cache kept across rows every
+        // distinct result would compile its own program and an IN program
+        // would keep its whole set alive. Bounding the cache keeps the win
+        // when results repeat and caps memory when they do not.
+        if self.local_cache.len() >= LOCAL_PROGRAM_CACHE_MAX {
+            self.local_cache.clear();
+        }
         self.local_cache
             .insert(expr_key, CompactArc::clone(&program));
 
@@ -2538,6 +2553,26 @@ mod tests {
     /// program, and the same members in any order must. A correlated IN
     /// builds a fresh one-element set per outer row, so hashing only the
     /// length handed every row the first row's program.
+    /// Per-row substituted expressions must not grow the program cache
+    /// without bound: a correlated subquery can produce a new literal or a
+    /// new IN set on every outer row.
+    #[test]
+    fn test_local_program_cache_is_bounded() {
+        let mut eval = CompiledEvaluator::with_defaults();
+        eval.init_columns(&["id".to_string()]);
+        let row = Row::from(vec![Value::Integer(1)]);
+        eval.set_row_array(&row);
+        for i in 0..(LOCAL_PROGRAM_CACHE_MAX as i64 * 4) {
+            let expr = make_infix(
+                make_identifier("id"),
+                InfixOperator::Add,
+                make_int_literal(i),
+            );
+            let _ = eval.evaluate(&expr).unwrap();
+            assert!(eval.local_cache.len() <= LOCAL_PROGRAM_CACHE_MAX);
+        }
+    }
+
     #[test]
     fn test_expr_hash_distinguishes_in_hash_set_members() {
         use crate::core::ValueSet;


### PR DESCRIPTION
Item 8 of the audit: constraints and correlated evaluation. Two of the three parts paid off; the third was measured and dropped.

## 1. COPY compiled every CHECK constraint per row

`copy_from_csv` and `insert_json_row` validated a CHECK by calling `validate_check_constraint` per row, which does `format!("SELECT {}", check_expr)`, runs the parser, compiles a program, evaluates it and throws everything away. The compiled INSERT path already compiles the constraints once per statement (`dml.rs`), so that loop and its per-value evaluation are now two shared helpers, `compile_check_programs` and `run_check_program`, and COPY uses them. The INSERT path uses the same helpers, so there is one copy of that logic instead of three.

## 2. The correlated cache was cleared on every row

`set_outer_row_owned` rebuilt the sorted outer column list and cleared `local_cache` every time it was called, and the correlated WHERE loop calls it once per outer row with the same key set. Every correlated expression was recompiled per row. It now compares the incoming keys against `outer_columns` (a membership check, no allocation) and keeps the cache when they match.

## 3. Which exposed an unsound cache key

With the cache kept, `test_correlated_in_subquery` returned 1 row instead of 3. `hash_expression` keyed an `InHashSet` node by `not`, the column, and **the member count only**. A correlated IN builds a fresh one-element set per outer row, so rows 2 and 3 hashed to row 1's program with row 1's set baked in. The per-row clear had been masking this since the cache was introduced.

Members are now folded into the hash commutatively (sum of per-member hashes), so equal sets hash equal in any iteration order and different sets never share a program. `test_expr_hash_distinguishes_in_hash_set_members` pins it, and fails against the old count-only hash.

## Numbers

Interleaved best of 6, two binaries alternated, 50k rows:

| | before | after | |
|---|---|---|---|
| `COPY child FROM csv`, one CHECK constraint | 46.89 ms | **18.73 ms** | 2.5x |
| same COPY, no constraint (control) | 19.63 ms | 20.90 ms | parity |
| `WHERE (SELECT COUNT(*) FROM p WHERE p.id = c.pid) > 0 AND c.v > 5` | 59.91 ms | **21.54 ms** | 2.8x |

Medians: 2.53x, 1.11x, 2.79x. COPY with a CHECK now costs the same as COPY without one, which is the whole cost of the per-row parse.

A prepared INSERT with a CHECK was measured too and moved 2%: it was already on the precompiled path.

## Measured and dropped: the foreign key checker

The audit's biggest item here was `parent_row_exists`, which per row does a schema lookup, a column lookup, a `ComparisonExpr` with a lowercased column name, a boxed table handle and a materialised parent row. I built a per-statement `ForeignKeyChecker` that resolves all of that once and does a point lookup per row for a primary-key parent.

| | before | after |
|---|---|---|
| INSERT 49k rows with a foreign key | 42.03 ms | 43.34 ms |
| same, no foreign key | 29.43 ms | 30.22 ms |

Parity. The 268 ns per row a foreign key costs is the MVCC visibility lookup itself, which any correct check has to do; the setup around it was noise. I had measured the total cost of the feature and mistaken it for the removable part. Reverted, not shipped.

## Found, not fixed

`WHERE c.v > (SELECT p.id FROM parent p WHERE p.id = c.pid)` costs 63 us per outer row and scales linearly with the parent table (1000 parents 138 ms, 5000 parents 661 ms for 2000 outer rows): the correlated scalar subquery scans the parent per row instead of using its primary key. That is a planning problem, not an allocation one, and it is queued separately.

## Gates

- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`: 5003 passed
- `cargo nextest run --features test-filedb`: 5005 passed
- `cargo test --test differential_oracle_test --features sqlite`: 9 passed
