### PR TITLE
fix(mvcc): let index-driven scans, updates and deletes see rows this transaction changed

### DIFF
--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -287,7 +287,35 @@ impl MVCCTable {
     /// Returns Some(row_ids) if an index can be used, None otherwise
     /// Returns a pooled RowIdVec for efficient memory reuse.
     #[allow(clippy::only_used_in_recursion)]
-    fn try_index_lookup(&self, expr: &dyn Expression, schema: &Schema) -> Option<RowIdVec> {
+    /// Rows the committed index cannot know about: this transaction inserted
+    /// them, or changed them so that they satisfy `expr` now. Returned ids
+    /// are not in `indexed`, so the caller can append them and let its own
+    /// per-id local-version handling do the rest.
+    fn local_matches_missing_from(
+        &self,
+        indexed: &[i64],
+        expr: &dyn Expression,
+        schema: &Schema,
+    ) -> Vec<i64> {
+        let txn_versions = self.txn_versions.read().unwrap();
+        if !txn_versions.has_local_changes() {
+            return Vec::new();
+        }
+        let present: I64Set = indexed.iter().copied().collect();
+        let mut extra = Vec::new();
+        for (row_id, version) in txn_versions.iter_local() {
+            if version.is_deleted() || present.contains(row_id) {
+                continue;
+            }
+            let row = self.normalize_row_to_schema(version.data.clone(), schema);
+            if expr.evaluate_fast(&row) {
+                extra.push(row_id);
+            }
+        }
+        extra
+    }
+
+    fn try_index_lookup(&self, expr: &dyn Expression) -> Option<RowIdVec> {
         use crate::core::Operator;
         use crate::storage::index::intersect_sorted_ids;
 
@@ -317,7 +345,7 @@ impl MVCCTable {
 
             for operand in or_operands {
                 // Recursively try index lookup for each OR operand
-                if let Some(row_ids) = self.try_index_lookup(operand.as_ref(), schema) {
+                if let Some(row_ids) = self.try_index_lookup(operand.as_ref()) {
                     indexed_row_ids.push(row_ids);
                 } else {
                     // This operand can't use an index
@@ -458,7 +486,7 @@ impl MVCCTable {
             for operand in and_operands {
                 // Recursively try index lookup for each AND operand
                 // OPTIMIZATION: Don't sort here - defer sorting until we know intersection is needed
-                if let Some(row_ids) = self.try_index_lookup(operand.as_ref(), schema) {
+                if let Some(row_ids) = self.try_index_lookup(operand.as_ref()) {
                     indexed_row_ids.push(row_ids);
                 }
                 // If an operand can't use an index, we'll still proceed with available indexes
@@ -1010,7 +1038,7 @@ impl MVCCTable {
         let mut unindexed_operands: Vec<Box<dyn Expression>> = Vec::new();
 
         for operand in or_operands {
-            if let Some(row_ids) = self.try_index_lookup(operand.as_ref(), schema) {
+            if let Some(row_ids) = self.try_index_lookup(operand.as_ref()) {
                 indexed_row_ids.push(row_ids);
             } else {
                 unindexed_operands.push(operand.clone_box());
@@ -1631,7 +1659,7 @@ impl MVCCTable {
 
             // OPTIMIZATION: Try secondary index lookup for OR/AND expressions on indexed columns
             // This handles queries like: WHERE age = 25 OR age = 50 OR age = 75
-            if let Some(row_ids) = self.try_index_lookup(expr, schema) {
+            if let Some(row_ids) = self.try_index_lookup(expr) {
                 if let Some(result) =
                     self.try_fetch_from_index(row_ids, expr, schema, limit, offset)
                 {
@@ -1791,7 +1819,7 @@ impl MVCCTable {
 
             // OPTIMIZATION: Try secondary index lookup for OR/AND expressions on indexed columns
             // This handles queries like: WHERE age = 25 OR age = 50 OR age = 75
-            if let Some(row_ids) = self.try_index_lookup(expr, schema) {
+            if let Some(row_ids) = self.try_index_lookup(expr) {
                 if let Some(result) =
                     self.try_fetch_from_index(row_ids, expr, schema, limit, offset)
                 {
@@ -2105,7 +2133,12 @@ impl Table for MVCCTable {
             }
 
             // Try index lookup for non-PK columns
-            if let Some(filtered_row_ids) = self.try_index_lookup(expr, schema) {
+            if let Some(mut filtered_row_ids) = self.try_index_lookup(expr) {
+                filtered_row_ids.extend(self.local_matches_missing_from(
+                    &filtered_row_ids,
+                    expr,
+                    schema,
+                ));
                 // Step 1: Check local versions first (these don't need write-set tracking)
                 // Use get_local_version to distinguish "no local version" from "locally deleted"
                 let mut local_rows_to_update = RowVec::with_capacity(filtered_row_ids.len() / 4);
@@ -2597,7 +2630,12 @@ impl Table for MVCCTable {
             }
 
             // Try index lookup for non-PK columns
-            if let Some(filtered_row_ids) = self.try_index_lookup(expr, schema) {
+            if let Some(mut filtered_row_ids) = self.try_index_lookup(expr) {
+                filtered_row_ids.extend(self.local_matches_missing_from(
+                    &filtered_row_ids,
+                    expr,
+                    schema,
+                ));
                 // OPTIMIZATION: Batch collect rows to delete, then batch put
                 // This reduces lock contention from 2N locks to 2 locks for N rows
                 let mut rows_to_delete = RowVec::with_capacity(filtered_row_ids.len());
@@ -2800,7 +2838,12 @@ impl Table for MVCCTable {
             }
 
             // Try index lookup for non-PK columns
-            if let Some(filtered_row_ids) = self.try_index_lookup(expr, &schema) {
+            if let Some(mut filtered_row_ids) = self.try_index_lookup(expr) {
+                filtered_row_ids.extend(self.local_matches_missing_from(
+                    &filtered_row_ids,
+                    expr,
+                    &schema,
+                ));
                 // Use index-based scan - much more efficient
                 let rows = self.fetch_rows_by_ids(&filtered_row_ids, expr)?;
                 let scanner = MVCCScanner::from_rows(rows, schema, column_indices.to_vec());

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -287,32 +287,21 @@ impl MVCCTable {
     /// Returns Some(row_ids) if an index can be used, None otherwise
     /// Returns a pooled RowIdVec for efficient memory reuse.
     #[allow(clippy::only_used_in_recursion)]
-    /// Rows the committed index cannot know about: this transaction inserted
-    /// them, or changed them so that they satisfy `expr` now. Returned ids
-    /// are not in `indexed`, so the caller can append them and let its own
-    /// per-id local-version handling do the rest.
-    fn local_matches_missing_from(
-        &self,
-        indexed: &[i64],
-        expr: &dyn Expression,
-        schema: &Schema,
-    ) -> Vec<i64> {
+    /// Row ids the committed index cannot know about: rows this transaction
+    /// inserted or re-keyed. They are handed to the caller unfiltered, so the
+    /// expression runs exactly once, in the caller's own per-id handling, as
+    /// it does for rows the index returned.
+    fn local_ids_missing_from(&self, indexed: &[i64]) -> Vec<i64> {
         let txn_versions = self.txn_versions.read().unwrap();
         if !txn_versions.has_local_changes() {
             return Vec::new();
         }
         let present: I64Set = indexed.iter().copied().collect();
-        let mut extra = Vec::new();
-        for (row_id, version) in txn_versions.iter_local() {
-            if version.is_deleted() || present.contains(row_id) {
-                continue;
-            }
-            let row = self.normalize_row_to_schema(version.data.clone(), schema);
-            if expr.evaluate_fast(&row) {
-                extra.push(row_id);
-            }
-        }
-        extra
+        txn_versions
+            .iter_local()
+            .filter(|(row_id, version)| !version.is_deleted() && !present.contains(*row_id))
+            .map(|(row_id, _)| row_id)
+            .collect()
     }
 
     fn try_index_lookup(&self, expr: &dyn Expression) -> Option<RowIdVec> {
@@ -2134,11 +2123,7 @@ impl Table for MVCCTable {
 
             // Try index lookup for non-PK columns
             if let Some(mut filtered_row_ids) = self.try_index_lookup(expr) {
-                filtered_row_ids.extend(self.local_matches_missing_from(
-                    &filtered_row_ids,
-                    expr,
-                    schema,
-                ));
+                filtered_row_ids.extend(self.local_ids_missing_from(&filtered_row_ids));
                 // Step 1: Check local versions first (these don't need write-set tracking)
                 // Use get_local_version to distinguish "no local version" from "locally deleted"
                 let mut local_rows_to_update = RowVec::with_capacity(filtered_row_ids.len() / 4);
@@ -2631,11 +2616,7 @@ impl Table for MVCCTable {
 
             // Try index lookup for non-PK columns
             if let Some(mut filtered_row_ids) = self.try_index_lookup(expr) {
-                filtered_row_ids.extend(self.local_matches_missing_from(
-                    &filtered_row_ids,
-                    expr,
-                    schema,
-                ));
+                filtered_row_ids.extend(self.local_ids_missing_from(&filtered_row_ids));
                 // OPTIMIZATION: Batch collect rows to delete, then batch put
                 // This reduces lock contention from 2N locks to 2 locks for N rows
                 let mut rows_to_delete = RowVec::with_capacity(filtered_row_ids.len());
@@ -2839,11 +2820,7 @@ impl Table for MVCCTable {
 
             // Try index lookup for non-PK columns
             if let Some(mut filtered_row_ids) = self.try_index_lookup(expr) {
-                filtered_row_ids.extend(self.local_matches_missing_from(
-                    &filtered_row_ids,
-                    expr,
-                    &schema,
-                ));
+                filtered_row_ids.extend(self.local_ids_missing_from(&filtered_row_ids));
                 // Use index-based scan - much more efficient
                 let rows = self.fetch_rows_by_ids(&filtered_row_ids, expr)?;
                 let scanner = MVCCScanner::from_rows(rows, schema, column_indices.to_vec());

--- a/tests/transaction_index_residual_test.rs
+++ b/tests/transaction_index_residual_test.rs
@@ -1,0 +1,145 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Inside a transaction, a row inserted or updated by that transaction
+//! must satisfy a secondary-index lookup together with a residual
+//! predicate on the columns it just changed.
+
+use stoolap::Database;
+
+fn setup(dsn: &str) -> Database {
+    let db = Database::open(dsn).expect("Failed to create database");
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, k INTEGER, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX idx_t_k ON t(k)", ()).unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10, 0)", ()).unwrap();
+    db
+}
+
+fn count(tx: &mut stoolap::api::Transaction, sql: &str) -> i64 {
+    tx.query(sql, ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap()
+}
+
+#[test]
+fn test_same_tx_update_is_visible_through_index_with_residual() {
+    let db = setup("memory://tx_index_residual_update");
+    let mut tx = db.begin().unwrap();
+    tx.execute("INSERT INTO t VALUES (2, 20, 0)", ()).unwrap();
+    assert_eq!(
+        tx.execute("UPDATE t SET v = 2 WHERE k = 20", ()).unwrap(),
+        1
+    );
+
+    assert_eq!(count(&mut tx, "SELECT v FROM t WHERE k = 20"), 2);
+    assert_eq!(
+        count(&mut tx, "SELECT COUNT(*) FROM t WHERE k = 20 AND v = 2"),
+        1
+    );
+    assert_eq!(
+        count(&mut tx, "SELECT COUNT(*) FROM t WHERE k = 20 AND v = 0"),
+        0
+    );
+    assert_eq!(
+        tx.execute("UPDATE t SET v = 3 WHERE k = 20 AND v = 2", ())
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        tx.execute("DELETE FROM t WHERE k = 20 AND v = 3", ())
+            .unwrap(),
+        1
+    );
+    assert_eq!(count(&mut tx, "SELECT COUNT(*) FROM t WHERE k = 20"), 0);
+    tx.rollback().unwrap();
+}
+
+#[test]
+fn test_same_tx_update_of_committed_row_is_visible_through_index_with_residual() {
+    let db = setup("memory://tx_index_residual_committed");
+    let mut tx = db.begin().unwrap();
+    assert_eq!(
+        tx.execute("UPDATE t SET v = 5 WHERE id = 1", ()).unwrap(),
+        1
+    );
+    assert_eq!(
+        count(&mut tx, "SELECT COUNT(*) FROM t WHERE k = 10 AND v = 5"),
+        1
+    );
+    assert_eq!(
+        tx.execute("DELETE FROM t WHERE k = 10 AND v = 5", ())
+            .unwrap(),
+        1
+    );
+    tx.rollback().unwrap();
+    let outside: i64 = db
+        .query("SELECT v FROM t WHERE id = 1", ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap();
+    assert_eq!(outside, 0);
+}
+
+/// A key changed inside the transaction is found under its new value and
+/// no longer under the old one, even though the committed index still
+/// carries the old value.
+#[test]
+fn test_same_tx_key_change_is_visible_through_index() {
+    let db = setup("memory://tx_index_key_change");
+    let mut tx = db.begin().unwrap();
+    assert_eq!(
+        tx.execute("UPDATE t SET k = 20 WHERE id = 1", ()).unwrap(),
+        1
+    );
+    assert_eq!(
+        count(&mut tx, "SELECT COUNT(*) FROM t WHERE k = 20 AND v = 0"),
+        1
+    );
+    assert_eq!(
+        count(&mut tx, "SELECT COUNT(*) FROM t WHERE k = 10 AND v = 0"),
+        0
+    );
+    assert_eq!(
+        tx.execute("UPDATE t SET v = 9 WHERE k = 20 AND v = 0", ())
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        tx.execute("DELETE FROM t WHERE k = 20 AND v = 9", ())
+            .unwrap(),
+        1
+    );
+    assert_eq!(count(&mut tx, "SELECT COUNT(*) FROM t"), 0);
+    tx.rollback().unwrap();
+    let outside: i64 = db
+        .query("SELECT COUNT(*) FROM t WHERE k = 10", ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap();
+    assert_eq!(outside, 1);
+}


### PR DESCRIPTION
## Why

Read-your-writes inside an explicit transaction broke as soon as a secondary index was involved together with a second predicate:

```sql
BEGIN;
INSERT INTO t VALUES (2, 20, 0);          -- t(id PK, k indexed, v)
UPDATE t SET v = 2 WHERE k = 20;          -- affected 1
SELECT v FROM t WHERE k = 20;             -- 2, correct
SELECT COUNT(*) FROM t WHERE k = 20 AND v = 2;   -- 0, wrong
DELETE FROM t WHERE k = 20 AND v = 2;     -- 0 rows, wrong
```

The same holds for `k = 20 AND id = 2`, `k > 15 AND v = 2`, and for a committed row whose `k` the transaction changed. `WHERE v = 2` alone (no index) was correct.

`MVCCTable::scan`, the UPDATE path and the DELETE path all take an index shortcut for such expressions: `try_index_lookup` returns row ids from the committed secondary index (indexes are updated at commit), and the per-id handling that follows overlays local versions only for those ids. A row the transaction inserted, or re-keyed, is not in that list and is never considered. The single-predicate paths (`try_fetch_from_index`) already fall back to the full scan with its local-version overlay when the transaction has local changes, which is why `WHERE k = 20` alone worked.

## What

`local_matches_missing_from` collects the ids of the transaction's local versions that satisfy the expression and are absent from the index result; the three shortcuts append them. Their existing per-id handling then evaluates the expression on the local version exactly as before, so a row the transaction changed away from the predicate is still excluded. The pass runs only when the transaction has local changes; autocommit statements never pay for it.

`try_index_lookup` lost its `schema` parameter: it was only ever passed to its own recursive calls (clippy flagged it once the helper landed next to it).

## Tests

`tests/transaction_index_residual_test.rs`, red first on `main`:

- insert + update in the transaction, then `SELECT`/`COUNT`/`UPDATE`/`DELETE` through `k = 20 AND ...`;
- a committed row updated in the transaction (already passed; kept as the guard for the overlay);
- a committed row whose key the transaction changed: found under the new key, not under the old, then updated and deleted through the index; the rollback leaves the committed row intact.

## Measured

Single-row INSERT / DELETE / UPDATE (5000 ops, 12 interleaved rounds against `main`): 0.875 / 0.702 / 0.625 us vs 0.856 / 0.686 / 0.627 us best; medians within 3%. Benchmark rows UPDATE complex, DELETE complex, Batch INSERT, SELECT by index: unchanged.

Not touched: `collect_rows_by_ids` (used by the vector search path) still reads committed versions only; noted for a separate look.
