### PR TITLE
fix(executor): probe pushed-down IN lists only on the primary key

### DIFF
--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -1216,6 +1216,7 @@ impl Executor {
         table_alias: Option<&str>,
         ctx: &ExecutionContext,
         classification: &Arc<QueryClassification>,
+        probe_secondary_index: bool,
     ) -> Result<Option<(Box<dyn QueryResult>, CompactArc<Vec<String>>, bool)>> {
         // Extract IN list info: (column_name, values, is_negated, remaining_predicate)
         let (column_name, values, is_negated, remaining_predicate) =
@@ -1239,7 +1240,14 @@ impl Executor {
         };
 
         // If not PK, check for index
+        // A secondary index probe collects every matching row id for every
+        // value before fetching, while the pushed-down range scan streams
+        // and stops at LIMIT; so it is only taken when a memory filter is
+        // needed anyway. Primary key values are the row ids themselves.
         let index = if !is_pk_column {
+            if !probe_secondary_index {
+                return Ok(None);
+            }
             match table.get_index_on_column(&column_name) {
                 Some(idx) => Some(idx),
                 None => return Ok(None), // No PK, no index, can't optimize

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -2481,9 +2481,11 @@ impl Executor {
         // where 'id' has an index or is PRIMARY KEY, probe directly instead of scanning all rows.
         // Tried even when the IN list pushed down: pushdown turns it into a
         // min..max range, which on spread-out values scans the whole table.
-        // Left to the normal pipeline: aggregation and window functions
-        // (this projection cannot compile them) and an ORDER BY key that is
-        // not projected (the sorter would not find it afterwards).
+        // Tried for every primary-key IN list, since pushdown would turn it
+        // into a min..max range; for other indexed columns only when a memory
+        // filter is needed anyway. Left to the normal pipeline: aggregation
+        // and window functions (this projection cannot compile them) and an
+        // ORDER BY key that is not projected (the sorter would not find it).
         if !has_outer_context
             && !classification.has_group_by
             && !classification.has_aggregation
@@ -2500,6 +2502,7 @@ impl Executor {
                         table_alias.as_deref(),
                         ctx,
                         classification,
+                        needs_memory_filter,
                     )?
                 {
                     return Ok((result, columns, limit_applied, None));


### PR DESCRIPTION
## Why

`bench-compare` on `main` after #76:

```
Complex JOIN+GROUP+HAVING      48.73 -> 464.29 us (+852.8%)
IN list (7 values)              2.05 ->   6.63 us (+223.2%)
LEFT JOIN + GROUP BY           45.47 ->  56.01 us  (+23.2%)
```

Reproduced with the benchmark binary at `main~1` vs `main`. All three come from #76 widening the IN-list probe path to fully pushable lists on **secondary** indexes: `age IN (7 values) LIMIT 100`, `o.status IN ('completed','shipped')` inside the join, and the batched `user_id IN (...)` probes the index nested loop join issues. A secondary-index probe collects every matching row id for every value and fetches them before LIMIT is applied; the pushed-down range scan streams and stops early.

## What

`try_in_list_index_optimization` takes `probe_secondary_index` (the old `needs_memory_filter` condition). Primary-key lists are still probed unconditionally, since their values are the row ids and the pushed-down min..max range of a spread-out list covers the whole table; secondary-index lists are probed only when a memory filter is needed anyway, exactly as before #76.

## Measured

Benchmark rows, best of 3 interleaved runs (machine noisy, direction is what matters):

| Test | before #76 | main | this PR |
|---|---|---|---|
| IN list (7 values) | 2.6 us | 7.7 us | 2.8 us |
| Complex JOIN+GROUP+HAVING | 66 us | 537 us | 53 us |
| LEFT JOIN + GROUP BY | 58 us | 63 us | 51 us |
| SELECT by ID | 0.14 us | 0.13 us | 0.15 us |

Cold-table primary-key probe (the reason for #76) is unchanged: `id IN (10)` 3.0 ms -> 3.8 us, `id IN (1000)` 3.2 ms -> 272 us.

## Tests

No behaviour change; the four IN-list and index optimizer targets pass (72 tests, including the shapes added in #76).
