### PR TITLE
perf(executor): probe IN-list ids even when the list pushed down as a range

### DIFF
--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -1216,7 +1216,7 @@ impl Executor {
         table_alias: Option<&str>,
         ctx: &ExecutionContext,
         classification: &Arc<QueryClassification>,
-    ) -> Result<Option<(Box<dyn QueryResult>, CompactArc<Vec<String>>)>> {
+    ) -> Result<Option<(Box<dyn QueryResult>, CompactArc<Vec<String>>, bool)>> {
         // Extract IN list info: (column_name, values, is_negated, remaining_predicate)
         let (column_name, values, is_negated, remaining_predicate) =
             match Self::extract_in_list_info(where_expr, ctx) {
@@ -1264,7 +1264,7 @@ impl Executor {
                     CompactArc::clone(&output_columns),
                     RowVec::new(),
                 );
-                return Ok(Some((Box::new(result), output_columns)));
+                return Ok(Some((Box::new(result), output_columns, false)));
             }
         }
 
@@ -1418,7 +1418,11 @@ impl Executor {
             CompactArc::new(self.get_output_column_names(&stmt.columns, all_columns, table_alias));
         let result =
             ExecutorResult::with_arc_columns(CompactArc::clone(&output_columns), projected_rows);
-        Ok(Some((Box::new(result), output_columns)))
+        // Without ORDER BY the LIMIT and OFFSET were applied above; the
+        // caller must not apply them a second time.
+        let limit_applied =
+            stmt.order_by.is_empty() && (stmt.limit.is_some() || stmt.offset.is_some());
+        Ok(Some((Box::new(result), output_columns, limit_applied)))
     }
 
     /// Extract IN list literal information from a WHERE clause.

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -1298,8 +1298,12 @@ impl Executor {
 
         // EARLY LIMIT OPTIMIZATION: When there's no ORDER BY and no remaining predicate,
         // we can apply LIMIT early to avoid fetching unnecessary rows
+        // LIMIT and OFFSET can be applied here only when nothing runs between
+        // this path and the result: no ORDER BY, and no DISTINCT that would
+        // otherwise see already-truncated rows.
+        let limit_here = stmt.order_by.is_empty() && !stmt.distinct && stmt.distinct_on.is_empty();
         let (early_limit_applied, early_limit, early_offset) =
-            if stmt.order_by.is_empty() && remaining_predicate.is_none() {
+            if limit_here && remaining_predicate.is_none() {
                 let offset = if let Some(ref offset_expr) = stmt.offset {
                     match ExpressionEval::compile(offset_expr, &[])
                         .ok()
@@ -1373,7 +1377,7 @@ impl Executor {
             } else if early_limit < rows.len() {
                 rows.truncate(early_limit);
             }
-        } else if stmt.order_by.is_empty() {
+        } else if limit_here {
             let offset = if let Some(ref offset_expr) = stmt.offset {
                 match ExpressionEval::compile(offset_expr, &[])
                     .ok()
@@ -1420,8 +1424,7 @@ impl Executor {
             ExecutorResult::with_arc_columns(CompactArc::clone(&output_columns), projected_rows);
         // Without ORDER BY the LIMIT and OFFSET were applied above; the
         // caller must not apply them a second time.
-        let limit_applied =
-            stmt.order_by.is_empty() && (stmt.limit.is_some() || stmt.offset.is_some());
+        let limit_applied = limit_here && (stmt.limit.is_some() || stmt.offset.is_some());
         Ok(Some((Box::new(result), output_columns, limit_applied)))
     }
 
@@ -1459,13 +1462,26 @@ impl Executor {
 
             // IN list with AND: column IN (...) AND other_condition
             Expression::Infix(infix) if infix.op_type == InfixOperator::And => {
-                // Try left side as IN list
-                if let Some((col, vals, neg, _)) = Self::extract_in_list_info(&infix.left, ctx) {
-                    return Some((col, vals, neg, Some((*infix.right).clone())));
+                // The IN list may sit under further ANDs; whatever those
+                // left over is kept together with this level's sibling.
+                let keep = |rest: Option<Expression>, sibling: &Expression| -> Expression {
+                    match rest {
+                        Some(rest) => Expression::Infix(InfixExpression {
+                            token: infix.token.clone(),
+                            left: Box::new(rest),
+                            operator: infix.operator.clone(),
+                            op_type: infix.op_type,
+                            right: Box::new(sibling.clone()),
+                        }),
+                        None => sibling.clone(),
+                    }
+                };
+                if let Some((col, vals, neg, rest)) = Self::extract_in_list_info(&infix.left, ctx) {
+                    return Some((col, vals, neg, Some(keep(rest, &infix.right))));
                 }
-                // Try right side as IN list
-                if let Some((col, vals, neg, _)) = Self::extract_in_list_info(&infix.right, ctx) {
-                    return Some((col, vals, neg, Some((*infix.left).clone())));
+                if let Some((col, vals, neg, rest)) = Self::extract_in_list_info(&infix.right, ctx)
+                {
+                    return Some((col, vals, neg, Some(keep(rest, &infix.left))));
                 }
                 None
             }

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -2478,24 +2478,24 @@ impl Executor {
 
         // FAST PATH: IN list literal index optimization
         // For queries like `SELECT * FROM table WHERE id IN (1, 2, 3, 5, 8)`
-        // where 'id' has an index or is PRIMARY KEY, probe directly instead of scanning all rows
+        // where 'id' has an index or is PRIMARY KEY, probe directly instead of scanning all rows.
+        // Tried even when the IN list pushed down: pushdown turns it into a
+        // min..max range, which on spread-out values scans the whole table.
         // Skip if query has aggregation: projection cannot compile aggregate functions
-        if needs_memory_filter
-            && !has_outer_context
-            && !classification.has_group_by
-            && !classification.has_aggregation
-        {
+        if !has_outer_context && !classification.has_group_by && !classification.has_aggregation {
             if let Some(where_expr) = where_to_use {
-                if let Some((result, columns)) = self.try_in_list_index_optimization(
-                    stmt,
-                    where_expr,
-                    &*table,
-                    &all_columns,
-                    table_alias.as_deref(),
-                    ctx,
-                    classification,
-                )? {
-                    return Ok((result, columns, false, None));
+                if let Some((result, columns, limit_applied)) = self
+                    .try_in_list_index_optimization(
+                        stmt,
+                        where_expr,
+                        &*table,
+                        &all_columns,
+                        table_alias.as_deref(),
+                        ctx,
+                        classification,
+                    )?
+                {
+                    return Ok((result, columns, limit_applied, None));
                 }
             }
         }

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -2481,8 +2481,15 @@ impl Executor {
         // where 'id' has an index or is PRIMARY KEY, probe directly instead of scanning all rows.
         // Tried even when the IN list pushed down: pushdown turns it into a
         // min..max range, which on spread-out values scans the whole table.
-        // Skip if query has aggregation: projection cannot compile aggregate functions
-        if !has_outer_context && !classification.has_group_by && !classification.has_aggregation {
+        // Left to the normal pipeline: aggregation and window functions
+        // (this projection cannot compile them) and an ORDER BY key that is
+        // not projected (the sorter would not find it afterwards).
+        if !has_outer_context
+            && !classification.has_group_by
+            && !classification.has_aggregation
+            && !classification.has_window_functions
+            && !order_by_needs_extra_columns
+        {
             if let Some(where_expr) = where_to_use {
                 if let Some((result, columns, limit_applied)) = self
                     .try_in_list_index_optimization(

--- a/tests/index_optimizer_test.rs
+++ b/tests/index_optimizer_test.rs
@@ -727,3 +727,72 @@ fn test_explain_shows_plan() {
     // EXPLAIN should return something about the query plan
     assert!(!lines.is_empty(), "Expected EXPLAIN to return plan lines");
 }
+
+/// A primary-key IN list whose values are spread across the table used to
+/// push down as a min..max range and scan everything. It now probes the
+/// listed ids directly, so every shape around it must still come out right,
+/// and LIMIT and OFFSET must be applied exactly once.
+#[test]
+fn test_spread_pk_in_list_probes_ids() {
+    let db = Database::open("memory://spread_pk_in_list").expect("Failed to create database");
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, grp INTEGER, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    for i in 1..=2000i64 {
+        db.execute("INSERT INTO t VALUES ($1, $2, $3)", (i, i % 7, i * 3))
+            .unwrap();
+    }
+    let ids = |sql: &str| -> Vec<i64> {
+        db.query(sql, ())
+            .unwrap()
+            .map(|r| r.unwrap().get::<i64>(0).unwrap())
+            .collect()
+    };
+
+    assert_eq!(
+        ids("SELECT id FROM t WHERE id IN (1999, 3, 1000, 42, 5000) ORDER BY id"),
+        vec![3, 42, 1000, 1999]
+    );
+    assert_eq!(
+        ids("SELECT id FROM t WHERE id IN (1999, 3, 1004, 42) AND grp = 3 ORDER BY id"),
+        vec![3, 1004]
+    );
+    assert_eq!(
+        ids("SELECT id FROM t WHERE id IN (1999, 3, 1000, 42) ORDER BY id DESC LIMIT 2"),
+        vec![1999, 1000]
+    );
+    assert_eq!(
+        ids("SELECT id FROM t WHERE id NOT IN (1, 2) AND id <= 4 ORDER BY id"),
+        vec![3, 4]
+    );
+    assert_eq!(
+        ids("SELECT id FROM t WHERE id IN (1999, 3, 1000, 42) AND v > 3000 ORDER BY id"),
+        vec![1999]
+    );
+    let count: i64 = db
+        .query("SELECT COUNT(*) FROM t WHERE id IN (1999, 3, 1000, 42)", ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap();
+    assert_eq!(count, 4);
+
+    // the probe path applies LIMIT and OFFSET itself when there is no
+    // ORDER BY and tells the caller so; they must not be applied twice
+    assert_eq!(
+        ids("SELECT id FROM t WHERE id IN (1, 2, 3, 4, 5) LIMIT 2 OFFSET 2").len(),
+        2
+    );
+    assert_eq!(
+        ids("SELECT id FROM t WHERE id IN (1, 2, 3, 4, 5) AND v > 0 OFFSET 2").len(),
+        3
+    );
+    assert_eq!(
+        ids("SELECT id FROM t WHERE grp IN (1, 2) AND v > 0 LIMIT 3 OFFSET 1").len(),
+        3
+    );
+}

--- a/tests/index_optimizer_test.rs
+++ b/tests/index_optimizer_test.rs
@@ -796,3 +796,67 @@ fn test_spread_pk_in_list_probes_ids() {
         3
     );
 }
+
+/// Shapes the IN-list probe path must either handle or leave to the normal
+/// pipeline: every AND conjunct kept, window functions, DISTINCT before
+/// LIMIT, and an ORDER BY key that is not projected.
+#[test]
+fn test_in_list_fast_path_keeps_query_semantics() {
+    let db =
+        Database::open("memory://in_list_fast_path_semantics").expect("Failed to create database");
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, grp INTEGER, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    for i in 1..=30i64 {
+        db.execute("INSERT INTO t VALUES ($1, $2, $3)", (i, i % 7, i * 3))
+            .unwrap();
+    }
+    let ids = |sql: &str| -> Vec<i64> {
+        db.query(sql, ())
+            .unwrap()
+            .map(|r| r.unwrap().get::<i64>(0).unwrap())
+            .collect()
+    };
+
+    // three conjuncts: id 1 has grp 1 and v 3, id 8 has grp 1 and v 24
+    assert_eq!(
+        ids("SELECT id FROM t WHERE id IN (1, 8, 15) AND grp = 1 AND v = 3"),
+        vec![1]
+    );
+    assert_eq!(
+        ids("SELECT id FROM t WHERE grp = 1 AND id IN (1, 8, 15) AND v = 24"),
+        vec![8]
+    );
+
+    // window function over the probed rows
+    let numbered: Vec<(i64, i64)> = db
+        .query(
+            "SELECT id, ROW_NUMBER() OVER (ORDER BY id) FROM t WHERE id IN (3, 1, 2) ORDER BY id",
+            (),
+        )
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            (r.get::<i64>(0).unwrap(), r.get::<i64>(1).unwrap())
+        })
+        .collect();
+    assert_eq!(numbered, vec![(1, 1), (2, 2), (3, 3)]);
+
+    // DISTINCT applies before LIMIT: ids 1 and 8 share grp 1, id 16 has grp 2
+    assert_eq!(
+        ids("SELECT DISTINCT grp FROM t WHERE id IN (1, 8, 16) ORDER BY grp LIMIT 2"),
+        vec![1, 2]
+    );
+    assert_eq!(
+        ids("SELECT DISTINCT grp FROM t WHERE id IN (1, 8, 16) LIMIT 2").len(),
+        2
+    );
+
+    // ORDER BY on a column that is not projected
+    assert_eq!(
+        ids("SELECT v FROM t WHERE id IN (1, 2, 3) ORDER BY id DESC"),
+        vec![9, 6, 3]
+    );
+}


### PR DESCRIPTION
## Why

Found while measuring Wave H storage fetches. `EXPLAIN SELECT * FROM t WHERE id IN (1,2,3)` shows `Index Scan using __pk_t_id, Index Cond: id >= 1 AND <= 3`: pushdown turns an IN list into a min..max range. With ids spread across the table the range covers everything, so ten ids on a sealed 100k-row table cost 3 ms (a full volume scan with `InListExpr` per row, per `sample`), and the hot table walked its whole PK index for a thousand ids.

`try_in_list_index_optimization` already probes the listed ids directly, but the call site only tried it when `needs_memory_filter` was set, which a pushable IN list never leaves behind.

## What

- The fast path is tried whenever the WHERE has an IN list on the primary key or an indexed column; it returns `None` otherwise, so other shapes are untouched.
- The path applies LIMIT and OFFSET itself when there is no ORDER BY but reported `order_limit_applied = false`, so the caller applied them a second time. `test_in_list_with_offset` caught it the moment plain IN lists reached the path. It now returns whether it applied them.

## Measured

100k rows, both binaries built from one probe source, interleaved, best of 3.

| Shape | main | this PR |
|---|---|---|
| sealed table, `id IN (10)` | 3.0 ms | 3.8 us |
| sealed table, `id IN (100)` | 3.1 ms | 22 us |
| sealed table, `id IN (1000)` | 3.2 ms | 270 us |
| hot table, `id IN (10)` | 18.5 us | 2.9 us |
| hot table, `id IN (1000)` | 201-247 us | 200-209 us |
| hot table, `age IN (3)` (secondary index, 3226 rows) | 68-73 us | 69-71 us |

Row counts identical on every shape.

## Tests

`test_spread_pk_in_list_probes_ids`: spread ids with ORDER BY, an extra predicate, LIMIT, NOT IN, COUNT, and LIMIT/OFFSET without ORDER BY applied exactly once. The four IN-list and index optimizer targets pass (71 tests).

Rows without ORDER BY now come back in id order from the probe rather than scan order, which is not a guarantee either way.
