### PR TITLE
fix(window): keep same-named windows apart and honour NULLS FIRST and LAST

### DIFF
--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -246,6 +246,9 @@ pub struct ColumnarOrderByValues {
     columns: Vec<Vec<Value>>,
     /// Ascending flags: one per ORDER BY column
     ascending: Vec<bool>,
+    /// Where NULLs sort, one per ORDER BY column: NULLS FIRST / LAST when
+    /// given, otherwise last ascending and first descending
+    nulls_first: Vec<bool>,
     /// Number of rows
     num_rows: usize,
 }
@@ -279,6 +282,15 @@ impl ColumnarOrderByValues {
     #[inline]
     pub fn is_ascending(&self, col_idx: usize) -> bool {
         self.ascending.get(col_idx).copied().unwrap_or(true)
+    }
+
+    /// Whether NULLs sort before non-NULL values in this column
+    #[inline]
+    pub fn nulls_first(&self, col_idx: usize) -> bool {
+        self.nulls_first
+            .get(col_idx)
+            .copied()
+            .unwrap_or_else(|| !self.is_ascending(col_idx))
     }
 
     /// Compare ORDER BY values of two rows for equality (without cloning)
@@ -1198,15 +1210,15 @@ impl Executor {
             match col_expr {
                 Expression::Window(window_expr) => {
                     // Window function - use pre-computed values
-                    let wf_name = if wf_idx < window_functions.len() {
-                        window_functions[wf_idx].column_name.clone()
+                    let output_name = format!("{}()", window_expr.function.function);
+                    let key = if wf_idx < window_functions.len() {
+                        window_functions[wf_idx].column_name.to_lowercase()
                     } else {
-                        format!("{}()", window_expr.function.function)
+                        output_name.to_lowercase()
                     };
                     items.push(SelectItem {
-                        output_name: wf_name.clone(),
-                        // OPTIMIZATION: Store lowercase for O(1) lookup in window_value_map
-                        source: SelectItemSource::WindowFunction(wf_name.to_lowercase()),
+                        output_name,
+                        source: SelectItemSource::WindowFunction(key),
                     });
                     wf_idx += 1;
                 }
@@ -1449,8 +1461,12 @@ impl Executor {
         for col_expr in &stmt.columns {
             match col_expr {
                 Expression::Window(window_expr) => {
-                    let wf_info =
+                    let mut wf_info =
                         self.extract_window_function_info(window_expr, &stmt.window_defs)?;
+                    // Two unaliased windows of the same function would share a
+                    // name; the internal one is unique, the output keeps the
+                    // function's own
+                    wf_info.column_name = format!("__wf_{}_0", col_idx);
                     window_functions.push(wf_info);
                     col_idx += 1;
                 }
@@ -2186,6 +2202,7 @@ impl Executor {
         let empty_order_by = ColumnarOrderByValues {
             columns: vec![],
             ascending: vec![],
+            nulls_first: vec![],
             num_rows: 0,
         };
         let order_by_values = precomputed_order_by.unwrap_or(&empty_order_by);
@@ -2398,6 +2415,7 @@ impl Executor {
         let empty_order_by = ColumnarOrderByValues {
             columns: vec![],
             ascending: vec![],
+            nulls_first: vec![],
             num_rows: 0,
         };
         let order_by_values = precomputed_order_by.unwrap_or(&empty_order_by);
@@ -2603,6 +2621,7 @@ impl Executor {
         let empty_order_by = ColumnarOrderByValues {
             columns: vec![],
             ascending: vec![],
+            nulls_first: vec![],
             num_rows: 0,
         };
         let order_by_values = precomputed_order_by.unwrap_or(&empty_order_by);
@@ -3226,12 +3245,17 @@ impl Executor {
             return ColumnarOrderByValues {
                 columns: vec![],
                 ascending: vec![],
+                nulls_first: vec![],
                 num_rows: 0,
             };
         }
 
         // Extract ascending flags once (not per row!)
         let ascending_flags: Vec<bool> = order_by.iter().map(|ob| ob.ascending).collect();
+        let nulls_first_flags: Vec<bool> = order_by
+            .iter()
+            .map(|ob| ob.nulls_first.unwrap_or(!ob.ascending))
+            .collect();
 
         // Check if any ORDER BY expression is complex (not a simple column reference)
         let has_complex_expr = order_by.iter().any(|ob| {
@@ -3331,6 +3355,7 @@ impl Executor {
         ColumnarOrderByValues {
             columns: result_columns,
             ascending: ascending_flags,
+            nulls_first: nulls_first_flags,
             num_rows,
         }
     }
@@ -3377,6 +3402,7 @@ impl Executor {
         if is_single_order_by {
             // Fast path: single ORDER BY column with type-specific comparison
             let ascending = order_by_values.is_ascending(0);
+            let nulls_first = order_by_values.nulls_first(0);
 
             // Get direct reference to the column for cache-efficient access
             let col = &order_by_values.columns[0];
@@ -3426,19 +3452,29 @@ impl Executor {
 
             match detected {
                 DetectedType::Integer
-                    if Self::sort_by_integer_key_columnar(row_indices, col, ascending) =>
+                    if Self::sort_by_integer_key_columnar(
+                        row_indices,
+                        col,
+                        ascending,
+                        nulls_first,
+                    ) =>
                 {
                     return;
                 }
                 DetectedType::Float
-                    if Self::sort_by_float_key_columnar(row_indices, col, ascending) =>
+                    if Self::sort_by_float_key_columnar(
+                        row_indices,
+                        col,
+                        ascending,
+                        nulls_first,
+                    ) =>
                 {
                     return;
                 }
                 _ => {}
             }
             // Mixed types, unknown, or drift past the sample - generic sort
-            Self::sort_single_column_columnar(row_indices, col, ascending);
+            Self::sort_single_column_columnar(row_indices, col, ascending, nulls_first);
             return;
         }
 
@@ -3469,20 +3505,22 @@ impl Executor {
         b: usize,
     ) -> Ordering {
         for col_idx in 0..order_by_values.num_columns() {
-            let a_val = order_by_values.get(a, col_idx);
-            let b_val = order_by_values.get(b, col_idx);
-
+            let a_val = order_by_values.get(a, col_idx).filter(|v| !v.is_null());
+            let b_val = order_by_values.get(b, col_idx).filter(|v| !v.is_null());
             let cmp = match (a_val, b_val) {
-                (Some(av), Some(bv)) => Self::compare_values_fast(av, bv),
+                (Some(av), Some(bv)) => {
+                    let cmp = Self::compare_values_fast(av, bv);
+                    if order_by_values.is_ascending(col_idx) {
+                        cmp
+                    } else {
+                        cmp.reverse()
+                    }
+                }
                 (None, None) => Ordering::Equal,
+                (None, _) if order_by_values.nulls_first(col_idx) => Ordering::Less,
                 (None, _) => Ordering::Greater,
+                (_, None) if order_by_values.nulls_first(col_idx) => Ordering::Greater,
                 (_, None) => Ordering::Less,
-            };
-
-            let cmp = if !order_by_values.is_ascending(col_idx) {
-                cmp.reverse()
-            } else {
-                cmp
             };
 
             if cmp != Ordering::Equal {
@@ -3540,6 +3578,7 @@ impl Executor {
         row_indices: &mut [usize],
         col: &[Value],
         ascending: bool,
+        nulls_first: bool,
     ) -> bool {
         const PARALLEL_THRESHOLD: usize = 50_000;
 
@@ -3589,11 +3628,11 @@ impl Executor {
             keyed.sort_unstable_by_key(|&(_, key)| std::cmp::Reverse(key));
         }
 
-        // Write back: NULLs strictly last ascending, first descending.
+        // Write back: NULLs strictly first or last, as the ORDER BY places them.
         // For floats this also fixes the old sentinel's misplacement of
         // NULLs before +inf and NaN
         let mut pos = 0;
-        if !ascending {
+        if nulls_first {
             for &idx in &null_indices {
                 row_indices[pos] = idx;
                 pos += 1;
@@ -3603,7 +3642,7 @@ impl Executor {
             row_indices[pos] = idx;
             pos += 1;
         }
-        if ascending {
+        if !nulls_first {
             for &idx in &null_indices {
                 row_indices[pos] = idx;
                 pos += 1;
@@ -3619,6 +3658,7 @@ impl Executor {
         row_indices: &mut [usize],
         col: &[Value],
         ascending: bool,
+        nulls_first: bool,
     ) -> bool {
         const PARALLEL_THRESHOLD: usize = 50_000;
 
@@ -3680,11 +3720,11 @@ impl Executor {
             keyed.sort_unstable_by_key(|&(_, key)| std::cmp::Reverse(key));
         }
 
-        // Write back: NULLs strictly last ascending, first descending.
+        // Write back: NULLs strictly first or last, as the ORDER BY places them.
         // For floats this also fixes the old sentinel's misplacement of
         // NULLs before +inf and NaN
         let mut pos = 0;
-        if !ascending {
+        if nulls_first {
             for &idx in &null_indices {
                 row_indices[pos] = idx;
                 pos += 1;
@@ -3694,7 +3734,7 @@ impl Executor {
             row_indices[pos] = idx;
             pos += 1;
         }
-        if ascending {
+        if !nulls_first {
             for &idx in &null_indices {
                 row_indices[pos] = idx;
                 pos += 1;
@@ -3704,23 +3744,30 @@ impl Executor {
     }
 
     /// Single column generic sort (columnar layout)
-    fn sort_single_column_columnar(row_indices: &mut [usize], col: &[Value], ascending: bool) {
+    fn sort_single_column_columnar(
+        row_indices: &mut [usize],
+        col: &[Value],
+        ascending: bool,
+        nulls_first: bool,
+    ) {
         const PARALLEL_THRESHOLD: usize = 10_000;
-
         let compare = |&a: &usize, &b: &usize| -> Ordering {
-            let a_val = col.get(a);
-            let b_val = col.get(b);
-
-            let cmp = match (a_val, b_val) {
-                (Some(a), Some(b)) => Self::compare_values_fast(a, b),
+            let a_val = col.get(a).filter(|v| !v.is_null());
+            let b_val = col.get(b).filter(|v| !v.is_null());
+            match (a_val, b_val) {
+                (Some(a), Some(b)) => {
+                    let cmp = Self::compare_values_fast(a, b);
+                    if ascending {
+                        cmp
+                    } else {
+                        cmp.reverse()
+                    }
+                }
                 (None, None) => Ordering::Equal,
+                (None, _) if nulls_first => Ordering::Less,
                 (None, _) => Ordering::Greater,
+                (_, None) if nulls_first => Ordering::Greater,
                 (_, None) => Ordering::Less,
-            };
-            if ascending {
-                cmp
-            } else {
-                cmp.reverse()
             }
         };
 
@@ -3781,6 +3828,7 @@ impl Executor {
         let empty_order_by = ColumnarOrderByValues {
             columns: vec![],
             ascending: vec![],
+            nulls_first: vec![],
             num_rows: 0,
         };
         let order_by_values: &ColumnarOrderByValues = cached_order_by.unwrap_or(&empty_order_by);

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -1225,11 +1225,14 @@ impl Executor {
                 Expression::Aliased(aliased) => {
                     if let Expression::Window(_) = aliased.expression.as_ref() {
                         // Aliased window function
-                        let alias = aliased.alias.value.to_string();
+                        let key = if wf_idx < window_functions.len() {
+                            window_functions[wf_idx].column_name.to_lowercase()
+                        } else {
+                            aliased.alias.value.to_string().to_lowercase()
+                        };
                         items.push(SelectItem {
-                            output_name: alias.clone(),
-                            // OPTIMIZATION: Store lowercase for O(1) lookup in window_value_map
-                            source: SelectItemSource::WindowFunction(alias.to_lowercase()),
+                            output_name: aliased.alias.value.to_string(),
+                            source: SelectItemSource::WindowFunction(key),
                         });
                         wf_idx += 1;
                     } else if let Expression::Identifier(id) = aliased.expression.as_ref() {
@@ -1474,7 +1477,9 @@ impl Executor {
                     if let Expression::Window(window_expr) = aliased.expression.as_ref() {
                         let mut wf_info =
                             self.extract_window_function_info(window_expr, &stmt.window_defs)?;
-                        wf_info.column_name = aliased.alias.value.to_string();
+                        // The alias is only the output name; the internal name
+                        // cannot collide with an alias or another window
+                        wf_info.column_name = format!("__wf_{}_0", col_idx);
                         window_functions.push(wf_info);
                     } else {
                         // Collect ALL window functions in the expression

--- a/tests/window_columns_nulls_test.rs
+++ b/tests/window_columns_nulls_test.rs
@@ -64,6 +64,25 @@ fn test_two_windows_with_the_same_function_keep_their_own_columns() {
     assert_eq!(got[99], vec![Some(100), Some(100), Some(1), Some(100)]);
 }
 
+/// An alias is only an output name: it must not collide with the internal
+/// key of another window, and two windows may even share an alias.
+#[test]
+fn test_window_aliases_never_collide_with_internal_keys() {
+    let db = setup("window_alias_keys");
+    let got = rows(
+        &db,
+        "SELECT id, ROW_NUMBER() OVER (ORDER BY id), ROW_NUMBER() OVER (ORDER BY amount DESC) AS __wf_1_0 FROM t ORDER BY id",
+    );
+    assert_eq!(got[0], vec![Some(1), Some(1), Some(100)]);
+    assert_eq!(got[99], vec![Some(100), Some(100), Some(1)]);
+    let got = rows(
+        &db,
+        "SELECT id, ROW_NUMBER() OVER (ORDER BY id) AS rn, ROW_NUMBER() OVER (ORDER BY amount DESC) AS rn FROM t ORDER BY id",
+    );
+    assert_eq!(got[0], vec![Some(1), Some(1), Some(100)]);
+    assert_eq!(got[99], vec![Some(100), Some(100), Some(1)]);
+}
+
 #[test]
 fn test_window_order_by_honours_nulls_first_and_last() {
     let db = setup("window_nulls_placement");

--- a/tests/window_columns_nulls_test.rs
+++ b/tests/window_columns_nulls_test.rs
@@ -1,0 +1,93 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Two window functions with the same name keep their own values, and a
+//! window's ORDER BY honours NULLS FIRST and NULLS LAST.
+
+use stoolap::Database;
+
+/// 100 rows: k is NULL for ids 1..=20 and 200 - id otherwise, amount is the id.
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, k INTEGER, amount FLOAT)",
+        (),
+    )
+    .unwrap();
+    for i in 1..=100i64 {
+        let k: Option<i64> = if i <= 20 { None } else { Some(200 - i) };
+        db.execute("INSERT INTO t VALUES ($1, $2, $3)", (i, k, i as f64))
+            .unwrap();
+    }
+    db
+}
+
+fn rows(db: &Database, sql: &str) -> Vec<Vec<Option<i64>>> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (0..row.len())
+                .map(|i| row.get::<Option<i64>>(i).unwrap())
+                .collect()
+        })
+        .collect()
+}
+
+#[test]
+fn test_two_windows_with_the_same_function_keep_their_own_columns() {
+    let db = setup("window_same_name_columns");
+    let got = rows(
+        &db,
+        "SELECT id, ROW_NUMBER() OVER (ORDER BY id), ROW_NUMBER() OVER (ORDER BY amount DESC) FROM t ORDER BY id",
+    );
+    assert_eq!(got.len(), 100);
+    assert_eq!(got[0], vec![Some(1), Some(1), Some(100)]);
+    assert_eq!(got[45], vec![Some(46), Some(46), Some(55)]);
+    assert_eq!(got[99], vec![Some(100), Some(100), Some(1)]);
+    let got = rows(
+        &db,
+        "SELECT id, COUNT(*) OVER (ORDER BY id), COUNT(*) OVER (ORDER BY amount DESC), COUNT(*) OVER () FROM t ORDER BY id",
+    );
+    assert_eq!(got[0], vec![Some(1), Some(1), Some(100), Some(100)]);
+    assert_eq!(got[99], vec![Some(100), Some(100), Some(1), Some(100)]);
+}
+
+#[test]
+fn test_window_order_by_honours_nulls_first_and_last() {
+    let db = setup("window_nulls_placement");
+    // default: NULLs last ascending, first descending; explicit forms flip that
+    for (order, null_row_rank, first_non_null_rank) in [
+        ("ASC", 81, 1),
+        ("DESC", 1, 21),
+        ("ASC NULLS LAST", 81, 1),
+        ("ASC NULLS FIRST", 1, 21),
+        ("DESC NULLS FIRST", 1, 21),
+        ("DESC NULLS LAST", 81, 1),
+    ] {
+        let got = rows(
+            &db,
+            &format!("SELECT id, ROW_NUMBER() OVER (ORDER BY k {order}) FROM t ORDER BY id"),
+        );
+        let rank_of = |id: i64| got[(id - 1) as usize][1].unwrap();
+        assert!(
+            (1..=20).all(|id| rank_of(id) >= null_row_rank && rank_of(id) < null_row_rank + 20),
+            "ORDER BY k {order}: NULL rows ranked {:?}",
+            (1..=20).map(rank_of).collect::<Vec<_>>()
+        );
+        // id 100 has the smallest non-null k, id 21 the largest
+        let smallest = if order.starts_with("ASC") { 100 } else { 21 };
+        assert_eq!(rank_of(smallest), first_non_null_rank, "ORDER BY k {order}");
+    }
+}


### PR DESCRIPTION
## Why

Two wrong results found while reviewing #86, both on `main`:

- `SELECT id, ROW_NUMBER() OVER (ORDER BY id), ROW_NUMBER() OVER (ORDER BY amount DESC) FROM t` returned `[id, <rank by amount>, NULL]`: both windows were filed under the name `ROW_NUMBER()`, so the second overwrote the first and the third column found nothing. Aliases avoided it.
- `ROW_NUMBER() OVER (ORDER BY k ASC NULLS FIRST)` ranked the NULL rows last: the window sorter placed NULLs by direction alone and only the cache key ever looked at `NULLS FIRST` / `LAST`.

## What

- `parse_window_functions` gives every top-level window, plain or aliased, a unique internal name from its position (`__wf_<column>_0`, the scheme nested windows already use); the select item keeps `FUNCTION()` or the alias as the output name and uses the internal name as the value key. No alias is ever a key, so an alias cannot collide with another window's name and two windows may share an alias.
- `ColumnarOrderByValues` carries a NULL placement per ORDER BY column: the explicit `NULLS FIRST` / `LAST` when given, otherwise last ascending and first descending, which is what the sorter did before. The typed integer and float fast paths write the NULL rows first or last by that flag, and the single-column and multi-column comparators order a NULL against a value by it instead of reversing a fixed "NULLs greatest" rule.

Without an explicit NULLS clause nothing changes.

## Tests

`tests/window_columns_nulls_test.rs`: two and three same-named windows keep their own columns (`ROW_NUMBER`, `COUNT(*)` with and without ORDER BY); an alias spelling another window's internal name and two windows with the same alias keep theirs; NULL rows and the first non-NULL row are ranked as expected for `ASC`, `DESC`, `ASC NULLS LAST`, `ASC NULLS FIRST`, `DESC NULLS FIRST`, `DESC NULLS LAST`. Both fail on `main`. Window, order, aggregation and group by targets pass in both database modes, plus both full suites.
