### PR TITLE
perf(join): stream the groups of a GROUP BY + LIMIT join through the right side's index

### DIFF
--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -742,7 +742,7 @@ impl Executor {
 
     /// Apply post-aggregation expressions to the result
     /// This handles expressions like `CASE WHEN SUM(x) > 100 THEN 'big' ELSE 'small' END`
-    fn apply_post_aggregation_expressions(
+    pub(crate) fn apply_post_aggregation_expressions(
         &self,
         stmt: &SelectStatement,
         ctx: &ExecutionContext,
@@ -1358,7 +1358,7 @@ impl Executor {
 
     /// Parse aggregate functions from SELECT list
     /// Returns: (aggregations, non_agg_columns, post_agg_expressions)
-    fn parse_aggregations(
+    pub(crate) fn parse_aggregations(
         &self,
         stmt: &SelectStatement,
     ) -> Result<(Vec<SqlAggregateFunction>, Vec<String>)> {
@@ -1643,7 +1643,7 @@ impl Executor {
     }
 
     /// Parse GROUP BY clause
-    fn parse_group_by(
+    pub(crate) fn parse_group_by(
         &self,
         stmt: &SelectStatement,
         _base_columns: &[String],

--- a/src/executor/operators/index_nested_loop.rs
+++ b/src/executor/operators/index_nested_loop.rs
@@ -300,6 +300,11 @@ impl IndexNestedLoopJoinOperator {
         self.outer_rows_seen
     }
 
+    /// The outer row the join is on, or ended on
+    pub fn last_outer_row(&self) -> Option<&Row> {
+        self.current_outer_row.as_ref()
+    }
+
     /// Look up matching inner rows for the current outer row.
     /// Uses internal buffers to avoid allocations.
     fn lookup_inner_rows(&mut self, key_value: &Value) -> Result<()> {

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -6567,6 +6567,16 @@ impl Executor {
         }) {
             return Ok(None);
         }
+        if stmt.group_by.modifier != crate::parser::ast::GroupByModifier::None {
+            return Ok(None);
+        }
+        if [left_filter, right_filter, cross_filter]
+            .into_iter()
+            .flatten()
+            .any(Self::has_subqueries)
+        {
+            return Ok(None);
+        }
         let group_by = self.parse_group_by(stmt, &[])?;
         let mut group_names = Vec::with_capacity(group_by.len());
         for item in &group_by {
@@ -6580,7 +6590,7 @@ impl Executor {
 
         // One transaction for the outer fetches and the inner probes; inside an
         // explicit transaction the outer side is read whole
-        let snapshot = match ctx.statement_snapshot() {
+        let mut snapshot = match ctx.statement_snapshot() {
             Some(snapshot) => snapshot.clone(),
             None => self.new_statement_snapshot(crate::core::IsolationLevel::ReadCommitted)?,
         };
@@ -6839,10 +6849,10 @@ impl Executor {
                 outer_result = more;
                 continue;
             }
-            let restart =
+            snapshot =
                 self.new_statement_snapshot(crate::core::IsolationLevel::SnapshotIsolation)?;
-            ctx_join = ctx.with_statement_snapshot(restart.clone());
-            inner_table = Some(self.join_table(&restart, &table_name)?);
+            ctx_join = ctx.with_statement_snapshot(snapshot.clone());
+            inner_table = Some(self.join_table(&snapshot, &table_name)?);
             consistent = true;
             groups.clear();
             outer_limit = Some(fetched.saturating_add(next));

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -6520,6 +6520,81 @@ impl Executor {
         Ok(StatementSnapshot::new(transaction))
     }
 
+    /// True when a filter carries a subquery anywhere inside it. The grouped
+    /// stream compiles its filters raw, where a subquery has no executor
+    fn filter_has_subquery(expr: &Expression) -> bool {
+        use crate::parser::ast::Expression as E;
+        let any = |exprs: &[Expression]| exprs.iter().any(Self::filter_has_subquery);
+        match expr {
+            E::ScalarSubquery(_) | E::Exists(_) | E::AllAny(_) => true,
+            E::Identifier(_)
+            | E::QualifiedIdentifier(_)
+            | E::IntegerLiteral(_)
+            | E::FloatLiteral(_)
+            | E::StringLiteral(_)
+            | E::BooleanLiteral(_)
+            | E::NullLiteral(_)
+            | E::IntervalLiteral(_)
+            | E::Parameter(_)
+            | E::Star(_)
+            | E::QualifiedStar(_)
+            | E::Default(_) => false,
+            E::Prefix(p) => Self::filter_has_subquery(&p.right),
+            E::Infix(i) => {
+                Self::filter_has_subquery(&i.left) || Self::filter_has_subquery(&i.right)
+            }
+            E::List(l) => any(&l.elements),
+            E::ExpressionList(l) => any(&l.expressions),
+            E::Distinct(d) => Self::filter_has_subquery(&d.expr),
+            E::In(i) => Self::filter_has_subquery(&i.left) || Self::filter_has_subquery(&i.right),
+            E::InHashSet(i) => Self::filter_has_subquery(&i.column),
+            E::Between(b) => {
+                Self::filter_has_subquery(&b.expr)
+                    || Self::filter_has_subquery(&b.lower)
+                    || Self::filter_has_subquery(&b.upper)
+            }
+            E::Like(l) => {
+                Self::filter_has_subquery(&l.left)
+                    || Self::filter_has_subquery(&l.pattern)
+                    || l.escape.as_deref().is_some_and(Self::filter_has_subquery)
+            }
+            E::Case(c) => {
+                c.value.as_deref().is_some_and(Self::filter_has_subquery)
+                    || c.when_clauses.iter().any(|w| {
+                        Self::filter_has_subquery(&w.condition)
+                            || Self::filter_has_subquery(&w.then_result)
+                    })
+                    || c.else_value
+                        .as_deref()
+                        .is_some_and(Self::filter_has_subquery)
+            }
+            E::Cast(c) => Self::filter_has_subquery(&c.expr),
+            E::FunctionCall(f) => Self::function_has_subquery(f),
+            E::Aliased(a) => Self::filter_has_subquery(&a.expression),
+            E::Window(w) => {
+                Self::function_has_subquery(&w.function)
+                    || any(&w.partition_by)
+                    || w.order_by
+                        .iter()
+                        .any(|o| Self::filter_has_subquery(&o.expression))
+            }
+            E::TableSource(_)
+            | E::JoinSource(_)
+            | E::SubquerySource(_)
+            | E::ValuesSource(_)
+            | E::CteReference(_)
+            | E::FunctionTableSource(_) => true,
+        }
+    }
+
+    fn function_has_subquery(f: &crate::parser::ast::FunctionCall) -> bool {
+        f.arguments.iter().any(Self::filter_has_subquery)
+            || f.filter.as_deref().is_some_and(Self::filter_has_subquery)
+            || f.order_by
+                .iter()
+                .any(|o| Self::filter_has_subquery(&o.expression))
+    }
+
     /// A GROUP BY + LIMIT join whose groups are the left rows: the right side
     /// is probed per left row through its index, each group is folded as the
     /// joined rows stream past, HAVING runs on the group at once, and the
@@ -6573,7 +6648,7 @@ impl Executor {
         if [left_filter, right_filter, cross_filter]
             .into_iter()
             .flatten()
-            .any(Self::has_subqueries)
+            .any(Self::filter_has_subquery)
         {
             return Ok(None);
         }

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -56,12 +56,13 @@ type DeferredProjection = (Vec<usize>, Vec<String>);
 /// Type alias for select execution results: (result, column_names, limit_offset_applied, deferred_projection)
 /// Using CompactArc<Vec<String>> for column names enables zero-copy sharing across query execution.
 /// The deferred_projection field is Some when projection should be applied after ORDER BY + LIMIT.
-type SelectResult = Result<(
+type SelectOutput = (
     Box<dyn QueryResult>,
     CompactArc<Vec<String>>,
     bool,
     Option<DeferredProjection>,
-)>;
+);
+type SelectResult = Result<SelectOutput>;
 
 use super::context::{
     clear_batch_aggregate_cache, clear_batch_aggregate_info_cache, clear_count_counter_cache,
@@ -191,6 +192,8 @@ fn partition_where_for_join(
 /// A GROUP BY + LIMIT join whose left side is fetched in a limited chunk
 struct SemijoinReduction {
     cap: usize,
+    want: usize,
+    offset: usize,
     limit: usize,
     left_key_col: String,
     right_key_col: String,
@@ -3962,6 +3965,20 @@ impl Executor {
         let (left_rows, left_columns, right_rows, right_columns) = if let Some(plan) =
             semijoin_limit
         {
+            if let Some(result) = self.try_grouped_index_join(
+                stmt,
+                ctx,
+                join_source,
+                &join_type,
+                left_alias.as_deref(),
+                right_alias.as_deref(),
+                left_filter.as_ref(),
+                right_filter.as_ref(),
+                cross_filter.as_ref(),
+                &plan,
+            )? {
+                return Ok(result);
+            }
             // Semi-join reduction for INNER/LEFT JOIN + GROUP BY: fetch the left
             // side with the limit, then the right side through an IN filter on
             // the join key (uses the index)
@@ -3970,6 +3987,7 @@ impl Executor {
                 limit,
                 left_key_col,
                 right_key_col,
+                ..
             } = plan;
             let left_cap = left_cap_override.unwrap_or(cap);
             let (left_result, left_cols, left_bounded) = self
@@ -6500,6 +6518,355 @@ impl Executor {
             transaction.set_isolation_level(isolation)?;
         }
         Ok(StatementSnapshot::new(transaction))
+    }
+
+    /// A GROUP BY + LIMIT join whose groups are the left rows: the right side
+    /// is probed per left row through its index, each group is folded as the
+    /// joined rows stream past, HAVING runs on the group at once, and the
+    /// scan stops after LIMIT + OFFSET groups. Nothing is materialised or
+    /// hashed and the answer is complete by construction. None when the shape
+    /// needs something this path does not do; the caller then reduces and
+    /// hashes as before.
+    #[allow(clippy::too_many_arguments)]
+    fn try_grouped_index_join(
+        &self,
+        stmt: &SelectStatement,
+        ctx: &ExecutionContext,
+        join_source: &JoinTableSource,
+        join_type: &str,
+        left_alias: Option<&str>,
+        right_alias: Option<&str>,
+        left_filter: Option<&Expression>,
+        right_filter: Option<&Expression>,
+        cross_filter: Option<&Expression>,
+        plan: &SemijoinReduction,
+    ) -> Result<Option<SelectOutput>> {
+        // A right-side filter on a LEFT JOIN changes what an unmatched left row
+        // means; the reduction handles that shape
+        if join_type != "INNER" && right_filter.is_some() {
+            return Ok(None);
+        }
+        let Some((table_name, lookup_strategy, _inner_key_col, outer_key_col)) = self
+            .check_index_nested_loop_opportunity(
+                &join_source.right,
+                join_source.condition.as_deref(),
+                join_type,
+                left_alias,
+                right_alias,
+            )
+        else {
+            return Ok(None);
+        };
+        let (aggregations, _) = self.parse_aggregations(stmt)?;
+        if aggregations.iter().any(|agg| {
+            agg.expression.is_some()
+                || agg.filter.is_some()
+                || !agg.order_by.is_empty()
+                || agg.hidden
+                || self.function_registry.get_aggregate(&agg.name).is_none()
+        }) {
+            return Ok(None);
+        }
+        let group_by = self.parse_group_by(stmt, &[])?;
+        let mut group_names = Vec::with_capacity(group_by.len());
+        for item in &group_by {
+            match item {
+                crate::executor::aggregation::GroupByItem::Column(name) => {
+                    group_names.push(name.clone())
+                }
+                _ => return Ok(None),
+            }
+        }
+
+        // One transaction for the outer fetches and the inner probes; inside an
+        // explicit transaction the outer side is read whole
+        let snapshot = match ctx.statement_snapshot() {
+            Some(snapshot) => snapshot.clone(),
+            None => self.new_statement_snapshot(crate::core::IsolationLevel::ReadCommitted)?,
+        };
+        let mut ctx_join = ctx.with_statement_snapshot(snapshot.clone());
+        let in_explicit_transaction = self.active_transaction.lock().unwrap().is_some();
+        let mut outer_limit = if in_explicit_transaction {
+            None
+        } else {
+            Some(plan.cap)
+        };
+        let (outer_result, outer_cols, outer_bounded) = self
+            .execute_table_expression_with_filter_limit(
+                &join_source.left,
+                &ctx_join,
+                left_filter,
+                outer_limit,
+                0,
+            )?;
+        if !outer_bounded {
+            outer_limit = None;
+        }
+        let unqualified = |name: &str| name.rfind('.').map_or(name, |p| &name[p + 1..]).to_string();
+        let outer_key_lower = outer_key_col.to_lowercase();
+        let outer_key_unqualified = unqualified(&outer_key_lower);
+        let Some(outer_key_idx) = outer_cols
+            .iter()
+            .position(|c| c.to_lowercase() == outer_key_lower)
+            .or_else(|| {
+                outer_cols
+                    .iter()
+                    .position(|c| unqualified(&c.to_lowercase()) == outer_key_unqualified)
+            })
+        else {
+            return Ok(None);
+        };
+        let inner_table = self.join_table(&snapshot, &table_name)?;
+        let inner_alias = right_alias.unwrap_or(&table_name);
+        let inner_cols: Vec<String> = inner_table
+            .schema()
+            .columns
+            .iter()
+            .map(|col| format!("{}.{}", inner_alias, col.name))
+            .collect();
+        let all_columns: Vec<String> = outer_cols
+            .iter()
+            .chain(inner_cols.iter())
+            .cloned()
+            .collect();
+
+        // Where each group column and aggregate argument lives in the joined row
+        let mut group_idx = Vec::with_capacity(group_names.len());
+        for name in &group_names {
+            match Self::find_column_index_by_name(name, &all_columns) {
+                Some(idx) => group_idx.push(idx),
+                None => return Ok(None),
+            }
+        }
+        let mut agg_idx = Vec::with_capacity(aggregations.len());
+        for agg in &aggregations {
+            if agg.column == "*" {
+                agg_idx.push(None);
+            } else {
+                match Self::find_column_index_by_name(&agg.column, &all_columns) {
+                    Some(idx) => agg_idx.push(Some(idx)),
+                    None => return Ok(None),
+                }
+            }
+        }
+        let mut result_columns: Vec<String> = group_names.clone();
+        for agg in &aggregations {
+            result_columns.push(
+                agg.alias
+                    .clone()
+                    .unwrap_or_else(|| agg.get_expression_name()),
+            );
+        }
+        let having = match &stmt.having {
+            Some(having) => {
+                let processed = self.process_where_subqueries(having, ctx)?;
+                let agg_aliases: Vec<(String, usize)> = aggregations
+                    .iter()
+                    .enumerate()
+                    .map(|(i, agg)| (agg.get_expression_name(), group_names.len() + i))
+                    .collect();
+                Some(
+                    RowFilter::with_aliases(&processed, &result_columns, &agg_aliases)?
+                        .with_context(ctx),
+                )
+            }
+            None => None,
+        };
+        let cross = match cross_filter {
+            Some(cross) => Some(RowFilter::new(cross, &all_columns)?.with_context(ctx)),
+            None => None,
+        };
+        let build_residual_filter = || {
+            right_filter.and_then(|rf| {
+                let qualified_rf = add_table_qualifier(rf, inner_alias);
+                JoinFilter::new(
+                    &qualified_rf,
+                    &outer_cols,
+                    &inner_cols,
+                    &self.function_registry,
+                )
+                .ok()
+                .map(|f| f.with_context(ctx))
+            })
+        };
+        let mut funcs: Vec<Box<dyn crate::functions::AggregateFunction>> =
+            Vec::with_capacity(aggregations.len());
+        for agg in &aggregations {
+            let mut func = self
+                .function_registry
+                .get_aggregate(&agg.name)
+                .ok_or_else(|| Error::internal(format!("aggregate {} vanished", agg.name)))?;
+            if !agg.extra_args.is_empty() {
+                func.configure(&agg.extra_args);
+            }
+            funcs.push(func);
+        }
+        let count_star = Value::Integer(1);
+        let op_join_type = OperatorJoinType::parse(join_type);
+        let want = plan.want;
+
+        // Fold one finished group into an output row; true when HAVING kept it
+        let finish = |first: &Row,
+                      funcs: &mut [Box<dyn crate::functions::AggregateFunction>],
+                      groups: &mut RowVec|
+         -> Result<bool> {
+            let mut values = Vec::with_capacity(result_columns.len());
+            for &idx in &group_idx {
+                values.push(first.get(idx).cloned().unwrap_or_else(Value::null_unknown));
+            }
+            for func in funcs.iter() {
+                values.push(func.result());
+            }
+            let row = Row::from_values(values);
+            if let Some(having) = &having {
+                if !having.matches_checked(&row)? {
+                    return Ok(false);
+                }
+            }
+            groups.push((groups.len() as i64, row));
+            Ok(true)
+        };
+
+        let mut groups = RowVec::new();
+        let mut outer_result = outer_result;
+        let mut inner_table = Some(inner_table);
+        let mut fetched = 0usize;
+        let mut consistent = false;
+        loop {
+            let outer_op: Box<dyn Operator> =
+                Box::new(QueryResultOperator::new(outer_result, outer_cols.clone()));
+            let mut op = IndexNestedLoopJoinOperator::new(
+                outer_op,
+                match inner_table.take() {
+                    Some(table) => table,
+                    None => self.join_table(&snapshot, &table_name)?,
+                },
+                inner_cols.iter().map(ColumnInfo::new).collect(),
+                op_join_type,
+                outer_key_idx,
+                lookup_strategy.clone(),
+                build_residual_filter(),
+            );
+            op.open()?;
+            // The group columns cover the left primary key, so a change in them
+            // is a new left row
+            let mut current: Option<Row> = None;
+            let mut enough = false;
+            while let Some(row_ref) = op.next()? {
+                let row = row_ref.into_owned();
+                if let Some(cross) = &cross {
+                    if !cross.matches_checked(&row)? {
+                        continue;
+                    }
+                }
+                let new_group = match &current {
+                    Some(first) => group_idx.iter().any(|&idx| first.get(idx) != row.get(idx)),
+                    None => true,
+                };
+                if new_group {
+                    if let Some(first) = current.take() {
+                        if finish(&first, &mut funcs, &mut groups)? && groups.len() >= want {
+                            enough = true;
+                            break;
+                        }
+                    }
+                    for func in funcs.iter_mut() {
+                        func.reset();
+                    }
+                    current = Some(row.clone());
+                }
+                for (i, agg) in aggregations.iter().enumerate() {
+                    let value = match agg_idx[i] {
+                        Some(idx) => row.get(idx),
+                        None => Some(&count_star),
+                    };
+                    if let Some(value) = value {
+                        funcs[i].accumulate(value, agg.distinct);
+                    }
+                }
+            }
+            if !enough {
+                if let Some(first) = current.take() {
+                    finish(&first, &mut funcs, &mut groups)?;
+                }
+            }
+            op.close()?;
+            if enough || groups.len() >= want {
+                break;
+            }
+            let cap = match outer_limit {
+                Some(cap) if op.outer_rows_seen() == cap => cap,
+                _ => break,
+            };
+            let boundary = op.last_outer_row().cloned();
+            fetched = fetched.saturating_add(cap);
+            let missing = want - groups.len();
+            let rate = groups.len() as f64 / fetched as f64;
+            let estimate = if rate > 0.0 {
+                ((missing as f64 / rate) * 2.0).ceil() as usize
+            } else {
+                usize::MAX
+            };
+            let next = estimate.clamp(32, fetched.saturating_mul(3).max(32));
+            outer_limit = Some(next);
+            if consistent {
+                let (more, _, bounded) = self.execute_table_expression_with_filter_limit(
+                    &join_source.left,
+                    &ctx_join,
+                    left_filter,
+                    Some(next),
+                    fetched,
+                )?;
+                debug_assert!(bounded);
+                outer_result = more;
+                continue;
+            }
+            // Read committed: one row of overlap tells whether a commit moved the
+            // boundary; if it did, restart on snapshot isolation
+            let (mut more, _, bounded) = self.execute_table_expression_with_filter_limit(
+                &join_source.left,
+                &ctx_join,
+                left_filter,
+                Some(next + 1),
+                fetched - 1,
+            )?;
+            debug_assert!(bounded);
+            let unmoved = more.next()
+                && boundary
+                    .as_ref()
+                    .is_some_and(|row| row.as_slice() == more.row().as_slice());
+            if unmoved {
+                outer_result = more;
+                continue;
+            }
+            let restart =
+                self.new_statement_snapshot(crate::core::IsolationLevel::SnapshotIsolation)?;
+            ctx_join = ctx.with_statement_snapshot(restart.clone());
+            inner_table = Some(self.join_table(&restart, &table_name)?);
+            consistent = true;
+            groups.clear();
+            outer_limit = Some(fetched.saturating_add(next));
+            fetched = 0;
+            outer_result = self
+                .execute_table_expression_with_filter_limit(
+                    &join_source.left,
+                    &ctx_join,
+                    left_filter,
+                    outer_limit,
+                    0,
+                )?
+                .0;
+        }
+
+        let (final_columns, final_rows) =
+            self.apply_post_aggregation_expressions(stmt, ctx, result_columns, groups)?;
+        let mut rows = final_rows.into_vec();
+        rows.drain(..plan.offset.min(rows.len()));
+        rows.truncate(plan.limit);
+        let columns = CompactArc::new(final_columns);
+        let result =
+            ExecutorResult::with_arc_columns(CompactArc::clone(&columns), RowVec::from_vec(rows));
+        Ok(Some((Box::new(result), columns, true, None)))
     }
 
     /// Runs a join operator to completion or to `limit` rows. The cross-table
@@ -9196,7 +9563,10 @@ impl Executor {
     /// expected after OFFSET). The first chunk is doubled for an INNER JOIN,
     /// where a left row without a match forms no group, and doubled again
     /// under HAVING, which drops groups after the fact
-    fn semijoin_caps(stmt: &SelectStatement, is_inner: bool) -> Option<(usize, usize)> {
+    fn semijoin_caps(
+        stmt: &SelectStatement,
+        is_inner: bool,
+    ) -> Option<(usize, usize, usize, usize)> {
         let eval = |e: &Expression| {
             ExpressionEval::compile(e, &[])
                 .ok()
@@ -9223,7 +9593,7 @@ impl Executor {
             cap = cap.saturating_mul(2);
         }
         // The chunk becomes a LIMIT literal, which is an i64
-        Some((cap.min(i64::MAX as usize), limit))
+        Some((cap.min(i64::MAX as usize), want, offset, limit))
     }
 
     /// Check if semi-join reduction optimization can be applied and return its plan
@@ -9269,7 +9639,7 @@ impl Executor {
         if classification.has_window_functions || stmt.distinct || !stmt.distinct_on.is_empty() {
             return None;
         }
-        let (cap, limit) = Self::semijoin_caps(stmt, is_inner)?;
+        let (cap, want, offset, limit) = Self::semijoin_caps(stmt, is_inner)?;
         // Each group must come from one left row, or a partial chunk would
         // give partial aggregates: GROUP BY has to cover the left primary key
         let left_alias = left_alias?;
@@ -9320,6 +9690,8 @@ impl Executor {
             // Swap the keys
             return Some(SemijoinReduction {
                 cap,
+                want,
+                offset,
                 limit,
                 left_key_col: right_key_col,
                 right_key_col: left_key_col,
@@ -9328,6 +9700,8 @@ impl Executor {
 
         Some(SemijoinReduction {
             cap,
+            want,
+            offset,
             limit,
             left_key_col,
             right_key_col,

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -4220,12 +4220,16 @@ impl Executor {
                 // stops short. Only a plain table takes the limit and can be
                 // fetched again from an offset; the fetch says whether it did.
                 // One snapshot serves every outer fetch and the inner probes
-                let snapshot = match ctx.statement_snapshot() {
+                // Read committed is the cheap default; snapshot isolation costs
+                // about two microseconds per join, so it is taken only when a
+                // continuation finds that a commit moved rows under it
+                let mut snapshot = match ctx.statement_snapshot() {
                     Some(snapshot) => snapshot.clone(),
-                    None => self.new_statement_snapshot()?,
+                    None => {
+                        self.new_statement_snapshot(crate::core::IsolationLevel::ReadCommitted)?
+                    }
                 };
-                let ctx_join = ctx.with_statement_snapshot(snapshot.clone());
-                let ctx = &ctx_join;
+                let mut ctx_join = ctx.with_statement_snapshot(snapshot.clone());
                 // An explicit transaction reads through its own transaction, whose
                 // isolation may let a commit move rows between two fetches, so
                 // the outer side is fetched whole there
@@ -4235,7 +4239,7 @@ impl Executor {
                 } else {
                     join_limit.map(|l| {
                         let l = l as usize;
-                        l.saturating_add(l / 8).max(100)
+                        l.saturating_add(l / 16).max(100)
                     })
                 };
 
@@ -4243,7 +4247,7 @@ impl Executor {
                 let (outer_result, outer_cols, outer_bounded) = self
                     .execute_table_expression_with_filter_limit(
                         outer_expr,
-                        ctx,
+                        &ctx_join,
                         nl_left_filter.as_ref(),
                         outer_limit,
                         0,
@@ -4355,6 +4359,7 @@ impl Executor {
                         let mut outer_result = outer_result;
                         let mut inner_table = Some(inner_table);
                         let mut fetched = 0usize;
+                        let mut consistent = false;
                         loop {
                             let outer_op: Box<dyn Operator> = Box::new(QueryResultOperator::new(
                                 outer_result,
@@ -4391,6 +4396,7 @@ impl Executor {
                             if result_rows.len() >= lim {
                                 break;
                             }
+                            let boundary = op.last_outer_row().cloned();
                             fetched = fetched.saturating_add(cap);
                             let missing = lim - result_rows.len();
                             let rate = result_rows.len() as f64 / fetched as f64;
@@ -4401,16 +4407,58 @@ impl Executor {
                             };
                             let next = estimate.clamp(32, fetched.saturating_mul(3));
                             outer_limit = Some(next);
-                            let (more, _, bounded) = self
+                            if consistent {
+                                let (more, _, bounded) = self
+                                    .execute_table_expression_with_filter_limit(
+                                        outer_expr,
+                                        &ctx_join,
+                                        nl_left_filter.as_ref(),
+                                        Some(next),
+                                        fetched,
+                                    )?;
+                                debug_assert!(bounded);
+                                outer_result = more;
+                                continue;
+                            }
+                            // Under read committed a commit may have moved rows before
+                            // the boundary. Fetch one row of overlap: when it is still
+                            // the row the chunk ended on, the rows after it are the
+                            // continuation; otherwise the join restarts on snapshot
+                            // isolation, where the chunks line up by construction
+                            let (mut more, _, bounded) = self
                                 .execute_table_expression_with_filter_limit(
                                     outer_expr,
-                                    ctx,
+                                    &ctx_join,
                                     nl_left_filter.as_ref(),
-                                    Some(next),
-                                    fetched,
+                                    Some(next + 1),
+                                    fetched - 1,
                                 )?;
                             debug_assert!(bounded);
-                            outer_result = more;
+                            let unmoved = more.next()
+                                && boundary
+                                    .as_ref()
+                                    .is_some_and(|row| row.as_slice() == more.row().as_slice());
+                            if unmoved {
+                                outer_result = more;
+                                continue;
+                            }
+                            snapshot = self.new_statement_snapshot(
+                                crate::core::IsolationLevel::SnapshotIsolation,
+                            )?;
+                            ctx_join = ctx.with_statement_snapshot(snapshot.clone());
+                            consistent = true;
+                            result_rows.clear();
+                            outer_limit = Some(fetched.saturating_add(next));
+                            fetched = 0;
+                            outer_result = self
+                                .execute_table_expression_with_filter_limit(
+                                    outer_expr,
+                                    &ctx_join,
+                                    nl_left_filter.as_ref(),
+                                    outer_limit,
+                                    0,
+                                )?
+                                .0;
                         }
                     } else {
                         // Batch INL for NO LIMIT - single batch fetch, O(1) lock overhead
@@ -6442,11 +6490,15 @@ impl Executor {
         snapshot.get_table(name)
     }
 
-    /// One transaction for every read of a statement, under snapshot isolation
-    /// so a later commit cannot move rows between two of its fetches
-    fn new_statement_snapshot(&self) -> Result<StatementSnapshot> {
+    /// One transaction for every read of a statement
+    fn new_statement_snapshot(
+        &self,
+        isolation: crate::core::IsolationLevel,
+    ) -> Result<StatementSnapshot> {
         let mut transaction = self.engine.begin_transaction()?;
-        transaction.set_isolation_level(crate::core::IsolationLevel::SnapshotIsolation)?;
+        if isolation != crate::core::IsolationLevel::ReadCommitted {
+            transaction.set_isolation_level(isolation)?;
+        }
         Ok(StatementSnapshot::new(transaction))
     }
 

--- a/tests/grouped_join_stream_test.rs
+++ b/tests/grouped_join_stream_test.rs
@@ -182,3 +182,60 @@ fn test_grouped_join_offset_and_limit() {
         assert!(all.contains(row), "unexpected {row:?}");
     }
 }
+
+#[test]
+fn test_grouped_join_rollup_keeps_the_total_row() {
+    let db = setup("grouped_join_rollup");
+    let with_limit = rows(
+        &db,
+        "SELECT u.id, COUNT(o.id) FROM users u INNER JOIN orders o ON u.id = o.user_id GROUP BY ROLLUP(u.id) LIMIT 1000",
+    );
+    let general = rows(
+        &db,
+        "SELECT u.id, COUNT(o.id) FROM users u INNER JOIN orders o ON u.id = o.user_id GROUP BY ROLLUP(u.id) ORDER BY u.id",
+    );
+    let mut with_limit = with_limit;
+    let mut general = general;
+    with_limit.sort();
+    general.sort();
+    assert_eq!(with_limit, general);
+    assert!(
+        general.iter().any(|row| row[0] == "NULL"),
+        "rollup total row"
+    );
+}
+
+#[test]
+fn test_grouped_join_where_subquery() {
+    let db = setup("grouped_join_where_subquery");
+    for from_where in [
+        "users u INNER JOIN orders o ON u.id = o.user_id WHERE o.amount > (SELECT AVG(amount) FROM orders)",
+        "users u INNER JOIN orders o ON u.id = o.user_id WHERE u.id IN (SELECT user_id FROM orders WHERE amount > 500)",
+        "users u INNER JOIN orders o ON u.id = o.user_id WHERE o.amount + u.id > (SELECT AVG(amount) FROM orders)",
+    ] {
+        check(&db, "u.id, COUNT(o.id), SUM(o.amount)", from_where, "GROUP BY u.id", 1000);
+        check(&db, "u.id, COUNT(o.id)", from_where, "GROUP BY u.id", 7);
+    }
+}
+
+#[test]
+fn test_limited_join_where_subquery() {
+    let db = setup("limited_join_where_subquery");
+    let general = rows(
+        &db,
+        "SELECT u.id, o.amount FROM users u INNER JOIN orders o ON u.id = o.user_id WHERE o.amount > (SELECT AVG(amount) FROM orders) ORDER BY u.id, o.amount",
+    );
+    let mut limited = rows(
+        &db,
+        "SELECT u.id, o.amount FROM users u INNER JOIN orders o ON u.id = o.user_id WHERE o.amount > (SELECT AVG(amount) FROM orders) LIMIT 1000",
+    );
+    limited.sort();
+    let mut general = general;
+    general.sort();
+    assert_eq!(limited, general);
+    let page = rows(
+        &db,
+        "SELECT u.id, o.amount FROM users u INNER JOIN orders o ON u.id = o.user_id WHERE o.amount > (SELECT AVG(amount) FROM orders) LIMIT 7",
+    );
+    assert_eq!(page.len(), 7.min(general.len()));
+}

--- a/tests/grouped_join_stream_test.rs
+++ b/tests/grouped_join_stream_test.rs
@@ -1,0 +1,184 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A GROUP BY + LIMIT join whose groups are the left rows streams its groups
+//! through the right side's index. Every shape is checked against the same
+//! query with an ORDER BY, which takes the general hash path.
+
+use stoolap::Database;
+
+/// 100 users, 400 orders: user k has k % 7 orders, amounts 1..; users with
+/// id % 10 == 0 have none. Every third order is 'shipped'.
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, active BOOLEAN)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount FLOAT, status TEXT)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX idx_orders_user_id ON orders(user_id)", ())
+        .unwrap();
+    for i in 1..=100i64 {
+        db.execute(
+            "INSERT INTO users VALUES ($1, $2, $3)",
+            (i, format!("U{i}"), i % 3 != 0),
+        )
+        .unwrap();
+    }
+    let mut id = 0i64;
+    for user in 1..=100i64 {
+        if user % 10 == 0 {
+            continue;
+        }
+        for k in 0..(user % 7) {
+            id += 1;
+            let status = if id % 3 == 0 { "shipped" } else { "completed" };
+            db.execute(
+                "INSERT INTO orders VALUES ($1, $2, $3, $4)",
+                (id, user, (user * 10 + k) as f64, status),
+            )
+            .unwrap();
+        }
+    }
+    db
+}
+
+fn rows(db: &Database, sql: &str) -> Vec<Vec<String>> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (0..row.len())
+                .map(|i| {
+                    row.get::<Option<String>>(i)
+                        .unwrap()
+                        .unwrap_or_else(|| "NULL".into())
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// The streamed result (LIMIT, no ORDER BY) must equal the general result
+/// (ORDER BY u.id, no LIMIT) once both are sorted, and its length the limit.
+fn check(db: &Database, select: &str, from_where: &str, group_having: &str, limit: usize) {
+    let streamed = format!("SELECT {select} FROM {from_where} {group_having} LIMIT {limit}");
+    let general = format!("SELECT {select} FROM {from_where} {group_having} ORDER BY u.id");
+    let mut got = rows(db, &streamed);
+    let mut want = rows(db, &general);
+    got.sort();
+    want.sort();
+    assert!(got.len() <= limit, "{streamed}: {} rows", got.len());
+    assert_eq!(got.len(), want.len().min(limit), "{streamed}");
+    for row in &got {
+        assert!(want.contains(row), "{streamed}: unexpected {row:?}");
+    }
+    if got.len() == want.len() {
+        assert_eq!(got, want, "{streamed}");
+    }
+}
+
+#[test]
+fn test_grouped_join_matches_the_general_path() {
+    let db = setup("grouped_join_stream");
+    let inner = "users u INNER JOIN orders o ON u.id = o.user_id";
+    let left = "users u LEFT JOIN orders o ON u.id = o.user_id";
+    check(
+        &db,
+        "u.name, COUNT(o.id)",
+        inner,
+        "GROUP BY u.id, u.name",
+        1000,
+    );
+    check(
+        &db,
+        "u.name, COUNT(o.id)",
+        inner,
+        "GROUP BY u.id, u.name",
+        10,
+    );
+    check(
+        &db,
+        "u.name, COUNT(o.id), COUNT(*)",
+        left,
+        "GROUP BY u.id, u.name",
+        1000,
+    );
+    check(&db, "u.name, COUNT(o.id)", left, "GROUP BY u.id, u.name", 7);
+    check(
+        &db,
+        "u.name, COUNT(DISTINCT o.status) AS kinds, SUM(o.amount) AS total, AVG(o.amount), MIN(o.amount), MAX(o.amount)",
+        inner,
+        "GROUP BY u.id, u.name",
+        1000,
+    );
+    check(
+        &db,
+        "u.name, COUNT(o.id) AS orders",
+        inner,
+        "GROUP BY u.id, u.name HAVING COUNT(o.id) > 2",
+        1000,
+    );
+    check(
+        &db,
+        "u.name, COUNT(o.id) AS orders",
+        inner,
+        "GROUP BY u.id, u.name HAVING COUNT(o.id) > 2",
+        5,
+    );
+    check(
+        &db,
+        "u.name, SUM(o.amount)",
+        &format!("{inner} WHERE u.active = true AND o.status = 'completed'"),
+        "GROUP BY u.id, u.name HAVING SUM(o.amount) > 100",
+        1000,
+    );
+    check(
+        &db,
+        "u.name, COUNT(o.id)",
+        &format!("{inner} WHERE o.amount > u.id * 10"),
+        "GROUP BY u.id, u.name",
+        1000,
+    );
+    check(
+        &db,
+        "u.name, SUM(o.amount) / COUNT(*) AS mean",
+        inner,
+        "GROUP BY u.id, u.name",
+        1000,
+    );
+    check(&db, "u.id, COUNT(o.id)", left, "GROUP BY u.id", 1000);
+}
+
+#[test]
+fn test_grouped_join_offset_and_limit() {
+    let db = setup("grouped_join_stream_offset");
+    let all = rows(
+        &db,
+        "SELECT u.name, COUNT(o.id) FROM users u INNER JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name ORDER BY u.id",
+    );
+    let page = rows(
+        &db,
+        "SELECT u.name, COUNT(o.id) FROM users u INNER JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name LIMIT 10 OFFSET 60",
+    );
+    assert_eq!(page.len(), 10.min(all.len() - 60));
+    for row in &page {
+        assert!(all.contains(row), "unexpected {row:?}");
+    }
+}

--- a/tests/grouped_join_stream_test.rs
+++ b/tests/grouped_join_stream_test.rs
@@ -239,3 +239,20 @@ fn test_limited_join_where_subquery() {
     );
     assert_eq!(page.len(), 7.min(general.len()));
 }
+
+#[test]
+fn test_grouped_join_where_nested_subquery() {
+    let db = setup("grouped_join_where_nested_subquery");
+    for from_where in [
+        "users u INNER JOIN orders o ON u.id = o.user_id WHERE o.amount BETWEEN (SELECT MIN(amount) FROM orders) AND (SELECT AVG(amount) FROM orders)",
+        "users u INNER JOIN orders o ON u.id = o.user_id WHERE o.amount IN (SELECT amount FROM orders WHERE amount > 900)",
+    ] {
+        let general = rows(
+            &db,
+            &format!("SELECT u.id, COUNT(o.id) FROM {from_where} GROUP BY u.id ORDER BY u.id"),
+        );
+        assert!(!general.is_empty(), "general path returns rows for {from_where}");
+        check(&db, "u.id, COUNT(o.id), SUM(o.amount)", from_where, "GROUP BY u.id", 1000);
+        check(&db, "u.id, COUNT(o.id)", from_where, "GROUP BY u.id", 7);
+    }
+}


### PR DESCRIPTION
## Why

`Complex JOIN+GROUP+HAVING` went from 45 us on the baseline (an incomplete answer: 44 rows for `LIMIT 50`) to about 85 us for the complete answer after #83 and #87. The profile of the correct path showed why: the GROUP BY reduction fetches a chunk of left rows, fetches every matching right row through an IN filter, hash joins them, hashes them again into groups and applies HAVING, computing all 200 groups of the chunk to keep 50. More than half the time was the hash aggregation and the joined rows it materialises.

## What

A streaming path for a GROUP BY + LIMIT join whose groups are the left rows (the reduction's own eligibility: INNER or LEFT JOIN, GROUP BY covering the left primary key and only left columns, LIMIT, no ORDER BY, window function or DISTINCT):

- The right side is probed per left row through its index with the streaming index nested loop operator; the right-side WHERE is its residual filter, a cross-table WHERE is applied per joined row.
- Each group is folded as the joined rows stream past, with the aggregate functions from the registry (`accumulate`, `result`, `reset`), COUNT(*) included, DISTINCT honoured. The group columns cover the left primary key, so a change in them is the next left row.
- HAVING runs on the finished group through the same `RowFilter::with_aliases` binding the hash path uses, the SELECT projection through `apply_post_aggregation_expressions`, and the scan stops after LIMIT + OFFSET groups have passed.
- The outer side is fetched in chunks with the continuation and snapshot rules of #89; inside an explicit transaction it is read whole.
- Not covered, and left to the reduction: an aggregate over an expression or with FILTER or ORDER BY, a GROUP BY expression, ROLLUP, CUBE or GROUPING SETS, a WHERE with a subquery, a LEFT JOIN with a right-side filter, a right key without an index.


## The statement snapshot opens read committed

#89 opens a statement snapshot for every limited index join so that the outer chunks and the inner probes read one state. It is opened under snapshot isolation, and setting that level costs about two microseconds per join, a fifth of the benchmark's INNER JOIN and Self JOIN rows. The first commit here changes that for the limited join and the grouped join alike:

- The snapshot opens read committed, the engine default, so no isolation call is made. Every outer fetch and every inner probe of one join still go through that one transaction.
- A continuation refetches one row of overlap before the next chunk. When it is still the row the previous chunk ended on, nothing moved under the join and the rows after it are the continuation. When a commit moved it, the join restarts from the beginning on a snapshot isolation transaction, where the chunks line up by construction. The index nested loop operator exposes the outer row it ended on for that check.
- The first chunk keeps a sixteenth of slack over the limit instead of an eighth.
- Inside an explicit transaction nothing changes: the outer side is read whole through the transaction.

## Measurements

Random benchmark-shaped data (`join_rand` probe, 10k users, 30k orders, unseeded), best of 6 interleaved runs against current main, in us:

| Query | main | this PR |
|---|---|---|
| INNER JOIN + GROUP BY + HAVING, LIMIT 50 | 88 | 48 |
| LEFT JOIN + GROUP BY, LIMIT 100 | 51 | 44 |
| INNER JOIN, LIMIT 100 | 13 | 12 |
| Self JOIN, LIMIT 100 | 8 | 6 |

`examples/benchmark` rows, three interleaved runs against current main on the same machine, median in us:

| Row | main | this PR |
|---|---|---|
| INNER JOIN | 18.5 | 15.4 |
| LEFT JOIN + GROUP BY | 55.3 | 48.2 |
| CTE + JOIN | 43.9 | 44.3 |
| Complex JOIN+GROUP+HAVING | 106.8 | 74.8 |
| Self JOIN (same age) | 10.5 | 9.6 |

The Complex row averages 20 executions with no warmup, about 1.2 ms of work, so a single slow first execution moves it a lot: one of the three runs here reported 306 us with the other 19 executions at their usual 55 to 65 us, the same effect main shows at a smaller size. Read that row from several runs.

## Tests

`tests/grouped_join_stream_test.rs` checks every shape against the same query with an ORDER BY, which takes the general hash path: INNER and LEFT, COUNT(*), COUNT(col), COUNT(DISTINCT), SUM, AVG, MIN, MAX, aliases, HAVING with and without early stop, a right-side and a left-side WHERE, a cross-table WHERE, an expression over aggregates in the SELECT, GROUP BY on the key alone, and OFFSET. A ROLLUP keeps its total row, and a WHERE with a scalar, IN or expression subquery matches the general path, for the grouped and the plain limited join. `join_limit_shortfall_test` still covers the reduction and the continuation. Join, group by, aggregation, subquery and CTE targets pass, plus both full suites.
