### PR TITLE
perf(executor): decide the IN-list column before evaluating its literals

### DIFF
--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -1219,6 +1219,21 @@ impl Executor {
         probe_secondary_index: bool,
     ) -> Result<Option<(Box<dyn QueryResult>, CompactArc<Vec<String>>, bool)>> {
         // Extract IN list info: (column_name, values, is_negated, remaining_predicate)
+        // Evaluating the list's literals is the expensive part of the
+        // extraction, so decide on the column first: a secondary-index list
+        // that will not be probed must not pay for values it never uses.
+        let schema = table.schema();
+        let pk_indices = schema.primary_key_indices();
+        let pk_name = if pk_indices.len() == 1 {
+            Some(schema.columns[pk_indices[0]].name_lower.as_str())
+        } else {
+            None
+        };
+        let is_pk_column = pk_name == Self::in_list_column(where_expr);
+        if !is_pk_column && !probe_secondary_index {
+            return Ok(None);
+        }
+
         let (column_name, values, is_negated, remaining_predicate) =
             match Self::extract_in_list_info(where_expr, ctx) {
                 Some(info) => info,
@@ -1231,23 +1246,11 @@ impl Executor {
             return Ok(None);
         }
 
-        // Check if this is a PRIMARY KEY column (O(1) lookup) or has an index
-        let schema = table.schema();
-        let pk_indices = schema.primary_key_indices();
-        let is_pk_column = pk_indices.len() == 1 && {
-            let pk_col_idx = pk_indices[0];
-            schema.columns[pk_col_idx].name_lower == column_name
-        };
-
-        // If not PK, check for index
         // A secondary index probe collects every matching row id for every
         // value before fetching, while the pushed-down range scan streams
         // and stops at LIMIT; so it is only taken when a memory filter is
         // needed anyway. Primary key values are the row ids themselves.
         let index = if !is_pk_column {
-            if !probe_secondary_index {
-                return Ok(None);
-            }
             match table.get_index_on_column(&column_name) {
                 Some(idx) => Some(idx),
                 None => return Ok(None), // No PK, no index, can't optimize
@@ -1438,6 +1441,22 @@ impl Executor {
 
     /// Extract IN list literal information from a WHERE clause.
     /// Returns (column_name, values, is_negated, remaining_predicate)
+    /// The column of the IN list `extract_in_list_info` would pick, found
+    /// without evaluating the list's values.
+    fn in_list_column(expr: &Expression) -> Option<&str> {
+        match expr {
+            Expression::In(in_expr) => match in_expr.left.as_ref() {
+                Expression::Identifier(id) => Some(id.value_lower.as_str()),
+                Expression::QualifiedIdentifier(qid) => Some(qid.name.value_lower.as_str()),
+                _ => None,
+            },
+            Expression::Infix(infix) if infix.op_type == InfixOperator::And => {
+                Self::in_list_column(&infix.left).or_else(|| Self::in_list_column(&infix.right))
+            }
+            _ => None,
+        }
+    }
+
     pub(crate) fn extract_in_list_info(
         expr: &Expression,
         ctx: &ExecutionContext,

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -1229,16 +1229,14 @@ impl Executor {
         } else {
             None
         };
-        let is_pk_column = pk_name == Self::in_list_column(where_expr);
-        if !is_pk_column && !probe_secondary_index {
-            return Ok(None);
-        }
-
         let (column_name, values, is_negated, remaining_predicate) =
-            match Self::extract_in_list_info(where_expr, ctx) {
+            match Self::extract_in_list_info(where_expr, ctx, &|column| {
+                probe_secondary_index || pk_name == Some(column)
+            }) {
                 Some(info) => info,
                 None => return Ok(None),
             };
+        let is_pk_column = pk_name == Some(column_name.as_str());
 
         // Skip if SELECT columns have correlated subqueries (need per-row context)
         // classification is passed from caller to avoid redundant cache lookups
@@ -1441,25 +1439,10 @@ impl Executor {
 
     /// Extract IN list literal information from a WHERE clause.
     /// Returns (column_name, values, is_negated, remaining_predicate)
-    /// The column of the IN list `extract_in_list_info` would pick, found
-    /// without evaluating the list's values.
-    fn in_list_column(expr: &Expression) -> Option<&str> {
-        match expr {
-            Expression::In(in_expr) => match in_expr.left.as_ref() {
-                Expression::Identifier(id) => Some(id.value_lower.as_str()),
-                Expression::QualifiedIdentifier(qid) => Some(qid.name.value_lower.as_str()),
-                _ => None,
-            },
-            Expression::Infix(infix) if infix.op_type == InfixOperator::And => {
-                Self::in_list_column(&infix.left).or_else(|| Self::in_list_column(&infix.right))
-            }
-            _ => None,
-        }
-    }
-
     pub(crate) fn extract_in_list_info(
         expr: &Expression,
         ctx: &ExecutionContext,
+        accept: &dyn Fn(&str) -> bool,
     ) -> Option<(String, Vec<Value>, bool, Option<Expression>)> {
         match expr {
             // Direct IN list: column IN (v1, v2, ...)
@@ -1470,6 +1453,11 @@ impl Executor {
                     Expression::QualifiedIdentifier(qid) => qid.name.value_lower.to_string(),
                     _ => return None, // Can't optimize complex left expressions
                 };
+                // Decided before the values are evaluated, so a list the
+                // caller would not probe costs nothing here.
+                if !accept(&column_name) {
+                    return None;
+                }
 
                 // Get the values from the right side (must be a literal list, not subquery)
                 let values = match in_expr.right.as_ref() {
@@ -1503,10 +1491,13 @@ impl Executor {
                         None => sibling.clone(),
                     }
                 };
-                if let Some((col, vals, neg, rest)) = Self::extract_in_list_info(&infix.left, ctx) {
+                if let Some((col, vals, neg, rest)) =
+                    Self::extract_in_list_info(&infix.left, ctx, accept)
+                {
                     return Some((col, vals, neg, Some(keep(rest, &infix.right))));
                 }
-                if let Some((col, vals, neg, rest)) = Self::extract_in_list_info(&infix.right, ctx)
+                if let Some((col, vals, neg, rest)) =
+                    Self::extract_in_list_info(&infix.right, ctx, accept)
                 {
                     return Some((col, vals, neg, Some(keep(rest, &infix.left))));
                 }

--- a/tests/index_optimizer_test.rs
+++ b/tests/index_optimizer_test.rs
@@ -860,3 +860,40 @@ fn test_in_list_fast_path_keeps_query_semantics() {
         vec![9, 6, 3]
     );
 }
+
+/// The primary-key decision must belong to the IN list that is actually
+/// extracted. A first IN over the key with a subquery on its right is
+/// skipped by the extraction; the values of the next IN, over another
+/// column, must then not be treated as row ids.
+#[test]
+fn test_in_list_pk_decision_follows_the_extracted_list() {
+    let db = Database::open("memory://in_list_pk_decision").expect("Failed to create database");
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, age INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE INDEX idx_t_age ON t(age)", ()).unwrap();
+    for i in 1..=30i64 {
+        db.execute("INSERT INTO t VALUES ($1, $2)", (i, i * 10))
+            .unwrap();
+    }
+    let ids = |sql: &str| -> Vec<i64> {
+        db.query(sql, ())
+            .unwrap()
+            .map(|r| r.unwrap().get::<i64>(0).unwrap())
+            .collect()
+    };
+
+    // no row has age 7; treating 7 as a row id would return id 7
+    assert_eq!(
+        ids("SELECT id FROM t WHERE id NOT IN (SELECT id FROM t WHERE id < 0) AND age IN (7)"),
+        Vec::<i64>::new()
+    );
+    // age 70 belongs to id 7; treating 70 as a row id would find nothing
+    assert_eq!(
+        ids("SELECT id FROM t WHERE id NOT IN (SELECT id FROM t WHERE id < 0) AND age IN (70)"),
+        vec![7]
+    );
+    assert_eq!(
+        ids("SELECT id FROM t WHERE age IN (70, 80) AND id IN (SELECT id FROM t WHERE id > 7) ORDER BY id"),
+        vec![8]
+    );
+}


### PR DESCRIPTION
## Why

`bench-compare` on `main` after #77 still showed `IN list (7 values)` at 2.05 -> 2.42 us. The gate now calls `try_in_list_index_optimization` for every pushable IN list, and the first thing that function did was `extract_in_list_info`, which compiles and evaluates each literal in the list. For `age IN (7 values)` that is seven small compiles just to learn afterwards that `age` is not the primary key and return `None`.

## What

`in_list_column` reads the IN column from the WHERE without evaluating values (same AND walk and same pick order as `extract_in_list_info`). A non-primary-key list that needs no memory filter now returns before any literal is touched; primary-key lists and memory-filter shapes proceed exactly as before.

## Measured

Benchmark binary, main vs this branch, 5 interleaved runs:

| Test | main best / median | this PR best / median |
|---|---|---|
| IN list (7 values) | 2.67 / 2.74 us | 2.14 / 2.29 us |
| SELECT by index (exact) | 3.05 / 3.25 us | 3.07 / 3.21 us |
| Complex JOIN+GROUP+HAVING | 47.9 / 48.5 us | 46.4 / 50.6 us |
| SELECT by ID | 0.11 / 0.12 us | 0.11 / 0.12 us |

Cold-table primary-key probe unchanged: `id IN (10)` 3.6 us, `id IN (1000)` 271 us.

## Tests

No behaviour change; the four IN-list and index optimizer targets pass (72 tests).
