### PR TITLE
perf(join): build projected join rows from the two inputs, resolve the projection without a map

### DIFF
--- a/src/core/row.rs
+++ b/src/core/row.rs
@@ -491,6 +491,17 @@ impl Row {
         self.storage.into_vec()
     }
 
+    /// One value out of a row that is being consumed: moved out of owned
+    /// storage, cloned out of shared storage. Avoids converting the whole
+    /// row when only a few columns are wanted.
+    #[inline]
+    pub fn take_or_clone(&mut self, idx: usize) -> Value {
+        match &mut self.storage {
+            RowStorage::Owned(vec) => std::mem::take(&mut vec[idx]),
+            RowStorage::Shared(arc) => arc[idx].clone(),
+        }
+    }
+
     /// Extract the first value, consuming the row
     #[inline]
     pub fn take_first_value(self) -> Option<Value> {

--- a/src/executor/operators/index_nested_loop.rs
+++ b/src/executor/operators/index_nested_loop.rs
@@ -199,30 +199,23 @@ impl IndexNestedLoopJoinOperator {
     /// Uses `get_unchecked` for performance - projection indices are validated
     /// at query planning time against the table schemas.
     #[inline]
-    fn combine_owned_into_buffer(&mut self, outer: Row, inner: Row) {
+    fn combine_owned_into_buffer(&mut self, mut outer: Row, mut inner: Row) {
         match &self.projection {
             Some(proj) => {
                 // Fused projection into buffer - columns are in SELECT order
                 self.row_buffer.clear();
                 self.row_buffer.reserve(proj.columns.len());
 
-                // OPTIMIZATION: Move values instead of cloning (we own both rows)
-                let mut outer_values = outer.into_values();
-                let mut inner_values = inner.into_values();
-
+                // Only the projected values leave the two rows; converting
+                // both rows to Vec<Value> first cloned every column of a
+                // shared row for the one or two that were kept.
                 for col_source in &proj.columns {
                     match col_source {
                         ColumnSource::Outer(idx) => {
-                            // SAFETY: indices validated at planning time against outer table schema.
-                            self.row_buffer.push(std::mem::take(unsafe {
-                                outer_values.get_unchecked_mut(*idx)
-                            }));
+                            self.row_buffer.push(outer.take_or_clone(*idx));
                         }
                         ColumnSource::Inner(idx) => {
-                            // SAFETY: indices validated at planning time against inner table schema.
-                            self.row_buffer.push(std::mem::take(unsafe {
-                                inner_values.get_unchecked_mut(*idx)
-                            }));
+                            self.row_buffer.push(inner.take_or_clone(*idx));
                         }
                     }
                 }
@@ -249,7 +242,7 @@ impl IndexNestedLoopJoinOperator {
     /// Uses `get_unchecked` for performance - projection indices are validated
     /// at query planning time against the table schemas.
     #[inline]
-    fn create_combined_row(&self, outer: &Row, inner: Row) -> Row {
+    fn create_combined_row(&self, outer: &Row, mut inner: Row) -> Row {
         match &self.projection {
             Some(proj) => {
                 // Fused projection: create only the columns we need, in SELECT order
@@ -257,7 +250,6 @@ impl IndexNestedLoopJoinOperator {
 
                 // We need to move from inner but clone from outer (we don't own outer)
                 let outer_slice = outer.as_slice();
-                let mut inner_values = inner.into_values();
 
                 for col_source in &proj.columns {
                     match col_source {
@@ -266,10 +258,7 @@ impl IndexNestedLoopJoinOperator {
                             values.push(unsafe { outer_slice.get_unchecked(*idx) }.clone());
                         }
                         ColumnSource::Inner(idx) => {
-                            // SAFETY: indices validated at planning time against inner table schema.
-                            values.push(std::mem::take(unsafe {
-                                inner_values.get_unchecked_mut(*idx)
-                            }));
+                            values.push(inner.take_or_clone(*idx));
                         }
                     }
                 }

--- a/src/executor/operators/index_nested_loop.rs
+++ b/src/executor/operators/index_nested_loop.rs
@@ -47,7 +47,19 @@ pub enum IndexLookupStrategy {
 }
 
 /// Specifies which side (outer or inner) a projected column comes from.
-#[derive(Clone, Copy)]
+/// A projected value out of a row that is being consumed. A source used
+/// more than once must be cloned every time; moving it would hand the
+/// second use a NULL.
+#[inline]
+fn take_or_clone(row: &mut Row, idx: usize, repeats: bool) -> Value {
+    if repeats {
+        row.as_slice()[idx].clone()
+    } else {
+        row.take_or_clone(idx)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ColumnSource {
     /// Column from outer row at given index
     Outer(usize),
@@ -62,6 +74,8 @@ pub enum ColumnSource {
 pub struct JoinProjection {
     /// Columns to extract, in SELECT order (preserves original column ordering)
     pub columns: Vec<ColumnSource>,
+    /// A source appears more than once, so values are cloned, not moved.
+    pub repeats_source: bool,
 }
 
 /// Index Nested Loop Join Operator.
@@ -178,7 +192,14 @@ impl IndexNestedLoopJoinOperator {
         columns: Vec<ColumnSource>,
         projected_schema: Vec<ColumnInfo>,
     ) -> Self {
-        self.projection = Some(JoinProjection { columns });
+        let repeats_source = columns
+            .iter()
+            .enumerate()
+            .any(|(i, c)| columns[..i].contains(c));
+        self.projection = Some(JoinProjection {
+            columns,
+            repeats_source,
+        });
         self.schema = projected_schema;
         self
     }
@@ -209,13 +230,16 @@ impl IndexNestedLoopJoinOperator {
                 // Only the projected values leave the two rows; converting
                 // both rows to Vec<Value> first cloned every column of a
                 // shared row for the one or two that were kept.
+                let repeats = proj.repeats_source;
                 for col_source in &proj.columns {
                     match col_source {
                         ColumnSource::Outer(idx) => {
-                            self.row_buffer.push(outer.take_or_clone(*idx));
+                            self.row_buffer
+                                .push(take_or_clone(&mut outer, *idx, repeats));
                         }
                         ColumnSource::Inner(idx) => {
-                            self.row_buffer.push(inner.take_or_clone(*idx));
+                            self.row_buffer
+                                .push(take_or_clone(&mut inner, *idx, repeats));
                         }
                     }
                 }
@@ -258,7 +282,7 @@ impl IndexNestedLoopJoinOperator {
                             values.push(unsafe { outer_slice.get_unchecked(*idx) }.clone());
                         }
                         ColumnSource::Inner(idx) => {
-                            values.push(inner.take_or_clone(*idx));
+                            values.push(take_or_clone(&mut inner, *idx, proj.repeats_source));
                         }
                     }
                 }
@@ -554,7 +578,14 @@ impl BatchIndexNestedLoopJoinOperator {
         columns: Vec<ColumnSource>,
         projected_schema: Vec<ColumnInfo>,
     ) -> Self {
-        self.projection = Some(JoinProjection { columns });
+        let repeats_source = columns
+            .iter()
+            .enumerate()
+            .any(|(i, c)| columns[..i].contains(c));
+        self.projection = Some(JoinProjection {
+            columns,
+            repeats_source,
+        });
         self.schema = projected_schema;
         self
     }

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -1892,15 +1892,21 @@ pub fn compute_join_projection(
     // Resolved by scanning the two short column lists instead of building a
     // map with an owned copy of every name on every execution.
     let columns_all = || outer_columns.iter().chain(inner_columns.iter());
+    // Duplicate full names resolve to the later column, as the index map
+    // built from these lists always did.
     let resolve = |name: &str| -> Option<usize> {
-        if let Some(i) = columns_all().position(|c| c.eq_ignore_ascii_case(name)) {
+        if let Some((i, _)) = columns_all()
+            .enumerate()
+            .filter(|(_, c)| eq_folded(c, name))
+            .last()
+        {
             return Some(i);
         }
         // "t.val" answers to "val" when no other column has that base name
         let mut found = None;
         for (i, c) in columns_all().enumerate() {
             if let Some(dot) = c.rfind('.') {
-                if c[dot + 1..].eq_ignore_ascii_case(name) {
+                if eq_folded(&c[dot + 1..], name) {
                     if found.is_some() {
                         return None;
                     }
@@ -1912,12 +1918,13 @@ pub fn compute_join_projection(
     };
     let resolve_qualified = |qualifier: &str, name: &str| -> Option<usize> {
         columns_all()
-            .position(|c| {
-                c.len() == qualifier.len() + 1 + name.len()
-                    && c.as_bytes()[qualifier.len()] == b'.'
-                    && c[..qualifier.len()].eq_ignore_ascii_case(qualifier)
-                    && c[qualifier.len() + 1..].eq_ignore_ascii_case(name)
+            .enumerate()
+            .filter(|(_, c)| {
+                c.split_once('.')
+                    .is_some_and(|(q, n)| eq_folded(q, qualifier) && eq_folded(n, name))
             })
+            .last()
+            .map(|(i, _)| i)
             .or_else(|| resolve(name))
     };
     let source = |idx: usize| {
@@ -1960,6 +1967,20 @@ pub fn compute_join_projection(
     })
 }
 
+/// Case-insensitive comparison of a column name against an already
+/// lowercased name, folding the Unicode way without allocating.
+#[inline]
+fn eq_folded(column: &str, lower: &str) -> bool {
+    if column.is_ascii() && lower.is_ascii() {
+        column.eq_ignore_ascii_case(lower)
+    } else {
+        column
+            .chars()
+            .flat_map(char::to_lowercase)
+            .eq(lower.chars())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1983,6 +2004,34 @@ mod tests {
             qualifier: Box::new(q),
             name: Box::new(n),
         })
+    }
+
+    /// Column names fold case the Unicode way, and when two columns share
+    /// a name the later one wins, as the column index map always did.
+    #[test]
+    fn test_join_projection_folds_unicode_and_prefers_the_later_duplicate() {
+        let outer = vec!["u.ÄNAME".to_string(), "u.x".to_string()];
+        let inner = vec!["o.x".to_string(), "x".to_string()];
+
+        let proj = compute_join_projection(&[qualified("u", "äname")], &outer, &inner)
+            .expect("Unicode-folded name must resolve");
+        assert!(matches!(proj.columns[0], ColumnSource::Outer(0)));
+
+        // bare `x`: exact matches only the unqualified inner column
+        let proj = compute_join_projection(&[ident("x")], &outer, &inner).unwrap();
+        assert!(matches!(proj.columns[0], ColumnSource::Inner(1)));
+
+        // `s.x` is not a full name; the bare fallback finds the exact `x`
+        let proj = compute_join_projection(&[qualified("s", "x")], &outer, &inner).unwrap();
+        assert!(matches!(proj.columns[0], ColumnSource::Inner(1)));
+        // without an exact `x`, two columns ending in `.x` are ambiguous
+        let two = vec!["u.x".to_string(), "o.x".to_string()];
+        assert!(compute_join_projection(&[ident("x")], &two, &[]).is_none());
+
+        // duplicate full names: the later one wins
+        let dup = vec!["v".to_string(), "v".to_string()];
+        let proj = compute_join_projection(&[ident("v")], &dup, &[]).unwrap();
+        assert!(matches!(proj.columns[0], ColumnSource::Outer(1)));
     }
 
     /// Outer values reach the subquery's WHERE, but names that belong to

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -1888,110 +1888,70 @@ pub fn compute_join_projection(
     outer_columns: &[String],
     inner_columns: &[String],
 ) -> Option<JoinProjectionIndices> {
-    // Build column index maps for fast lookup
     let outer_col_count = outer_columns.len();
-    let combined: Vec<String> = outer_columns
-        .iter()
-        .chain(inner_columns.iter())
-        .cloned()
-        .collect();
-    let col_index_map = build_column_index_map(&combined);
+    // Resolved by scanning the two short column lists instead of building a
+    // map with an owned copy of every name on every execution.
+    let columns_all = || outer_columns.iter().chain(inner_columns.iter());
+    let resolve = |name: &str| -> Option<usize> {
+        if let Some(i) = columns_all().position(|c| c.eq_ignore_ascii_case(name)) {
+            return Some(i);
+        }
+        // "t.val" answers to "val" when no other column has that base name
+        let mut found = None;
+        for (i, c) in columns_all().enumerate() {
+            if let Some(dot) = c.rfind('.') {
+                if c[dot + 1..].eq_ignore_ascii_case(name) {
+                    if found.is_some() {
+                        return None;
+                    }
+                    found = Some(i);
+                }
+            }
+        }
+        found
+    };
+    let resolve_qualified = |qualifier: &str, name: &str| -> Option<usize> {
+        columns_all()
+            .position(|c| {
+                c.len() == qualifier.len() + 1 + name.len()
+                    && c.as_bytes()[qualifier.len()] == b'.'
+                    && c[..qualifier.len()].eq_ignore_ascii_case(qualifier)
+                    && c[qualifier.len() + 1..].eq_ignore_ascii_case(name)
+            })
+            .or_else(|| resolve(name))
+    };
+    let source = |idx: usize| {
+        if idx < outer_col_count {
+            ColumnSource::Outer(idx)
+        } else {
+            ColumnSource::Inner(idx - outer_col_count)
+        }
+    };
 
-    let mut columns = Vec::new();
-    let mut output_columns = Vec::new();
-
+    let mut columns = Vec::with_capacity(select_exprs.len());
+    let mut output_columns = Vec::with_capacity(select_exprs.len());
     for expr in select_exprs {
-        match expr {
-            // SELECT * - cannot push down projection
-            Expression::Star(_) | Expression::QualifiedStar(_) => return None,
-
-            Expression::Identifier(id) => {
-                let col_lower = id.value_lower.as_str();
-                if let Some(&idx) = col_index_map.get(col_lower) {
-                    if idx < outer_col_count {
-                        columns.push(ColumnSource::Outer(idx));
-                    } else {
-                        columns.push(ColumnSource::Inner(idx - outer_col_count));
-                    }
-                    output_columns.push(id.value.to_string());
-                } else {
-                    // Column not found - cannot push down
-                    return None;
-                }
-            }
-
-            Expression::QualifiedIdentifier(qid) => {
-                // Try qualified name first
-                let full_name = format!("{}.{}", qid.qualifier.value_lower, qid.name.value_lower);
-                if let Some(&idx) = col_index_map.get(&full_name) {
-                    if idx < outer_col_count {
-                        columns.push(ColumnSource::Outer(idx));
-                    } else {
-                        columns.push(ColumnSource::Inner(idx - outer_col_count));
-                    }
-                    // Output column name is just the column name, not qualified
-                    // (SQL standard: SELECT e.name produces column "name", not "e.name")
-                    output_columns.push(qid.name.value.to_string());
-                } else if let Some(&idx) = col_index_map.get(qid.name.value_lower.as_str()) {
-                    // Fall back to unqualified name
-                    if idx < outer_col_count {
-                        columns.push(ColumnSource::Outer(idx));
-                    } else {
-                        columns.push(ColumnSource::Inner(idx - outer_col_count));
-                    }
-                    output_columns.push(qid.name.value.to_string());
-                } else {
-                    // Column not found - cannot push down
-                    return None;
-                }
-            }
-
+        let (idx, name) = match expr {
+            Expression::Identifier(id) => (resolve(&id.value_lower)?, id.value.to_string()),
+            Expression::QualifiedIdentifier(qid) => (
+                resolve_qualified(&qid.qualifier.value_lower, &qid.name.value_lower)?,
+                qid.name.value.to_string(),
+            ),
             Expression::Aliased(aliased) => {
-                // Handle aliased expressions - check if inner is a simple column
-                let alias_name = aliased.alias.value.to_string();
+                let alias = aliased.alias.value.to_string();
                 match &*aliased.expression {
-                    Expression::Identifier(id) => {
-                        let col_lower = id.value_lower.as_str();
-                        if let Some(&idx) = col_index_map.get(col_lower) {
-                            if idx < outer_col_count {
-                                columns.push(ColumnSource::Outer(idx));
-                            } else {
-                                columns.push(ColumnSource::Inner(idx - outer_col_count));
-                            }
-                            output_columns.push(alias_name);
-                        } else {
-                            return None;
-                        }
-                    }
-                    Expression::QualifiedIdentifier(qid) => {
-                        let full_name =
-                            format!("{}.{}", qid.qualifier.value_lower, qid.name.value_lower);
-                        if let Some(&idx) = col_index_map.get(&full_name) {
-                            if idx < outer_col_count {
-                                columns.push(ColumnSource::Outer(idx));
-                            } else {
-                                columns.push(ColumnSource::Inner(idx - outer_col_count));
-                            }
-                            output_columns.push(alias_name);
-                        } else if let Some(&idx) = col_index_map.get(qid.name.value_lower.as_str())
-                        {
-                            if idx < outer_col_count {
-                                columns.push(ColumnSource::Outer(idx));
-                            } else {
-                                columns.push(ColumnSource::Inner(idx - outer_col_count));
-                            }
-                            output_columns.push(alias_name);
-                        } else {
-                            return None;
-                        }
-                    }
+                    Expression::Identifier(id) => (resolve(&id.value_lower)?, alias),
+                    Expression::QualifiedIdentifier(qid) => (
+                        resolve_qualified(&qid.qualifier.value_lower, &qid.name.value_lower)?,
+                        alias,
+                    ),
                     _ => return None, // Complex expression - cannot push down
                 }
             }
-
-            // Any other expression type cannot be pushed down
             _ => return None,
-        }
+        };
+        columns.push(source(idx));
+        output_columns.push(name);
     }
 
     Some(JoinProjectionIndices {

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -1919,10 +1919,7 @@ pub fn compute_join_projection(
     let resolve_qualified = |qualifier: &str, name: &str| -> Option<usize> {
         columns_all()
             .enumerate()
-            .filter(|(_, c)| {
-                c.split_once('.')
-                    .is_some_and(|(q, n)| eq_folded(q, qualifier) && eq_folded(n, name))
-            })
+            .filter(|(_, c)| eq_folded_qualified(c, qualifier, name))
             .last()
             .map(|(i, _)| i)
             .or_else(|| resolve(name))
@@ -1981,6 +1978,25 @@ fn eq_folded(column: &str, lower: &str) -> bool {
     }
 }
 
+/// The same for `qualifier.name`, compared as one string so that a dot
+/// inside a quoted qualifier or name is not taken for the separator.
+#[inline]
+fn eq_folded_qualified(column: &str, qualifier: &str, name: &str) -> bool {
+    if column.is_ascii() && qualifier.is_ascii() && name.is_ascii() {
+        let q = qualifier.len();
+        column.len() == q + 1 + name.len()
+            && column.as_bytes()[q] == b'.'
+            && column[..q].eq_ignore_ascii_case(qualifier)
+            && column[q + 1..].eq_ignore_ascii_case(name)
+    } else {
+        let expected = qualifier
+            .chars()
+            .chain(std::iter::once('.'))
+            .chain(name.chars());
+        column.chars().flat_map(char::to_lowercase).eq(expected)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2032,6 +2048,20 @@ mod tests {
         let dup = vec!["v".to_string(), "v".to_string()];
         let proj = compute_join_projection(&[ident("v")], &dup, &[]).unwrap();
         assert!(matches!(proj.columns[0], ColumnSource::Outer(1)));
+    }
+
+    /// A quoted alias may contain a dot; `"a.b".x` must match the column
+    /// `a.b.x` as a whole and not fall back to a bare `x` elsewhere.
+    #[test]
+    fn test_join_projection_keeps_dots_inside_a_qualifier() {
+        let outer = vec!["x".to_string()];
+        let inner = vec!["a.b.id".to_string(), "a.b.x".to_string()];
+        let proj = compute_join_projection(&[qualified("a.b", "x")], &outer, &inner).unwrap();
+        assert!(matches!(proj.columns[0], ColumnSource::Inner(1)));
+
+        let unicode = vec!["Ä.b.x".to_string()];
+        let proj = compute_join_projection(&[qualified("ä.b", "x")], &unicode, &[]).unwrap();
+        assert!(matches!(proj.columns[0], ColumnSource::Outer(0)));
     }
 
     /// Outer values reach the subquery's WHERE, but names that belong to

--- a/tests/join_simple_test.rs
+++ b/tests/join_simple_test.rs
@@ -352,3 +352,50 @@ fn test_cross_join() {
         );
     }
 }
+
+/// A column projected twice through the index nested loop join must come
+/// back twice. The fused projection used to move the value out on its
+/// first use and hand back NULL on the second.
+#[test]
+fn test_inl_join_projects_a_repeated_column_twice() {
+    let db = Database::open("memory://inl_repeated_column").expect("Failed to create database");
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount FLOAT)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX idx_orders_user_id ON orders(user_id)", ())
+        .unwrap();
+    for i in 1..=20i64 {
+        db.execute(
+            "INSERT INTO users VALUES ($1, $2)",
+            (i, format!("User_{}", i)),
+        )
+        .unwrap();
+    }
+    for i in 1..=60i64 {
+        db.execute(
+            "INSERT INTO orders VALUES ($1, $2, $3)",
+            (i, (i % 20) + 1, i as f64),
+        )
+        .unwrap();
+    }
+    let rows: Vec<(String, f64, f64, String)> = db
+        .query(
+            "SELECT u.name, o.amount, o.amount, u.name FROM users u INNER JOIN orders o ON u.id = o.user_id LIMIT 5",
+            (),
+        )
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            (r.get(0).unwrap(), r.get(1).unwrap(), r.get(2).unwrap(), r.get(3).unwrap())
+        })
+        .collect();
+    assert_eq!(rows.len(), 5);
+    for (name, a, b, name2) in rows {
+        assert_eq!(a, b, "amount must be projected twice");
+        assert_eq!(name, name2, "name must be projected twice");
+    }
+}


### PR DESCRIPTION
## Why

The two join rows where SQLite still led in BENCHMARKS.md: INNER JOIN (19.7 vs 12.1 us) and Self JOIN (12.6 vs 8.8 us). A `sample` profile of the INNER JOIN benchmark shape put 16% of the time in `combine_owned_into_buffer` (mostly `RowStorage::into_vec`) and 7% in `compute_join_projection`.

- `combine_owned_into_buffer` and `create_combined_row` converted both input rows to `Vec<Value>` before picking the one or two projected columns. For a shared row that clones every column; for an owned `CompactVec` it reallocates.
- `compute_join_projection` built a combined `Vec<String>` of every column name plus a lowercase `StringMap` on each execution of the statement.

## What

- `Row::take_or_clone(idx)`: moves the value out of owned storage, clones it out of shared storage. The two combine paths take only the projected values from the rows they own.
- `compute_join_projection` resolves each SELECT column by scanning the two column lists (usually under 20 names) instead of building a map, with the same rules as `build_column_index_map`: exact case-insensitive match first, then a qualified column's base name when exactly one column carries it. A qualified reference is matched piecewise, without formatting the name.

## Measured

Probe with the benchmark's tables (10k users, 50k orders, same indexes), 10 interleaved rounds against `main`, best / median:

| Shape | main | this PR | |
|---|---|---|---|
| INNER JOIN with LIMIT 100 | 19.3 / 20.7 us | 14.8 / 15.3 us | 1.30x / 1.35x |
| Self JOIN on age, LIMIT 100 | 12.0 / 12.4 us | 9.0 / 9.1 us | 1.33x / 1.36x |
| LEFT JOIN + GROUP BY | 52.7 / 54.0 us | 52.8 / 54.0 us | parity |
| Complex JOIN+GROUP+HAVING | 60.1 / 61.4 us | 60.4 / 62.0 us | parity |

The two aggregate shapes do not use projection pushdown, so they are unchanged by design.

## Tests

No behaviour change; the three join targets (25 tests) and the `utils` and `index_nested_loop` unit tests (87) pass, plus both full suites.

Still on the profile for this shape, for a follow-up: the hash index copies the whole id list for `status = 'completed'` (16.7k ids) on every execution although the outer side only needs a few hundred rows, and the outer side re-checks the status predicate on rows the index already matched exactly.
