### PR TITLE
perf(join): continue a short LIMIT join from where its outer chunk ended

### DIFF
--- a/src/executor/context.rs
+++ b/src/executor/context.rs
@@ -677,6 +677,32 @@ pub fn cache_exists_correlation(
 ///
 /// Note: This struct uses Arc for immutable shared data to make cloning cheap
 /// during correlated subquery processing where context is cloned per row.
+/// A transaction shared by every read of one statement
+#[derive(Clone)]
+pub struct StatementSnapshot(Arc<Mutex<Box<dyn crate::storage::traits::Transaction>>>);
+
+impl StatementSnapshot {
+    pub fn new(transaction: Box<dyn crate::storage::traits::Transaction>) -> Self {
+        Self(Arc::new(Mutex::new(transaction)))
+    }
+
+    pub fn get_table(
+        &self,
+        name: &str,
+    ) -> crate::core::Result<Box<dyn crate::storage::traits::Table>> {
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get_table(name)
+    }
+}
+
+impl std::fmt::Debug for StatementSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("StatementSnapshot")
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ExecutionContext {
     /// Query parameters ($1, $2, etc.) - wrapped in Arc for cheap cloning
@@ -710,6 +736,9 @@ pub struct ExecutionContext {
     cte_data: Option<Arc<CteDataMap>>,
     /// Current transaction ID for CURRENT_TRANSACTION_ID() function
     transaction_id: Option<u64>,
+    /// One transaction for every fetch of a statement that has no explicit
+    /// transaction, so its reads share a snapshot
+    statement_snapshot: Option<StatementSnapshot>,
 }
 
 /// Type alias for CTE data: (columns, rows) with Arc for zero-copy sharing
@@ -745,6 +774,7 @@ impl ExecutionContext {
             outer_columns: None,
             cte_data: None,
             transaction_id: None,
+            statement_snapshot: None,
         }
     }
 
@@ -905,6 +935,7 @@ impl ExecutionContext {
             outer_columns: self.outer_columns.clone(),
             cte_data: self.cte_data.clone(),
             transaction_id: self.transaction_id,
+            statement_snapshot: self.statement_snapshot.clone(),
         }
     }
 
@@ -925,6 +956,7 @@ impl ExecutionContext {
             outer_columns: self.outer_columns.clone(),
             cte_data: self.cte_data.clone(),
             transaction_id: self.transaction_id,
+            statement_snapshot: self.statement_snapshot.clone(),
         }
     }
 
@@ -960,6 +992,7 @@ impl ExecutionContext {
             outer_columns: Some(outer_columns), // Arc clone = cheap
             cte_data: self.cte_data.clone(),    // Arc clone = cheap
             transaction_id: self.transaction_id,
+            statement_snapshot: self.statement_snapshot.clone(),
         }
     }
 
@@ -1012,6 +1045,7 @@ impl ExecutionContext {
             outer_columns: self.outer_columns.clone(),
             cte_data: Some(cte_data),
             transaction_id: self.transaction_id,
+            statement_snapshot: self.statement_snapshot.clone(),
         }
     }
 
@@ -1026,6 +1060,18 @@ impl ExecutionContext {
     }
 
     /// Create a new context with a transaction ID
