### PR TITLE
chore(common): close CompactVec edge cases, exact IntoIter size, stale docs

### DIFF
--- a/src/common/compact_vec.rs
+++ b/src/common/compact_vec.rs
@@ -33,6 +33,10 @@ use std::slice;
 
 /// A compact vector that uses 16 bytes instead of Vec's 24 bytes.
 /// Stores length and capacity as u32 (max 4 billion elements).
+const _: () = assert!(
+    mem::size_of::<CompactVec<u8>>() == 16 && mem::size_of::<Option<CompactVec<u8>>>() == 16
+);
+
 pub struct CompactVec<T> {
     ptr: NonNull<T>,
     /// Packed length (low 32 bits) and capacity (high 32 bits)
@@ -82,6 +86,13 @@ impl<T> CompactVec<T> {
         }
 
         let cap = capacity.min(u32::MAX as usize) as u32;
+
+        if mem::size_of::<T>() == 0 {
+            return Self {
+                ptr: NonNull::dangling(),
+                len_cap: Self::pack(0, cap),
+            };
+        }
 
         // Allocate memory
         let layout = Layout::array::<T>(cap as usize).unwrap();
@@ -205,6 +216,10 @@ impl<T> CompactVec<T> {
         let len = Self::unpack_len(self.len_cap) as usize;
         let cap = Self::unpack_cap(self.len_cap) as usize;
         let required = len.saturating_add(additional);
+        assert!(
+            required <= u32::MAX as usize,
+            "CompactVec capacity overflow"
+        );
 
         if required > cap {
             let new_cap = required.max(cap.saturating_mul(2)).min(u32::MAX as usize);
@@ -218,9 +233,13 @@ impl<T> CompactVec<T> {
         let len = Self::unpack_len(self.len_cap) as usize;
         let cap = Self::unpack_cap(self.len_cap) as usize;
         let required = len.saturating_add(additional);
+        assert!(
+            required <= u32::MAX as usize,
+            "CompactVec capacity overflow"
+        );
 
         if required > cap {
-            self.realloc(required.min(u32::MAX as usize));
+            self.realloc(required);
         }
     }
 
@@ -232,6 +251,7 @@ impl<T> CompactVec<T> {
         } else {
             cap.saturating_mul(2).min(u32::MAX as usize)
         };
+        assert!(new_cap > cap, "CompactVec capacity overflow");
 
         self.realloc(new_cap);
     }
@@ -1470,6 +1490,30 @@ mod tests {
     }
 
     /// Repeated small reservations must grow geometrically, not once per call.
+    /// A zero-sized element type never touches the allocator, with or
+    /// without a requested capacity.
+    #[test]
+    fn test_zero_sized_elements_with_capacity() {
+        let mut v: CompactVec<()> = CompactVec::with_capacity(8);
+        assert_eq!(v.capacity(), 8);
+        for _ in 0..20 {
+            v.push(());
+        }
+        assert_eq!(v.len(), 20);
+        assert_eq!(v.pop(), Some(()));
+        v.clear();
+        assert!(v.is_empty());
+    }
+
+    /// The length and capacity share one u32 each; asking for more is an
+    /// error, not a silent cap that a later push would write past.
+    #[test]
+    #[should_panic(expected = "CompactVec capacity overflow")]
+    fn test_reserve_past_u32_panics() {
+        let mut v: CompactVec<u8> = CompactVec::new();
+        v.reserve(u32::MAX as usize + 1);
+    }
+
     #[test]
     fn test_reserve_amortizes_and_reserve_exact_does_not() {
         let mut v: CompactVec<u64> = CompactVec::new();

--- a/src/common/compact_vec.rs
+++ b/src/common/compact_vec.rs
@@ -1499,7 +1499,6 @@ mod tests {
         assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 3);
     }
 
-    /// Repeated small reservations must grow geometrically, not once per call.
     /// A zero-sized element type never touches the allocator, with or
     /// without a requested capacity.
     #[test]
@@ -1525,6 +1524,7 @@ mod tests {
         v.reserve(u32::MAX as usize);
     }
 
+    /// Repeated small reservations must grow geometrically, not once per call.
     #[test]
     fn test_reserve_amortizes_and_reserve_exact_does_not() {
         let mut v: CompactVec<u64> = CompactVec::new();

--- a/src/common/compact_vec.rs
+++ b/src/common/compact_vec.rs
@@ -31,12 +31,14 @@ use std::ops::{Deref, DerefMut, Index, IndexMut};
 use std::ptr::{self, NonNull};
 use std::slice;
 
-/// A compact vector that uses 16 bytes instead of Vec's 24 bytes.
-/// Stores length and capacity as u32 (max 4 billion elements).
+// One pointer plus two u32s, and the pointer's niche keeps Option free.
 const _: () = assert!(
-    mem::size_of::<CompactVec<u8>>() == 16 && mem::size_of::<Option<CompactVec<u8>>>() == 16
+    mem::size_of::<CompactVec<u8>>() == mem::size_of::<usize>() + 2 * mem::size_of::<u32>()
+        && mem::size_of::<Option<CompactVec<u8>>>() == mem::size_of::<CompactVec<u8>>()
 );
 
+/// A compact vector: one pointer plus two u32s, 16 bytes on 64-bit targets
+/// against Vec's 24. Holds at most u32::MAX elements.
 pub struct CompactVec<T> {
     ptr: NonNull<T>,
     /// Packed length (low 32 bits) and capacity (high 32 bits)
@@ -215,11 +217,10 @@ impl<T> CompactVec<T> {
         // Unpack once
         let len = Self::unpack_len(self.len_cap) as usize;
         let cap = Self::unpack_cap(self.len_cap) as usize;
-        let required = len.saturating_add(additional);
-        assert!(
-            required <= u32::MAX as usize,
-            "CompactVec capacity overflow"
-        );
+        let required = len
+            .checked_add(additional)
+            .filter(|&required| required <= u32::MAX as usize)
+            .expect("CompactVec capacity overflow");
 
         if required > cap {
             let new_cap = required.max(cap.saturating_mul(2)).min(u32::MAX as usize);
@@ -232,11 +233,10 @@ impl<T> CompactVec<T> {
     pub fn reserve_exact(&mut self, additional: usize) {
         let len = Self::unpack_len(self.len_cap) as usize;
         let cap = Self::unpack_cap(self.len_cap) as usize;
-        let required = len.saturating_add(additional);
-        assert!(
-            required <= u32::MAX as usize,
-            "CompactVec capacity overflow"
-        );
+        let required = len
+            .checked_add(additional)
+            .filter(|&required| required <= u32::MAX as usize)
+            .expect("CompactVec capacity overflow");
 
         if required > cap {
             self.realloc(required);
@@ -1511,7 +1511,8 @@ mod tests {
     #[should_panic(expected = "CompactVec capacity overflow")]
     fn test_reserve_past_u32_panics() {
         let mut v: CompactVec<u8> = CompactVec::new();
-        v.reserve(u32::MAX as usize + 1);
+        v.push(1);
+        v.reserve(u32::MAX as usize);
     }
 
     #[test]

--- a/src/common/compact_vec.rs
+++ b/src/common/compact_vec.rs
@@ -31,11 +31,21 @@ use std::ops::{Deref, DerefMut, Index, IndexMut};
 use std::ptr::{self, NonNull};
 use std::slice;
 
-// One pointer plus two u32s, and the pointer's niche keeps Option free.
-const _: () = assert!(
-    mem::size_of::<CompactVec<u8>>() == mem::size_of::<usize>() + 2 * mem::size_of::<u32>()
-        && mem::size_of::<Option<CompactVec<u8>>>() == mem::size_of::<CompactVec<u8>>()
-);
+// One pointer plus a packed u64, padded to the larger of their alignments
+// (16 bytes on 64-bit and wasm32, 12 on i686), and the pointer's niche
+// keeps Option free.
+const _: () = {
+    let align = if mem::align_of::<u64>() > mem::align_of::<usize>() {
+        mem::align_of::<u64>()
+    } else {
+        mem::align_of::<usize>()
+    };
+    let expected = (mem::size_of::<usize>() + mem::size_of::<u64>()).next_multiple_of(align);
+    assert!(
+        mem::size_of::<CompactVec<u8>>() == expected
+            && mem::size_of::<Option<CompactVec<u8>>>() == mem::size_of::<CompactVec<u8>>()
+    );
+};
 
 /// A compact vector: one pointer plus two u32s, 16 bytes on 64-bit targets
 /// against Vec's 24. Holds at most u32::MAX elements.

--- a/src/common/i64_map.rs
+++ b/src/common/i64_map.rs
@@ -948,6 +948,7 @@ pub struct IntoIter<V> {
     slots: Box<[Slot<V>]>,
     pos: usize,
     min_slot: Option<V>,
+    remaining: usize,
 }
 
 impl<V> Iterator for IntoIter<V> {
@@ -964,6 +965,7 @@ impl<V> Iterator for IntoIter<V> {
                 // SAFETY: slot.key != EMPTY means the value is initialized.
                 let value = unsafe { slot.value.as_ptr().read() };
                 slot.key = EMPTY; // Mark as consumed to prevent double-drop
+                self.remaining -= 1;
                 return Some((key, value));
             }
         }
@@ -971,12 +973,15 @@ impl<V> Iterator for IntoIter<V> {
         self.min_slot.take().map(|v| (EMPTY, v))
     }
 
+    /// Exact: the entries still in the table plus the pending side slot.
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let pending = usize::from(self.min_slot.is_some());
-        (pending, Some(self.slots.len() - self.pos + pending))
+        let remaining = self.remaining + usize::from(self.min_slot.is_some());
+        (remaining, Some(remaining))
     }
 }
+
+impl<V> ExactSizeIterator for IntoIter<V> {}
 
 impl<V> Drop for IntoIter<V> {
     fn drop(&mut self) {
@@ -1003,11 +1008,13 @@ impl<V> IntoIterator for I64Map<V> {
     fn into_iter(mut self) -> Self::IntoIter {
         let slots = std::mem::take(&mut self.slots);
         let min_slot = self.min_slot.take();
+        let remaining = self.len;
         self.len = 0; // Prevent drop from cleaning up values we're moving out
         IntoIter {
             slots,
             pos: 0,
             min_slot,
+            remaining,
         }
     }
 }
@@ -1996,6 +2003,24 @@ mod tests {
 
     /// `collect()` sizes its allocation from the lower bound, so a drain that
     /// reported 0 forced a Vec to grow through every doubling.
+    #[test]
+    fn test_into_iter_size_hint_is_exact() {
+        let mut map: I64Map<u64> = I64Map::new();
+        for i in 0..100 {
+            map.insert(i, i as u64);
+        }
+        map.insert(i64::MIN, 0);
+        let mut iter = map.into_iter();
+        assert_eq!(iter.len(), 101);
+        for expected in (0..101).rev() {
+            assert_eq!(iter.size_hint(), (expected + 1, Some(expected + 1)));
+            assert!(iter.next().is_some());
+            assert_eq!(iter.len(), expected);
+        }
+        assert!(iter.next().is_none());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+    }
+
     #[test]
     fn test_drain_size_hint_is_exact() {
         let mut map: I64Map<u64> = I64Map::new();

--- a/src/common/smart_string.rs
+++ b/src/common/smart_string.rs
@@ -194,6 +194,8 @@ impl SmartString {
         Self::new(s)
     }
 
+    /// The capacity is not reserved: a `SmartString` decides between its
+    /// inline buffer and the heap on each write, so this is `default()`.
     #[inline]
     pub fn with_capacity(_capacity: usize) -> Self {
         Self::default()

--- a/src/core/value.rs
+++ b/src/core/value.rs
@@ -141,9 +141,9 @@ impl Value {
         Value::Text(value.into())
     }
 
-    /// Create a text value from Arc<str> (zero-copy for heap strings)
+    /// Create a text value from an `Arc<str>`.
     ///
-    /// Preserves the Arc reference for O(1) clone and sharing.
+    /// The bytes are copied into a `SmartString`; the `Arc` is not kept.
     pub fn text_arc(value: Arc<str>) -> Self {
         Value::Text(SmartString::from(value))
     }

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -105,14 +105,14 @@ impl fmt::Display for TokenType {
 
 /// Token represents a lexical token
 ///
-/// Uses SmartString for literal to avoid heap allocation for tokens up to 24 bytes
+/// Uses SmartString for literal to avoid heap allocation for tokens up to 15 bytes
 /// (covers most SQL tokens: keywords, operators, short identifiers, numbers).
 /// For error tokens, the literal field contains the error message.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Token {
     /// The type of the token
     pub token_type: TokenType,
-    /// The literal string value (SmartString inlines strings up to 24 bytes)
+    /// The literal string value (SmartString inlines strings up to 15 bytes)
     /// For error tokens, this contains the error message instead.
     pub literal: SmartString,
     /// The position in the source

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -479,7 +479,7 @@ pub struct SealedIndexCleanup {
 pub struct VersionStore {
     /// Row versions indexed by row ID (CowBTree for O(1) snapshot cloning)
     versions: CowBTreeMap<VersionChainEntry>,
-    /// The name of the table this store belongs to (SmartString for inline storage ≤24 bytes)
+    /// The name of the table this store belongs to (SmartString inlines up to 15 bytes)
     table_name: SmartString,
     /// Table schema (Arc for zero-cost cloning on read)
     schema: RwLock<CompactArc<Schema>>,


### PR DESCRIPTION
## What

Non-breaking hygiene from the `src/common` audit. No performance claims, so no measurements.

- `CompactVec::with_capacity` allocated a zero-sized layout for a zero-sized element type, which the allocator contract forbids. It now takes the same no-allocation path `realloc` already had. Test `test_zero_sized_elements_with_capacity` (runs under Miri).
- `CompactVec::reserve`, `reserve_exact` and `grow` silently saturated at `u32::MAX`; a later push would have written past the table. They now panic with `CompactVec capacity overflow`, like `Vec`. Test `test_reserve_past_u32_panics`.
- The 16-byte size and the `Option` niche are checked at compile time (`const _: () = assert!(...)`) instead of only in a test.
- `I64Map::IntoIter` reports an exact `size_hint` and implements `ExactSizeIterator`, like `Drain` does. Test `test_into_iter_size_hint_is_exact`.
- Docs: `Value::text_arc` copies rather than keeping the `Arc`; three comments still said `SmartString` inlines 24 bytes (it is 15); `SmartString::with_capacity` now says the capacity is not reserved.

## Left out on purpose

- Making `CompactArc::data_ptr_mut` an `unsafe fn`: 74 call sites in `cow_btree` would change with no behavioural difference. Producing a raw pointer is safe; every dereference already sits in an `unsafe` block.
- Alignment guard for values stored in a `CompactArc<[u8]>` node: `CowBTree::new` already asserts `align_of::<V>() <= 8`.
- Deleting dead `SmartString` API (`from_string_heap`, `new_text`, `make_shared`, `into_shared`, `concat_many`) and `CompactArc::new_with_meta`: public, so 0.5.0 with `cow_hashmap` and `buffer_pool`.
- `I64Map::retain` in place: backward-shift deletion during a forward scan can revisit a kept entry after a wrap-around, which would call the predicate twice. The current collect-then-remove version is correct and allocates nothing when nothing is removed.
