### PR TITLE
fix(join): a LIMIT join keeps fetching until the limit is met

### DIFF
--- a/src/executor/operators/index_nested_loop.rs
+++ b/src/executor/operators/index_nested_loop.rs
@@ -121,6 +121,8 @@ pub struct IndexNestedLoopJoinOperator {
     // State tracking
     opened: bool,
     outer_exhausted: bool,
+    // Outer rows pulled so far; the executor uses it to see a full chunk
+    outer_rows_seen: usize,
 }
 
 impl IndexNestedLoopJoinOperator {
@@ -175,6 +177,7 @@ impl IndexNestedLoopJoinOperator {
             true_expr: ConstBoolExpr::true_expr(),
             opened: false,
             outer_exhausted: false,
+            outer_rows_seen: 0,
         }
     }
 
@@ -293,6 +296,10 @@ impl IndexNestedLoopJoinOperator {
         }
     }
 
+    pub fn outer_rows_seen(&self) -> usize {
+        self.outer_rows_seen
+    }
+
     /// Look up matching inner rows for the current outer row.
     /// Uses internal buffers to avoid allocations.
     fn lookup_inner_rows(&mut self, key_value: &Value) -> Result<()> {
@@ -340,6 +347,7 @@ impl IndexNestedLoopJoinOperator {
         match self.outer.next()? {
             Some(row_ref) => {
                 let outer_row = row_ref.into_owned();
+                self.outer_rows_seen += 1;
 
                 // Get the join key value from the outer row
                 let key_value = match outer_row.get(self.outer_key_idx) {

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3899,6 +3899,7 @@ impl Executor {
             left_alias.as_deref(),
             left_table,
             &join_source.condition,
+            classification,
         );
 
         let (left_rows, left_columns, right_rows, right_columns) = if let Some(plan) =
@@ -9042,6 +9043,7 @@ impl Executor {
         left_alias: Option<&str>,
         left_table: Option<&str>,
         join_condition: &Option<Box<Expression>>,
+        classification: &QueryClassification,
     ) -> Option<SemijoinReduction> {
         // Applies to INNER JOIN and LEFT JOIN (not RIGHT or FULL)
         let is_inner = join_type == "INNER";
@@ -9061,6 +9063,11 @@ impl Executor {
             return None;
         }
 
+        // A window function or DISTINCT runs on the grouped rows afterwards and
+        // needs every group, not a chunk that already meets the limit
+        if classification.has_window_functions || stmt.distinct || !stmt.distinct_on.is_empty() {
+            return None;
+        }
         let (cap, limit) = Self::semijoin_caps(stmt, is_inner)?;
         // Each group must come from one left row, or a partial chunk would
         // give partial aggregates: GROUP BY has to cover the left primary key

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -188,6 +188,23 @@ fn partition_where_for_join(
     )
 }
 
+/// A GROUP BY + LIMIT join whose left side is fetched in a limited chunk
+struct SemijoinReduction {
+    cap: usize,
+    limit: usize,
+    left_key_col: String,
+    right_key_col: String,
+}
+
+/// The left chunk the last reduction pass used; execute_join_source retries
+/// with a larger one when the final rows stop short of the limit
+#[derive(Clone, Copy)]
+struct ReductionPass {
+    cap: usize,
+    chunk_full: bool,
+    limit: usize,
+}
+
 impl Executor {
     /// Multi-column ORDER BY comparator over precomputed sort keys, with
     /// NULLS FIRST/LAST semantics (default: NULLS LAST for ASC, FIRST for
@@ -3726,13 +3743,60 @@ impl Executor {
         Ok((Box::new(result), output_columns, false, deferred_proj))
     }
 
-    /// Execute a JOIN source
+    /// Execute a JOIN source. A GROUP BY + LIMIT join fetches its left side in
+    /// a limited chunk; when the final rows stop short of the limit and the
+    /// chunk was full, the join runs again with a larger chunk
     fn execute_join_source(
         &self,
         join_source: &JoinTableSource,
         stmt: &SelectStatement,
         ctx: &ExecutionContext,
         classification: &std::sync::Arc<QueryClassification>,
+    ) -> SelectResult {
+        let reduction = std::cell::Cell::new(None);
+        let mut left_cap = None;
+        loop {
+            let (result, columns, flag, deferred) = self.execute_join_source_capped(
+                join_source,
+                stmt,
+                ctx,
+                classification,
+                left_cap,
+                &reduction,
+            )?;
+            let pass = match reduction.get() {
+                Some(pass) if pass.chunk_full => pass,
+                _ => return Ok((result, columns, flag, deferred)),
+            };
+            let (result, short) = match result.exact_len() {
+                Some(len) => (result, len < pass.limit),
+                None => {
+                    let result_columns = result
+                        .columns_arc()
+                        .unwrap_or_else(|| CompactArc::new(result.columns().to_vec()));
+                    let rows = Self::materialize_result_arc(result)?;
+                    let short = rows.len() < pass.limit;
+                    let result: Box<dyn QueryResult> = Box::new(
+                        ExecutorResult::with_arc_columns_shared_rows(result_columns, rows),
+                    );
+                    (result, short)
+                }
+            };
+            if !short {
+                return Ok((result, columns, flag, deferred));
+            }
+            left_cap = Some(pass.cap.saturating_mul(4));
+        }
+    }
+
+    fn execute_join_source_capped(
+        &self,
+        join_source: &JoinTableSource,
+        stmt: &SelectStatement,
+        ctx: &ExecutionContext,
+        classification: &std::sync::Arc<QueryClassification>,
+        left_cap_override: Option<usize>,
+        reduction: &std::cell::Cell<Option<ReductionPass>>,
     ) -> SelectResult {
         // classification is passed from caller to avoid redundant cache lookups
 
@@ -3825,30 +3889,38 @@ impl Executor {
         // Pattern: LEFT JOIN + GROUP BY on left columns only + LIMIT N + no ORDER BY
         // Optimization: limit left side first, filter right side with IN clause (uses index)
         // This reduces materialization from O(L + R) to O(N + N*avg_matches)
+        let left_table = match join_source.left.as_ref() {
+            Expression::TableSource(ts) => Some(ts.name.value.as_str()),
+            _ => None,
+        };
         let semijoin_limit = self.get_semijoin_reduction_limit(
             &join_type,
             stmt,
             left_alias.as_deref(),
+            left_table,
             &join_source.condition,
         );
 
-        let (left_rows, left_columns, right_rows, right_columns) = if let Some((
-            limit_n,
-            left_key_col,
-            right_key_col,
-        )) = semijoin_limit
+        let (left_rows, left_columns, right_rows, right_columns) = if let Some(plan) =
+            semijoin_limit
         {
-            // Semi-join reduction for INNER/LEFT JOIN + GROUP BY
-            // Step 1: Execute and materialize left side with limit (pushdown for efficiency)
+            // Semi-join reduction for INNER/LEFT JOIN + GROUP BY: fetch the left
+            // side with the limit, then the right side through an IN filter on
+            // the join key (uses the index)
+            let SemijoinReduction {
+                cap,
+                limit,
+                left_key_col,
+                right_key_col,
+            } = plan;
+            let left_cap = left_cap_override.unwrap_or(cap);
             let (left_result, left_cols) = self.execute_table_expression_with_filter_limit(
                 &join_source.left,
                 ctx,
                 left_filter.as_ref(),
-                Some(limit_n),
+                Some(left_cap),
             )?;
             let left_rows = Self::materialize_result_arc(left_result)?;
-
-            // Step 2: Extract join key values from limited left rows
             let left_key_idx = Self::find_column_index_by_name(&left_key_col, &left_cols);
             let join_key_values: Vec<Value> = if let Some(idx) = left_key_idx {
                 left_rows
@@ -3859,12 +3931,8 @@ impl Executor {
             } else {
                 Vec::new()
             };
-
-            // Step 3: Build combined filter for right side with IN clause
             let right_filter_with_in = if !join_key_values.is_empty() {
-                // Create IN expression: right_key_col IN (v1, v2, ..., vN)
                 let in_expr = self.build_in_filter_expression(&right_key_col, &join_key_values);
-                // Combine with existing right filter if any
                 match (right_filter.clone(), in_expr) {
                     (Some(existing), Some(in_filter)) => {
                         Some(Expression::Infix(InfixExpression::new(
@@ -3880,15 +3948,17 @@ impl Executor {
             } else {
                 right_filter.clone()
             };
-
-            // Step 4: Execute right side with IN filter (uses index on right_key_col)
             let (right_result, right_cols) = self.execute_table_expression_with_filter(
                 &join_source.right,
                 ctx,
                 right_filter_with_in.as_ref(),
             )?;
             let right_rows = Self::materialize_result_arc(right_result)?;
-
+            reduction.set(Some(ReductionPass {
+                cap: left_cap,
+                chunk_full: left_rows.len() == left_cap,
+                limit,
+            }));
             (left_rows, left_cols, right_rows, right_cols)
         } else {
             // Skip Index Nested Loop if query has aggregation or window functions
@@ -4084,10 +4154,9 @@ impl Executor {
                     None
                 };
 
-                // For outer table, use a reasonable limit multiplier
-                // We need enough rows to produce join_limit results, assuming some miss rate
-                // Use 4x multiplier as heuristic (handles up to 75% miss rate)
-                let outer_limit = join_limit.map(|l| (l as usize).saturating_mul(4).max(100));
+                // The outer side is fetched in chunks: the first one is the limit
+                // itself and the join below fetches more when it stops short
+                let mut outer_limit = join_limit.map(|l| (l as usize).max(100));
 
                 // Execute outer side with limit optimization for true early termination
                 let (outer_result, outer_cols) = self.execute_table_expression_with_filter_limit(
@@ -4147,32 +4216,26 @@ impl Executor {
                         all
                     };
 
-                    // Create residual filter from nl_right_filter if present
-                    // This allows early termination during Index Nested Loop
-                    let residual_filter = if let Some(ref rf) = nl_right_filter {
-                        // Re-qualify the filter with inner table alias
-                        let qualified_rf = add_table_qualifier(rf, inner_alias);
-                        JoinFilter::new(
-                            &qualified_rf,
-                            &outer_cols,
-                            &inner_cols,
-                            &self.function_registry,
-                        )
-                        .ok()
-                        .map(|f| f.with_context(ctx))
-                    } else {
-                        None
+                    // Residual filter from nl_right_filter, re-qualified with the
+                    // inner alias; built per pass since the operator owns it
+                    let build_residual_filter = || {
+                        nl_right_filter.as_ref().and_then(|rf| {
+                            let qualified_rf = add_table_qualifier(rf, inner_alias);
+                            JoinFilter::new(
+                                &qualified_rf,
+                                &outer_cols,
+                                &inner_cols,
+                                &self.function_registry,
+                            )
+                            .ok()
+                            .map(|f| f.with_context(ctx))
+                        })
                     };
 
                     // Execute Index Nested Loop Join using operators
                     // Use batch version for NO LIMIT (reduces lock overhead from O(N) to O(1))
                     // Use streaming version for LIMIT queries (supports early termination)
 
-                    // Convert to operator types
-                    let outer_op: Box<dyn Operator> =
-                        Box::new(QueryResultOperator::new(outer_result, outer_cols.clone()));
-                    let inner_schema_info: Vec<ColumnInfo> =
-                        inner_cols.iter().map(ColumnInfo::new).collect();
                     let op_join_type = OperatorJoinType::parse(&join_type);
 
                     // Try to push projection into the join operator for ~2.3x speedup
@@ -4190,71 +4253,98 @@ impl Executor {
                         None
                     };
 
-                    let mut join_op: Box<dyn Operator> = if join_limit.is_some() {
-                        // Streaming INL for early termination with LIMIT
-                        let op = IndexNestedLoopJoinOperator::new(
-                            outer_op,
-                            inner_table,
-                            inner_schema_info,
-                            op_join_type,
-                            outer_idx,
-                            lookup_strategy.clone(),
-                            residual_filter,
-                        );
-
-                        // Apply projection pushdown if available
-                        if let Some(ref proj) = projection_pushdown {
-                            let projected_schema: Vec<ColumnInfo> =
-                                proj.output_columns.iter().map(ColumnInfo::new).collect();
-                            Box::new(op.with_projection(proj.columns.clone(), projected_schema))
-                        } else {
-                            Box::new(op)
+                    // A cross-table WHERE filter counts toward LIMIT, so it is
+                    // applied per joined row rather than after collection
+                    let cross_row_filter = match cross_filter {
+                        Some(ref cross) => {
+                            Some(RowFilter::new(cross, &all_columns)?.with_context(ctx))
+                        }
+                        None => None,
+                    };
+                    let mut result_rows = RowVec::new();
+                    if join_limit.is_some() {
+                        // Streaming INL for early termination with LIMIT. When the
+                        // joined rows stop short of the limit and the outer chunk
+                        // was full, the next pass fetches a larger chunk
+                        let mut outer_result = outer_result;
+                        let mut inner_table = Some(inner_table);
+                        loop {
+                            let outer_op: Box<dyn Operator> = Box::new(QueryResultOperator::new(
+                                outer_result,
+                                outer_cols.clone(),
+                            ));
+                            let mut op = IndexNestedLoopJoinOperator::new(
+                                outer_op,
+                                match inner_table.take() {
+                                    Some(table) => table,
+                                    None => txn.get_table(&table_name)?,
+                                },
+                                inner_cols.iter().map(ColumnInfo::new).collect(),
+                                op_join_type,
+                                outer_idx,
+                                lookup_strategy.clone(),
+                                build_residual_filter(),
+                            );
+                            if let Some(ref proj) = projection_pushdown {
+                                let projected_schema: Vec<ColumnInfo> =
+                                    proj.output_columns.iter().map(ColumnInfo::new).collect();
+                                op = op.with_projection(proj.columns.clone(), projected_schema);
+                            }
+                            result_rows.clear();
+                            Self::collect_join_rows(
+                                &mut op,
+                                join_limit,
+                                cross_row_filter.as_ref(),
+                                &mut result_rows,
+                            )?;
+                            let short =
+                                join_limit.is_some_and(|lim| result_rows.len() < lim as usize);
+                            let chunk_full =
+                                outer_limit.is_some_and(|cap| op.outer_rows_seen() == cap);
+                            if !(short && chunk_full) {
+                                break;
+                            }
+                            outer_limit = outer_limit.map(|cap| cap.saturating_mul(4));
+                            outer_result = self
+                                .execute_table_expression_with_filter_limit(
+                                    outer_expr,
+                                    ctx,
+                                    nl_left_filter.as_ref(),
+                                    outer_limit,
+                                )?
+                                .0;
                         }
                     } else {
                         // Batch INL for NO LIMIT - single batch fetch, O(1) lock overhead
+                        let outer_op: Box<dyn Operator> =
+                            Box::new(QueryResultOperator::new(outer_result, outer_cols.clone()));
                         let op = BatchIndexNestedLoopJoinOperator::new(
                             outer_op,
                             inner_table,
-                            inner_schema_info,
+                            inner_cols.iter().map(ColumnInfo::new).collect(),
                             op_join_type,
                             outer_idx,
                             lookup_strategy.clone(),
-                            residual_filter,
+                            build_residual_filter(),
                         );
-
-                        // Apply projection pushdown if available
-                        if let Some(ref proj) = projection_pushdown {
-                            let projected_schema: Vec<ColumnInfo> =
-                                proj.output_columns.iter().map(ColumnInfo::new).collect();
-                            Box::new(op.with_projection(proj.columns.clone(), projected_schema))
-                        } else {
-                            Box::new(op)
-                        }
-                    };
-
-                    // Execute and collect results with synthetic row IDs
-                    join_op.open()?;
-                    let mut result_rows = RowVec::new();
-                    let mut row_id = 0i64;
-                    while let Some(row_ref) = join_op.next()? {
-                        result_rows.push((row_id, row_ref.into_owned()));
-                        row_id += 1;
-                        if let Some(lim) = join_limit {
-                            if result_rows.len() >= lim as usize {
-                                break;
-                            }
-                        }
+                        let mut join_op: Box<dyn Operator> =
+                            if let Some(ref proj) = projection_pushdown {
+                                let projected_schema: Vec<ColumnInfo> =
+                                    proj.output_columns.iter().map(ColumnInfo::new).collect();
+                                Box::new(op.with_projection(proj.columns.clone(), projected_schema))
+                            } else {
+                                Box::new(op)
+                            };
+                        Self::collect_join_rows(
+                            join_op.as_mut(),
+                            None,
+                            cross_row_filter.as_ref(),
+                            &mut result_rows,
+                        )?;
                     }
-                    join_op.close()?;
 
                     // No rotation needed - all_columns matches physical order
                     let mut final_rows = result_rows;
-
-                    // Apply cross-table WHERE filters if any
-                    if let Some(ref cross) = cross_filter {
-                        let filter = RowFilter::new(cross, &all_columns)?.with_context(ctx);
-                        filter.retain_checked(&mut final_rows)?;
-                    }
 
                     // Check for aggregation/window functions that need special handling
                     let has_agg = classification.has_aggregation;
@@ -6212,6 +6302,30 @@ impl Executor {
             return Err(err);
         }
         Ok(rows)
+    }
+
+    /// Runs a join operator to completion or to `limit` rows. The cross-table
+    /// filter is applied per row so filtered rows never count toward the limit.
+    fn collect_join_rows(
+        join_op: &mut dyn Operator,
+        limit: Option<u64>,
+        cross: Option<&RowFilter>,
+        out: &mut RowVec,
+    ) -> Result<()> {
+        join_op.open()?;
+        while let Some(row_ref) = join_op.next()? {
+            let row = row_ref.into_owned();
+            if let Some(filter) = cross {
+                if !filter.matches_checked(&row)? {
+                    continue;
+                }
+            }
+            out.push((out.len() as i64, row));
+            if limit.is_some_and(|lim| out.len() >= lim as usize) {
+                break;
+            }
+        }
+        join_op.close()
     }
 
     /// Materialize a result into an CompactArc<Vec<Row>> for zero-copy sharing with joins
@@ -8880,6 +8994,36 @@ impl Executor {
         }
     }
 
+    /// LIMIT and OFFSET of a GROUP BY + LIMIT join as (initial left chunk, rows
+    /// expected after OFFSET). An INNER JOIN over-fetches its first chunk since
+    /// a left row without a match forms no group
+    fn semijoin_caps(stmt: &SelectStatement, is_inner: bool) -> Option<(usize, usize)> {
+        let eval = |e: &Expression| {
+            ExpressionEval::compile(e, &[])
+                .ok()
+                .and_then(|mut eval| eval.eval_slice(&Row::new()).ok())
+                .and_then(|v| match v {
+                    Value::Integer(n) if n >= 0 => Some(n as usize),
+                    _ => None,
+                })
+        };
+        let limit = eval(stmt.limit.as_ref()?)?;
+        if limit == 0 {
+            return None;
+        }
+        let offset = match &stmt.offset {
+            Some(e) => eval(e)?,
+            None => 0,
+        };
+        let want = limit.saturating_add(offset);
+        let cap = if is_inner {
+            want.saturating_mul(2)
+        } else {
+            want
+        };
+        Some((cap, limit))
+    }
+
     /// Check if semi-join reduction optimization can be applied and return parameters
     /// Returns Some((limit_value, left_key_col, right_key_col)) if applicable, None otherwise
     ///
@@ -8896,8 +9040,9 @@ impl Executor {
         join_type: &str,
         stmt: &SelectStatement,
         left_alias: Option<&str>,
+        left_table: Option<&str>,
         join_condition: &Option<Box<Expression>>,
-    ) -> Option<(usize, String, String)> {
+    ) -> Option<SemijoinReduction> {
         // Applies to INNER JOIN and LEFT JOIN (not RIGHT or FULL)
         let is_inner = join_type == "INNER";
         let is_left = join_type.contains("LEFT") && !join_type.contains("FULL");
@@ -8916,8 +9061,27 @@ impl Executor {
             return None;
         }
 
-        // Check that GROUP BY references only left table columns
+        let (cap, limit) = Self::semijoin_caps(stmt, is_inner)?;
+        // Each group must come from one left row, or a partial chunk would
+        // give partial aggregates: GROUP BY has to cover the left primary key
         let left_alias = left_alias?;
+        let left_schema = self.engine.get_table_schema(left_table?).ok()?;
+        let pk_columns = left_schema.primary_key_columns();
+        let pk_covered = !pk_columns.is_empty()
+            && pk_columns.iter().all(|pk| {
+                stmt.group_by.columns.iter().any(|col| match col {
+                    Expression::QualifiedIdentifier(qid) => {
+                        qid.qualifier.value.eq_ignore_ascii_case(left_alias)
+                            && qid.name.value.eq_ignore_ascii_case(&pk.name)
+                    }
+                    Expression::Identifier(id) => id.value.eq_ignore_ascii_case(&pk.name),
+                    _ => false,
+                })
+            });
+        if !pk_covered {
+            return None;
+        }
+        // Check that GROUP BY references only left table columns
         for col in &stmt.group_by.columns {
             if !self.column_references_table(col, left_alias) {
                 return None;
@@ -8946,45 +9110,20 @@ impl Executor {
                 return None;
             }
             // Swap the keys
-            let limit_value = stmt.limit.as_ref().and_then(|e| {
-                ExpressionEval::compile(e, &[])
-                    .ok()
-                    .and_then(|mut eval| eval.eval_slice(&Row::new()).ok())
-                    .and_then(|v| match v {
-                        Value::Integer(n) if n > 0 => Some(n as usize),
-                        _ => None,
-                    })
-            })?;
-            // For INNER JOIN, over-fetch to account for rows without matches
-            // Use 2x multiplier as a balance between accuracy and performance
-            let adjusted_limit = if is_inner {
-                limit_value * 2
-            } else {
-                limit_value
-            };
-            return Some((adjusted_limit, right_key_col, left_key_col));
+            return Some(SemijoinReduction {
+                cap,
+                limit,
+                left_key_col: right_key_col,
+                right_key_col: left_key_col,
+            });
         }
 
-        // Get LIMIT value
-        let limit_value = stmt.limit.as_ref().and_then(|e| {
-            ExpressionEval::compile(e, &[])
-                .ok()
-                .and_then(|mut eval| eval.eval_slice(&Row::new()).ok())
-                .and_then(|v| match v {
-                    Value::Integer(n) if n > 0 => Some(n as usize),
-                    _ => None,
-                })
-        })?;
-
-        // For INNER JOIN, over-fetch to account for rows without matches
-        // Use 2x multiplier as a balance between accuracy and performance
-        let adjusted_limit = if is_inner {
-            limit_value * 2
-        } else {
-            limit_value
-        };
-
-        Some((adjusted_limit, left_key_col, right_key_col))
+        Some(SemijoinReduction {
+            cap,
+            limit,
+            left_key_col,
+            right_key_col,
+        })
     }
 
     /// Check if a column expression references a specific table

--- a/src/executor/result.rs
+++ b/src/executor/result.rs
@@ -400,6 +400,10 @@ impl QueryResult for ExecutorResult {
         self.insert_id
     }
 
+    fn exact_len(&self) -> Option<usize> {
+        self.current_index.is_none().then_some(self.len)
+    }
+
     fn try_into_arc_rows(&mut self) -> Option<CompactArc<Vec<Row>>> {
         // Take ownership of rows and return as Arc
         let rows = std::mem::replace(&mut self.rows, RowStorage::Owned(RowVec::new()));
@@ -827,6 +831,14 @@ impl LimitedResult {
 }
 
 impl QueryResult for LimitedResult {
+    fn exact_len(&self) -> Option<usize> {
+        if self.offset_applied || self.returned_count > 0 {
+            return None;
+        }
+        let inner = self.inner.exact_len()?.saturating_sub(self.offset);
+        Some(self.limit.map_or(inner, |limit| inner.min(limit)))
+    }
+
     fn columns(&self) -> &[String] {
         &self.columns
     }

--- a/src/storage/traits/result.rs
+++ b/src/storage/traits/result.rs
@@ -115,6 +115,12 @@ pub trait QueryResult: Send {
         None
     }
 
+    /// The exact number of rows a fresh result will yield, when it is known
+    /// without iterating. Default implementation returns None.
+    fn exact_len(&self) -> Option<usize> {
+        None
+    }
+
     /// Returns a pending error from the last `next()` call, if any.
     ///
     /// When `next()` returns false due to a runtime error (e.g. invalid REGEXP

--- a/tests/join_limit_shortfall_test.rs
+++ b/tests/join_limit_shortfall_test.rs
@@ -114,3 +114,30 @@ fn test_group_by_limit_reduction_grows_the_left_chunk() {
         .unwrap();
     assert_eq!(total, 50);
 }
+
+/// A window function or DISTINCT runs on the grouped rows after the join
+/// produced them, so the reduction must hand over every group.
+#[test]
+fn test_group_by_limit_reduction_stays_off_under_a_window_function() {
+    let db = setup("join_limit_window", true);
+    let totals: Vec<i64> = db
+        .query(
+            "SELECT u.name, COUNT(o.id), COUNT(*) OVER () AS total FROM users u INNER JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name LIMIT 10",
+            (),
+        )
+        .unwrap()
+        .map(|row| row.unwrap().get::<i64>(2).unwrap())
+        .collect();
+    assert_eq!(totals.len(), 10);
+    assert!(totals.iter().all(|&t| t == 50), "window saw {totals:?}");
+}
+
+#[test]
+fn test_group_by_limit_reduction_stays_off_under_distinct() {
+    let db = setup("join_limit_distinct", true);
+    // the 50 matched users are 50..=99, so u.id / 10 takes five values
+    assert_eq!(
+        count(&db, "SELECT DISTINCT u.id / 10 FROM users u INNER JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name LIMIT 10"),
+        5
+    );
+}

--- a/tests/join_limit_shortfall_test.rs
+++ b/tests/join_limit_shortfall_test.rs
@@ -1,0 +1,116 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A join with LIMIT fetches its outer or left side in a limited chunk. The
+//! chunk must grow until the limit is met, whatever drops rows after it:
+//! outer rows without a match, a cross-table WHERE, HAVING, or a right-side
+//! filter on a LEFT JOIN.
+
+use stoolap::Database;
+
+fn count(db: &Database, sql: &str) -> usize {
+    db.query(sql, ()).unwrap().count()
+}
+
+/// 100 users; 1000 orders of which one in twenty points at a user, the rest
+/// at ids that do not exist. With `late`, the matched users are 50..=99 so
+/// the first left chunk of a GROUP BY reduction has no group at all.
+fn setup(name: &str, late: bool) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount FLOAT)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX idx_orders_user_id ON orders(user_id)", ())
+        .unwrap();
+    for i in 1..=100i64 {
+        db.execute("INSERT INTO users VALUES ($1, $2)", (i, format!("U{i}")))
+            .unwrap();
+    }
+    for i in 1..=1000i64 {
+        let uid = if i % 20 != 0 {
+            100_000 + i
+        } else if late {
+            100 - i / 20
+        } else {
+            i / 20
+        };
+        db.execute("INSERT INTO orders VALUES ($1, $2, $3)", (i, uid, i as f64))
+            .unwrap();
+    }
+    db
+}
+
+#[test]
+fn test_inl_join_limit_keeps_fetching_outer_rows_without_a_match() {
+    let db = setup("join_limit_inl_outer", false);
+    assert_eq!(
+        count(&db, "SELECT o.amount, u.name FROM orders o INNER JOIN users u ON o.user_id = u.id LIMIT 100"),
+        50
+    );
+    assert_eq!(
+        count(&db, "SELECT u.name FROM users u INNER JOIN orders o ON u.id = o.user_id WHERE o.amount > 0 LIMIT 100"),
+        50
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT u.name FROM users u INNER JOIN orders o ON u.id = o.user_id LIMIT 30"
+        ),
+        30
+    );
+}
+
+#[test]
+fn test_inl_join_limit_counts_rows_after_the_cross_table_filter() {
+    let db = setup("join_limit_cross_filter", false);
+    assert_eq!(
+        count(&db, "SELECT u.name, o.amount FROM users u INNER JOIN orders o ON u.id = o.user_id WHERE (u.id + o.id) % 2 = 0 LIMIT 10"),
+        10
+    );
+    assert_eq!(
+        count(&db, "SELECT u.name, o.amount FROM users u INNER JOIN orders o ON u.id = o.user_id WHERE (u.id + o.id) % 2 = 0"),
+        25
+    );
+}
+
+#[test]
+fn test_group_by_limit_reduction_grows_the_left_chunk() {
+    let db = setup("join_limit_group_by", true);
+    assert_eq!(
+        count(&db, "SELECT u.name, COUNT(o.id) FROM users u INNER JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name LIMIT 10"),
+        10
+    );
+    assert_eq!(
+        count(&db, "SELECT u.name, COUNT(o.id) FROM users u INNER JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name HAVING COUNT(o.id) >= 1 LIMIT 10"),
+        10
+    );
+    assert_eq!(
+        count(&db, "SELECT u.name, COUNT(o.id) FROM users u LEFT JOIN orders o ON u.id = o.user_id WHERE o.amount > 0 GROUP BY u.id, u.name LIMIT 10"),
+        10
+    );
+    // every matched user is one group: the values must be complete, not partial
+    let total: i64 = db
+        .query("SELECT SUM(c) FROM (SELECT COUNT(o.id) AS c FROM users u INNER JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name LIMIT 50) t", ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap();
+    assert_eq!(total, 50);
+}


### PR DESCRIPTION
## Why

Started as the J2 join fixed-cost pass and turned into a correctness fix. Both LIMIT pushdowns on joins fetch one capped chunk of the driving side and never come back for more:

- The index nested loop join reads `4 x LIMIT` outer rows (min 100). When most outer rows have no match, the result stops short. With 1000 orders of which 50 point at an existing user, `SELECT o.amount, u.name FROM orders o INNER JOIN users u ON o.user_id = u.id LIMIT 100` returns 20 rows instead of 50.
- A cross-table WHERE was applied after the rows had been counted against the limit, so `... WHERE (u.id + o.id) % 2 = 0 LIMIT 10` returns 5 rows when 25 qualify.
- The GROUP BY semi-join reduction caps the left side at `LIMIT` (`2 x LIMIT` for INNER JOIN). When the first left rows have no match, or HAVING or a right-side filter drops groups, it returns fewer groups than exist, down to none: `SELECT u.name, COUNT(o.id) FROM users u INNER JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name LIMIT 10` returns 0 rows when the matched users sit at the end of the table.

## What

- Index nested loop with LIMIT: the outer side is fetched in chunks. The first chunk is the limit itself (min 100, as before) instead of four times it. When the joined rows stop short of the limit and the chunk was full, the join runs again with a chunk four times larger. The operator reports how many outer rows it pulled so a full chunk is detected exactly. The cross-table filter is applied per joined row by a shared collector, so only surviving rows count toward the limit.
- GROUP BY semi-join reduction: `execute_join_source` wraps the join in the same kind of loop. The reduction records the left chunk it used and whether it was full; when the final rows (after HAVING, OFFSET and LIMIT) stop short and the chunk was full, the join reruns with a left chunk four times larger. The reduction is only exact when each group comes from one left row, so GROUP BY now has to cover the left table's primary key; the initial chunk includes OFFSET. It stays off under a window function, `DISTINCT` or `DISTINCT ON`, which run on the grouped rows afterwards and need every group.
- `QueryResult::exact_len` gives the rerun check the length of a fresh materialized or limited result without iterating it. This is what keeps LEFT JOIN + GROUP BY at parity.

## Measurements

Probe at benchmark scale (10k users, 50k orders, memory), best of 6 interleaved runs against a main binary built from the same probe source:

| Query | main | this PR |
|---|---|---|
| INNER JOIN, LIMIT 100 | 14 us | 12 us |
| Self JOIN, LIMIT 100 | 8 us | 6 us |
| LEFT JOIN + GROUP BY, LIMIT 100 | 52 us | 52 us |
| INNER JOIN + GROUP BY + HAVING, LIMIT 50 | 60 us | 59 us |

The two wins come from the smaller first outer chunk: 100 outer rows instead of 400 for a join that matches every row.

## Tests

`tests/join_limit_shortfall_test.rs`: outer rows without a match (both join orders, with a WHERE, LIMIT 30), cross-table filter counted after filtering, GROUP BY reduction with late matches, with HAVING, with a right-side filter on a LEFT JOIN, a check that the grouped values are complete rather than partial, a window function over the grouped rows, and DISTINCT over them. All fail on `main`. Join, limit, hash join, aggregation targets pass, plus both full suites.

## Left open

GROUP BY with `LIMIT n OFFSET m` applies LIMIT before OFFSET, on a single table as well (50 groups: `LIMIT 10 OFFSET 45` returns 0 rows, `LIMIT 10 OFFSET 5` returns 5). Pre-existing on `main`, aggregation path, separate fix.