+    /// The statement-scoped snapshot, if the statement carries one
+    pub fn statement_snapshot(&self) -> Option<&StatementSnapshot> {
+        self.statement_snapshot.as_ref()
+    }
+
+    /// A copy of this context whose reads go through `snapshot`
+    pub fn with_statement_snapshot(&self, snapshot: StatementSnapshot) -> Self {
+        let mut ctx = self.clone();
+        ctx.statement_snapshot = Some(snapshot);
+        ctx
+    }
+
     pub fn with_transaction_id(&self, txn_id: u64) -> Self {
         Self {
             params: self.params.clone(),
@@ -1041,6 +1087,7 @@ impl ExecutionContext {
             outer_columns: self.outer_columns.clone(),
             cte_data: self.cte_data.clone(),
             transaction_id: Some(txn_id),
+            statement_snapshot: self.statement_snapshot.clone(),
         }
     }
 

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -4226,10 +4226,18 @@ impl Executor {
                 };
                 let ctx_join = ctx.with_statement_snapshot(snapshot.clone());
                 let ctx = &ctx_join;
-                let mut outer_limit = join_limit.map(|l| {
-                    let l = l as usize;
-                    l.saturating_add(l / 8).max(100)
-                });
+                // An explicit transaction reads through its own transaction, whose
+                // isolation may let a commit move rows between two fetches, so
+                // the outer side is fetched whole there
+                let in_explicit_transaction = self.active_transaction.lock().unwrap().is_some();
+                let mut outer_limit = if in_explicit_transaction {
+                    None
+                } else {
+                    join_limit.map(|l| {
+                        let l = l as usize;
+                        l.saturating_add(l / 8).max(100)
+                    })
+                };
 
                 // Execute outer side with limit optimization for true early termination
                 let (outer_result, outer_cols, outer_bounded) = self
@@ -6367,10 +6375,16 @@ impl Executor {
             };
             // Get classification for the synthetic SELECT statement
             let classification = get_classification(&select_all);
-            // The scan says whether it applied the synthetic LIMIT and OFFSET;
-            // a path that did not (AS OF among them) hands back every row
+            // The scan says whether it applied the synthetic LIMIT and OFFSET. A
+            // path that did not may still have stopped early at their sum, so
+            // the pair is applied here, as the select layer would
             let (result, columns, applied, _) =
                 self.execute_simple_table_scan(ts, &select_all, ctx, &classification)?;
+            let result: Box<dyn QueryResult> = if applied {
+                result
+            } else {
+                Box::new(LimitedResult::new(result, Some(limit), row_offset))
+            };
 
             // Prefix column names with table alias (or table name if no alias)
             // Use custom_alias from Aliased expression if provided
@@ -6386,7 +6400,7 @@ impl Executor {
                 .map(|col| format!("{}.{}", table_alias, col))
                 .collect();
 
-            return Ok((result, qualified_columns, applied));
+            return Ok((result, qualified_columns, true));
         }
 
         // Fall back to standard execution for other cases

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -1168,11 +1168,17 @@ impl Executor {
         ctx: &ExecutionContext,
         filter: Option<&Expression>,
         limit: Option<usize>,
-    ) -> Result<(Box<dyn QueryResult>, Vec<String>)> {
+        offset: usize,
+    ) -> Result<(Box<dyn QueryResult>, Vec<String>, bool)> {
         // Only push limit to TVF generation when no filter will discard rows afterwards.
         // With a filter, we must generate all rows first, then filter, then let
-        // downstream processing handle the limit.
-        let tvf_limit = if filter.is_some() { None } else { limit };
+        // downstream processing handle the limit. The flag says whether the
+        // limit and offset were applied here.
+        let tvf_limit = if filter.is_some() {
+            None
+        } else {
+            limit.map(|l| l.saturating_add(offset))
+        };
 
         // Extract range bounds from the filter to narrow TVF generation range.
         // This avoids materializing millions of rows when a selective predicate exists.
@@ -1210,9 +1216,15 @@ impl Executor {
             let row_filter = RowFilter::new(filter_expr, &qualified_columns)?.with_context(ctx);
             row_filter.retain_checked(&mut result_rows)?;
         }
+        let bounded = tvf_limit.is_some();
+        if bounded && offset > 0 {
+            let mut rows = result_rows.into_vec();
+            rows.drain(..offset.min(rows.len()));
+            result_rows = RowVec::from_vec(rows);
+        }
 
         let result: Box<dyn QueryResult> = Box::new(ExecutorResult::new(column_names, result_rows));
-        Ok((result, qualified_columns))
+        Ok((result, qualified_columns, bounded))
     }
 
     /// LIMIT + OFFSET when both are integer literals (OFFSET may be absent),
@@ -4210,7 +4222,7 @@ impl Executor {
                 // One snapshot serves every outer fetch and the inner probes
                 let snapshot = match ctx.statement_snapshot() {
                     Some(snapshot) => snapshot.clone(),
-                    None => StatementSnapshot::new(self.engine.begin_transaction()?),
+                    None => self.new_statement_snapshot()?,
                 };
                 let ctx_join = ctx.with_statement_snapshot(snapshot.clone());
                 let ctx = &ctx_join;
@@ -6245,7 +6257,8 @@ impl Executor {
                 Ok((result, columns.to_vec()))
             }
             Expression::FunctionTableSource(tvf_source) => {
-                Self::execute_tvf_for_join(tvf_source, ctx, filter, None)
+                Self::execute_tvf_for_join(tvf_source, ctx, filter, None, 0)
+                    .map(|(result, columns, _)| (result, columns))
             }
             _ => Err(Error::NotSupported(
                 "Unsupported table expression type".to_string(),
@@ -6278,8 +6291,7 @@ impl Executor {
             _ => None,
         };
         if let Some(tvf_source) = tvf_source {
-            return Self::execute_tvf_for_join(tvf_source, ctx, filter, row_limit)
-                .map(|(result, columns)| (result, columns, false));
+            return Self::execute_tvf_for_join(tvf_source, ctx, filter, row_limit, row_offset);
         }
 
         // Extract TableSource from the expression (handles both direct and aliased)
@@ -6355,7 +6367,9 @@ impl Executor {
             };
             // Get classification for the synthetic SELECT statement
             let classification = get_classification(&select_all);
-            let (result, columns, _, _) =
+            // The scan says whether it applied the synthetic LIMIT and OFFSET;
+            // a path that did not (AS OF among them) hands back every row
+            let (result, columns, applied, _) =
                 self.execute_simple_table_scan(ts, &select_all, ctx, &classification)?;
 
             // Prefix column names with table alias (or table name if no alias)
@@ -6372,7 +6386,7 @@ impl Executor {
                 .map(|col| format!("{}.{}", table_alias, col))
                 .collect();
 
-            return Ok((result, qualified_columns, true));
+            return Ok((result, qualified_columns, applied));
         }
 
         // Fall back to standard execution for other cases
@@ -6398,6 +6412,14 @@ impl Executor {
             return Err(err);
         }
         Ok(rows)
+    }
+
+    /// One transaction for every read of a statement, under snapshot isolation
+    /// so a later commit cannot move rows between two of its fetches
+    fn new_statement_snapshot(&self) -> Result<StatementSnapshot> {
+        let mut transaction = self.engine.begin_transaction()?;
+        transaction.set_isolation_level(crate::core::IsolationLevel::SnapshotIsolation)?;
+        Ok(StatementSnapshot::new(transaction))
     }
 
     /// Runs a join operator to completion or to `limit` rows. The cross-table

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -4277,7 +4277,7 @@ impl Executor {
 
                 if let Some(outer_idx) = outer_key_idx {
                     // Get inner table for schema and row fetching
-                    let inner_table = snapshot.get_table(&table_name)?;
+                    let inner_table = self.join_table(&snapshot, &table_name)?;
                     let inner_schema = inner_table.schema();
 
                     // Build inner columns list (qualified)
@@ -4364,7 +4364,7 @@ impl Executor {
                                 outer_op,
                                 match inner_table.take() {
                                     Some(table) => table,
-                                    None => snapshot.get_table(&table_name)?,
+                                    None => self.join_table(&snapshot, &table_name)?,
                                 },
                                 inner_cols.iter().map(ColumnInfo::new).collect(),
                                 op_join_type,
@@ -6426,6 +6426,20 @@ impl Executor {
             return Err(err);
         }
         Ok(rows)
+    }
+
+    /// The inner table of a join: from the explicit transaction when one is
+    /// active, so the join sees what the transaction changed, otherwise from
+    /// the statement snapshot the outer side reads through
+    fn join_table(
+        &self,
+        snapshot: &StatementSnapshot,
+        name: &str,
+    ) -> Result<Box<dyn crate::storage::traits::Table>> {
+        if let Some(active) = self.active_transaction.lock().unwrap().as_ref() {
+            return active.transaction.get_table(name);
+        }
+        snapshot.get_table(name)
     }
 
     /// One transaction for every read of a statement, under snapshot isolation

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -67,7 +67,7 @@ use super::context::{
     clear_batch_aggregate_cache, clear_batch_aggregate_info_cache, clear_count_counter_cache,
     clear_exists_correlation_cache, clear_exists_fetcher_cache, clear_exists_index_cache,
     clear_exists_pred_key_cache, clear_exists_predicate_cache, clear_exists_schema_cache,
-    ExecutionContext, TimeoutGuard,
+    ExecutionContext, StatementSnapshot, TimeoutGuard,
 };
 use super::expression::{
     compile_expression, CompiledEvaluator, ExecuteContext, ExprVM, ExpressionEval, JoinFilter,
@@ -2042,29 +2042,53 @@ impl Executor {
             (table, None)
         } else {
             drop(active_tx); // Release lock before creating new transaction
-                             // No active transaction - create a standalone transaction
-            let tx = self.engine.begin_transaction()?;
-
-            // Check for AS OF (temporal query)
-            if let Some(ref as_of) = table_source.as_of {
-                return self.execute_temporal_query(
-                    table_name,
-                    as_of,
-                    stmt,
-                    ctx,
-                    &*tx,
-                    classification,
-                );
-            }
-
-            let table = tx.get_table(table_name).map_err(|e| {
-                if matches!(e, Error::TableNotFound(_)) {
-                    Error::TableOrViewNotFound(table_name.to_string())
-                } else {
-                    e
+                             // No active transaction: a statement-scoped snapshot, when the
+                             // statement carries one, keeps every fetch on one transaction;
+                             // otherwise a standalone transaction
+            if let Some(snapshot) = ctx.statement_snapshot() {
+                if let Some(ref as_of) = table_source.as_of {
+                    let tx = self.engine.begin_transaction()?;
+                    return self.execute_temporal_query(
+                        table_name,
+                        as_of,
+                        stmt,
+                        ctx,
+                        &*tx,
+                        classification,
+                    );
                 }
-            })?;
-            (table, Some(tx))
+                let table = snapshot.get_table(table_name).map_err(|e| {
+                    if matches!(e, Error::TableNotFound(_)) {
+                        Error::TableOrViewNotFound(table_name.to_string())
+                    } else {
+                        e
+                    }
+                })?;
+                (table, None)
+            } else {
+                let tx = self.engine.begin_transaction()?;
+
+                // Check for AS OF (temporal query)
+                if let Some(ref as_of) = table_source.as_of {
+                    return self.execute_temporal_query(
+                        table_name,
+                        as_of,
+                        stmt,
+                        ctx,
+                        &*tx,
+                        classification,
+                    );
+                }
+
+                let table = tx.get_table(table_name).map_err(|e| {
+                    if matches!(e, Error::TableNotFound(_)) {
+                        Error::TableOrViewNotFound(table_name.to_string())
+                    } else {
+                        e
+                    }
+                })?;
+                (table, Some(tx))
+            }
         };
 
         // Build column list from schema: refcount bump, not a per-statement
@@ -3936,13 +3960,14 @@ impl Executor {
                 right_key_col,
             } = plan;
             let left_cap = left_cap_override.unwrap_or(cap);
-            let (left_result, left_cols) = self.execute_table_expression_with_filter_limit(
-                &join_source.left,
-                ctx,
-                left_filter.as_ref(),
-                Some(left_cap),
-                0,
-            )?;
+            let (left_result, left_cols, left_bounded) = self
+                .execute_table_expression_with_filter_limit(
+                    &join_source.left,
+                    ctx,
+                    left_filter.as_ref(),
+                    Some(left_cap),
+                    0,
+                )?;
             let left_rows = Self::materialize_result_arc(left_result)?;
             let left_key_idx = Self::find_column_index_by_name(&left_key_col, &left_cols);
             let join_key_values: Vec<Value> = if let Some(idx) = left_key_idx {
@@ -3979,7 +4004,7 @@ impl Executor {
             let right_rows = Self::materialize_result_arc(right_result)?;
             reduction.set(Some(ReductionPass {
                 cap: left_cap,
-                chunk_full: left_rows.len() == left_cap,
+                chunk_full: left_bounded && left_rows.len() == left_cap,
                 limit,
             }));
             (left_rows, left_cols, right_rows, right_cols)
@@ -4178,36 +4203,34 @@ impl Executor {
                 };
 
                 // The outer side is fetched in chunks: the first one is the limit
-                // itself and the join below fetches more when it stops short. Only
-                // a table can be fetched again from an offset; any other source is
-                // fetched whole
-                let outer_source: &Expression = outer_expr;
-                let outer_is_table = match outer_source {
-                    Expression::TableSource(_) => true,
-                    Expression::Aliased(a) => {
-                        matches!(a.expression.as_ref(), Expression::TableSource(_))
-                    }
-                    _ => false,
+                // plus an eighth of slack, so the odd outer row without a match
+                // needs no second fetch, and the join below fetches more when it
+                // stops short. Only a plain table takes the limit and can be
+                // fetched again from an offset; the fetch says whether it did.
+                // One snapshot serves every outer fetch and the inner probes
+                let snapshot = match ctx.statement_snapshot() {
+                    Some(snapshot) => snapshot.clone(),
+                    None => StatementSnapshot::new(self.engine.begin_transaction()?),
                 };
-                // A little slack over the limit covers the odd outer row without a
-                // match, so the common case needs no second fetch
-                let mut outer_limit = if outer_is_table {
-                    join_limit.map(|l| {
-                        let l = l as usize;
-                        l.saturating_add(l / 8).max(100)
-                    })
-                } else {
-                    None
-                };
+                let ctx_join = ctx.with_statement_snapshot(snapshot.clone());
+                let ctx = &ctx_join;
+                let mut outer_limit = join_limit.map(|l| {
+                    let l = l as usize;
+                    l.saturating_add(l / 8).max(100)
+                });
 
                 // Execute outer side with limit optimization for true early termination
-                let (outer_result, outer_cols) = self.execute_table_expression_with_filter_limit(
-                    outer_expr,
-                    ctx,
-                    nl_left_filter.as_ref(),
-                    outer_limit,
-                    0,
-                )?;
+                let (outer_result, outer_cols, outer_bounded) = self
+                    .execute_table_expression_with_filter_limit(
+                        outer_expr,
+                        ctx,
+                        nl_left_filter.as_ref(),
+                        outer_limit,
+                        0,
+                    )?;
+                if !outer_bounded {
+                    outer_limit = None;
+                }
 
                 // Find the outer key index in outer columns
                 // OPTIMIZATION: Pre-compute lowercase column names to avoid per-column to_lowercase()
@@ -4234,8 +4257,7 @@ impl Executor {
 
                 if let Some(outer_idx) = outer_key_idx {
                     // Get inner table for schema and row fetching
-                    let txn = self.engine.begin_transaction()?;
-                    let inner_table = txn.get_table(&table_name)?;
+                    let inner_table = snapshot.get_table(&table_name)?;
                     let inner_schema = inner_table.schema();
 
                     // Build inner columns list (qualified)
@@ -4322,7 +4344,7 @@ impl Executor {
                                 outer_op,
                                 match inner_table.take() {
                                     Some(table) => table,
-                                    None => txn.get_table(&table_name)?,
+                                    None => snapshot.get_table(&table_name)?,
                                 },
                                 inner_cols.iter().map(ColumnInfo::new).collect(),
                                 op_join_type,
@@ -4359,15 +4381,16 @@ impl Executor {
                             };
                             let next = estimate.clamp(32, fetched.saturating_mul(3));
                             outer_limit = Some(next);
-                            outer_result = self
+                            let (more, _, bounded) = self
                                 .execute_table_expression_with_filter_limit(
                                     outer_expr,
                                     ctx,
                                     nl_left_filter.as_ref(),
                                     Some(next),
                                     fetched,
-                                )?
-                                .0;
+                                )?;
+                            debug_assert!(bounded);
+                            outer_result = more;
                         }
                     } else {
                         // Batch INL for NO LIMIT - single batch fetch, O(1) lock overhead
@@ -6231,9 +6254,9 @@ impl Executor {
     }
 
     /// Execute a table expression with optional filter, row limit and row offset.
-    /// For simple table sources, adds LIMIT to enable true early termination.
-    /// This is optimized for Index Nested Loop joins where we need only enough rows
-    /// to produce the requested LIMIT results.
+    /// The flag says whether the limit and offset were applied: only a plain
+    /// table takes them; a CTE, a view, a subquery or a table function comes
+    /// back whole and cannot be fetched again from an offset.
     pub(crate) fn execute_table_expression_with_filter_limit(
         &self,
         expr: &Expression,
@@ -6241,7 +6264,7 @@ impl Executor {
         filter: Option<&Expression>,
         row_limit: Option<usize>,
         row_offset: usize,
-    ) -> Result<(Box<dyn QueryResult>, Vec<String>)> {
+    ) -> Result<(Box<dyn QueryResult>, Vec<String>, bool)> {
         // Handle FunctionTableSource with limit passthrough
         let tvf_source = match expr {
             Expression::FunctionTableSource(fts) => Some(fts.as_ref()),
@@ -6255,7 +6278,8 @@ impl Executor {
             _ => None,
         };
         if let Some(tvf_source) = tvf_source {
-            return Self::execute_tvf_for_join(tvf_source, ctx, filter, row_limit);
+            return Self::execute_tvf_for_join(tvf_source, ctx, filter, row_limit)
+                .map(|(result, columns)| (result, columns, false));
         }
 
         // Extract TableSource from the expression (handles both direct and aliased)
@@ -6266,12 +6290,16 @@ impl Executor {
                     (ts, Some(aliased.alias.value.clone()))
                 } else {
                     // Not a table source, fall back to standard execution
-                    return self.execute_table_expression_with_filter(expr, ctx, filter);
+                    return self
+                        .execute_table_expression_with_filter(expr, ctx, filter)
+                        .map(|(result, columns)| (result, columns, false));
                 }
             }
             _ => {
                 // Not a table source, fall back to standard execution
-                return self.execute_table_expression_with_filter(expr, ctx, filter);
+                return self
+                    .execute_table_expression_with_filter(expr, ctx, filter)
+                    .map(|(result, columns)| (result, columns, false));
             }
         };
 
@@ -6281,12 +6309,16 @@ impl Executor {
 
             // Skip if this is a CTE reference - CTEs are already materialized
             if ctx.get_cte_by_lower(table_name).is_some() {
-                return self.execute_table_expression_with_filter(expr, ctx, filter);
+                return self
+                    .execute_table_expression_with_filter(expr, ctx, filter)
+                    .map(|(result, columns)| (result, columns, false));
             }
 
             // Skip if this is a view
             if self.engine.get_view_lowercase(table_name)?.is_some() {
-                return self.execute_table_expression_with_filter(expr, ctx, filter);
+                return self
+                    .execute_table_expression_with_filter(expr, ctx, filter)
+                    .map(|(result, columns)| (result, columns, false));
             }
 
             // Create a SELECT * statement with WHERE clause AND LIMIT
@@ -6340,11 +6372,12 @@ impl Executor {
                 .map(|col| format!("{}.{}", table_alias, col))
                 .collect();
 
-            return Ok((result, qualified_columns));
+            return Ok((result, qualified_columns, true));
         }
 
         // Fall back to standard execution for other cases
         self.execute_table_expression_with_filter(expr, ctx, filter)
+            .map(|(result, columns)| (result, columns, false))
     }
 
     /// Materialize a result into a RowVec

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3941,6 +3941,7 @@ impl Executor {
                 ctx,
                 left_filter.as_ref(),
                 Some(left_cap),
+                0,
             )?;
             let left_rows = Self::materialize_result_arc(left_result)?;
             let left_key_idx = Self::find_column_index_by_name(&left_key_col, &left_cols);
@@ -4177,8 +4178,27 @@ impl Executor {
                 };
 
                 // The outer side is fetched in chunks: the first one is the limit
-                // itself and the join below fetches more when it stops short
-                let mut outer_limit = join_limit.map(|l| (l as usize).max(100));
+                // itself and the join below fetches more when it stops short. Only
+                // a table can be fetched again from an offset; any other source is
+                // fetched whole
+                let outer_source: &Expression = outer_expr;
+                let outer_is_table = match outer_source {
+                    Expression::TableSource(_) => true,
+                    Expression::Aliased(a) => {
+                        matches!(a.expression.as_ref(), Expression::TableSource(_))
+                    }
+                    _ => false,
+                };
+                // A little slack over the limit covers the odd outer row without a
+                // match, so the common case needs no second fetch
+                let mut outer_limit = if outer_is_table {
+                    join_limit.map(|l| {
+                        let l = l as usize;
+                        l.saturating_add(l / 8).max(100)
+                    })
+                } else {
+                    None
+                };
 
                 // Execute outer side with limit optimization for true early termination
                 let (outer_result, outer_cols) = self.execute_table_expression_with_filter_limit(
@@ -4186,6 +4206,7 @@ impl Executor {
                     ctx,
                     nl_left_filter.as_ref(),
                     outer_limit,
+                    0,
                 )?;
 
                 // Find the outer key index in outer columns
@@ -4287,9 +4308,11 @@ impl Executor {
                     if join_limit.is_some() {
                         // Streaming INL for early termination with LIMIT. When the
                         // joined rows stop short of the limit and the outer chunk
-                        // was full, the next pass fetches a larger chunk
+                        // was full, the next pass continues with the outer rows
+                        // after the chunk, sized from the match rate so far
                         let mut outer_result = outer_result;
                         let mut inner_table = Some(inner_table);
+                        let mut fetched = 0usize;
                         loop {
                             let outer_op: Box<dyn Operator> = Box::new(QueryResultOperator::new(
                                 outer_result,
@@ -4312,27 +4335,37 @@ impl Executor {
                                     proj.output_columns.iter().map(ColumnInfo::new).collect();
                                 op = op.with_projection(proj.columns.clone(), projected_schema);
                             }
-                            result_rows.clear();
                             Self::collect_join_rows(
                                 &mut op,
                                 join_limit,
                                 cross_row_filter.as_ref(),
                                 &mut result_rows,
                             )?;
-                            let short =
-                                join_limit.is_some_and(|lim| result_rows.len() < lim as usize);
-                            let chunk_full =
-                                outer_limit.is_some_and(|cap| op.outer_rows_seen() == cap);
-                            if !(short && chunk_full) {
+                            let lim = join_limit.unwrap_or(0) as usize;
+                            let cap = match outer_limit {
+                                Some(cap) if op.outer_rows_seen() == cap => cap,
+                                _ => break,
+                            };
+                            if result_rows.len() >= lim {
                                 break;
                             }
-                            outer_limit = outer_limit.map(|cap| cap.saturating_mul(4));
+                            fetched = fetched.saturating_add(cap);
+                            let missing = lim - result_rows.len();
+                            let rate = result_rows.len() as f64 / fetched as f64;
+                            let estimate = if rate > 0.0 {
+                                ((missing as f64 / rate) * 2.0).ceil() as usize
+                            } else {
+                                usize::MAX
+                            };
+                            let next = estimate.clamp(32, fetched.saturating_mul(3));
+                            outer_limit = Some(next);
                             outer_result = self
                                 .execute_table_expression_with_filter_limit(
                                     outer_expr,
                                     ctx,
                                     nl_left_filter.as_ref(),
-                                    outer_limit,
+                                    Some(next),
+                                    fetched,
                                 )?
                                 .0;
                         }
@@ -6197,7 +6230,7 @@ impl Executor {
         }
     }
 
-    /// Execute a table expression with optional filter and row limit.
+    /// Execute a table expression with optional filter, row limit and row offset.
     /// For simple table sources, adds LIMIT to enable true early termination.
     /// This is optimized for Index Nested Loop joins where we need only enough rows
     /// to produce the requested LIMIT results.
@@ -6207,6 +6240,7 @@ impl Executor {
         ctx: &ExecutionContext,
         filter: Option<&Expression>,
         row_limit: Option<usize>,
+        row_offset: usize,
     ) -> Result<(Box<dyn QueryResult>, Vec<String>)> {
         // Handle FunctionTableSource with limit passthrough
         let tvf_source = match expr {
@@ -6277,7 +6311,14 @@ impl Executor {
                         value: limit as i64,
                     },
                 ))),
-                offset: None,
+                offset: (row_offset > 0).then(|| {
+                    Box::new(Expression::IntegerLiteral(
+                        crate::parser::ast::IntegerLiteral {
+                            token: dummy_token(&row_offset.to_string(), TokenType::Integer),
+                            value: row_offset as i64,
+                        },
+                    ))
+                }),
                 set_operations: vec![],
             };
             // Get classification for the synthetic SELECT statement

--- a/tests/join_limit_shortfall_test.rs
+++ b/tests/join_limit_shortfall_test.rs
@@ -275,16 +275,16 @@ fn test_inl_join_limit_over_a_correlated_outer_filter_keeps_continuing() {
     assert_eq!(ids, (1..=50).map(|i| i * 20).collect::<Vec<i64>>());
 }
 
-/// Inside an explicit transaction the outer side is fetched whole; the
-/// answer must still be complete.
+/// Inside an explicit transaction the outer side is fetched whole and both
+/// sides read through that transaction, so the join sees the rows it
+/// inserted and misses the ones it deleted before any commit.
 #[test]
 fn test_inl_join_limit_inside_an_explicit_transaction() {
     let db = setup("join_limit_explicit_tx", false);
+    let joined =
+        "SELECT o.amount, u.name FROM orders o INNER JOIN users u ON o.user_id = u.id LIMIT 100";
     db.execute("BEGIN", ()).unwrap();
-    assert_eq!(
-        count(&db, "SELECT o.amount, u.name FROM orders o INNER JOIN users u ON o.user_id = u.id LIMIT 100"),
-        50
-    );
+    assert_eq!(count(&db, joined), 50);
     assert_eq!(
         count(
             &db,
@@ -292,5 +292,19 @@ fn test_inl_join_limit_inside_an_explicit_transaction() {
         ),
         30
     );
-    db.execute("COMMIT", ()).unwrap();
+    // an uncommitted matching pair: the new user is on the inner side
+    db.execute("INSERT INTO users VALUES (101, 'U101')", ())
+        .unwrap();
+    db.execute("INSERT INTO orders VALUES (1001, 101, 1001.0)", ())
+        .unwrap();
+    assert_eq!(count(&db, joined), 51);
+    assert_eq!(
+        count(&db, "SELECT o.amount FROM orders o INNER JOIN users u ON o.user_id = u.id WHERE o.id = 1001 LIMIT 10"),
+        1
+    );
+    // an uncommitted delete on the inner side takes its match away
+    db.execute("DELETE FROM users WHERE id = 1", ()).unwrap();
+    assert_eq!(count(&db, joined), 50);
+    db.execute("ROLLBACK", ()).unwrap();
+    assert_eq!(count(&db, joined), 50);
 }

--- a/tests/join_limit_shortfall_test.rs
+++ b/tests/join_limit_shortfall_test.rs
@@ -236,8 +236,11 @@ fn test_inl_join_limit_over_a_table_function_outer_reads_it_whole() {
 #[test]
 fn test_inl_join_limit_over_a_temporal_outer_never_repeats_rows() {
     let db = setup("join_limit_temporal_outer", false);
-    db.execute("CREATE TABLE first100 (id INTEGER PRIMARY KEY, user_id INTEGER)", ())
-        .unwrap();
+    db.execute(
+        "CREATE TABLE first100 (id INTEGER PRIMARY KEY, user_id INTEGER)",
+        (),
+    )
+    .unwrap();
     for i in 1..=100i64 {
         let uid = if i % 20 == 0 { i / 20 } else { 100_000 + i };
         db.execute("INSERT INTO first100 VALUES ($1, $2)", (i, uid))
@@ -253,4 +256,41 @@ fn test_inl_join_limit_over_a_temporal_outer_never_repeats_rows() {
         .collect();
     ids.sort_unstable();
     assert_eq!(ids, vec![20, 40, 60, 80, 100]);
+}
+
+/// A correlated filter on the outer side takes a scan path that stops early
+/// at the chunk without reporting it; the fetch must still bound and continue.
+#[test]
+fn test_inl_join_limit_over_a_correlated_outer_filter_keeps_continuing() {
+    let db = setup("join_limit_correlated_outer", false);
+    let mut ids: Vec<i64> = db
+        .query(
+            "SELECT o.id FROM orders o INNER JOIN users u ON o.user_id = u.id WHERE o.amount >= (SELECT MIN(o2.amount) FROM orders o2 WHERE o2.user_id = o.user_id) LIMIT 100",
+            (),
+        )
+        .unwrap()
+        .map(|row| row.unwrap().get::<i64>(0).unwrap())
+        .collect();
+    ids.sort_unstable();
+    assert_eq!(ids, (1..=50).map(|i| i * 20).collect::<Vec<i64>>());
+}
+
+/// Inside an explicit transaction the outer side is fetched whole; the
+/// answer must still be complete.
+#[test]
+fn test_inl_join_limit_inside_an_explicit_transaction() {
+    let db = setup("join_limit_explicit_tx", false);
+    db.execute("BEGIN", ()).unwrap();
+    assert_eq!(
+        count(&db, "SELECT o.amount, u.name FROM orders o INNER JOIN users u ON o.user_id = u.id LIMIT 100"),
+        50
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT u.name FROM users u INNER JOIN orders o ON u.id = o.user_id LIMIT 30"
+        ),
+        30
+    );
+    db.execute("COMMIT", ()).unwrap();
 }

--- a/tests/join_limit_shortfall_test.rs
+++ b/tests/join_limit_shortfall_test.rs
@@ -156,3 +156,55 @@ fn test_group_by_limit_reduction_survives_a_huge_limit() {
         50
     );
 }
+
+/// The outer side is fetched chunk by chunk; the rows across the chunk
+/// boundaries must be exactly the matching ones, none repeated or missing.
+#[test]
+fn test_inl_join_limit_chunks_neither_repeat_nor_skip_rows() {
+    let db = setup("join_limit_chunk_boundaries", false);
+    let mut ids: Vec<i64> = db
+        .query(
+            "SELECT o.id FROM orders o INNER JOIN users u ON o.user_id = u.id LIMIT 100",
+            (),
+        )
+        .unwrap()
+        .map(|row| row.unwrap().get::<i64>(0).unwrap())
+        .collect();
+    ids.sort_unstable();
+    assert_eq!(ids, (1..=50).map(|i| i * 20).collect::<Vec<i64>>());
+    let mut ids: Vec<i64> = db
+        .query(
+            "SELECT o.id FROM orders o INNER JOIN users u ON o.user_id = u.id LIMIT 30",
+            (),
+        )
+        .unwrap()
+        .map(|row| row.unwrap().get::<i64>(0).unwrap())
+        .collect();
+    assert_eq!(ids.len(), 30);
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), 30);
+}
+
+/// A CTE or a view on the outer side comes back whole; the join must not
+/// treat it as a chunk and read it again from the start.
+#[test]
+fn test_inl_join_limit_over_a_cte_or_view_outer_never_repeats_rows() {
+    let db = setup("join_limit_cte_view_outer", false);
+    db.execute("CREATE VIEW first_orders AS SELECT * FROM orders WHERE id <= 100", ())
+        .unwrap();
+    // exactly 100 outer rows, five of them with a user: the first chunk is
+    // consumed and still short of the limit
+    for sql in [
+        "WITH w AS (SELECT * FROM orders WHERE id <= 100) SELECT w.id FROM w INNER JOIN users u ON w.user_id = u.id LIMIT 10",
+        "SELECT f.id FROM first_orders f INNER JOIN users u ON f.user_id = u.id LIMIT 10",
+    ] {
+        let mut ids: Vec<i64> = db
+            .query(sql, ())
+            .unwrap()
+            .map(|row| row.unwrap().get::<i64>(0).unwrap())
+            .collect();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![20, 40, 60, 80, 100], "{sql}");
+    }
+}

--- a/tests/join_limit_shortfall_test.rs
+++ b/tests/join_limit_shortfall_test.rs
@@ -191,8 +191,11 @@ fn test_inl_join_limit_chunks_neither_repeat_nor_skip_rows() {
 #[test]
 fn test_inl_join_limit_over_a_cte_or_view_outer_never_repeats_rows() {
     let db = setup("join_limit_cte_view_outer", false);
-    db.execute("CREATE VIEW first_orders AS SELECT * FROM orders WHERE id <= 100", ())
-        .unwrap();
+    db.execute(
+        "CREATE VIEW first_orders AS SELECT * FROM orders WHERE id <= 100",
+        (),
+    )
+    .unwrap();
     // exactly 100 outer rows, five of them with a user: the first chunk is
     // consumed and still short of the limit
     for sql in [
@@ -207,4 +210,47 @@ fn test_inl_join_limit_over_a_cte_or_view_outer_never_repeats_rows() {
         ids.sort_unstable();
         assert_eq!(ids, vec![20, 40, 60, 80, 100], "{sql}");
     }
+}
+
+/// A table function on the outer side cannot be fetched again from an
+/// offset, so its first fetch must not be cut at the chunk.
+#[test]
+fn test_inl_join_limit_over_a_table_function_outer_reads_it_whole() {
+    let db = Database::open("memory://join_limit_tvf_outer").unwrap();
+    db.execute("CREATE TABLE sparse (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    db.execute("INSERT INTO sparse VALUES (150)", ()).unwrap();
+    let ids: Vec<i64> = db
+        .query(
+            "SELECT g.value FROM generate_series(1, 200) g INNER JOIN sparse s ON g.value = s.id LIMIT 1",
+            (),
+        )
+        .unwrap()
+        .map(|row| row.unwrap().get::<i64>(0).unwrap())
+        .collect();
+    assert_eq!(ids, vec![150]);
+}
+
+/// A temporal outer source hands back every row, so the join must not take it
+/// for a full chunk and read it again.
+#[test]
+fn test_inl_join_limit_over_a_temporal_outer_never_repeats_rows() {
+    let db = setup("join_limit_temporal_outer", false);
+    db.execute("CREATE TABLE first100 (id INTEGER PRIMARY KEY, user_id INTEGER)", ())
+        .unwrap();
+    for i in 1..=100i64 {
+        let uid = if i % 20 == 0 { i / 20 } else { 100_000 + i };
+        db.execute("INSERT INTO first100 VALUES ($1, $2)", (i, uid))
+            .unwrap();
+    }
+    let mut ids: Vec<i64> = db
+        .query(
+            "SELECT f.id FROM first100 AS OF TIMESTAMP '2099-01-01 00:00:00' f INNER JOIN users u ON f.user_id = u.id LIMIT 10",
+            (),
+        )
+        .unwrap()
+        .map(|row| row.unwrap().get::<i64>(0).unwrap())
+        .collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![20, 40, 60, 80, 100]);
 }


### PR DESCRIPTION
## Why

Measuring `main` against the BENCHMARKS.md baseline showed `INNER JOIN` at 23 us against 19.7 us. #83 made a LIMIT join fetch an outer chunk the size of the limit and rerun from the start with a chunk four times larger when the joined rows stop short. On the benchmark the delete phase leaves one order in a hundred without a user, so every execution of `... INNER JOIN ... WHERE o.status = 'completed' LIMIT 100` joined 100 rows, came up one short, and joined 400 more. The same query with no missing user runs in 11.6 us.

## What

- The continuation keeps the joined rows and fetches only the outer rows after the chunk, through a new row offset on `execute_table_expression_with_filter_limit` (a `SELECT * ... LIMIT n OFFSET m` on the table). The next chunk is sized from the shortfall and the match rate so far, at least 32 rows and at most three times what was fetched, so a run with no matches at all still grows geometrically.
- The first chunk carries a sixteenth of slack over the limit (min 100), so the odd missing match is covered without a second fetch.
- The outer fetch always hands back exactly the chunk for a plain table: when `execute_simple_table_scan` says it did not apply the synthetic LIMIT and OFFSET (an AS OF path, or a path that stopped early at their sum without applying them), the fetch applies the pair through the normal limited result. A table function applies them too when it has no filter, generating `offset + limit` rows; a CTE, a view, a subquery or a filtered table function comes back whole. The join drops its chunk limit when the first fetch says so.
- Every outer fetch and the inner probes of a join run on one transaction: `ExecutionContext` carries a `StatementSnapshot`, created by the join before its first fetch, and `execute_simple_table_scan` reads through it instead of opening a standalone transaction when the statement has no explicit one. The snapshot opens read committed, the default; a continuation fetches one row of overlap and, if that row is no longer the one the chunk ended on, the join restarts on a snapshot isolation transaction, where every chunk is consistent by construction. Snapshot isolation on every join would cost about two microseconds, a fifth of the benchmark's join rows.
- Inside an explicit transaction the scan reads through that transaction, whose isolation may let a commit move rows between fetches, so the outer side is fetched whole there, and the inner table comes from that transaction too, so the join sees the rows the transaction inserted, changed or deleted.

## Measurements

Full benchmark binary, one machine:

| Row | baseline 435bf023 | main | this PR |
|---|---|---|---|
| INNER JOIN | 19.7 us | 23.1 us | 12.0 to 13.0 us |
| Self JOIN | 13.4 us | 7.5 us | 7.7 to 8.1 us |
| Complex JOIN+GROUP+HAVING | 49.5 us (44 rows for LIMIT 50) | 80.4 us | 80 to 96 us |

Random benchmark-shaped data, best of 5 against a baseline binary: INNER JOIN 19 to 12 us, Self JOIN 11 to 6 us, LEFT JOIN + GROUP BY 52 to 51 us. Against the pre-PR main over eight rounds the medians are equal: INNER JOIN 12.0 vs 12.1 us, Self JOIN 7.0 vs 7.0 us.

## Tests

`tests/join_limit_shortfall_test.rs` keeps covering a join that needs several continuations (5 matches per 100 outer rows), asserts that the rows across chunk boundaries are exactly the matching ones, none repeated or missing, and checks a CTE, a view and a temporal (AS OF) source of exactly 100 rows on the outer side, which must return their five matches once each, plus a table function outer whose only match sits past the first chunk, an outer with a correlated filter, and the shortfall queries inside an explicit transaction with an uncommitted matching pair and an uncommitted delete. Join, limit and offset targets pass, plus both full suites.
