### PR TITLE
perf(executor): let a correlated subquery reach the primary key when names clash

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -2281,9 +2281,15 @@ impl Executor {
                 // to enable predicate pushdown for index usage.
                 // Example: WHERE o.user_id = u.id -> WHERE o.user_id = 42
                 if let Some(outer_row) = ctx.outer_row() {
-                    let substituted_expr =
-                        super::utils::substitute_outer_references(where_expr, outer_row);
                     let schema = table.schema();
+                    let scope = super::utils::InnerScope {
+                        table: table_name,
+                        alias: table_alias.as_deref(),
+                        schema,
+                    };
+                    let substituted_expr = super::utils::substitute_outer_references_in_scope(
+                        where_expr, outer_row, &scope,
+                    );
                     // Try to push down the substituted expression
                     let (storage_expr, needs_filter) =
                         pushdown::try_pushdown(&substituted_expr, schema, Some(ctx));

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -138,8 +138,10 @@ pub struct InnerScope<'a> {
 }
 
 impl InnerScope<'_> {
+    /// With an alias only the alias names the inner table; the table's own
+    /// name may then be an alias in the outer query.
     fn owns_qualifier(&self, qualifier: &str) -> bool {
-        qualifier == self.table || self.alias == Some(qualifier)
+        qualifier == self.alias.unwrap_or(self.table)
     }
 
     fn owns_column(&self, column: &str) -> bool {
@@ -2053,13 +2055,8 @@ mod tests {
 
         let is_literal = |expr: &Expression, expected: i64| matches!(expr, Expression::IntegerLiteral(l) if l.value == expected);
 
-        // inner references, qualified by alias or table name, or bare
-        for expr in [
-            qualified("p", "id"),
-            qualified("parent", "id"),
-            ident("id"),
-            ident("name"),
-        ] {
+        // inner references, qualified by the alias or bare
+        for expr in [qualified("p", "id"), ident("id"), ident("name")] {
             let out = substitute_outer_references_in_scope(&expr, &outer, &scope);
             assert!(
                 matches!(
@@ -2082,6 +2079,29 @@ mod tests {
         assert!(is_literal(
             &substitute_outer_references_in_scope(&ident("pid"), &outer, &scope),
             7
+        ));
+
+        // with an alias, the table name is not inner: it may be an outer alias
+        outer.insert(CompactArc::from("parent.id"), Value::Integer(5));
+        outer.insert(CompactArc::from("parent.pid"), Value::Integer(7));
+        assert!(is_literal(
+            &substitute_outer_references_in_scope(&qualified("parent", "id"), &outer, &scope),
+            5
+        ));
+        assert!(is_literal(
+            &substitute_outer_references_in_scope(&qualified("parent", "pid"), &outer, &scope),
+            7
+        ));
+
+        // without an alias, the table name is the inner qualifier
+        let bare = InnerScope {
+            table: "parent",
+            alias: None,
+            schema: &schema,
+        };
+        assert!(matches!(
+            substitute_outer_references_in_scope(&qualified("parent", "id"), &outer, &bare),
+            Expression::QualifiedIdentifier(_)
         ));
     }
 

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -32,7 +32,7 @@ use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 use crate::common::StringMap;
 
 use crate::core::value::NULL_VALUE;
-use crate::core::{DataType, Operator, Row, Value};
+use crate::core::{DataType, Operator, Row, Schema, Value};
 use crate::executor::operators::index_nested_loop::ColumnSource;
 use crate::parser::ast::{
     BetweenExpression, BooleanLiteral, Expression, FloatLiteral, FunctionCall, Identifier,
@@ -125,7 +125,37 @@ pub fn substitute_outer_references(
     outer_row: &FxHashMap<CompactArc<str>, Value>,
 ) -> Expression {
     // Use the internal function that returns Option for copy-on-write semantics
-    substitute_outer_references_inner(expr, outer_row).unwrap_or_else(|| expr.clone())
+    substitute_outer_references_inner(expr, outer_row, None).unwrap_or_else(|| expr.clone())
+}
+
+/// The table a correlated subquery scans. References into it are left
+/// alone: an inner column may share its name with an outer one, and SQL
+/// binds the nearer scope first.
+pub struct InnerScope<'a> {
+    pub table: &'a str,
+    pub alias: Option<&'a str>,
+    pub schema: &'a Schema,
+}
+
+impl InnerScope<'_> {
+    fn owns_qualifier(&self, qualifier: &str) -> bool {
+        qualifier == self.table || self.alias == Some(qualifier)
+    }
+
+    fn owns_column(&self, column: &str) -> bool {
+        self.schema.column_index_map().contains_key(column)
+    }
+}
+
+/// Like [`substitute_outer_references`], but leaves references to the
+/// subquery's own table untouched so the outer values it does substitute
+/// can drive index and primary key lookups.
+pub fn substitute_outer_references_in_scope(
+    expr: &Expression,
+    outer_row: &FxHashMap<CompactArc<str>, Value>,
+    scope: &InnerScope<'_>,
+) -> Expression {
+    substitute_outer_references_inner(expr, outer_row, Some(scope)).unwrap_or_else(|| expr.clone())
 }
 
 /// Internal helper that returns None if no substitution was made (avoids cloning).
@@ -133,10 +163,14 @@ pub fn substitute_outer_references(
 fn substitute_outer_references_inner(
     expr: &Expression,
     outer_row: &FxHashMap<CompactArc<str>, Value>,
+    scope: Option<&InnerScope<'_>>,
 ) -> Option<Expression> {
     match expr {
         // Check if this is an outer reference
         Expression::QualifiedIdentifier(qid) => {
+            if scope.is_some_and(|s| s.owns_qualifier(&qid.qualifier.value_lower)) {
+                return None;
+            }
             // Try qualified name: "alias.column"
             // Use .as_str() for lookups since map now uses CompactArc<str> keys
             let qualified_name = format!("{}.{}", qid.qualifier.value_lower, qid.name.value_lower);
@@ -152,6 +186,9 @@ fn substitute_outer_references_inner(
 
         // Check unqualified identifiers too
         Expression::Identifier(id) => {
+            if scope.is_some_and(|s| s.owns_column(&id.value_lower)) {
+                return None;
+            }
             if let Some(value) = outer_row.get(id.value_lower.as_str()) {
                 return Some(value_to_expression(value));
             }
@@ -160,8 +197,8 @@ fn substitute_outer_references_inner(
 
         // Recursively handle infix expressions (AND, OR, comparisons)
         Expression::Infix(infix) => {
-            let new_left = substitute_outer_references_inner(&infix.left, outer_row);
-            let new_right = substitute_outer_references_inner(&infix.right, outer_row);
+            let new_left = substitute_outer_references_inner(&infix.left, outer_row, scope);
+            let new_right = substitute_outer_references_inner(&infix.right, outer_row, scope);
 
             // Only create new expression if something changed
             if new_left.is_some() || new_right.is_some() {
@@ -178,19 +215,20 @@ fn substitute_outer_references_inner(
         }
 
         // Recursively handle prefix expressions (NOT)
-        Expression::Prefix(prefix) => substitute_outer_references_inner(&prefix.right, outer_row)
-            .map(|new_right| {
+        Expression::Prefix(prefix) => {
+            substitute_outer_references_inner(&prefix.right, outer_row, scope).map(|new_right| {
                 Expression::Prefix(PrefixExpression {
                     token: prefix.token.clone(),
                     operator: prefix.operator.clone(),
                     op_type: prefix.op_type,
                     right: Box::new(new_right),
                 })
-            }),
+            })
+        }
 
         // Handle IN expressions
         Expression::In(in_expr) => {
-            let new_left = substitute_outer_references_inner(&in_expr.left, outer_row);
+            let new_left = substitute_outer_references_inner(&in_expr.left, outer_row, scope);
             let new_right = match &*in_expr.right {
                 Expression::List(list) => {
                     // Check if any element changed
@@ -199,7 +237,7 @@ fn substitute_outer_references_inner(
                         .elements
                         .iter()
                         .map(|e| {
-                            let result = substitute_outer_references_inner(e, outer_row);
+                            let result = substitute_outer_references_inner(e, outer_row, scope);
                             if result.is_some() {
                                 any_changed = true;
                             }
@@ -220,7 +258,7 @@ fn substitute_outer_references_inner(
                         None
                     }
                 }
-                other => substitute_outer_references_inner(other, outer_row),
+                other => substitute_outer_references_inner(other, outer_row, scope),
             };
 
             if new_left.is_some() || new_right.is_some() {
@@ -237,9 +275,9 @@ fn substitute_outer_references_inner(
 
         // Handle BETWEEN expressions
         Expression::Between(between) => {
-            let new_expr = substitute_outer_references_inner(&between.expr, outer_row);
-            let new_lower = substitute_outer_references_inner(&between.lower, outer_row);
-            let new_upper = substitute_outer_references_inner(&between.upper, outer_row);
+            let new_expr = substitute_outer_references_inner(&between.expr, outer_row, scope);
+            let new_lower = substitute_outer_references_inner(&between.lower, outer_row, scope);
+            let new_upper = substitute_outer_references_inner(&between.upper, outer_row, scope);
 
             if new_expr.is_some() || new_lower.is_some() || new_upper.is_some() {
                 Some(Expression::Between(BetweenExpression {
@@ -256,12 +294,12 @@ fn substitute_outer_references_inner(
 
         // Handle LIKE expressions
         Expression::Like(like) => {
-            let new_left = substitute_outer_references_inner(&like.left, outer_row);
-            let new_pattern = substitute_outer_references_inner(&like.pattern, outer_row);
+            let new_left = substitute_outer_references_inner(&like.left, outer_row, scope);
+            let new_pattern = substitute_outer_references_inner(&like.pattern, outer_row, scope);
             let new_escape = like
                 .escape
                 .as_ref()
-                .and_then(|e| substitute_outer_references_inner(e, outer_row));
+                .and_then(|e| substitute_outer_references_inner(e, outer_row, scope));
 
             if new_left.is_some() || new_pattern.is_some() || new_escape.is_some() {
                 Some(Expression::Like(LikeExpression {
@@ -288,7 +326,7 @@ fn substitute_outer_references_inner(
                 .arguments
                 .iter()
                 .map(|arg| {
-                    let result = substitute_outer_references_inner(arg, outer_row);
+                    let result = substitute_outer_references_inner(arg, outer_row, scope);
                     if result.is_some() {
                         any_changed = true;
                     }
@@ -299,7 +337,7 @@ fn substitute_outer_references_inner(
             let new_filter = func
                 .filter
                 .as_ref()
-                .and_then(|f| substitute_outer_references_inner(f, outer_row));
+                .and_then(|f| substitute_outer_references_inner(f, outer_row, scope));
             if new_filter.is_some() {
                 any_changed = true;
             }
@@ -1963,6 +2001,89 @@ pub fn compute_join_projection(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn ident(name: &str) -> Expression {
+        Expression::Identifier(Identifier {
+            token: dummy_token_clone(),
+            value: name.into(),
+            value_lower: name.to_lowercase().into(),
+        })
+    }
+
+    fn qualified(qualifier: &str, name: &str) -> Expression {
+        let (Expression::Identifier(q), Expression::Identifier(n)) =
+            (ident(qualifier), ident(name))
+        else {
+            unreachable!()
+        };
+        Expression::QualifiedIdentifier(QualifiedIdentifier {
+            token: dummy_token_clone(),
+            qualifier: Box::new(q),
+            name: Box::new(n),
+        })
+    }
+
+    /// Outer values reach the subquery's WHERE, but names that belong to
+    /// the inner table are left alone even when the outer row has a column
+    /// of the same name.
+    #[test]
+    fn test_substitute_outer_references_respects_inner_scope() {
+        use crate::core::SchemaBuilder;
+
+        let schema = SchemaBuilder::new("parent")
+            .add_primary_key("id", DataType::Integer)
+            .add("Name", DataType::Text)
+            .build();
+        let scope = InnerScope {
+            table: "parent",
+            alias: Some("p"),
+            schema: &schema,
+        };
+        let mut outer: FxHashMap<CompactArc<str>, Value> = FxHashMap::default();
+        for (key, value) in [
+            ("c.id", 3),
+            ("id", 3),
+            ("c.pid", 7),
+            ("pid", 7),
+            ("c.name", 9),
+            ("name", 9),
+        ] {
+            outer.insert(CompactArc::from(key), Value::Integer(value));
+        }
+
+        let is_literal = |expr: &Expression, expected: i64| matches!(expr, Expression::IntegerLiteral(l) if l.value == expected);
+
+        // inner references, qualified by alias or table name, or bare
+        for expr in [
+            qualified("p", "id"),
+            qualified("parent", "id"),
+            ident("id"),
+            ident("name"),
+        ] {
+            let out = substitute_outer_references_in_scope(&expr, &outer, &scope);
+            assert!(
+                matches!(
+                    out,
+                    Expression::Identifier(_) | Expression::QualifiedIdentifier(_)
+                ),
+                "{expr} must not be substituted"
+            );
+        }
+
+        // outer references, qualified or bare, still become literals
+        assert!(is_literal(
+            &substitute_outer_references_in_scope(&qualified("c", "pid"), &outer, &scope),
+            7
+        ));
+        assert!(is_literal(
+            &substitute_outer_references_in_scope(&qualified("c", "id"), &outer, &scope),
+            3
+        ));
+        assert!(is_literal(
+            &substitute_outer_references_in_scope(&ident("pid"), &outer, &scope),
+            7
+        ));
+    }
 
     // ============================================================================
     // Token Creation Tests

--- a/tests/correlated_subquery_test.rs
+++ b/tests/correlated_subquery_test.rs
@@ -1466,3 +1466,62 @@ fn test_correlated_scalar_qualified_sum() {
     assert!((customers[2].2.unwrap_or(0.0) - 150.0).abs() < 0.1); // Charlie: 150
     assert!((customers[3].2.unwrap_or(0.0) - 300.0).abs() < 0.1); // David: 300
 }
+
+/// The inner table's columns share names with the outer table's. Each
+/// shape binds the name to the inner scope, and the outer value that is
+/// substituted must still reach the primary key.
+#[test]
+fn test_correlated_inner_scope_shadows_outer_names() {
+    let db = Database::open("memory://correlated_inner_scope").expect("Failed to create database");
+    db.execute(
+        "CREATE TABLE parent (id INTEGER PRIMARY KEY, name TEXT)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    for i in 1..=10i64 {
+        db.execute("INSERT INTO parent VALUES ($1, $2)", (i, format!("p{}", i)))
+            .unwrap();
+        db.execute("INSERT INTO child VALUES ($1, $2, $3)", (i, 11 - i, i))
+            .unwrap();
+    }
+    let count = |sql: &str| -> i64 {
+        db.query(sql, ())
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .get(0)
+            .unwrap()
+    };
+
+    // qualified inner column, outer column of the same name
+    assert_eq!(
+        count("SELECT COUNT(*) FROM child c WHERE c.v > (SELECT p.id FROM parent p WHERE p.id = c.pid)"),
+        5
+    );
+    // unqualified inner column shadows the outer one
+    assert_eq!(
+        count("SELECT COUNT(*) FROM child c WHERE c.v > (SELECT id FROM parent WHERE id = c.pid)"),
+        5
+    );
+    // inner column used twice, once against a literal
+    assert_eq!(
+        count("SELECT COUNT(*) FROM child c WHERE (SELECT p.name FROM parent p WHERE p.id = 5 AND p.id <> c.id) = 'p5'"),
+        9
+    );
+    // outer-only name in an aggregate shape
+    assert_eq!(
+        count("SELECT COUNT(*) FROM child c WHERE (SELECT COUNT(*) FROM parent p WHERE p.id >= c.v) = 11 - c.v"),
+        10
+    );
+    // EXISTS with the clashing name
+    assert_eq!(
+        count("SELECT COUNT(*) FROM child c WHERE EXISTS (SELECT 1 FROM parent p WHERE p.id = c.pid AND p.id > c.id)"),
+        5
+    );
+}


### PR DESCRIPTION
## Why

A correlated subquery whose inner table shares a column name with the outer table ran as a full scan of the inner table on every outer row. `substitute_outer_references` replaced every identifier it could find in the outer row map, and that map carries unqualified names too, so `p.id` in `SELECT p.id FROM parent p WHERE p.id = c.pid` was rewritten to the outer row's `id`. The predicate became a constant, pushdown gave up, and the memory filter walked all of `parent` for each child row. With a non-clashing column name the same query already took the primary key path.

## What

- `InnerScope` (table name, alias, schema) plus `substitute_outer_references_in_scope`: a qualified identifier whose qualifier is the inner table, or a bare identifier that names an inner column, is never substituted. SQL binds the nearer scope first.
- `execute_simple_table_scan` passes the scope; the substituted `p.id = 7` now pushes down to a PK lookup.
- The public `substitute_outer_references` keeps its signature and behaviour.

## Measured

`cs_probe`, 1000 parents, 2000 children, both binaries built from one source, interleaved, best of 8, against `main` at 55d4895c.

| Shape | main | this PR | |
|---|---|---|---|
| `c.v > (SELECT p.id FROM parent p WHERE p.id = c.pid)` | 397.4 ms | 12.7 ms | 31x |
| same, no alias, bare `id` | 375.9 ms | 11.1 ms | 34x |
| same plus `AND p.name <> 'zz'` | 614.8 ms | 14.9 ms | 41x |
| non-clashing inner column (`pkey`) | 12.4 ms | 11.7 ms | parity |
| correlated `COUNT(*) > 0` | 1.52 ms | 1.55 ms | parity |

Row counts identical on every shape.

## Tests

- `test_substitute_outer_references_respects_inner_scope`: alias-qualified, table-qualified and bare inner names stay; qualified and bare outer names become literals; a mixed-case inner column is recognised.
- `test_correlated_inner_scope_shadows_outer_names`: five clashing-name shapes with hand-checked counts.

Not in scope: an unqualified reference to an outer-only column from inside a subquery (`WHERE p.id = pid`) fails with "Column not found" on `main` as well.
