### PR TITLE
fix(executor): an alias hides the inner table's name in correlation detection

### DIFF
--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -851,11 +851,10 @@ impl QueryClassification {
             Expression::Identifier(ident) => {
                 tables.push(ident.value_lower.to_string());
             }
+            // An alias hides the table's own name: with `FROM t t2` only
+            // `t2` qualifies inner columns, and `t` may be an outer alias.
             Expression::Aliased(aliased) => {
-                // Add alias (use value_lower for case-insensitive matching)
                 tables.push(aliased.alias.value_lower.to_string());
-                // Also collect from inner expression
-                Self::collect_tables_recursive(&aliased.expression, tables);
             }
             Expression::JoinSource(join) => {
                 Self::collect_tables_recursive(&join.left, tables);
@@ -868,10 +867,10 @@ impl QueryClassification {
                 }
             }
             Expression::TableSource(table) => {
-                // Add table name and alias if present
-                tables.push(table.name.value_lower.to_string());
                 if let Some(ref alias) = table.alias {
                     tables.push(alias.value_lower.to_string());
+                } else {
+                    tables.push(table.name.value_lower.to_string());
                 }
             }
             Expression::FunctionTableSource(fs) => {
@@ -1420,5 +1419,29 @@ mod tests {
         let c_corr = get_classification(&correlated);
         assert!(!c_local.where_has_correlated_subqueries);
         assert!(c_corr.where_has_correlated_subqueries);
+    }
+
+    /// With `FROM parent p` only `p` names the inner table, so `parent.pid`
+    /// is an outer reference even though the outer alias equals the inner
+    /// table's name. Without an alias the table name is inner.
+    #[test]
+    fn alias_hides_the_inner_table_name() {
+        let parse = |sql: &str| {
+            let mut parser = crate::parser::Parser::new(sql);
+            let mut program = parser.parse_program().unwrap();
+            match program.statements.pop().unwrap() {
+                crate::parser::ast::Statement::Select(s) => s,
+                other => panic!("expected SELECT, got {:?}", other),
+            }
+        };
+        let shadowed = parse(
+            "SELECT * FROM child parent WHERE EXISTS (SELECT 1 FROM parent p WHERE p.id = parent.pid)",
+        );
+        let bare =
+            parse("SELECT * FROM child x WHERE EXISTS (SELECT 1 FROM parent WHERE parent.id = 1)");
+
+        clear_cache();
+        assert!(get_classification(&shadowed).where_has_correlated_subqueries);
+        assert!(!get_classification(&bare).where_has_correlated_subqueries);
     }
 }

--- a/tests/correlated_subquery_test.rs
+++ b/tests/correlated_subquery_test.rs
@@ -1524,4 +1524,15 @@ fn test_correlated_inner_scope_shadows_outer_names() {
         count("SELECT COUNT(*) FROM child c WHERE EXISTS (SELECT 1 FROM parent p WHERE p.id = c.pid AND p.id > c.id)"),
         5
     );
+
+    // the outer alias is the inner table's name: with `FROM parent p` only
+    // `p` is inner, so `parent.id` and `parent.pid` are outer values
+    assert_eq!(
+        count("SELECT COUNT(*) FROM child parent WHERE (SELECT p.name FROM parent p WHERE parent.id = 5 AND p.id = parent.pid) = 'p6'"),
+        1
+    );
+    assert_eq!(
+        count("SELECT COUNT(*) FROM child parent WHERE EXISTS (SELECT 1 FROM parent p WHERE parent.id = 5 AND p.id = parent.pid)"),
+        1
+    );
 }


### PR DESCRIPTION
## Why

Found while addressing the #71 review. This failed on `main`:

```sql
SELECT COUNT(*) FROM child parent
WHERE (SELECT p.name FROM parent p WHERE parent.id = 5 AND p.id = parent.pid) = 'p6';
-- Compile error: Column 'parent.pid' not found
```

`QueryClassification::collect_tables_recursive` listed both the table name and its alias as inner qualifiers, so `parent.pid` counted as inner, the subquery was classified as uncorrelated, `process_where_subqueries` ran it once without an outer row, and the WHERE was compiled with no outer context. `Executor::collect_table_names_from_source` (the detector used at execution time) already applied the SQL rule: with an alias only the alias names the inner table, and the table name may be an outer alias.

## What

The classifier's collector now pushes the alias when there is one and the table name otherwise, for both `TableSource` and `Aliased` sources, matching the executor's detector.

## Tests

- `alias_hides_the_inner_table_name` (classification): `FROM child parent ... (SELECT 1 FROM parent p WHERE p.id = parent.pid)` is correlated; `FROM child x ... (SELECT 1 FROM parent WHERE parent.id = 1)` is not. Fails on `main`.
- `test_correlated_inner_scope_shadows_outer_names` gains the two shadowed-alias shapes from the #71 review, scalar and EXISTS, each returning 1 row. Both error on `main`.
