### PR TITLE
fix(common): release an oversized I64Map table after a drain

### DIFF
--- a/src/common/i64_map.rs
+++ b/src/common/i64_map.rs
@@ -601,7 +601,12 @@ impl<V> I64Map<V> {
     /// entry the iterator has not reached yet stays in the map, so a leaked
     /// drain leaves a consistent, merely undrained map behind.
     pub fn drain(&mut self) -> Drain<'_, V> {
-        Drain { map: self, pos: 0 }
+        let start_len = self.len;
+        Drain {
+            map: self,
+            pos: 0,
+            start_len,
+        }
     }
 
     #[inline(always)]
@@ -1010,6 +1015,7 @@ impl<V> IntoIterator for I64Map<V> {
 pub struct Drain<'a, V> {
     map: &'a mut I64Map<V>,
     pos: usize,
+    start_len: usize,
 }
 
 // =============================================================================
@@ -1498,6 +1504,13 @@ impl<V> Drop for Drain<'_, V> {
     fn drop(&mut self) {
         // Consume remaining elements so they are dropped and the map is empty
         for _ in self.by_ref() {}
+        // A table far larger than the batch it just held would tax every
+        // later drain with its empty slots, so it is released here, sized
+        // for that batch.
+        let cap = self.map.slots.len();
+        if cap > MIN_SHRINK_CAPACITY && self.start_len < cap / SHRINK_DIVISOR {
+            *self.map = I64Map::with_capacity(self.start_len);
+        }
     }
 }
 
@@ -1930,6 +1943,27 @@ mod tests {
         map.insert(first, "c");
         assert_eq!(map.len(), 2);
         assert_eq!(map.get(first).copied(), Some("c"));
+    }
+
+    /// One large batch must not leave every later small drain scanning a
+    /// table sized for it: the table is released once the batch it held
+    /// is far below its capacity.
+    #[test]
+    fn test_drain_releases_an_oversized_table() {
+        let mut map: I64Map<u64> = I64Map::new();
+        for i in 0..2000 {
+            map.insert(i, i as u64);
+        }
+        assert_eq!(map.drain().count(), 2000);
+        let grown = map.capacity();
+        assert!(grown > MIN_SHRINK_CAPACITY);
+
+        map.insert(1, 1);
+        assert_eq!(map.drain().count(), 1);
+        assert_eq!(map.capacity(), MIN_CAPACITY);
+        assert!(map.is_empty());
+        map.insert(2, 2);
+        assert_eq!(map.get(2), Some(&2));
     }
 
     #[test]

--- a/src/common/i64_map.rs
+++ b/src/common/i64_map.rs
@@ -590,16 +590,17 @@ impl<V> I64Map<V> {
         }
     }
 
-    /// Drains all entries from the map, returning an iterator over them
-    #[inline]
-    /// Move every entry out, leaving the map empty with its table intact.
+    /// Move every entry out, leaving the map empty.
     ///
-    /// The iterator borrows the map and empties slots as it yields them, so
-    /// the map's capacity survives the drain. Swapping in a fresh 8-slot
-    /// table, as this used to, meant every pooled transaction map came back
-    /// at minimum size and regrew from scratch on the next transaction. An
-    /// entry the iterator has not reached yet stays in the map, so a leaked
-    /// drain leaves a consistent, merely undrained map behind.
+    /// The iterator borrows the map and empties slots as it yields them.
+    /// The table is kept when the drained batch filled a fair share of it,
+    /// so a pooled transaction map does not regrow from the minimum size on
+    /// every transaction. A table far larger than the batch it held is
+    /// released and rebuilt for that batch size, so one large batch does
+    /// not tax every later small drain with its empty slots. An entry the
+    /// iterator has not reached yet stays in the map, so a leaked drain
+    /// leaves a consistent, merely undrained map behind.
+    #[inline]
     pub fn drain(&mut self) -> Drain<'_, V> {
         let start_len = self.len;
         Drain {
@@ -1966,6 +1967,8 @@ mod tests {
         assert_eq!(map.get(2), Some(&2));
     }
 
+    /// A batch that filled a fair share of the table keeps it: the map is
+    /// reusable afterwards without growing again.
     #[test]
     fn test_drain_keeps_capacity() {
         let mut map: I64Map<u64> = I64Map::new();
@@ -1977,7 +1980,11 @@ mod tests {
         let drained = map.drain().count();
         assert_eq!(drained, 1000);
         assert!(map.is_empty());
-        assert_eq!(map.capacity(), before, "drain must keep the table");
+        assert_eq!(
+            map.capacity(),
+            before,
+            "drain must keep a table its batch filled"
+        );
 
         // and the map is fully usable afterwards, without growing
         for i in 0..1000 {


### PR DESCRIPTION
## Why

`./tools/bench-compare.py` on `main` after #70 showed INSERT single 0.82 -> 1.79 us and DELETE by ID 0.69 -> 1.60 us. Reproduced with the real `examples/benchmark` (5 interleaved runs against 2526f538): 0.98 -> 1.98 us and 0.79 -> 1.82 us.

The in-place drain from #70 keeps a table at whatever size its largest batch needed. The benchmark runs UPDATE complex (hundreds of rows per statement) right before INSERT single, so the transaction store's `local_versions` and `write_set` grew to hundreds of slots and every later single-row commit scanned all of them. A probe without that bulk phase showed no difference at any commit since the baseline; the same probe with a bulk phase showed +0.5 us on INSERT, DELETE and UPDATE at #70 only.

## What

`Drain::drop` releases the table when the batch it just held was far below capacity, using the map's existing shrink thresholds (`MIN_SHRINK_CAPACITY`, `SHRINK_DIVISOR`), and sizes the new table for that batch. A 100-row batch keeps its 256 slots, so the commit win from #70 stays; a single row after a bulk batch gets the minimum table back.

## Measured

Real `examples/benchmark`, interleaved against 2526f538 (the BENCHMARKS.md commit), best / median of 5:

| Test | baseline | this PR |
|---|---|---|
| INSERT single | 0.773 / 0.822 us | 0.768 / 0.774 us |
| DELETE by ID | 0.643 / 0.653 us | 0.598 / 0.612 us |
| UPDATE by ID | 0.592 / 0.620 us | 0.617 / 0.632 us |
| UPDATE complex | 54.3 / 58.8 us | 51.9 / 55.5 us |

Single-row DML after a bulk phase, 5000 ops, against 55d4895c (before #70): INSERT 0.724 -> 0.659 us, DELETE 0.614 -> 0.555 us, UPDATE 0.553 -> 0.493 us.

2000 transactions of 100 UPDATEs, 12 interleaved rounds against 55d4895c: 1.036x best, 1.044x median, so #70's win is kept.

## Tests

`test_drain_releases_an_oversized_table` fails on `main` (capacity stays 4096) and passes here; `test_drain_keeps_capacity` still passes, so a batch-sized table is not released.
