### PR TITLE
perf(join): size the first GROUP BY chunk for HAVING and grow it twofold

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3785,7 +3785,7 @@ impl Executor {
             if !short {
                 return Ok((result, columns, flag, deferred));
             }
-            left_cap = Some(pass.cap.saturating_mul(2));
+            left_cap = Some(pass.cap.saturating_mul(2).min(i64::MAX as usize));
         }
     }
 
@@ -9025,11 +9025,11 @@ impl Executor {
         if stmt.having.is_some() {
             cap = cap.saturating_mul(2);
         }
-        Some((cap, limit))
+        // The chunk becomes a LIMIT literal, which is an i64
+        Some((cap.min(i64::MAX as usize), limit))
     }
 
-    /// Check if semi-join reduction optimization can be applied and return parameters
-    /// Returns Some((limit_value, left_key_col, right_key_col)) if applicable, None otherwise
+    /// Check if semi-join reduction optimization can be applied and return its plan
     ///
     /// Conditions for semi-join reduction:
     /// 1. INNER JOIN or LEFT JOIN (not RIGHT or FULL)
@@ -9037,8 +9037,9 @@ impl Executor {
     /// 3. LIMIT is present with no ORDER BY (for correctness)
     /// 4. Single equality join condition (a.col = b.col)
     ///
-    /// For INNER JOIN, we over-fetch left rows (2x limit) since some may not have matches.
-    /// For LEFT JOIN, exact limit is used since all left rows produce output.
+    /// The first left chunk is the limit, doubled for an INNER JOIN since some
+    /// left rows may not have matches and doubled again under HAVING; the join
+    /// reruns with twice the chunk when the result stops short.
     fn get_semijoin_reduction_limit(
         &self,
         join_type: &str,

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -197,7 +197,7 @@ struct SemijoinReduction {
 }
 
 /// The left chunk the last reduction pass used; execute_join_source retries
-/// with a larger one when the final rows stop short of the limit
+/// with twice the chunk when the final rows stop short of the limit
 #[derive(Clone, Copy)]
 struct ReductionPass {
     cap: usize,
@@ -3785,7 +3785,7 @@ impl Executor {
             if !short {
                 return Ok((result, columns, flag, deferred));
             }
-            left_cap = Some(pass.cap.saturating_mul(4));
+            left_cap = Some(pass.cap.saturating_mul(2));
         }
     }
 
@@ -8996,8 +8996,9 @@ impl Executor {
     }
 
     /// LIMIT and OFFSET of a GROUP BY + LIMIT join as (initial left chunk, rows
-    /// expected after OFFSET). An INNER JOIN over-fetches its first chunk since
-    /// a left row without a match forms no group
+    /// expected after OFFSET). The first chunk is doubled for an INNER JOIN,
+    /// where a left row without a match forms no group, and doubled again
+    /// under HAVING, which drops groups after the fact
     fn semijoin_caps(stmt: &SelectStatement, is_inner: bool) -> Option<(usize, usize)> {
         let eval = |e: &Expression| {
             ExpressionEval::compile(e, &[])
@@ -9017,11 +9018,13 @@ impl Executor {
             None => 0,
         };
         let want = limit.saturating_add(offset);
-        let cap = if is_inner {
-            want.saturating_mul(2)
-        } else {
-            want
-        };
+        let mut cap = want;
+        if is_inner {
+            cap = cap.saturating_mul(2);
+        }
+        if stmt.having.is_some() {
+            cap = cap.saturating_mul(2);
+        }
         Some((cap, limit))
     }
 

--- a/tests/join_limit_shortfall_test.rs
+++ b/tests/join_limit_shortfall_test.rs
@@ -141,3 +141,18 @@ fn test_group_by_limit_reduction_stays_off_under_distinct() {
         5
     );
 }
+
+/// The reduction doubles its left chunk and turns it into a LIMIT literal;
+/// a huge LIMIT must not overflow into a negative one.
+#[test]
+fn test_group_by_limit_reduction_survives_a_huge_limit() {
+    let db = setup("join_limit_huge", true);
+    assert_eq!(
+        count(&db, "SELECT u.name, COUNT(o.id) FROM users u LEFT JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name HAVING COUNT(o.id) >= 0 LIMIT 5000000000000000000"),
+        100
+    );
+    assert_eq!(
+        count(&db, "SELECT u.name, COUNT(o.id) FROM users u INNER JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name HAVING COUNT(o.id) >= 1 LIMIT 5000000000000000000"),
+        50
+    );
+}


### PR DESCRIPTION
## Why

Measuring the benchmark on `main` against the BENCHMARKS.md baseline (435bf023) showed one real regression: `Complex JOIN+GROUP+HAVING` at 213 to 240 us against 52 us. Since #83 the GROUP BY reduction reruns the join with a larger left chunk when the final rows stop short of the limit. On the benchmark's data the first chunk of 100 active users yields 44 groups after `HAVING COUNT(o.id) > 1`, so every execution reran with 400 rows. The baseline's 52 us measured an incomplete answer: 44 rows for `LIMIT 50`.

## What

- `semijoin_caps` doubles the first left chunk under HAVING, on top of the doubling an INNER JOIN already had, so the benchmark query is answered by one 200-row pass.
- A rerun doubles the chunk instead of quadrupling it, so a rerun that still happens costs at most twice the pass before it.

## Measurements

Random data shaped like the benchmark (10k users, 50k orders, random user ids and statuses), best of 5 interleaved runs against a 435bf023 binary built from the same probe source:

| Query | baseline | this PR |
|---|---|---|
| INNER JOIN + GROUP BY + HAVING, LIMIT 50 | 49 us (44 rows) | 90 us (50 rows) |
| LEFT JOIN + GROUP BY, LIMIT 100 | 52 us | 53 us |
| INNER JOIN, LIMIT 100 | 19 us | 11 us |
| Self JOIN, LIMIT 100 | 12 us | 6 us |

One full benchmark run on this branch puts the row at 91 us; `main` sits at 213 to 240 us over six runs. The remaining gap to the baseline is the price of the complete answer: about 115 left rows are needed for 50 groups here, and the pass cost grows with the chunk.

## Tests

`tests/join_limit_shortfall_test.rs` still covers the rerun and gains a huge-LIMIT case: the doubled chunk is capped at `i64::MAX` before it becomes the synthetic LIMIT literal, so `LIMIT 5000000000000000000` with HAVING no longer overflows into a negative literal. Join, limit and group by targets pass, plus both full suites.
