### PR TITLE
fix(executor): apply OFFSET before LIMIT, and only once, on every early-exit path

### DIFF
--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -418,16 +418,23 @@ impl Executor {
             && stmt.having.is_none()
             && !stmt.distinct;
 
+        // OFFSET is applied after aggregation, so the groups it skips must be
+        // built too: the pushed limit is LIMIT + OFFSET
         let aggregation_limit = if can_push_limit {
-            stmt.limit.as_ref().and_then(|limit_expr| {
-                let mut eval = ExpressionEval::compile(limit_expr, &[])
-                    .ok()?
-                    .with_context(ctx);
+            let eval_usize = |expr: &Expression| {
+                let mut eval = ExpressionEval::compile(expr, &[]).ok()?.with_context(ctx);
                 eval.eval_slice(&Row::new()).ok().and_then(|v| match v {
                     crate::core::Value::Integer(n) if n >= 0 => Some(n as usize),
                     _ => None,
                 })
-            })
+            };
+            let limit = stmt.limit.as_deref().and_then(eval_usize);
+            match stmt.offset.as_deref() {
+                None => limit,
+                Some(offset_expr) => {
+                    limit.and_then(|l| eval_usize(offset_expr).map(|o| l.saturating_add(o)))
+                }
+            }
         } else {
             None
         };

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -529,20 +529,16 @@ impl Executor {
         None
     }
 
-    /// Check if all window functions in the statement are safe for LIMIT pushdown.
-    ///
-    /// Safe functions (don't depend on total row count):
-    /// - ROW_NUMBER, RANK, DENSE_RANK
-    /// - LAG, LEAD
-    /// - FIRST_VALUE, LAST_VALUE, NTH_VALUE
-    ///
-    /// Unsafe functions (depend on total row count):
-    /// - NTILE (bucket size depends on total count)
-    /// - PERCENT_RANK (formula: (rank-1)/(total-1))
-    /// - CUME_DIST (formula: rows_up_to_current/total)
-    pub(crate) fn is_window_safe_for_limit_pushdown(stmt: &SelectStatement) -> bool {
+    /// Whether every window function in the statement can run on a fetch cut at
+    /// LIMIT + OFFSET rows in the given index order: each window must follow
+    /// that order exactly and must not look past the current row.
+    pub(crate) fn is_window_safe_for_limit_pushdown(
+        stmt: &SelectStatement,
+        order_col: &str,
+        ascending: bool,
+    ) -> bool {
         for col_expr in &stmt.columns {
-            if !Self::is_expr_window_safe(col_expr) {
+            if !Self::is_expr_window_safe(col_expr, order_col, ascending) {
                 return false;
             }
         }
@@ -551,10 +547,26 @@ impl Executor {
 
     /// Check if a single expression's window function (if any) is safe for LIMIT pushdown
     /// Recursively checks all nested expressions for unsafe window functions
-    fn is_expr_window_safe(expr: &Expression) -> bool {
+    fn is_expr_window_safe(expr: &Expression, order_col: &str, ascending: bool) -> bool {
         match expr {
             Expression::Window(window_expr) => {
                 use crate::parser::ast::{WindowFrameBound, WindowFrameUnit};
+                // The fetch follows one window's ORDER BY; a window that is
+                // partitioned, ordered by anything else or by more than that
+                // key would rank a cut subset
+                let follows_fetch_order = window_expr.partition_by.is_empty()
+                    && window_expr.order_by.len() == 1
+                    && window_expr.order_by[0].ascending == ascending
+                    && match &window_expr.order_by[0].expression {
+                        Expression::Identifier(id) => id.value.eq_ignore_ascii_case(order_col),
+                        Expression::QualifiedIdentifier(qid) => {
+                            qid.name.value.eq_ignore_ascii_case(order_col)
+                        }
+                        _ => false,
+                    };
+                if !follows_fetch_order {
+                    return false;
+                }
                 let func_name = window_expr.function.function.to_uppercase();
                 // A fetch cut at LIMIT rows is wrong for anything that looks past
                 // the current row: total-count functions, LEAD, a frame that
@@ -587,26 +599,32 @@ impl Executor {
                         "ROW_NUMBER" | "RANK" | "DENSE_RANK" | "LAG" | "FIRST_VALUE"
                     )
             }
-            Expression::Aliased(aliased) => Self::is_expr_window_safe(&aliased.expression),
+            Expression::Aliased(aliased) => {
+                Self::is_expr_window_safe(&aliased.expression, order_col, ascending)
+            }
             // Recursively check expressions that can contain window functions
             Expression::Case(case_expr) => {
                 // Check operand if present (simple CASE expression)
                 if let Some(value) = &case_expr.value {
-                    if !Self::is_expr_window_safe(value) {
+                    if !Self::is_expr_window_safe(value, order_col, ascending) {
                         return false;
                     }
                 }
                 // Check all WHEN conditions and results
                 for when_clause in &case_expr.when_clauses {
-                    if !Self::is_expr_window_safe(&when_clause.condition)
-                        || !Self::is_expr_window_safe(&when_clause.then_result)
+                    if !Self::is_expr_window_safe(&when_clause.condition, order_col, ascending)
+                        || !Self::is_expr_window_safe(
+                            &when_clause.then_result,
+                            order_col,
+                            ascending,
+                        )
                     {
                         return false;
                     }
                 }
                 // Check ELSE clause if present
                 if let Some(else_expr) = &case_expr.else_value {
-                    if !Self::is_expr_window_safe(else_expr) {
+                    if !Self::is_expr_window_safe(else_expr, order_col, ascending) {
                         return false;
                     }
                 }
@@ -614,14 +632,19 @@ impl Executor {
             }
             Expression::FunctionCall(func) => {
                 // Check all function arguments
-                func.arguments.iter().all(Self::is_expr_window_safe)
+                func.arguments
+                    .iter()
+                    .all(|e| Self::is_expr_window_safe(e, order_col, ascending))
             }
             Expression::Infix(infix) => {
                 // Check both sides of binary expression (e.g., window_func + 1)
-                Self::is_expr_window_safe(&infix.left) && Self::is_expr_window_safe(&infix.right)
+                Self::is_expr_window_safe(&infix.left, order_col, ascending)
+                    && Self::is_expr_window_safe(&infix.right, order_col, ascending)
             }
-            Expression::Cast(cast) => Self::is_expr_window_safe(&cast.expr),
-            Expression::Prefix(prefix) => Self::is_expr_window_safe(&prefix.right),
+            Expression::Cast(cast) => Self::is_expr_window_safe(&cast.expr, order_col, ascending),
+            Expression::Prefix(prefix) => {
+                Self::is_expr_window_safe(&prefix.right, order_col, ascending)
+            }
             Expression::ScalarSubquery(_) => {
                 // Scalar subqueries have their own evaluation context, their window functions
                 // don't affect the outer query's LIMIT pushdown safety
@@ -629,35 +652,42 @@ impl Executor {
             }
             Expression::In(in_expr) => {
                 // Check the left expression and right expression (which contains the list)
-                Self::is_expr_window_safe(&in_expr.left)
-                    && Self::is_expr_window_safe(&in_expr.right)
+                Self::is_expr_window_safe(&in_expr.left, order_col, ascending)
+                    && Self::is_expr_window_safe(&in_expr.right, order_col, ascending)
             }
             Expression::Between(between) => {
-                Self::is_expr_window_safe(&between.expr)
-                    && Self::is_expr_window_safe(&between.lower)
-                    && Self::is_expr_window_safe(&between.upper)
+                Self::is_expr_window_safe(&between.expr, order_col, ascending)
+                    && Self::is_expr_window_safe(&between.lower, order_col, ascending)
+                    && Self::is_expr_window_safe(&between.upper, order_col, ascending)
             }
             Expression::List(list) => {
                 // Check all expressions in the list
-                list.elements.iter().all(Self::is_expr_window_safe)
+                list.elements
+                    .iter()
+                    .all(|e| Self::is_expr_window_safe(e, order_col, ascending))
             }
             Expression::ExpressionList(expr_list) => {
                 // Check all expressions in the list
-                expr_list.expressions.iter().all(Self::is_expr_window_safe)
+                expr_list
+                    .expressions
+                    .iter()
+                    .all(|e| Self::is_expr_window_safe(e, order_col, ascending))
             }
             Expression::Like(like) => {
-                Self::is_expr_window_safe(&like.left)
-                    && Self::is_expr_window_safe(&like.pattern)
+                Self::is_expr_window_safe(&like.left, order_col, ascending)
+                    && Self::is_expr_window_safe(&like.pattern, order_col, ascending)
                     && like
                         .escape
                         .as_ref()
-                        .is_none_or(|e| Self::is_expr_window_safe(e))
+                        .is_none_or(|e| Self::is_expr_window_safe(e, order_col, ascending))
             }
             Expression::Exists(_) | Expression::AllAny(_) => {
                 // EXISTS and ALL/ANY have their own subquery context
                 true
             }
-            Expression::Distinct(distinct) => Self::is_expr_window_safe(&distinct.expr),
+            Expression::Distinct(distinct) => {
+                Self::is_expr_window_safe(&distinct.expr, order_col, ascending)
+            }
             // Leaf expressions - no nested window functions
             Expression::Identifier(_)
             | Expression::QualifiedIdentifier(_)

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -554,9 +554,27 @@ impl Executor {
     fn is_expr_window_safe(expr: &Expression) -> bool {
         match expr {
             Expression::Window(window_expr) => {
+                use crate::parser::ast::WindowFrameBound;
                 let func_name = window_expr.function.function.to_uppercase();
-                // These functions depend on total row count - NOT safe
-                !matches!(func_name.as_str(), "NTILE" | "PERCENT_RANK" | "CUME_DIST")
+                // A fetch cut at LIMIT rows is wrong for anything that looks past
+                // the current row: total-count functions, LEAD, a frame that
+                // reaches forward, or a named window whose frame is not visible here
+                let forward = |b: &WindowFrameBound| {
+                    matches!(
+                        b,
+                        WindowFrameBound::Following(_) | WindowFrameBound::UnboundedFollowing
+                    )
+                };
+                let reaches_forward = window_expr.window_ref.is_some()
+                    || window_expr
+                        .frame
+                        .as_ref()
+                        .is_some_and(|f| forward(&f.start) || f.end.as_ref().is_some_and(forward));
+                !reaches_forward
+                    && !matches!(
+                        func_name.as_str(),
+                        "NTILE" | "PERCENT_RANK" | "CUME_DIST" | "LEAD"
+                    )
             }
             Expression::Aliased(aliased) => Self::is_expr_window_safe(&aliased.expression),
             // Recursively check expressions that can contain window functions
@@ -873,6 +891,9 @@ impl Executor {
                 Some(info) => info,
                 None => return Ok(None),
             };
+        // LIMIT and OFFSET can be applied here only when nothing runs on the
+        // rows afterwards: no ORDER BY to sort them and no DISTINCT to merge them
+        let limit_here = stmt.order_by.is_empty() && !stmt.distinct && stmt.distinct_on.is_empty();
 
         // Skip correlated subqueries - they can't be pre-evaluated
         if Self::is_subquery_correlated(&subquery.subquery) {
@@ -1022,9 +1043,7 @@ impl Executor {
 
                 // Stop early only when nothing after this point drops or reorders
                 // rows; the shared tail applies OFFSET and LIMIT once
-                let target = if limit == usize::MAX
-                    || !stmt.order_by.is_empty()
-                    || remaining_predicate.is_some()
+                let target = if limit == usize::MAX || !limit_here || remaining_predicate.is_some()
                 {
                     usize::MAX
                 } else {
@@ -1071,7 +1090,7 @@ impl Executor {
         // EARLY LIMIT OPTIMIZATION: When there's no ORDER BY and no remaining predicate,
         // we can apply LIMIT early to avoid fetching unnecessary rows
         let (early_limit_applied, early_limit, early_offset) =
-            if stmt.order_by.is_empty() && remaining_predicate.is_none() {
+            if limit_here && remaining_predicate.is_none() {
                 let offset = if let Some(ref offset_expr) = stmt.offset {
                     match ExpressionEval::compile(offset_expr, &[])
                         .ok()
@@ -1145,7 +1164,7 @@ impl Executor {
             } else if early_limit < rows.len() {
                 rows.truncate(early_limit);
             }
-        } else if stmt.order_by.is_empty() {
+        } else if limit_here {
             let offset = if let Some(ref offset_expr) = stmt.offset {
                 match ExpressionEval::compile(offset_expr, &[])
                     .ok()
@@ -1191,11 +1210,7 @@ impl Executor {
         let result =
             ExecutorResult::with_arc_columns(CompactArc::clone(&output_columns), projected_rows);
         // OFFSET and LIMIT were applied above unless ORDER BY has to run first
-        Ok(Some((
-            Box::new(result),
-            output_columns,
-            stmt.order_by.is_empty(),
-        )))
+        Ok(Some((Box::new(result), output_columns, limit_here)))
     }
 
     /// IN list literal index optimization
@@ -1588,6 +1603,9 @@ impl Executor {
                 Some(info) => info,
                 None => return Ok(None),
             };
+        // LIMIT and OFFSET can be applied here only when nothing runs on the
+        // rows afterwards: no ORDER BY to sort them and no DISTINCT to merge them
+        let limit_here = stmt.order_by.is_empty() && !stmt.distinct && stmt.distinct_on.is_empty();
 
         // Check if this is a PRIMARY KEY column (O(1) lookup) or has an index
         let schema = table.schema();
@@ -1615,8 +1633,7 @@ impl Executor {
 
         // EARLY LIMIT CHECK: Compute limit+offset before collecting row_ids
         // This allows us to stop collection early when there's no ORDER BY
-        let early_termination_target = if stmt.order_by.is_empty() && remaining_predicate.is_none()
-        {
+        let early_termination_target = if limit_here && remaining_predicate.is_none() {
             let offset = stmt
                 .offset
                 .as_ref()
@@ -1737,7 +1754,7 @@ impl Executor {
         // EARLY LIMIT OPTIMIZATION: When there's no ORDER BY and no remaining predicate,
         // we can apply LIMIT early to avoid fetching unnecessary rows
         let (early_limit_applied, early_limit, early_offset) =
-            if stmt.order_by.is_empty() && remaining_predicate.is_none() {
+            if limit_here && remaining_predicate.is_none() {
                 let offset = if let Some(ref offset_expr) = stmt.offset {
                     match ExpressionEval::compile(offset_expr, &[])
                         .ok()
@@ -1803,7 +1820,7 @@ impl Executor {
             } else if early_limit < rows.len() {
                 rows.truncate(early_limit);
             }
-        } else if stmt.order_by.is_empty() {
+        } else if limit_here {
             let offset = if let Some(ref offset_expr) = stmt.offset {
                 match ExpressionEval::compile(offset_expr, &[])
                     .ok()
@@ -1849,11 +1866,7 @@ impl Executor {
         let result =
             ExecutorResult::with_arc_columns(CompactArc::clone(&output_columns), projected_rows);
         // OFFSET and LIMIT were applied above unless ORDER BY has to run first
-        Ok(Some((
-            Box::new(result),
-            output_columns,
-            stmt.order_by.is_empty(),
-        )))
+        Ok(Some((Box::new(result), output_columns, limit_here)))
     }
 
     /// Extract InHashSet information from a WHERE clause.

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -866,7 +866,7 @@ impl Executor {
         table_alias: Option<&str>,
         ctx: &ExecutionContext,
         classification: &Arc<QueryClassification>,
-    ) -> Result<Option<(Box<dyn QueryResult>, CompactArc<Vec<String>>)>> {
+    ) -> Result<Option<(Box<dyn QueryResult>, CompactArc<Vec<String>>, bool)>> {
         // Extract IN subquery info: (column_name, subquery, is_negated, remaining_predicate)
         let (column_name, subquery, is_negated, remaining_predicate) =
             match Self::extract_in_subquery_info(where_expr) {
@@ -961,7 +961,7 @@ impl Executor {
                     CompactArc::clone(&output_columns),
                     RowVec::new(),
                 );
-                return Ok(Some((Box::new(result), output_columns)));
+                return Ok(Some((Box::new(result), output_columns, true)));
             }
         }
 
@@ -1020,7 +1020,12 @@ impl Executor {
                     })
                     .unwrap_or(usize::MAX);
 
-                let target = if limit == usize::MAX {
+                // Stop early only when nothing after this point drops or reorders
+                // rows; the shared tail applies OFFSET and LIMIT once
+                let target = if limit == usize::MAX
+                    || !stmt.order_by.is_empty()
+                    || remaining_predicate.is_some()
+                {
                     usize::MAX
                 } else {
                     offset.saturating_add(limit)
@@ -1036,18 +1041,6 @@ impl Executor {
                             break;
                         }
                     }
-                }
-
-                // Apply offset
-                if offset > 0 && offset < all_row_ids.len() {
-                    all_row_ids = all_row_ids.split_off(offset);
-                } else if offset >= all_row_ids.len() {
-                    all_row_ids.clear();
-                }
-
-                // Apply limit
-                if limit < all_row_ids.len() {
-                    all_row_ids.truncate(limit);
                 }
             } else {
                 // IN: PRIMARY KEY - the value IS the row_id (for INTEGER PK)
@@ -1197,7 +1190,12 @@ impl Executor {
             CompactArc::new(self.get_output_column_names(&stmt.columns, all_columns, table_alias));
         let result =
             ExecutorResult::with_arc_columns(CompactArc::clone(&output_columns), projected_rows);
-        Ok(Some((Box::new(result), output_columns)))
+        // OFFSET and LIMIT were applied above unless ORDER BY has to run first
+        Ok(Some((
+            Box::new(result),
+            output_columns,
+            stmt.order_by.is_empty(),
+        )))
     }
 
     /// IN list literal index optimization
@@ -1583,7 +1581,7 @@ impl Executor {
         all_columns: &[String],
         table_alias: Option<&str>,
         ctx: &ExecutionContext,
-    ) -> Result<Option<(Box<dyn QueryResult>, CompactArc<Vec<String>>)>> {
+    ) -> Result<Option<(Box<dyn QueryResult>, CompactArc<Vec<String>>, bool)>> {
         // Extract InHashSet info: (column_name, values, is_negated, remaining_predicate)
         let (column_name, values, is_negated, remaining_predicate) =
             match Self::extract_in_hashset_info(where_expr) {
@@ -1728,7 +1726,7 @@ impl Executor {
             ));
             let result =
                 ExecutorResult::with_arc_columns(CompactArc::clone(&output_columns), RowVec::new());
-            return Ok(Some((Box::new(result), output_columns)));
+            return Ok(Some((Box::new(result), output_columns, true)));
         }
 
         // Sort row_ids for better cache locality during version lookup
@@ -1850,7 +1848,12 @@ impl Executor {
             CompactArc::new(self.get_output_column_names(&stmt.columns, all_columns, table_alias));
         let result =
             ExecutorResult::with_arc_columns(CompactArc::clone(&output_columns), projected_rows);
-        Ok(Some((Box::new(result), output_columns)))
+        // OFFSET and LIMIT were applied above unless ORDER BY has to run first
+        Ok(Some((
+            Box::new(result),
+            output_columns,
+            stmt.order_by.is_empty(),
+        )))
     }
 
     /// Extract InHashSet information from a WHERE clause.

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -554,7 +554,7 @@ impl Executor {
     fn is_expr_window_safe(expr: &Expression) -> bool {
         match expr {
             Expression::Window(window_expr) => {
-                use crate::parser::ast::WindowFrameBound;
+                use crate::parser::ast::{WindowFrameBound, WindowFrameUnit};
                 let func_name = window_expr.function.function.to_uppercase();
                 // A fetch cut at LIMIT rows is wrong for anything that looks past
                 // the current row: total-count functions, LEAD, a frame that
@@ -565,15 +565,26 @@ impl Executor {
                         WindowFrameBound::Following(_) | WindowFrameBound::UnboundedFollowing
                     )
                 };
+                let frame = window_expr.frame.as_ref();
                 let reaches_forward = window_expr.window_ref.is_some()
-                    || window_expr
-                        .frame
-                        .as_ref()
+                    || frame
                         .is_some_and(|f| forward(&f.start) || f.end.as_ref().is_some_and(forward));
-                !reaches_forward
-                    && !matches!(
+                if reaches_forward
+                    || matches!(
                         func_name.as_str(),
                         "NTILE" | "PERCENT_RANK" | "CUME_DIST" | "LEAD"
+                    )
+                {
+                    return false;
+                }
+                // A ROWS frame ending at the current row never reads past it. Any
+                // other frame, the implicit RANGE one included, also covers the
+                // current row's later peers, which the cut fetch may not hold, so
+                // only functions that ignore the frame end stay safe there
+                frame.is_some_and(|f| f.unit == WindowFrameUnit::Rows)
+                    || matches!(
+                        func_name.as_str(),
+                        "ROW_NUMBER" | "RANK" | "DENSE_RANK" | "LAG" | "FIRST_VALUE"
                     )
             }
             Expression::Aliased(aliased) => Self::is_expr_window_safe(&aliased.expression),

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3504,6 +3504,13 @@ impl Executor {
                     let schema = table.schema();
                     let pk_columns = schema.primary_key_columns();
                     let is_pk = pk_columns.len() == 1 && pk_columns[0].name_lower == col_lower;
+                    // The index orders NULLs its own way, so a fetch cut at LIMIT
+                    // rows is only right for a column that has none
+                    let no_nulls = is_pk
+                        || schema
+                            .columns
+                            .iter()
+                            .any(|c| c.name_lower == col_lower && !c.nullable);
                     let has_index = is_pk || table.get_index_on_column(&col_name).is_some();
 
                     if has_index {
@@ -3515,7 +3522,7 @@ impl Executor {
                         let has_order_by = !stmt.order_by.is_empty();
                         let is_window_safe =
                             Self::is_window_safe_for_limit_pushdown(stmt, &col_name, ascending);
-                        let fetch_limit = if !has_order_by && is_window_safe {
+                        let fetch_limit = if !has_order_by && is_window_safe && no_nulls {
                             Self::literal_fetch_limit(stmt).unwrap_or(usize::MAX)
                         } else {
                             usize::MAX

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -1215,6 +1215,22 @@ impl Executor {
         Ok((result, qualified_columns))
     }
 
+    /// LIMIT + OFFSET when both are integer literals (OFFSET may be absent),
+    /// for fetch paths that stop early and leave OFFSET to be applied afterwards.
+    fn literal_fetch_limit(stmt: &SelectStatement) -> Option<usize> {
+        let limit = match stmt.limit.as_deref() {
+            Some(Expression::IntegerLiteral(lit)) if lit.value > 0 => lit.value as usize,
+            _ => return None,
+        };
+        match stmt.offset.as_deref() {
+            None => Some(limit),
+            Some(Expression::IntegerLiteral(lit)) if lit.value >= 0 => {
+                Some(limit.saturating_add(lit.value as usize))
+            }
+            Some(_) => None,
+        }
+    }
+
     /// Extract a simple LIMIT value from a SelectStatement, if present and evaluable.
     fn extract_limit_hint(stmt: &SelectStatement, ctx: &ExecutionContext) -> Option<usize> {
         let limit_expr = stmt.limit.as_ref()?;
@@ -2479,16 +2495,18 @@ impl Executor {
             && !classification.has_aggregation
         {
             if let Some(where_expr) = where_to_use {
-                if let Some((result, columns)) = self.try_in_subquery_index_optimization(
-                    stmt,
-                    where_expr,
-                    &*table,
-                    &all_columns,
-                    table_alias.as_deref(),
-                    ctx,
-                    classification,
-                )? {
-                    return Ok((result, columns, false, None));
+                if let Some((result, columns, limit_applied)) = self
+                    .try_in_subquery_index_optimization(
+                        stmt,
+                        where_expr,
+                        &*table,
+                        &all_columns,
+                        table_alias.as_deref(),
+                        ctx,
+                        classification,
+                    )?
+                {
+                    return Ok((result, columns, limit_applied, None));
                 }
             }
         }
@@ -2957,15 +2975,17 @@ impl Executor {
                 && !classification.select_has_correlated_subqueries
             {
                 if let Some(ref where_expr) = processed_where {
-                    if let Some((result, columns)) = self.try_in_hashset_index_optimization(
-                        stmt,
-                        where_expr,
-                        &*table,
-                        &all_columns,
-                        table_alias.as_deref(),
-                        ctx,
-                    )? {
-                        return Ok((result, columns, false, None));
+                    if let Some((result, columns, limit_applied)) = self
+                        .try_in_hashset_index_optimization(
+                            stmt,
+                            where_expr,
+                            &*table,
+                            &all_columns,
+                            table_alias.as_deref(),
+                            ctx,
+                        )?
+                    {
+                        return Ok((result, columns, limit_applied, None));
                     }
                 }
             }
@@ -3014,7 +3034,7 @@ impl Executor {
                             .and_then(|e| e.with_context(ctx).eval_slice(&Row::new()).ok())
                             .and_then(|v| {
                                 if let Value::Integer(l) = v {
-                                    Some(offset + l.max(0) as usize)
+                                    Some((offset, l.max(0) as usize))
                                 } else {
                                     None
                                 }
@@ -3025,7 +3045,8 @@ impl Executor {
                 };
 
                 // Use early termination path if we have a target
-                if let Some(target) = early_termination_target {
+                if let Some((early_offset, early_limit)) = early_termination_target {
+                    let target = early_offset.saturating_add(early_limit);
                     // OPTIMIZATION: For memory-filter + LIMIT, use iterative fetching
                     // with early termination. We fetch in batches to avoid loading
                     // all rows when only a few are needed.
@@ -3079,6 +3100,12 @@ impl Executor {
                             table.collect_rows_with_limit(storage_expr.as_deref(), target, 0)?;
                     }
 
+                    // The rows OFFSET skips were collected too; drop them and cut to
+                    // LIMIT here, since this path reports both as applied
+                    let mut trimmed = result_rows.into_vec();
+                    trimmed.drain(..early_offset.min(trimmed.len()));
+                    trimmed.truncate(early_limit);
+                    let result_rows = RowVec::from_vec(trimmed);
                     // Project rows and return early - LIMIT/OFFSET already applied
                     let projected_rows = self.project_rows_with_alias(
                         &stmt.columns,
@@ -3408,28 +3435,22 @@ impl Executor {
                         // because we need all rows to sort before applying LIMIT
                         let has_order_by = !stmt.order_by.is_empty();
                         if !has_order_by {
-                            if let Some(limit_expr) = &stmt.limit {
-                                if let Expression::IntegerLiteral(lit) = limit_expr.as_ref() {
-                                    if lit.value > 0 {
-                                        let limit_val = lit.value as usize;
-                                        // Use lazy partition fetching - returns early!
-                                        let result = self
-                                            .execute_select_with_window_functions_lazy_partition(
-                                                stmt,
-                                                ctx,
-                                                table.as_ref(),
-                                                &all_columns,
-                                                &partition_col,
-                                                limit_val,
-                                            );
-                                        if let Ok(query_result) = result {
-                                            let columns =
-                                                CompactArc::new(query_result.columns().to_vec());
-                                            return Ok((query_result, columns, false, None));
-                                        }
-                                        // Fall through to regular path if optimization fails
-                                    }
+                            if let Some(limit_val) = Self::literal_fetch_limit(stmt) {
+                                // Use lazy partition fetching - returns early!
+                                let result = self
+                                    .execute_select_with_window_functions_lazy_partition(
+                                        stmt,
+                                        ctx,
+                                        table.as_ref(),
+                                        &all_columns,
+                                        &partition_col,
+                                        limit_val,
+                                    );
+                                if let Ok(query_result) = result {
+                                    let columns = CompactArc::new(query_result.columns().to_vec());
+                                    return Ok((query_result, columns, false, None));
                                 }
+                                // Fall through to regular path if optimization fails
                             }
                         }
 
@@ -3492,19 +3513,7 @@ impl Executor {
                         let has_order_by = !stmt.order_by.is_empty();
                         let is_window_safe = Self::is_window_safe_for_limit_pushdown(stmt);
                         let fetch_limit = if !has_order_by && is_window_safe {
-                            if let Some(limit_expr) = &stmt.limit {
-                                if let Expression::IntegerLiteral(lit) = limit_expr.as_ref() {
-                                    if lit.value > 0 {
-                                        lit.value as usize
-                                    } else {
-                                        usize::MAX
-                                    }
-                                } else {
-                                    usize::MAX
-                                }
-                            } else {
-                                usize::MAX
-                            }
+                            Self::literal_fetch_limit(stmt).unwrap_or(usize::MAX)
                         } else {
                             usize::MAX
                         };
@@ -9733,17 +9742,9 @@ impl Executor {
         let mut result_row_id = 0i64;
         let num_aggs = simple_aggs.len();
 
-        // Parse LIMIT for early termination
-        // With streaming aggregation, we can stop once we have LIMIT groups that pass HAVING
-        let limit_for_early_exit = stmt.limit.as_ref().and_then(|limit_expr| {
-            ExpressionEval::compile(limit_expr, &[])
-                .ok()
-                .and_then(|e| e.with_context(ctx).eval_slice(&Row::new()).ok())
-                .and_then(|v| match v {
-                    Value::Integer(n) if n > 0 => Some(n as usize),
-                    _ => None,
-                })
-        });
+        // With streaming aggregation we can stop once LIMIT + OFFSET groups pass
+        // HAVING; OFFSET is applied by the caller and must find its groups here
+        let limit_for_early_exit = Self::extract_limit_hint(stmt, ctx);
 
         // Use streaming callback to avoid upfront allocation of all groups.
         // This is more efficient because:
@@ -9938,15 +9939,8 @@ impl Executor {
             None => return Ok(None), // Fall back to regular GROUP BY
         }
 
-        // Apply LIMIT if present
-        if let Some(ref limit_expr) = stmt.limit {
-            if let Ok(Value::Integer(n)) = ExpressionEval::compile(limit_expr, &[])
-                .and_then(|e| e.with_context(ctx).eval_slice(&Row::new()))
-            {
-                if n >= 0 {
-                    result_rows.truncate(n as usize);
-                }
-            }
+        if let Some(keep) = limit_for_early_exit {
+            result_rows.truncate(keep);
         }
 
         let result_columns = CompactArc::new(result_columns);

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3513,7 +3513,8 @@ impl Executor {
                         // Safe: ROW_NUMBER, RANK, DENSE_RANK, LAG, LEAD, FIRST_VALUE, LAST_VALUE
                         // Unsafe: NTILE, PERCENT_RANK, CUME_DIST (need total count)
                         let has_order_by = !stmt.order_by.is_empty();
-                        let is_window_safe = Self::is_window_safe_for_limit_pushdown(stmt);
+                        let is_window_safe =
+                            Self::is_window_safe_for_limit_pushdown(stmt, &col_name, ascending);
                         let fetch_limit = if !has_order_by && is_window_safe {
                             Self::literal_fetch_limit(stmt).unwrap_or(usize::MAX)
                         } else {

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3008,7 +3008,9 @@ impl Executor {
                 let can_early_terminate = !classification.has_order_by
                     && !classification.has_group_by
                     && !classification.has_aggregation
-                    && !classification.has_window_functions;
+                    && !classification.has_window_functions
+                    && !stmt.distinct
+                    && stmt.distinct_on.is_empty();
 
                 let early_termination_target = if can_early_terminate {
                     let offset = stmt

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3504,14 +3504,16 @@ impl Executor {
                     let schema = table.schema();
                     let pk_columns = schema.primary_key_columns();
                     let is_pk = pk_columns.len() == 1 && pk_columns[0].name_lower == col_lower;
-                    // The index orders NULLs its own way, so a fetch cut at LIMIT
-                    // rows is only right for a column that has none
+                    // Rows fetched in index order are taken as sorted, but the index
+                    // orders NULLs its own way, so only a column without NULLs may
+                    // skip the window's own sort
                     let no_nulls = is_pk
                         || schema
                             .columns
                             .iter()
                             .any(|c| c.name_lower == col_lower && !c.nullable);
-                    let has_index = is_pk || table.get_index_on_column(&col_name).is_some();
+                    let has_index =
+                        no_nulls && (is_pk || table.get_index_on_column(&col_name).is_some());
 
                     if has_index {
                         // OPTIMIZATION: If we have LIMIT without top-level ORDER BY,
@@ -3522,7 +3524,7 @@ impl Executor {
                         let has_order_by = !stmt.order_by.is_empty();
                         let is_window_safe =
                             Self::is_window_safe_for_limit_pushdown(stmt, &col_name, ascending);
-                        let fetch_limit = if !has_order_by && is_window_safe && no_nulls {
+                        let fetch_limit = if !has_order_by && is_window_safe {
                             Self::literal_fetch_limit(stmt).unwrap_or(usize::MAX)
                         } else {
                             usize::MAX

--- a/tests/index_optimizer_test.rs
+++ b/tests/index_optimizer_test.rs
@@ -582,12 +582,28 @@ fn test_window_row_number_with_limit() {
         )
         .expect("Failed to query");
 
+    // every returned row must carry its true rank by price, whichever rows
+    // the limit picked
+    let true_rank: std::collections::HashMap<i64, i64> = db
+        .query(
+            "SELECT id, ROW_NUMBER() OVER (ORDER BY price) FROM products",
+            (),
+        )
+        .expect("Failed to query")
+        .map(|row| {
+            let row = row.expect("Failed to get row");
+            (row.get::<i64>(0).unwrap(), row.get::<i64>(1).unwrap())
+        })
+        .collect();
+
     let mut count = 0;
     for row in result {
         let row = row.expect("Failed to get row");
+        let id: i64 = row.get(0).unwrap();
         let rn: i64 = row.get(2).unwrap();
         count += 1;
         assert!((1..=5).contains(&rn), "Expected row number 1-5, got {}", rn);
+        assert_eq!(rn, true_rank[&id], "row {id} carries another row's rank");
     }
 
     assert_eq!(count, 5, "Expected 5 rows");

--- a/tests/index_optimizer_test.rs
+++ b/tests/index_optimizer_test.rs
@@ -24,7 +24,7 @@ fn setup_indexed_table(db: &Database) {
         "CREATE TABLE products (
             id INTEGER PRIMARY KEY,
             name TEXT,
-            price FLOAT,
+            price FLOAT NOT NULL,
             category TEXT,
             stock INTEGER
         )",

--- a/tests/offset_before_limit_test.rs
+++ b/tests/offset_before_limit_test.rs
@@ -205,7 +205,7 @@ fn test_lead_sees_the_row_after_the_limit_window() {
 fn test_range_frame_peers_survive_the_limit_window() {
     let db = Database::open("memory://offset_range_peers").unwrap();
     db.execute(
-        "CREATE TABLE sales (id INTEGER PRIMARY KEY, category INTEGER, amount FLOAT)",
+        "CREATE TABLE sales (id INTEGER PRIMARY KEY, category INTEGER NOT NULL, amount FLOAT)",
         (),
     )
     .unwrap();
@@ -265,28 +265,33 @@ fn test_second_window_with_another_order_keeps_the_full_fetch() {
     assert_eq!(row.get::<i64>(2).unwrap(), 55);
 }
 
-/// The index orders NULLs its own way; the window's ORDER BY may not. A cut
-/// fetch over a nullable column could therefore start with the wrong rows,
-/// so the limited result must equal the same slice of the unlimited one.
+/// The index orders NULLs its own way; the window's ORDER BY may not. Rows
+/// fetched in index order must not be taken as pre-sorted on a nullable
+/// column, with or without a limit: a table without the index is the oracle.
 #[test]
-fn test_window_limit_over_a_nullable_index_column_matches_the_full_result() {
+fn test_window_over_a_nullable_index_column_matches_the_unindexed_table() {
     let db = Database::open("memory://offset_nullable_window").unwrap();
-    db.execute(
-        "CREATE TABLE events (id INTEGER PRIMARY KEY, k INTEGER)",
-        (),
-    )
-    .unwrap();
+    for table in ["events", "events_plain"] {
+        db.execute(
+            &format!("CREATE TABLE {table} (id INTEGER PRIMARY KEY, k INTEGER)"),
+            (),
+        )
+        .unwrap();
+        for i in 1..=20i64 {
+            db.execute(&format!("INSERT INTO {table} VALUES ($1, NULL)"), (i,))
+                .unwrap();
+        }
+        for i in 21..=100i64 {
+            db.execute(
+                &format!("INSERT INTO {table} VALUES ($1, $2)"),
+                (i, 200 - i),
+            )
+            .unwrap();
+        }
+    }
     db.execute("CREATE INDEX idx_events_k ON events(k) USING BTREE", ())
         .unwrap();
-    for i in 1..=20i64 {
-        db.execute("INSERT INTO events VALUES ($1, NULL)", (i,))
-            .unwrap();
-    }
-    for i in 21..=100i64 {
-        db.execute("INSERT INTO events VALUES ($1, $2)", (i, 200 - i))
-            .unwrap();
-    }
-    let read = |sql: &str| -> Vec<(i64, Option<i64>, i64)> {
+    let read = |sql: &str| -> Vec<(i64, Option<i64>, Option<i64>)> {
         db.query(sql, ())
             .unwrap()
             .map(|row| {
@@ -294,29 +299,47 @@ fn test_window_limit_over_a_nullable_index_column_matches_the_full_result() {
                 (
                     row.get::<i64>(0).unwrap(),
                     row.get::<Option<i64>>(1).unwrap(),
-                    row.get::<i64>(2).unwrap(),
+                    row.get::<Option<i64>>(2).unwrap(),
                 )
             })
             .collect()
     };
-    for (order, off) in [
-        ("ASC", 0),
-        ("ASC", 15),
-        ("DESC", 0),
-        ("DESC", 75),
-        ("ASC NULLS FIRST", 15),
-        ("DESC NULLS LAST", 75),
-    ] {
+    for order in ["ASC", "DESC", "ASC NULLS FIRST", "DESC NULLS LAST"] {
+        // aggregates take the pre-sorted rows as they come, ranking sorts itself
+        for func in ["ROW_NUMBER()", "COUNT(*)", "SUM(k)"] {
+            let oracle = read(&format!(
+                "SELECT id, k, {func} OVER (ORDER BY k {order}) AS v FROM events_plain ORDER BY id"
+            ));
+            let indexed = read(&format!(
+                "SELECT id, k, {func} OVER (ORDER BY k {order}) AS v FROM events ORDER BY id"
+            ));
+            assert_eq!(indexed, oracle, "{func} OVER (ORDER BY k {order})");
+        }
         let full = read(&format!(
             "SELECT id, k, ROW_NUMBER() OVER (ORDER BY k {order}) AS rn FROM events"
         ));
-        let cut = read(&format!(
-            "SELECT id, k, ROW_NUMBER() OVER (ORDER BY k {order}) AS rn FROM events LIMIT 10 OFFSET {off}"
-        ));
-        assert_eq!(
-            cut,
-            full[off..off + 10].to_vec(),
-            "ORDER BY k {order} OFFSET {off}"
-        );
+        for off in [0, 15, 75] {
+            let cut = read(&format!(
+                "SELECT id, k, ROW_NUMBER() OVER (ORDER BY k {order}) AS rn FROM events LIMIT 10 OFFSET {off}"
+            ));
+            assert_eq!(
+                cut,
+                full[off..off + 10].to_vec(),
+                "ORDER BY k {order} OFFSET {off}"
+            );
+        }
     }
+    // the first NULL row sorts after the 80 non-null rows by default
+    let rn: i64 = db
+        .query(
+            "SELECT id, ROW_NUMBER() OVER (ORDER BY k) AS rn FROM events ORDER BY id LIMIT 1",
+            (),
+        )
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(1)
+        .unwrap();
+    assert_eq!(rn, 81);
 }

--- a/tests/offset_before_limit_test.rs
+++ b/tests/offset_before_limit_test.rs
@@ -244,3 +244,23 @@ fn test_range_frame_peers_survive_the_limit_window() {
         .unwrap();
     assert_eq!(last, 73.0);
 }
+
+/// The index-order fetch follows one window's ORDER BY; every other window
+/// in the SELECT must order the same way, or it would rank a cut subset.
+#[test]
+fn test_second_window_with_another_order_keeps_the_full_fetch() {
+    let db = setup("offset_second_window_order");
+    let row = db
+        .query(
+            "SELECT id, ROW_NUMBER() OVER (ORDER BY id) AS by_id, ROW_NUMBER() OVER (ORDER BY amount DESC) AS by_amount FROM orders LIMIT 10 OFFSET 45",
+            (),
+        )
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 46);
+    assert_eq!(row.get::<i64>(1).unwrap(), 46);
+    // amount 46 is the 55th largest of 100, not the 10th of a 55-row subset
+    assert_eq!(row.get::<i64>(2).unwrap(), 55);
+}

--- a/tests/offset_before_limit_test.rs
+++ b/tests/offset_before_limit_test.rs
@@ -196,3 +196,51 @@ fn test_lead_sees_the_row_after_the_limit_window() {
     assert_eq!(rows[0], (46, Some(47)));
     assert_eq!(rows[9], (55, Some(56)));
 }
+
+/// With ORDER BY the default window frame is RANGE up to the current row,
+/// which includes the current row's later peers. A fetch cut at LIMIT +
+/// OFFSET rows can split the last peer group, so peer-sensitive functions
+/// must not use it.
+#[test]
+fn test_range_frame_peers_survive_the_limit_window() {
+    let db = Database::open("memory://offset_range_peers").unwrap();
+    db.execute(
+        "CREATE TABLE sales (id INTEGER PRIMARY KEY, category INTEGER, amount FLOAT)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE INDEX idx_sales_category ON sales(category) USING BTREE",
+        (),
+    )
+    .unwrap();
+    for i in 1..=100i64 {
+        db.execute(
+            "INSERT INTO sales VALUES ($1, $2, $3)",
+            (i, (i - 1) % 50 + 1, i as f64),
+        )
+        .unwrap();
+    }
+    // row 45 in category order is the first row of category 23; its frame holds
+    // every row of categories 1..=23, including its peer past the 45th row
+    for sql in [
+        "SELECT category, SUM(amount) OVER (ORDER BY category) FROM sales LIMIT 1 OFFSET 44",
+        "SELECT category, SUM(amount) OVER (ORDER BY category RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM sales LIMIT 1 OFFSET 44",
+    ] {
+        let row = db.query(sql, ()).unwrap().next().unwrap().unwrap();
+        assert_eq!(row.get::<i64>(0).unwrap(), 23, "{sql}");
+        assert_eq!(row.get::<f64>(1).unwrap(), 1702.0, "{sql}");
+    }
+    let last: f64 = db
+        .query(
+            "SELECT LAST_VALUE(amount) OVER (ORDER BY category) FROM sales LIMIT 1 OFFSET 44",
+            (),
+        )
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap();
+    assert_eq!(last, 73.0);
+}

--- a/tests/offset_before_limit_test.rs
+++ b/tests/offset_before_limit_test.rs
@@ -1,0 +1,158 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! OFFSET skips rows before LIMIT counts them, and is applied exactly once,
+//! on every path that stops early: GROUP BY, window fetches, subqueries in
+//! WHERE and joins.
+
+use stoolap::Database;
+
+fn count(db: &Database, sql: &str) -> usize {
+    db.query(sql, ()).unwrap().count()
+}
+
+/// 50 groups: user ids 1..=50, each with two orders.
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount FLOAT)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX idx_orders_user_id ON orders(user_id)", ())
+        .unwrap();
+    for i in 1..=50i64 {
+        db.execute("INSERT INTO users VALUES ($1, $2)", (i, format!("U{i}")))
+            .unwrap();
+    }
+    for i in 1..=100i64 {
+        db.execute(
+            "INSERT INTO orders VALUES ($1, $2, $3)",
+            (i, (i - 1) % 50 + 1, i as f64),
+        )
+        .unwrap();
+    }
+    db
+}
+
+#[test]
+fn test_group_by_offset_is_applied_before_limit() {
+    let db = setup("group_by_offset_single");
+    for (sql, expect) in [
+        ("SELECT user_id, COUNT(*) FROM orders GROUP BY user_id LIMIT 10 OFFSET 45", 5),
+        ("SELECT user_id, COUNT(*) FROM orders GROUP BY user_id LIMIT 10 OFFSET 5", 10),
+        ("SELECT user_id, SUM(amount) FROM orders GROUP BY user_id ORDER BY user_id LIMIT 10 OFFSET 45", 5),
+        ("SELECT user_id, COUNT(*) FROM orders GROUP BY user_id HAVING COUNT(*) = 2 LIMIT 10 OFFSET 45", 5),
+        ("SELECT user_id, COUNT(*) FROM orders WHERE amount > 0 GROUP BY user_id LIMIT 10 OFFSET 45", 5),
+        ("SELECT user_id FROM orders GROUP BY user_id OFFSET 45", 5),
+    ] {
+        assert_eq!(count(&db, sql), expect, "{sql}");
+    }
+}
+
+#[test]
+fn test_group_by_offset_is_applied_before_limit_on_joins() {
+    let db = setup("group_by_offset_join");
+    for (sql, expect) in [
+        ("SELECT u.name, COUNT(o.id) FROM users u INNER JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name LIMIT 10 OFFSET 45", 5),
+        ("SELECT u.name, COUNT(o.id) FROM users u LEFT JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name LIMIT 10 OFFSET 5", 10),
+        ("SELECT u.name, COUNT(o.id) FROM users u INNER JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name HAVING COUNT(o.id) = 2 LIMIT 10 OFFSET 45", 5),
+    ] {
+        assert_eq!(count(&db, sql), expect, "{sql}");
+    }
+}
+
+#[test]
+fn test_offset_is_applied_before_limit_on_other_pushdown_paths() {
+    let db = setup("offset_other_paths");
+    for (sql, expect) in [
+        ("SELECT id FROM users WHERE id > 10 ORDER BY id LIMIT 10 OFFSET 35", 5),
+        ("SELECT id, ROW_NUMBER() OVER (ORDER BY id) FROM users LIMIT 10 OFFSET 45", 5),
+        ("SELECT id, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY id) FROM orders LIMIT 10 OFFSET 95", 5),
+        ("WITH c AS (SELECT * FROM users) SELECT * FROM c LIMIT 10 OFFSET 45", 5),
+        ("SELECT user_id, COUNT(*) FROM orders GROUP BY user_id HAVING COUNT(*) > 0 LIMIT 10 OFFSET 45", 5),
+        ("SELECT DISTINCT user_id FROM orders LIMIT 10 OFFSET 45", 5),
+        ("SELECT * FROM users WHERE id IN (SELECT user_id FROM orders) LIMIT 10 OFFSET 45", 5),
+        ("SELECT u.name FROM users u INNER JOIN orders o ON u.id = o.user_id LIMIT 10 OFFSET 95", 5),
+    ] {
+        assert_eq!(count(&db, sql), expect, "{sql}");
+    }
+}
+
+/// The streaming GROUP BY walks a BTREE index in order and stops early at
+/// the limit; the groups OFFSET skips must be walked too.
+#[test]
+fn test_streaming_group_by_offset_is_applied_before_limit() {
+    let db = Database::open("memory://streaming_group_by_offset").unwrap();
+    db.execute(
+        "CREATE TABLE sales (id INTEGER PRIMARY KEY, category INTEGER, amount FLOAT)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE INDEX idx_sales_category ON sales(category) USING BTREE",
+        (),
+    )
+    .unwrap();
+    for i in 1..=100i64 {
+        db.execute(
+            "INSERT INTO sales VALUES ($1, $2, $3)",
+            (i, (i - 1) % 50 + 1, i as f64),
+        )
+        .unwrap();
+    }
+    for (sql, expect) in [
+        ("SELECT category, SUM(amount) FROM sales GROUP BY category LIMIT 10 OFFSET 45", 5),
+        ("SELECT category, COUNT(*) FROM sales GROUP BY category LIMIT 10 OFFSET 5", 10),
+        ("SELECT category, COUNT(*) FROM sales GROUP BY category HAVING COUNT(*) = 2 LIMIT 10 OFFSET 45", 5),
+    ] {
+        assert_eq!(count(&db, sql), expect, "{sql}");
+    }
+}
+
+/// A subquery in WHERE takes fast paths that apply LIMIT and OFFSET on their
+/// own; they must skip the OFFSET rows and report the pair as applied so the
+/// caller does not skip them again.
+#[test]
+fn test_subquery_where_offset_is_applied_once() {
+    let db = setup("offset_subquery_where");
+    let ids: Vec<String> = (1..=50).map(|i| i.to_string()).collect();
+    let in_list = format!(
+        "SELECT * FROM users WHERE id IN ({}) LIMIT 10 OFFSET 45",
+        ids.join(",")
+    );
+    for (sql, expect) in [
+        (in_list.as_str(), 5),
+        ("SELECT * FROM users WHERE id IN (SELECT user_id FROM orders) LIMIT 10 OFFSET 45", 5),
+        ("SELECT * FROM users WHERE id IN (SELECT user_id FROM orders) OFFSET 45", 5),
+        ("SELECT * FROM orders WHERE user_id IN (SELECT id FROM users) LIMIT 10 OFFSET 95", 5),
+        ("SELECT * FROM users WHERE id NOT IN (SELECT user_id FROM orders WHERE user_id > 40) LIMIT 10 OFFSET 35", 5),
+        ("SELECT * FROM users u WHERE EXISTS (SELECT 1 FROM orders o WHERE o.user_id = u.id) LIMIT 10 OFFSET 45", 5),
+        ("SELECT * FROM users WHERE id > (SELECT MIN(id) FROM users) LIMIT 10 OFFSET 44", 5),
+        ("SELECT * FROM orders WHERE amount > (SELECT AVG(amount) FROM orders) LIMIT 10 OFFSET 45", 5),
+    ] {
+        assert_eq!(count(&db, sql), expect, "{sql}");
+    }
+    let names: Vec<String> = db
+        .query(
+            "SELECT name FROM users WHERE id IN (SELECT user_id FROM orders) ORDER BY name DESC LIMIT 3",
+            (),
+        )
+        .unwrap()
+        .map(|row| row.unwrap().get::<String>(0).unwrap())
+        .collect();
+    assert_eq!(names, ["U9", "U8", "U7"]);
+}

--- a/tests/offset_before_limit_test.rs
+++ b/tests/offset_before_limit_test.rs
@@ -156,3 +156,43 @@ fn test_subquery_where_offset_is_applied_once() {
         .collect();
     assert_eq!(names, ["U9", "U8", "U7"]);
 }
+
+/// DISTINCT runs after projection, so an early exit must not cut rows before
+/// it, and the paths that apply LIMIT and OFFSET themselves must leave the
+/// pair to the caller when DISTINCT is present.
+#[test]
+fn test_distinct_keeps_limit_and_offset_after_deduplication() {
+    let db = setup("offset_distinct_paths");
+    for (sql, expect) in [
+        ("SELECT DISTINCT user_id FROM orders WHERE amount > 0 LIMIT 10 OFFSET 45", 5),
+        ("SELECT DISTINCT user_id FROM orders WHERE user_id IN (SELECT id FROM users) LIMIT 10 OFFSET 45", 5),
+        ("SELECT DISTINCT u.id % 10 FROM users u WHERE EXISTS (SELECT 1 FROM orders o WHERE o.user_id = u.id) LIMIT 3 OFFSET 8", 2),
+        ("SELECT DISTINCT user_id FROM orders WHERE user_id IN (SELECT id FROM users) LIMIT 10", 10),
+    ] {
+        assert_eq!(count(&db, sql), expect, "{sql}");
+    }
+}
+
+/// LEAD looks past the last fetched row, so the index-order window fetch
+/// must not stop at LIMIT + OFFSET rows.
+#[test]
+fn test_lead_sees_the_row_after_the_limit_window() {
+    let db = setup("offset_lead_window");
+    let rows: Vec<(i64, Option<i64>)> = db
+        .query(
+            "SELECT id, LEAD(id) OVER (ORDER BY id) FROM orders LIMIT 10 OFFSET 45",
+            (),
+        )
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (
+                row.get::<i64>(0).unwrap(),
+                row.get::<Option<i64>>(1).unwrap(),
+            )
+        })
+        .collect();
+    assert_eq!(rows.len(), 10);
+    assert_eq!(rows[0], (46, Some(47)));
+    assert_eq!(rows[9], (55, Some(56)));
+}

--- a/tests/offset_before_limit_test.rs
+++ b/tests/offset_before_limit_test.rs
@@ -264,3 +264,59 @@ fn test_second_window_with_another_order_keeps_the_full_fetch() {
     // amount 46 is the 55th largest of 100, not the 10th of a 55-row subset
     assert_eq!(row.get::<i64>(2).unwrap(), 55);
 }
+
+/// The index orders NULLs its own way; the window's ORDER BY may not. A cut
+/// fetch over a nullable column could therefore start with the wrong rows,
+/// so the limited result must equal the same slice of the unlimited one.
+#[test]
+fn test_window_limit_over_a_nullable_index_column_matches_the_full_result() {
+    let db = Database::open("memory://offset_nullable_window").unwrap();
+    db.execute(
+        "CREATE TABLE events (id INTEGER PRIMARY KEY, k INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX idx_events_k ON events(k) USING BTREE", ())
+        .unwrap();
+    for i in 1..=20i64 {
+        db.execute("INSERT INTO events VALUES ($1, NULL)", (i,))
+            .unwrap();
+    }
+    for i in 21..=100i64 {
+        db.execute("INSERT INTO events VALUES ($1, $2)", (i, 200 - i))
+            .unwrap();
+    }
+    let read = |sql: &str| -> Vec<(i64, Option<i64>, i64)> {
+        db.query(sql, ())
+            .unwrap()
+            .map(|row| {
+                let row = row.unwrap();
+                (
+                    row.get::<i64>(0).unwrap(),
+                    row.get::<Option<i64>>(1).unwrap(),
+                    row.get::<i64>(2).unwrap(),
+                )
+            })
+            .collect()
+    };
+    for (order, off) in [
+        ("ASC", 0),
+        ("ASC", 15),
+        ("DESC", 0),
+        ("DESC", 75),
+        ("ASC NULLS FIRST", 15),
+        ("DESC NULLS LAST", 75),
+    ] {
+        let full = read(&format!(
+            "SELECT id, k, ROW_NUMBER() OVER (ORDER BY k {order}) AS rn FROM events"
+        ));
+        let cut = read(&format!(
+            "SELECT id, k, ROW_NUMBER() OVER (ORDER BY k {order}) AS rn FROM events LIMIT 10 OFFSET {off}"
+        ));
+        assert_eq!(
+            cut,
+            full[off..off + 10].to_vec(),
+            "ORDER BY k {order} OFFSET {off}"
+        );
+    }
+}


### PR DESCRIPTION
## Why

Follow-up to the note left in #83: `GROUP BY ... LIMIT n OFFSET m` applied LIMIT before OFFSET. Looking for the cause turned up a family of early-exit paths with the same shape of mistake, in both directions.

Rows are built, then the caller applies OFFSET and LIMIT unless the path reports them as applied. With 50 groups and `LIMIT 10 OFFSET 45`:

- Grouped aggregation with a WHERE, window fetches by partition or index order, and the streaming GROUP BY over a BTREE index stop at `LIMIT` rows, so after the caller skips 45 nothing is left: 0 rows instead of 5.
- The IN and NOT IN subquery index path applies OFFSET and LIMIT itself but reported them as not applied, so the caller skipped 45 again: 0 rows, also for `OFFSET 45` without a LIMIT. NOT IN on the primary key trimmed its ids before the shared tail trimmed them once more.
- The hash-set index path, which an EXISTS is rewritten into when no direct index probe is available (a file-backed database after #82), had the same flag problem: `EXISTS (...) LIMIT 10 OFFSET 45` returned 0 rows there.
- The early termination scan for a subquery in WHERE (`amount > (SELECT AVG(...))`) collected `LIMIT + OFFSET` rows and reported both as applied without skipping any: 50 rows instead of 5.

## What

- `aggregation_limit`, the window fetch limits (`literal_fetch_limit`) and the streaming GROUP BY early exit (`extract_limit_hint`) build `LIMIT + OFFSET` rows.
- The early termination scan drops the OFFSET rows and cuts to LIMIT before reporting the pair as applied.
- `try_in_subquery_index_optimization` and `try_in_hashset_index_optimization` return whether they applied OFFSET and LIMIT (they do unless ORDER BY or DISTINCT has to run on the rows first), and the callers pass that through. The early termination scan stays off under DISTINCT for the same reason.
- The index-order window fetch keeps the full fetch for LEAD, for a frame that reaches forward, for a named window, and under any frame other than an explicit ROWS one for every function except ROW_NUMBER, RANK, DENSE_RANK, LAG and FIRST_VALUE: the implicit RANGE frame includes the current row's later peers, which a fetch cut at LIMIT + OFFSET rows may not hold. The cut fetch is also used only when every window in the SELECT orders by exactly the column and direction the fetch follows, with no PARTITION BY; a second window ordered another way would rank the cut subset. And the whole index-order path, cut or not, is taken only when that column is the primary key or declared NOT NULL: the index places NULLs where Value's ordering does, the window's ORDER BY places them the other way round by default, and the pre-sorted aggregate path takes the rows as they come. The NOT IN primary key walk stops early only when nothing later can drop or reorder rows, and leaves the trimming to the shared tail.

Without an OFFSET nothing changes on these paths; the early termination scan moves at most `LIMIT` rows once more.

## Tests

`tests/offset_before_limit_test.rs`: GROUP BY on a scan, a filtered scan, with HAVING, with ORDER BY, over joins (INNER, LEFT, HAVING), the streaming BTREE GROUP BY, window fetches by index order and by partition, keyset pagination, a CTE, DISTINCT, and IN / NOT IN / EXISTS / scalar subqueries in WHERE, plus an ORDER BY over the IN subquery path to show the set is sorted before it is limited, DISTINCT over the early termination, IN subquery and hash-set paths, LEAD over the window fetch, SUM / LAST_VALUE over an ORDER BY window whose last peer group the cut fetch would split, two ROW_NUMBER windows ordered by different columns, and a nullable BTREE column checked against the same data in a table without the index, for ROW_NUMBER, COUNT(*) and SUM in ASC, DESC and explicit NULLS FIRST / LAST, plus the limited result against the same slice of the unlimited one. The GROUP BY, window, partition, IN subquery, NOT IN and scalar cases fail on `main`; the EXISTS case fails on `main` with the file-backed test feature. Subquery, limit, group by, window, aggregation and join targets pass (420 tests), plus both full suites.
