### PR TITLE
fix(storage): keep sealed rows visible to executor index probes

### DIFF
--- a/src/executor/cte.rs
+++ b/src/executor/cte.rs
@@ -2191,12 +2191,12 @@ impl Executor {
             if schema.columns[pk_idx].name_lower == table_col_lower {
                 // It's a primary key lookup - most efficient!
                 IndexLookupStrategy::PrimaryKey
-            } else if let Some(index) = table.get_index_on_column(&table_col_unqualified) {
+            } else if let Some(index) = table.lookup_index_on_column(&table_col_unqualified) {
                 IndexLookupStrategy::SecondaryIndex(index)
             } else {
                 return Ok(None);
             }
-        } else if let Some(index) = table.get_index_on_column(&table_col_unqualified) {
+        } else if let Some(index) = table.lookup_index_on_column(&table_col_unqualified) {
             IndexLookupStrategy::SecondaryIndex(index)
         } else {
             return Ok(None);

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -895,7 +895,7 @@ impl Executor {
 
         // If not PK, check for index
         let index = if !is_pk_column {
-            match table.get_index_on_column(&column_name) {
+            match table.lookup_index_on_column(&column_name) {
                 Some(idx) => Some(idx),
                 None => return Ok(None), // No PK, no index, can't optimize
             }
@@ -1249,7 +1249,7 @@ impl Executor {
         // and stops at LIMIT; so it is only taken when a memory filter is
         // needed anyway. Primary key values are the row ids themselves.
         let index = if !is_pk_column {
-            match table.get_index_on_column(&column_name) {
+            match table.lookup_index_on_column(&column_name) {
                 Some(idx) => Some(idx),
                 None => return Ok(None), // No PK, no index, can't optimize
             }
@@ -1607,7 +1607,7 @@ impl Executor {
 
         // If not PK, check for index (only for non-negated IN)
         let index = if !is_pk_column {
-            match table.get_index_on_column(&column_name) {
+            match table.lookup_index_on_column(&column_name) {
                 Some(idx) => Some(idx),
                 None => return Ok(None), // No PK, no index, can't optimize
             }

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -9179,7 +9179,7 @@ impl Executor {
         }
 
         // Check if there's a secondary index on the inner column
-        if let Some(index) = table.get_index_on_column(&inner_col_unqualified) {
+        if let Some(index) = table.lookup_index_on_column(&inner_col_unqualified) {
             return Some((
                 table_name,
                 IndexLookupStrategy::SecondaryIndex(index),
@@ -9456,7 +9456,7 @@ impl Executor {
         };
 
         // Check for B-tree or primary key index on GROUP BY column
-        let btree_index = match table.get_index_on_column(&group_col_name) {
+        let btree_index = match table.lookup_index_on_column(&group_col_name) {
             Some(idx)
                 if idx.index_type() == IndexType::BTree
                     || idx.index_type() == IndexType::PrimaryKey =>

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -483,7 +483,7 @@ impl Executor {
             Some(idx) => idx,
             None => {
                 // First time: get index from engine and cache it
-                let indexes = match self.engine.get_all_indexes(&correlation.inner_table) {
+                let indexes = match self.engine.get_lookup_indexes(&correlation.inner_table) {
                     Ok(idxs) => idxs,
                     Err(_) => return Ok(None), // Table not found, fall back
                 };
@@ -828,7 +828,7 @@ impl Executor {
             Some(idx) => idx,
             None => {
                 // First time: get index from engine and cache it
-                let indexes = match self.engine.get_all_indexes(&correlation.inner_table) {
+                let indexes = match self.engine.get_lookup_indexes(&correlation.inner_table) {
                     Ok(idxs) => idxs,
                     Err(_) => return Ok(None), // Table not found, fall back
                 };
@@ -2992,7 +2992,7 @@ impl Executor {
 
                 // Check for index on correlation column
                 if inner_table
-                    .get_index_on_column(&info.inner_column)
+                    .lookup_index_on_column(&info.inner_column)
                     .is_some()
                 {
                     return true;

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -492,6 +492,33 @@ fn parse_volume_id(path: &std::path::Path) -> Option<u64> {
         .and_then(|hex| u64::from_str_radix(hex, 16).ok())
 }
 
+/// Get or create a segment manager for a table.
+fn get_or_create_segment_manager(
+    segment_managers: &RwLock<
+        FxHashMap<String, Arc<crate::storage::volume::manifest::SegmentManager>>,
+    >,
+    persistence: &Option<PersistenceManager>,
+    table_name: &str,
+) -> Arc<crate::storage::volume::manifest::SegmentManager> {
+    // Fast path: read lock (common case during WAL replay — manager already exists)
+    {
+        let mgrs = segment_managers.read().unwrap();
+        if let Some(mgr) = mgrs.get(table_name) {
+            return Arc::clone(mgr);
+        }
+    }
+    // Slow path: write lock (first access, creates new manager)
+    let mut mgrs = segment_managers.write().unwrap();
+    mgrs.entry(table_name.to_string())
+        .or_insert_with(|| {
+            let vol_dir = persistence.as_ref().map(|pm| pm.path().join("volumes"));
+            Arc::new(crate::storage::volume::manifest::SegmentManager::new(
+                table_name, vol_dir,
+            ))
+        })
+        .clone()
+}
+
 impl MVCCEngine {
     /// Creates a new MVCC engine with the given configuration
     pub fn new(config: Config) -> Self {
@@ -2898,27 +2925,7 @@ impl MVCCEngine {
         &self,
         table_name: &str,
     ) -> Arc<crate::storage::volume::manifest::SegmentManager> {
-        // Fast path: read lock (common case during WAL replay — manager already exists)
-        {
-            let mgrs = self.segment_managers.read().unwrap();
-            if let Some(mgr) = mgrs.get(table_name) {
-                return Arc::clone(mgr);
-            }
-        }
-        // Slow path: write lock (first access, creates new manager)
-        let mut mgrs = self.segment_managers.write().unwrap();
-        mgrs.entry(table_name.to_string())
-            .or_insert_with(|| {
-                let vol_dir = self
-                    .persistence
-                    .as_ref()
-                    .as_ref()
-                    .map(|pm| pm.path().join("volumes"));
-                Arc::new(crate::storage::volume::manifest::SegmentManager::new(
-                    table_name, vol_dir,
-                ))
-            })
-            .clone()
+        get_or_create_segment_manager(&self.segment_managers, &self.persistence, table_name)
     }
 
     /// Clean up stale .dv files from disk left over by previous versions.
@@ -6993,39 +7000,40 @@ impl TransactionEngineOperations for EngineOperations {
             }
         };
 
-        // Create MVCC table with shared transaction version store
-        let mut table = MVCCTable::new_with_shared_store(txn_id, version_store, txn_versions);
-        if self.persistence.is_some() {
-            table.mark_seal_capable();
-        }
+        let table = MVCCTable::new_with_shared_store(txn_id, version_store, txn_versions);
 
-        // If segments exist for this table, wrap in SegmentedTable.
-        // For snapshot isolation transactions, pass the begin_seq so tombstone
-        // filtering respects the snapshot's point-in-time view of cold data.
-        let mgrs = self.segment_managers.read().unwrap();
-        if let Some(mgr) = mgrs.get(&*table_name_lower) {
-            if mgr.has_segments() {
-                let mgr = Arc::clone(mgr);
-                drop(mgrs);
-                if self.registry.get_isolation_level(txn_id)
-                    == crate::IsolationLevel::SnapshotIsolation
-                {
-                    let begin_seq = self.registry.get_transaction_begin_sequence(txn_id) as u64;
-                    return Ok(Box::new(
-                        crate::storage::volume::table::SegmentedTable::with_snapshot_seq(
-                            Box::new(table),
-                            mgr,
-                            begin_seq,
-                        ),
-                    ));
-                }
-                return Ok(Box::new(
-                    crate::storage::volume::table::SegmentedTable::new(Box::new(table), mgr),
-                ));
+        // A persistent database may seal rows at any moment, so its tables
+        // always go through the segment-aware wrapper, even before the first
+        // seal. Elsewhere the wrapper is only needed once segments exist.
+        // For snapshot isolation transactions, pass the begin_seq so
+        // tombstone filtering respects the snapshot's point-in-time view of
+        // cold data.
+        let mgr = if self.persistence.is_some() {
+            get_or_create_segment_manager(
+                &self.segment_managers,
+                &self.persistence,
+                &table_name_lower,
+            )
+        } else {
+            let mgrs = self.segment_managers.read().unwrap();
+            match mgrs.get(&*table_name_lower) {
+                Some(mgr) if mgr.has_segments() => Arc::clone(mgr),
+                _ => return Ok(Box::new(table)),
             }
+        };
+        if self.registry.get_isolation_level(txn_id) == crate::IsolationLevel::SnapshotIsolation {
+            let begin_seq = self.registry.get_transaction_begin_sequence(txn_id) as u64;
+            return Ok(Box::new(
+                crate::storage::volume::table::SegmentedTable::with_snapshot_seq(
+                    Box::new(table),
+                    mgr,
+                    begin_seq,
+                ),
+            ));
         }
-
-        Ok(Box::new(table))
+        Ok(Box::new(
+            crate::storage::volume::table::SegmentedTable::new(Box::new(table), mgr),
+        ))
     }
 
     fn create_table(&self, name: &str, schema: Schema) -> Result<Box<dyn Table>> {

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -6094,12 +6094,9 @@ impl Engine for MVCCEngine {
     }
 
     fn get_lookup_indexes(&self, table_name: &str) -> Result<Vec<std::sync::Arc<dyn Index>>> {
-        let sealed = {
-            let mgrs = self.segment_managers.read().unwrap();
-            mgrs.get(&table_name.to_lowercase())
-                .is_some_and(|mgr| mgr.has_segments())
-        };
-        if sealed {
+        // A persistent database may seal rows at any moment, so a hot index
+        // handed out now could lose them before the caller probes it.
+        if self.persistence.is_some() {
             return Ok(Vec::new());
         }
         self.get_all_indexes(table_name)
@@ -6997,7 +6994,10 @@ impl TransactionEngineOperations for EngineOperations {
         };
 
         // Create MVCC table with shared transaction version store
-        let table = MVCCTable::new_with_shared_store(txn_id, version_store, txn_versions);
+        let mut table = MVCCTable::new_with_shared_store(txn_id, version_store, txn_versions);
+        if self.persistence.is_some() {
+            table.mark_seal_capable();
+        }
 
         // If segments exist for this table, wrap in SegmentedTable.
         // For snapshot isolation transactions, pass the begin_seq so tombstone

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -6093,6 +6093,18 @@ impl Engine for MVCCEngine {
         Ok(store.get_all_indexes().into_vec())
     }
 
+    fn get_lookup_indexes(&self, table_name: &str) -> Result<Vec<std::sync::Arc<dyn Index>>> {
+        let sealed = {
+            let mgrs = self.segment_managers.read().unwrap();
+            mgrs.get(&table_name.to_lowercase())
+                .is_some_and(|mgr| mgr.has_segments())
+        };
+        if sealed {
+            return Ok(Vec::new());
+        }
+        self.get_all_indexes(table_name)
+    }
+
     fn get_isolation_level(&self) -> IsolationLevel {
         self.registry.get_global_isolation_level()
     }

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -40,6 +40,10 @@ pub struct MVCCTable {
     version_store: Arc<VersionStore>,
     /// Transaction-local version store (shared between multiple MVCCTable instances for same txn+table)
     txn_versions: Arc<RwLock<TransactionVersionStore>>,
+    /// The database persists to disk and may seal rows into volumes, which
+    /// takes them out of the hot indexes; executor probes must not rely on
+    /// those indexes then.
+    seal_capable: bool,
     /// Cached schema for returning references (Arc clone from version_store - O(1) instead of cloning)
     cached_schema: CompactArc<Schema>,
 }
@@ -55,6 +59,7 @@ impl MVCCTable {
         // CompactArc clone - O(1) reference count increment, not full schema clone
         let cached_schema = version_store.schema().clone();
         Self {
+            seal_capable: false,
             txn_id,
             version_store,
             txn_versions: Arc::new(RwLock::new(txn_versions)),
@@ -64,6 +69,11 @@ impl MVCCTable {
 
     /// Creates a new MVCC table with a shared transaction version store
     /// (used by the engine's get_table_for_transaction to share stores)
+    /// Rows of this table can be sealed into volumes; see `seal_capable`.
+    pub fn mark_seal_capable(&mut self) {
+        self.seal_capable = true;
+    }
+
     pub fn new_with_shared_store(
         txn_id: i64,
         version_store: Arc<VersionStore>,
@@ -72,6 +82,7 @@ impl MVCCTable {
         // CompactArc clone - O(1) reference count increment, not full schema clone
         let cached_schema = version_store.schema().clone();
         Self {
+            seal_capable: false,
             txn_id,
             version_store,
             txn_versions,
@@ -3360,6 +3371,13 @@ impl Table for MVCCTable {
     }
 
     fn get_index_on_column(&self, column_name: &str) -> Option<std::sync::Arc<dyn Index>> {
+        self.version_store.get_index_by_column(column_name)
+    }
+
+    fn lookup_index_on_column(&self, column_name: &str) -> Option<std::sync::Arc<dyn Index>> {
+        if self.seal_capable {
+            return None;
+        }
         self.version_store.get_index_by_column(column_name)
     }
 

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -40,10 +40,6 @@ pub struct MVCCTable {
     version_store: Arc<VersionStore>,
     /// Transaction-local version store (shared between multiple MVCCTable instances for same txn+table)
     txn_versions: Arc<RwLock<TransactionVersionStore>>,
-    /// The database persists to disk and may seal rows into volumes, which
-    /// takes them out of the hot indexes; executor probes must not rely on
-    /// those indexes then.
-    seal_capable: bool,
     /// Cached schema for returning references (Arc clone from version_store - O(1) instead of cloning)
     cached_schema: CompactArc<Schema>,
 }
@@ -59,7 +55,6 @@ impl MVCCTable {
         // CompactArc clone - O(1) reference count increment, not full schema clone
         let cached_schema = version_store.schema().clone();
         Self {
-            seal_capable: false,
             txn_id,
             version_store,
             txn_versions: Arc::new(RwLock::new(txn_versions)),
@@ -69,11 +64,6 @@ impl MVCCTable {
 
     /// Creates a new MVCC table with a shared transaction version store
     /// (used by the engine's get_table_for_transaction to share stores)
-    /// Rows of this table can be sealed into volumes; see `seal_capable`.
-    pub fn mark_seal_capable(&mut self) {
-        self.seal_capable = true;
-    }
-
     pub fn new_with_shared_store(
         txn_id: i64,
         version_store: Arc<VersionStore>,
@@ -82,7 +72,6 @@ impl MVCCTable {
         // CompactArc clone - O(1) reference count increment, not full schema clone
         let cached_schema = version_store.schema().clone();
         Self {
-            seal_capable: false,
             txn_id,
             version_store,
             txn_versions,
@@ -3371,13 +3360,6 @@ impl Table for MVCCTable {
     }
 
     fn get_index_on_column(&self, column_name: &str) -> Option<std::sync::Arc<dyn Index>> {
-        self.version_store.get_index_by_column(column_name)
-    }
-
-    fn lookup_index_on_column(&self, column_name: &str) -> Option<std::sync::Arc<dyn Index>> {
-        if self.seal_capable {
-            return None;
-        }
         self.version_store.get_index_by_column(column_name)
     }
 

--- a/src/storage/traits/engine.rs
+++ b/src/storage/traits/engine.rs
@@ -99,6 +99,12 @@ pub trait Engine: Send + Sync {
     /// Gets all index objects for a table
     fn get_all_indexes(&self, table_name: &str) -> Result<Vec<std::sync::Arc<dyn Index>>>;
 
+    /// Indexes the executor may probe directly: every visible row of the
+    /// table is in them. Empty for a table with rows outside its indexes.
+    fn get_lookup_indexes(&self, table_name: &str) -> Result<Vec<std::sync::Arc<dyn Index>>> {
+        self.get_all_indexes(table_name)
+    }
+
     /// Gets the current default isolation level
     fn get_isolation_level(&self) -> IsolationLevel;
 

--- a/src/storage/traits/table.rs
+++ b/src/storage/traits/table.rs
@@ -732,6 +732,14 @@ pub trait Table: Send + Sync {
         None // Default implementation - override in concrete tables
     }
 
+    /// An index on `column_name` whose row ids cover every visible row of
+    /// the table, so the executor may probe it directly. A table that keeps
+    /// part of its rows outside the index returns None and the executor
+    /// scans instead.
+    fn lookup_index_on_column(&self, column_name: &str) -> Option<std::sync::Arc<dyn Index>> {
+        self.get_index_on_column(column_name)
+    }
+
     /// Gets all unique indexes on the table (for constraint checking).
     ///
     /// Returns a list of (index_name, column_names) for each unique index.

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -98,7 +98,8 @@ impl SegmentedTable {
 
     /// Runs `f` on the hot table while no rows are sealed. The seal fence is
     /// held across the check and the call, so the first seal cannot remove
-    /// hot rows in between. None once segments exist.
+    /// hot rows in between. None once segments exist. Readers that merge hot
+    /// and cold values hold the fence for their whole body instead.
     fn unsealed<T>(&self, f: impl FnOnce(&dyn Table) -> T) -> Option<T> {
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         if self.segment_mgr.has_segments() {
@@ -2276,6 +2277,7 @@ impl Table for SegmentedTable {
         // may be off by a few rows during the brief overlap window, but
         // this avoids an O(total_rows) HashSet collection that made ALL
         // queries slow during checkpoint.
+        let _seal_guard = self.segment_mgr.acquire_seal_read();
         let seg = self.segment_mgr.deduped_row_count();
         let pending = self.segment_mgr.pending_tombstone_count(self.txn_id());
         let overlap = self.segment_mgr.seal_overlap();
@@ -2296,6 +2298,7 @@ impl Table for SegmentedTable {
         if self.snapshot_seq.is_some() {
             return None;
         }
+        let _seal_guard = self.segment_mgr.acquire_seal_read();
         let hot_count = self.hot.fast_row_count()?;
         let seg = self.segment_mgr.deduped_row_count();
         let pending = self.segment_mgr.pending_tombstone_count(self.txn_id());
@@ -2316,6 +2319,7 @@ impl Table for SegmentedTable {
         if self.snapshot_seq.is_some() {
             return None;
         }
+        let _seal_guard = self.segment_mgr.acquire_seal_read();
         let hot_result = self.hot.sum_column(col_idx);
 
         if !self.segment_mgr.has_segments() {
@@ -2445,6 +2449,7 @@ impl Table for SegmentedTable {
         if self.snapshot_seq.is_some() {
             return None;
         }
+        let _seal_guard = self.segment_mgr.acquire_seal_read();
         let hot_result = self.hot.min_column(col_idx);
 
         if !self.segment_mgr.has_segments() {
@@ -2748,6 +2753,7 @@ impl Table for SegmentedTable {
         if self.snapshot_seq.is_some() {
             return None;
         }
+        let _seal_guard = self.segment_mgr.acquire_seal_read();
         let hot_result = self.hot.max_column(col_idx);
 
         if !self.segment_mgr.has_segments() {
@@ -3045,8 +3051,9 @@ impl Table for SegmentedTable {
         if self.snapshot_seq.is_some() {
             return None;
         }
-        if let Some(result) = self.unsealed(|hot| hot.get_partition_count(column_name)) {
-            return result;
+        let _seal_guard = self.segment_mgr.acquire_seal_read();
+        if !self.segment_mgr.has_segments() {
+            return self.hot.get_partition_count(column_name);
         }
 
         // During seal, hot+cold overlap — can't reliably count
@@ -3301,10 +3308,9 @@ impl Table for SegmentedTable {
         if self.snapshot_seq.is_some() {
             return None;
         }
-        if let Some(result) =
-            self.unsealed(|hot| hot.collect_rows_grouped_by_partition(column_name))
-        {
-            return result;
+        let _seal_guard = self.segment_mgr.acquire_seal_read();
+        if !self.segment_mgr.has_segments() {
+            return self.hot.collect_rows_grouped_by_partition(column_name);
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
@@ -3384,10 +3390,11 @@ impl Table for SegmentedTable {
         if self.snapshot_seq.is_some() {
             return Ok(None);
         }
-        if let Some(result) =
-            self.unsealed(|hot| hot.get_rows_for_partition_value(column_name, partition_value))
-        {
-            return result;
+        let _seal_guard = self.segment_mgr.acquire_seal_read();
+        if !self.segment_mgr.has_segments() {
+            return self
+                .hot
+                .get_rows_for_partition_value(column_name, partition_value);
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
@@ -4213,6 +4220,7 @@ impl Table for SegmentedTable {
         if self.snapshot_seq.is_some() {
             return None;
         }
+        let _seal_guard = self.segment_mgr.acquire_seal_read();
         // Bail out: during seal, hot+cold overlap makes aggregation unreliable
         if self.segment_mgr.seal_overlap() > 0 {
             return None;
@@ -5043,10 +5051,11 @@ impl Table for SegmentedTable {
         if group_by_indices.len() != 1 {
             return None;
         }
-        if let Some(result) =
-            self.unsealed(|hot| hot.compute_grouped_aggregates(group_by_indices, aggregates))
-        {
-            return result;
+        let _seal_guard = self.segment_mgr.acquire_seal_read();
+        if !self.segment_mgr.has_segments() {
+            return self
+                .hot
+                .compute_grouped_aggregates(group_by_indices, aggregates);
         }
 
         // During seal, hot+cold overlap — can't reliably aggregate

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -3852,6 +3852,15 @@ impl Table for SegmentedTable {
         self.hot.get_index_on_column(column_name)
     }
 
+    /// The hot index holds ids for unsealed rows only; once rows live in
+    /// sealed segments a direct probe would miss them.
+    fn lookup_index_on_column(&self, column_name: &str) -> Option<Arc<dyn Index>> {
+        if self.segment_mgr.has_segments() {
+            return None;
+        }
+        self.hot.get_index_on_column(column_name)
+    }
+
     fn get_index(&self, name: &str) -> Option<Arc<dyn Index>> {
         self.hot.get_index(name)
     }

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -3852,13 +3852,10 @@ impl Table for SegmentedTable {
         self.hot.get_index_on_column(column_name)
     }
 
-    /// The hot index holds ids for unsealed rows only; once rows live in
-    /// sealed segments a direct probe would miss them.
-    fn lookup_index_on_column(&self, column_name: &str) -> Option<Arc<dyn Index>> {
-        if self.segment_mgr.has_segments() {
-            return None;
-        }
-        self.hot.get_index_on_column(column_name)
+    /// The hot index holds ids for unsealed rows only, and the next seal
+    /// can move rows out of it at any moment, so it is never probed directly.
+    fn lookup_index_on_column(&self, _column_name: &str) -> Option<Arc<dyn Index>> {
+        None
     }
 
     fn get_index(&self, name: &str) -> Option<Arc<dyn Index>> {

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -96,6 +96,17 @@ impl SegmentedTable {
         }
     }
 
+    /// Runs `f` on the hot table while no rows are sealed. The seal fence is
+    /// held across the check and the call, so the first seal cannot remove
+    /// hot rows in between. None once segments exist.
+    fn unsealed<T>(&self, f: impl FnOnce(&dyn Table) -> T) -> Option<T> {
+        let _seal_guard = self.segment_mgr.acquire_seal_read();
+        if self.segment_mgr.has_segments() {
+            return None;
+        }
+        Some(f(&*self.hot))
+    }
+
     /// Get the transaction ID for per-txn tombstone tracking.
     fn txn_id(&self) -> i64 {
         self.hot.txn_id()
@@ -1757,8 +1768,8 @@ impl Table for SegmentedTable {
         column_indices: &[usize],
         where_expr: Option<&dyn Expression>,
     ) -> Result<Box<dyn Scanner>> {
-        if !self.segment_mgr.has_segments() {
-            return self.hot.scan(column_indices, where_expr);
+        if let Some(result) = self.unsealed(|hot| hot.scan(column_indices, where_expr)) {
+            return result;
         }
 
         // Collect hot rows FIRST to get a consistent snapshot of hot row_ids.
@@ -1790,8 +1801,8 @@ impl Table for SegmentedTable {
     }
 
     fn collect_all_rows(&self, where_expr: Option<&dyn Expression>) -> Result<RowVec> {
-        if !self.segment_mgr.has_segments() {
-            return self.hot.collect_all_rows(where_expr);
+        if let Some(result) = self.unsealed(|hot| hot.collect_all_rows(where_expr)) {
+            return result;
         }
 
         // Scan hot FIRST to get a consistent snapshot. The skip set is
@@ -1816,8 +1827,8 @@ impl Table for SegmentedTable {
     }
 
     fn collect_all_rows_unsorted(&self) -> Result<RowVec> {
-        if !self.segment_mgr.has_segments() {
-            return self.hot.collect_all_rows_unsorted();
+        if let Some(result) = self.unsealed(|hot| hot.collect_all_rows_unsorted()) {
+            return result;
         }
 
         let hot_rows = self.hot.collect_all_rows_unsorted()?;
@@ -1838,8 +1849,8 @@ impl Table for SegmentedTable {
     }
 
     fn collect_rows_by_ids(&self, row_ids: &[i64]) -> Result<RowVec> {
-        if !self.segment_mgr.has_segments() {
-            return self.hot.collect_rows_by_ids(row_ids);
+        if let Some(result) = self.unsealed(|hot| hot.collect_rows_by_ids(row_ids)) {
+            return result;
         }
 
         let schema = self.hot.schema().clone();
@@ -1896,8 +1907,10 @@ impl Table for SegmentedTable {
         filter: &dyn Expression,
         buffer: &mut RowVec,
     ) -> Result<()> {
-        if !self.segment_mgr.has_segments() {
-            return self.hot.fetch_rows_by_ids_into(row_ids, filter, buffer);
+        if let Some(result) =
+            self.unsealed(|hot| hot.fetch_rows_by_ids_into(row_ids, filter, buffer))
+        {
+            return result;
         }
 
         let mut hot_ids = Vec::new();
@@ -1947,8 +1960,10 @@ impl Table for SegmentedTable {
         limit: usize,
         offset: usize,
     ) -> Result<RowVec> {
-        if !self.segment_mgr.has_segments() {
-            return self.hot.collect_rows_with_limit(where_expr, limit, offset);
+        if let Some(result) =
+            self.unsealed(|hot| hot.collect_rows_with_limit(where_expr, limit, offset))
+        {
+            return result;
         }
 
         let target = limit + offset;
@@ -2058,10 +2073,10 @@ impl Table for SegmentedTable {
         limit: usize,
         offset: usize,
     ) -> Result<RowVec> {
-        if !self.segment_mgr.has_segments() {
-            return self
-                .hot
-                .collect_rows_with_limit_unordered(where_expr, limit, offset);
+        if let Some(result) =
+            self.unsealed(|hot| hot.collect_rows_with_limit_unordered(where_expr, limit, offset))
+        {
+            return result;
         }
 
         let target = limit + offset;
@@ -2193,10 +2208,10 @@ impl Table for SegmentedTable {
         limit: usize,
         offset: usize,
     ) -> Result<Vec<Row>> {
-        if !self.segment_mgr.has_segments() {
-            return self
-                .hot
-                .collect_rows_sorted_with_limit(sort_col_idx, ascending, limit, offset);
+        if let Some(result) = self.unsealed(|hot| {
+            hot.collect_rows_sorted_with_limit(sort_col_idx, ascending, limit, offset)
+        }) {
+            return result;
         }
         // Collect all merged rows, sort, take limit
         let mut rows = self.collect_all_rows(None)?;
@@ -3030,8 +3045,8 @@ impl Table for SegmentedTable {
         if self.snapshot_seq.is_some() {
             return None;
         }
-        if !self.segment_mgr.has_segments() {
-            return self.hot.get_partition_count(column_name);
+        if let Some(result) = self.unsealed(|hot| hot.get_partition_count(column_name)) {
+            return result;
         }
 
         // During seal, hot+cold overlap — can't reliably count
@@ -3099,8 +3114,8 @@ impl Table for SegmentedTable {
         if self.snapshot_seq.is_some() {
             return None;
         }
-        if !self.segment_mgr.has_segments() {
-            return self.hot.get_partition_values(column_name);
+        if let Some(result) = self.unsealed(|hot| hot.get_partition_values(column_name)) {
+            return result;
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
@@ -3286,8 +3301,10 @@ impl Table for SegmentedTable {
         if self.snapshot_seq.is_some() {
             return None;
         }
-        if !self.segment_mgr.has_segments() {
-            return self.hot.collect_rows_grouped_by_partition(column_name);
+        if let Some(result) =
+            self.unsealed(|hot| hot.collect_rows_grouped_by_partition(column_name))
+        {
+            return result;
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
@@ -3367,10 +3384,10 @@ impl Table for SegmentedTable {
         if self.snapshot_seq.is_some() {
             return Ok(None);
         }
-        if !self.segment_mgr.has_segments() {
-            return self
-                .hot
-                .get_rows_for_partition_value(column_name, partition_value);
+        if let Some(result) =
+            self.unsealed(|hot| hot.get_rows_for_partition_value(column_name, partition_value))
+        {
+            return result;
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
@@ -3477,10 +3494,10 @@ impl Table for SegmentedTable {
         limit: usize,
         offset: usize,
     ) -> Option<RowVec> {
-        if !self.segment_mgr.has_segments() {
-            return self
-                .hot
-                .collect_rows_ordered_by_index(column_name, ascending, limit, offset);
+        if let Some(result) = self.unsealed(|hot| {
+            hot.collect_rows_ordered_by_index(column_name, ascending, limit, offset)
+        }) {
+            return result;
         }
 
         // Snapshot isolation: the merge path doesn't filter by snapshot_seq.
@@ -3692,10 +3709,10 @@ impl Table for SegmentedTable {
         ascending: bool,
         limit: usize,
     ) -> Option<RowVec> {
-        if !self.segment_mgr.has_segments() {
-            return self
-                .hot
-                .collect_rows_pk_keyset(start_after, start_from, ascending, limit);
+        if let Some(result) = self
+            .unsealed(|hot| hot.collect_rows_pk_keyset(start_after, start_from, ascending, limit))
+        {
+            return result;
         }
         // Hot PK index doesn't cover cold data — can't use keyset pagination
         None
@@ -3922,8 +3939,8 @@ impl Table for SegmentedTable {
     }
 
     fn get_index_min_value(&self, column_name: &str) -> Option<Value> {
-        if !self.segment_mgr.has_segments() {
-            return self.hot.get_index_min_value(column_name);
+        if let Some(result) = self.unsealed(|hot| hot.get_index_min_value(column_name)) {
+            return result;
         }
         let hot_min = self.hot.get_index_min_value(column_name);
         let segments = self.segment_mgr.get_segments_ordered_meta();
@@ -3963,8 +3980,8 @@ impl Table for SegmentedTable {
     }
 
     fn get_index_max_value(&self, column_name: &str) -> Option<Value> {
-        if !self.segment_mgr.has_segments() {
-            return self.hot.get_index_max_value(column_name);
+        if let Some(result) = self.unsealed(|hot| hot.get_index_max_value(column_name)) {
+            return result;
         }
         let hot_max = self.hot.get_index_max_value(column_name);
         let segments = self.segment_mgr.get_segments_ordered_meta();
@@ -4024,8 +4041,8 @@ impl Table for SegmentedTable {
         columns: &[&str],
         expr: Option<&dyn Expression>,
     ) -> Result<Box<dyn QueryResult>> {
-        if !self.segment_mgr.has_segments() {
-            return self.hot.select(columns, expr);
+        if let Some(result) = self.unsealed(|hot| hot.select(columns, expr)) {
+            return result;
         }
         let all_rows = self.collect_all_rows(expr)?;
         let col_names: Vec<String> = columns.iter().map(|c| c.to_string()).collect();
@@ -4040,8 +4057,8 @@ impl Table for SegmentedTable {
         expr: Option<&dyn Expression>,
         aliases: &FxHashMap<String, String>,
     ) -> Result<Box<dyn QueryResult>> {
-        if !self.segment_mgr.has_segments() {
-            return self.hot.select_with_aliases(columns, expr, aliases);
+        if let Some(result) = self.unsealed(|hot| hot.select_with_aliases(columns, expr, aliases)) {
+            return result;
         }
         self.select(columns, expr)
     }
@@ -4053,10 +4070,10 @@ impl Table for SegmentedTable {
         temporal_type: &str,
         temporal_value: i64,
     ) -> Result<Box<dyn QueryResult>> {
-        if !self.segment_mgr.has_segments() {
-            return self
-                .hot
-                .select_as_of(columns, expr, temporal_type, temporal_value);
+        if let Some(result) =
+            self.unsealed(|hot| hot.select_as_of(columns, expr, temporal_type, temporal_value))
+        {
+            return result;
         }
 
         // Historical point-in-time queries on segment-backed tables are not
@@ -5026,10 +5043,10 @@ impl Table for SegmentedTable {
         if group_by_indices.len() != 1 {
             return None;
         }
-        if !self.segment_mgr.has_segments() {
-            return self
-                .hot
-                .compute_grouped_aggregates(group_by_indices, aggregates);
+        if let Some(result) =
+            self.unsealed(|hot| hot.compute_grouped_aggregates(group_by_indices, aggregates))
+        {
+            return result;
         }
 
         // During seal, hot+cold overlap — can't reliably aggregate

--- a/tests/sealed_index_visibility_test.rs
+++ b/tests/sealed_index_visibility_test.rs
@@ -1,0 +1,147 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Once rows are sealed into volumes, the hot secondary index no longer
+//! knows them. Every executor path that probes an index directly must still
+//! see those rows, both right after a checkpoint and after a reopen.
+
+use stoolap::Database;
+
+fn count(db: &Database, sql: &str) -> i64 {
+    db.query(sql, ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap()
+}
+
+fn rows(db: &Database, sql: &str) -> usize {
+    db.query(sql, ()).unwrap().count()
+}
+
+fn populate(db: &Database) {
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount FLOAT)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX idx_orders_user_id ON orders(user_id)", ())
+        .unwrap();
+    for i in 1..=20i64 {
+        db.execute(
+            "INSERT INTO users VALUES ($1, $2)",
+            (i, format!("User_{}", i)),
+        )
+        .unwrap();
+    }
+    for i in 1..=60i64 {
+        db.execute(
+            "INSERT INTO orders VALUES ($1, $2, $3)",
+            (i, (i % 20) + 1, i as f64),
+        )
+        .unwrap();
+    }
+}
+
+/// The same answers the hot table gives: 60 joined rows, 3 orders per user.
+fn assert_index_paths_see_every_row(db: &Database, label: &str) {
+    assert_eq!(
+        rows(
+            db,
+            "SELECT u.name, o.amount FROM users u INNER JOIN orders o ON u.id = o.user_id"
+        ),
+        60,
+        "{label}: index nested loop join"
+    );
+    assert_eq!(
+        rows(
+            db,
+            "SELECT u.name, o.amount FROM users u INNER JOIN orders o ON u.id = o.user_id LIMIT 10"
+        ),
+        10,
+        "{label}: index nested loop join with LIMIT"
+    );
+    assert_eq!(
+        rows(
+            db,
+            "SELECT u.id FROM users u LEFT JOIN orders o ON u.id = o.user_id"
+        ),
+        60,
+        "{label}: left join"
+    );
+    assert_eq!(
+        count(db, "SELECT COUNT(*) FROM orders WHERE user_id IN (5, 7)"),
+        6,
+        "{label}: IN list on the indexed column"
+    );
+    assert_eq!(
+        count(
+            db,
+            "SELECT SUM(c) FROM (SELECT (SELECT COUNT(*) FROM orders o WHERE o.user_id = u.id) AS c FROM users u) t"
+        ),
+        60,
+        "{label}: correlated COUNT through the index"
+    );
+    assert_eq!(
+        count(
+            db,
+            "SELECT COUNT(*) FROM users u WHERE EXISTS (SELECT 1 FROM orders o WHERE o.user_id = u.id)"
+        ),
+        20,
+        "{label}: correlated EXISTS through the index"
+    );
+    assert_eq!(
+        count(
+            db,
+            "SELECT COUNT(*) FROM orders WHERE user_id IN (SELECT id FROM users WHERE id <= 5)"
+        ),
+        15,
+        "{label}: IN subquery on the indexed column"
+    );
+}
+
+#[test]
+fn test_sealed_rows_stay_visible_to_index_probes() {
+    let dir = std::env::temp_dir().join(format!("stoolap_sealed_index_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let dsn = format!("file://{}", dir.display());
+    {
+        let db = Database::open(&dsn).expect("Failed to create database");
+        populate(&db);
+        assert_index_paths_see_every_row(&db, "before checkpoint");
+        db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        assert_index_paths_see_every_row(&db, "after checkpoint");
+        db.execute("INSERT INTO orders VALUES (61, 5, 61.0)", ())
+            .unwrap();
+        assert_eq!(
+            rows(
+                &db,
+                "SELECT u.name, o.amount FROM users u INNER JOIN orders o ON u.id = o.user_id"
+            ),
+            61,
+            "after checkpoint and one hot insert"
+        );
+        db.execute("DELETE FROM orders WHERE id = 61", ()).unwrap();
+        db.close().unwrap();
+    }
+    let db = Database::open(&dsn).expect("Failed to reopen database");
+    assert_index_paths_see_every_row(&db, "after reopen");
+    db.close().unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Why

Found while writing a sealed-rows test for #81. On a file-backed database, every executor path that probes a secondary index directly stops seeing rows once they are sealed into volumes, which happens on `PRAGMA CHECKPOINT`, on the background checkpoint cycle, and on close:

```sql
PRAGMA CHECKPOINT;
SELECT u.name, o.amount FROM users u INNER JOIN orders o ON u.id = o.user_id;
-- 0 rows (60 before the checkpoint; COUNT(*) over the same join still 60)
INSERT INTO orders VALUES (61, 5, 61.0);
-- the same join now returns 1 row: only the hot one
```

`SegmentedTable::get_index_on_column` and the engine's `get_all_indexes` hand out the hot index, whose ids cover unsealed rows only. Affected: index nested loop join with a secondary index (`IndexLookupStrategy::SecondaryIndex`), IN-list / IN-subquery / IN-hashset probes, correlated EXISTS and COUNT through an index, recursive CTE probes, the GROUP BY btree path. Not affected: primary-key probes, plain `WHERE col = v` scans (the volume filter path reads sealed rows through zone maps and bloom filters), memory databases.

This is the "hot index after seal" item from the July review; it was marked not reproducible then.

## What

- `Table::lookup_index_on_column` and `StorageEngine::get_lookup_indexes`: an index the executor may probe on its own, meaning its ids cover every visible row. The default implementations delegate to the existing methods, so memory tables are unchanged.
- The rule for a persistent database is static, not a check on the current segment state. Such a database can seal at any moment, so the engine hands out every one of its tables through `SegmentedTable`, creating the segment manager on first use (the same helper the seal path uses). `SegmentedTable::lookup_index_on_column` returns `None` and `get_lookup_indexes` returns empty for a persistent database, so no segment-state check sits on the probe path. Before this, a persistent table had no manager until its first seal and came back as a bare `MVCCTable`; a handle taken before the first checkpoint kept reading the hot store after sealed rows were removed from it.
- Inside the wrapper, the hot-only short circuits (`scan`, `collect_*`, `fetch_rows_by_ids_into`, `select*`, partition and index min/max, grouped aggregates) run under the seal read fence through one helper, so the `has_segments` decision and the hot snapshot cannot be split by a seal. The readers that merge a hot value with cold values (`row_count`, `fast_row_count`, `sum_column`, `min_column`, `max_column`, the filtered and grouped aggregates, the partition readers) hold the fence for their whole body, so a seal cannot complete between the hot and the cold half; `seal_overlap()` alone did not cover a seal that finished in between. The remaining hot-first paths (active ids, distinct values, unique conflict, index min/max) merge into sets or min/max, where a row seen on both sides changes nothing.
- The probing consumers switch to the lookup variants and therefore use their scan paths on persistent databases. DDL, SHOW and EXPLAIN keep `get_index_on_column` / `get_all_indexes` for metadata. The vector-search probe is left as is.

Persistent databases lose the direct-probe fast paths for these shapes until a cold-aware index exists; a wrong answer is not a fast path.

## Tests

`tests/sealed_index_visibility_test.rs`: INL join with and without LIMIT, LEFT JOIN, IN list, correlated COUNT, correlated EXISTS, IN subquery; asserted before a checkpoint, after it, after a hot insert on top, and after a reopen. Fails on `main` at the first post-checkpoint assertion (0 rows instead of 60). The join, index optimizer, correlated subquery and subquery coverage targets pass (134 tests), plus both full suites.
