### PR TITLE
perf(join): filter the inner fetch and project the joined row in the grouped stream

### DIFF
--- a/src/executor/operators/index_nested_loop.rs
+++ b/src/executor/operators/index_nested_loop.rs
@@ -29,7 +29,7 @@ use crate::core::value::NULL_VALUE;
 use crate::core::{Result, Row, RowVec, Value};
 use crate::executor::expression::JoinFilter;
 use crate::executor::operator::{ColumnInfo, Operator, RowRef};
-use crate::storage::expression::ConstBoolExpr;
+use crate::storage::expression::{ConstBoolExpr, Expression};
 use crate::storage::traits::{Index, Table};
 use smallvec::SmallVec;
 
@@ -117,6 +117,8 @@ pub struct IndexNestedLoopJoinOperator {
 
     // Expression for fetching rows (always true - we apply residual separately)
     true_expr: ConstBoolExpr,
+    // A predicate on inner columns the fetch applies instead of the residual
+    inner_filter: Option<Box<dyn Expression>>,
 
     // State tracking
     opened: bool,
@@ -175,6 +177,7 @@ impl IndexNestedLoopJoinOperator {
             // Pre-allocate row buffer to avoid per-row allocation
             row_buffer: Row::with_capacity(total_cols),
             true_expr: ConstBoolExpr::true_expr(),
+            inner_filter: None,
             opened: false,
             outer_exhausted: false,
             outer_rows_seen: 0,
@@ -204,6 +207,13 @@ impl IndexNestedLoopJoinOperator {
             repeats_source,
         });
         self.schema = projected_schema;
+        self
+    }
+
+    /// A filter the inner fetch applies to each candidate row, for a
+    /// predicate on inner columns only
+    pub fn with_inner_filter(mut self, filter: Box<dyn Expression>) -> Self {
+        self.inner_filter = Some(filter);
         self
     }
 
@@ -340,9 +350,13 @@ impl IndexNestedLoopJoinOperator {
         }
 
         // Fetch matching rows directly into inner_rows buffer
+        let filter: &dyn Expression = match &self.inner_filter {
+            Some(filter) => filter.as_ref(),
+            None => &self.true_expr,
+        };
         self.inner_table.fetch_rows_by_ids_into(
             &self.row_id_buffer,
-            &self.true_expr,
+            filter,
             &mut self.current_inner_rows,
         )
     }

--- a/src/executor/pushdown/mod.rs
+++ b/src/executor/pushdown/mod.rs
@@ -231,15 +231,17 @@ impl PushdownRegistry {
         (None, true)
     }
 
-    /// Try to convert an expression, returning only the storage expression
-    /// (for internal use in compound rules)
-    pub(crate) fn convert_expr(
+    /// A child converted whole, for a rule whose result would be wider than
+    /// the predicate with a partial child inside it
+    pub(crate) fn convert_expr_exact(
         &self,
         expr: &ast::Expression,
         ctx: &PushdownContext<'_>,
     ) -> Option<Box<dyn StorageExpr>> {
-        let (storage_expr, _) = self.try_pushdown_with_ctx(expr, ctx);
-        storage_expr
+        match self.try_pushdown_with_ctx(expr, ctx) {
+            (Some(storage_expr), false) => Some(storage_expr),
+            _ => None,
+        }
     }
 }
 

--- a/src/executor/pushdown/rules.rs
+++ b/src/executor/pushdown/rules.rs
@@ -331,17 +331,16 @@ impl PushdownRule for LogicalXorRule {
         };
 
         // XOR is equivalent to: (A AND NOT B) OR (NOT A AND B)
-        let left1 = registry().convert_expr_exact(&infix.left, ctx);
-        let right1 = registry().convert_expr_exact(&infix.right, ctx);
-        let left2 = registry().convert_expr_exact(&infix.left, ctx);
-        let right2 = registry().convert_expr_exact(&infix.right, ctx);
+        let left = registry().convert_expr_exact(&infix.left, ctx);
+        let right = registry().convert_expr_exact(&infix.right, ctx);
 
-        match (left1, right1, left2, right2) {
-            (Some(mut l1), Some(mut r1), Some(mut l2), Some(mut r2)) => {
+        match (left, right) {
+            (Some(mut l1), Some(mut r1)) => {
                 l1.prepare_for_schema(ctx.schema);
                 r1.prepare_for_schema(ctx.schema);
-                l2.prepare_for_schema(ctx.schema);
-                r2.prepare_for_schema(ctx.schema);
+                // Each operand converted once, so both places carry the same value
+                let l2 = l1.clone();
+                let r2 = r1.clone();
 
                 // (left AND NOT right) OR (NOT left AND right)
                 let left_and_not_right = AndExpr::new(vec![l1, Box::new(NotExpr::new(r1))]);

--- a/src/executor/pushdown/rules.rs
+++ b/src/executor/pushdown/rules.rs
@@ -271,8 +271,8 @@ impl PushdownRule for LogicalOrRule {
 
         // For OR: can only push if BOTH sides are fully pushable
         // (partial pushdown of OR would change semantics)
-        let left = registry().convert_expr(&infix.left, ctx);
-        let right = registry().convert_expr(&infix.right, ctx);
+        let left = registry().convert_expr_exact(&infix.left, ctx);
+        let right = registry().convert_expr_exact(&infix.right, ctx);
 
         match (left, right) {
             (Some(mut l), Some(mut r)) => {
@@ -303,7 +303,7 @@ impl PushdownRule for LogicalNotRule {
         };
 
         // NOT requires the inner expression to be fully pushable
-        match registry().convert_expr(&prefix.right, ctx) {
+        match registry().convert_expr_exact(&prefix.right, ctx) {
             Some(mut inner) => {
                 inner.prepare_for_schema(ctx.schema);
                 PushdownResult::Converted(Box::new(NotExpr::new(inner)))
@@ -331,10 +331,10 @@ impl PushdownRule for LogicalXorRule {
         };
 
         // XOR is equivalent to: (A AND NOT B) OR (NOT A AND B)
-        let left1 = registry().convert_expr(&infix.left, ctx);
-        let right1 = registry().convert_expr(&infix.right, ctx);
-        let left2 = registry().convert_expr(&infix.left, ctx);
-        let right2 = registry().convert_expr(&infix.right, ctx);
+        let left1 = registry().convert_expr_exact(&infix.left, ctx);
+        let right1 = registry().convert_expr_exact(&infix.right, ctx);
+        let left2 = registry().convert_expr_exact(&infix.left, ctx);
+        let right2 = registry().convert_expr_exact(&infix.right, ctx);
 
         match (left1, right1, left2, right2) {
             (Some(mut l1), Some(mut r1), Some(mut l2), Some(mut r2)) => {

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -6794,17 +6794,16 @@ impl Executor {
             None => None,
         };
         // A right-side filter the storage layer takes whole runs inside the
-        // inner fetch; a partial or refused one stays a residual on the joined row
-        let build_inner_filter = |table: &dyn crate::storage::traits::Table| {
-            right_filter.and_then(|rf| {
-                let rf = crate::executor::utils::strip_table_qualifier(rf, inner_alias);
-                match pushdown::try_pushdown(&rf, table.schema(), Some(ctx)) {
-                    (Some(expr), false) => Some(expr),
-                    _ => None,
-                }
-            })
-        };
-        let pushed_inner = build_inner_filter(inner_table.as_ref()).is_some();
+        // inner fetch, built once so every chunk sees the same predicate; a
+        // partial or refused one stays a residual on the joined row
+        let inner_filter = right_filter.and_then(|rf| {
+            let rf = crate::executor::utils::strip_table_qualifier(rf, inner_alias);
+            match pushdown::try_pushdown(&rf, inner_table.schema(), Some(ctx)) {
+                (Some(expr), false) => Some(expr),
+                _ => None,
+            }
+        });
+        let pushed_inner = inner_filter.is_some();
         let build_residual_filter = || {
             if pushed_inner {
                 return None;
@@ -6871,7 +6870,6 @@ impl Executor {
                 Some(table) => table,
                 None => self.join_table(&snapshot, &table_name)?,
             };
-            let inner_filter = build_inner_filter(table.as_ref());
             let mut op = IndexNestedLoopJoinOperator::new(
                 outer_op,
                 table,
@@ -6881,8 +6879,8 @@ impl Executor {
                 lookup_strategy.clone(),
                 build_residual_filter(),
             );
-            if let Some(filter) = inner_filter {
-                op = op.with_inner_filter(filter);
+            if let Some(filter) = &inner_filter {
+                op = op.with_inner_filter(filter.clone());
             }
             if let Some((sources, schema)) = &projection {
                 op = op.with_projection(sources.clone(), schema.clone());

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -6734,6 +6734,38 @@ impl Executor {
                 }
             }
         }
+        // Without a cross filter the operator builds only the columns the
+        // groups and aggregates read
+        let projection = if cross_filter.is_none() {
+            use crate::executor::operators::index_nested_loop::ColumnSource;
+            let mut sources: Vec<ColumnSource> = Vec::new();
+            let mut names: Vec<String> = Vec::new();
+            let mut place = |idx: usize| -> usize {
+                let source = if idx < outer_cols.len() {
+                    ColumnSource::Outer(idx)
+                } else {
+                    ColumnSource::Inner(idx - outer_cols.len())
+                };
+                match sources.iter().position(|s| *s == source) {
+                    Some(at) => at,
+                    None => {
+                        sources.push(source);
+                        names.push(all_columns[idx].clone());
+                        sources.len() - 1
+                    }
+                }
+            };
+            for idx in group_idx.iter_mut() {
+                *idx = place(*idx);
+            }
+            for idx in agg_idx.iter_mut().flatten() {
+                *idx = place(*idx);
+            }
+            let schema: Vec<ColumnInfo> = names.iter().map(ColumnInfo::new).collect();
+            Some((sources, schema))
+        } else {
+            None
+        };
         let mut result_columns: Vec<String> = group_names.clone();
         for agg in &aggregations {
             result_columns.push(
@@ -6761,7 +6793,18 @@ impl Executor {
             Some(cross) => Some(RowFilter::new(cross, &all_columns)?.with_context(ctx)),
             None => None,
         };
+        // A right-side filter the storage layer can evaluate runs inside the
+        // inner fetch; any other stays a residual on the joined row
+        let build_inner_filter = || {
+            right_filter
+                .map(|rf| crate::executor::utils::strip_table_qualifier(rf, inner_alias))
+                .and_then(|rf| crate::executor::expr_converter::convert_ast_to_storage_expr(&rf))
+        };
+        let pushed_inner = build_inner_filter().is_some();
         let build_residual_filter = || {
+            if pushed_inner {
+                return None;
+            }
             right_filter.and_then(|rf| {
                 let qualified_rf = add_table_qualifier(rf, inner_alias);
                 JoinFilter::new(
@@ -6820,18 +6863,29 @@ impl Executor {
         loop {
             let outer_op: Box<dyn Operator> =
                 Box::new(QueryResultOperator::new(outer_result, outer_cols.clone()));
+            let table = match inner_table.take() {
+                Some(table) => table,
+                None => self.join_table(&snapshot, &table_name)?,
+            };
+            let inner_filter = build_inner_filter().map(|mut filter| {
+                filter.prepare_for_schema(table.schema());
+                filter
+            });
             let mut op = IndexNestedLoopJoinOperator::new(
                 outer_op,
-                match inner_table.take() {
-                    Some(table) => table,
-                    None => self.join_table(&snapshot, &table_name)?,
-                },
+                table,
                 inner_cols.iter().map(ColumnInfo::new).collect(),
                 op_join_type,
                 outer_key_idx,
                 lookup_strategy.clone(),
                 build_residual_filter(),
             );
+            if let Some(filter) = inner_filter {
+                op = op.with_inner_filter(filter);
+            }
+            if let Some((sources, schema)) = &projection {
+                op = op.with_projection(sources.clone(), schema.clone());
+            }
             op.open()?;
             // The group columns cover the left primary key, so a change in them
             // is a new left row

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -6793,14 +6793,18 @@ impl Executor {
             Some(cross) => Some(RowFilter::new(cross, &all_columns)?.with_context(ctx)),
             None => None,
         };
-        // A right-side filter the storage layer can evaluate runs inside the
-        // inner fetch; any other stays a residual on the joined row
-        let build_inner_filter = || {
-            right_filter
-                .map(|rf| crate::executor::utils::strip_table_qualifier(rf, inner_alias))
-                .and_then(|rf| crate::executor::expr_converter::convert_ast_to_storage_expr(&rf))
+        // A right-side filter the storage layer takes whole runs inside the
+        // inner fetch; a partial or refused one stays a residual on the joined row
+        let build_inner_filter = |table: &dyn crate::storage::traits::Table| {
+            right_filter.and_then(|rf| {
+                let rf = crate::executor::utils::strip_table_qualifier(rf, inner_alias);
+                match pushdown::try_pushdown(&rf, table.schema(), Some(ctx)) {
+                    (Some(expr), false) => Some(expr),
+                    _ => None,
+                }
+            })
         };
-        let pushed_inner = build_inner_filter().is_some();
+        let pushed_inner = build_inner_filter(inner_table.as_ref()).is_some();
         let build_residual_filter = || {
             if pushed_inner {
                 return None;
@@ -6867,10 +6871,7 @@ impl Executor {
                 Some(table) => table,
                 None => self.join_table(&snapshot, &table_name)?,
             };
-            let inner_filter = build_inner_filter().map(|mut filter| {
-                filter.prepare_for_schema(table.schema());
-                filter
-            });
+            let inner_filter = build_inner_filter(table.as_ref());
             let mut op = IndexNestedLoopJoinOperator::new(
                 outer_op,
                 table,

--- a/tests/grouped_join_stream_test.rs
+++ b/tests/grouped_join_stream_test.rs
@@ -356,3 +356,70 @@ fn test_grouped_join_right_filter_typed_literals() {
         assert_eq!(page.len(), 5.min(general.len()), "{from_where}");
     }
 }
+
+#[test]
+fn test_pushdown_or_with_a_partial_child() {
+    let db = Database::open("memory://pushdown_or_partial_child").unwrap();
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount FLOAT, status TEXT)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX idx_orders_user_id ON orders(user_id)", ())
+        .unwrap();
+    let mut expected_rows = 0i64;
+    let mut expected_groups: Vec<Vec<String>> = Vec::new();
+    let mut id = 0;
+    for user in 1..=30i64 {
+        db.execute(
+            "INSERT INTO users VALUES ($1, $2)",
+            (user, format!("user{user}")),
+        )
+        .unwrap();
+        let mut per_user = 0i64;
+        for k in 0..3i64 {
+            id += 1;
+            let status = if (user + k) % 2 == 0 { "c_1" } else { "cx1" };
+            let amount = (user * 10 + k) as f64 - 15.0;
+            db.execute(
+                "INSERT INTO orders VALUES ($1, $2, $3, $4)",
+                (id, user, amount, status),
+            )
+            .unwrap();
+            if (amount > 10.0 && status == "c_1") || amount < 0.0 {
+                per_user += 1;
+            }
+        }
+        expected_rows += per_user;
+        if per_user > 0 {
+            expected_groups.push(vec![user.to_string(), per_user.to_string()]);
+        }
+    }
+    let scanned: i64 = db
+        .query(
+            "SELECT COUNT(*) FROM orders WHERE (amount > 10 AND status LIKE 'c!_%' ESCAPE '!') OR amount < 0",
+            (),
+        )
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap();
+    assert_eq!(
+        scanned, expected_rows,
+        "scan with the OR of a partial child"
+    );
+    let mut streamed = rows(
+        &db,
+        "SELECT u.id, COUNT(o.id) FROM users u INNER JOIN orders o ON u.id = o.user_id WHERE (o.amount > 10 AND o.status LIKE 'c!_%' ESCAPE '!') OR o.amount < 0 GROUP BY u.id LIMIT 1000",
+    );
+    streamed.sort();
+    expected_groups.sort();
+    assert_eq!(
+        streamed, expected_groups,
+        "grouped stream with the OR of a partial child"
+    );
+}

--- a/tests/grouped_join_stream_test.rs
+++ b/tests/grouped_join_stream_test.rs
@@ -293,3 +293,66 @@ fn test_grouped_join_right_filters() {
         check(&db, "u.name, COUNT(o.id)", &from_where, group, 9);
     }
 }
+
+#[test]
+fn test_grouped_join_right_filter_typed_literals() {
+    let db = Database::open("memory://grouped_join_typed_literals").unwrap();
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount FLOAT, status TEXT, created_at TIMESTAMP)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX idx_orders_user_id ON orders(user_id)", ())
+        .unwrap();
+    for user in 1..=30i64 {
+        db.execute(
+            "INSERT INTO users VALUES ($1, $2)",
+            (user, format!("user{user}")),
+        )
+        .unwrap();
+    }
+    let mut id = 0;
+    for user in 1..=30i64 {
+        for k in 0..3i64 {
+            id += 1;
+            let status = if (user + k) % 2 == 0 { "c_1" } else { "cx1" };
+            let created = if k == 0 {
+                "2024-01-15 10:00:00"
+            } else {
+                "2024-08-15 10:00:00"
+            };
+            db.execute(
+                &format!(
+                    "INSERT INTO orders VALUES ({id}, {user}, {}, '{status}', TIMESTAMP '{created}')",
+                    user * 10 + k
+                ),
+                (),
+            )
+            .unwrap();
+        }
+    }
+    for from_where in [
+        "users u INNER JOIN orders o ON u.id = o.user_id WHERE o.status LIKE 'c!_%' ESCAPE '!'",
+        "users u INNER JOIN orders o ON u.id = o.user_id WHERE o.created_at > TIMESTAMP '2024-06-01 00:00:00'",
+    ] {
+        let mut general = rows(
+            &db,
+            &format!("SELECT u.id, COUNT(o.id) FROM {from_where} GROUP BY u.id ORDER BY u.id"),
+        );
+        assert!(!general.is_empty(), "general path returns rows for {from_where}");
+        let mut streamed = rows(
+            &db,
+            &format!("SELECT u.id, COUNT(o.id) FROM {from_where} GROUP BY u.id LIMIT 1000"),
+        );
+        streamed.sort();
+        general.sort();
+        assert_eq!(streamed, general, "{from_where}");
+        let page = rows(
+            &db,
+            &format!("SELECT u.id, COUNT(o.id) FROM {from_where} GROUP BY u.id LIMIT 5"),
+        );
+        assert_eq!(page.len(), 5.min(general.len()), "{from_where}");
+    }
+}

--- a/tests/grouped_join_stream_test.rs
+++ b/tests/grouped_join_stream_test.rs
@@ -370,6 +370,7 @@ fn test_pushdown_or_with_a_partial_child() {
     db.execute("CREATE INDEX idx_orders_user_id ON orders(user_id)", ())
         .unwrap();
     let mut expected_rows = 0i64;
+    let mut expected_xor = 0i64;
     let mut expected_groups: Vec<Vec<String>> = Vec::new();
     let mut id = 0;
     for user in 1..=30i64 {
@@ -390,6 +391,9 @@ fn test_pushdown_or_with_a_partial_child() {
             .unwrap();
             if (amount > 10.0 && status == "c_1") || amount < 0.0 {
                 per_user += 1;
+            }
+            if (amount > 10.0 && status == "c_1") ^ (amount < 0.0) {
+                expected_xor += 1;
             }
         }
         expected_rows += per_user;
@@ -412,6 +416,18 @@ fn test_pushdown_or_with_a_partial_child() {
         scanned, expected_rows,
         "scan with the OR of a partial child"
     );
+    let xor: i64 = db
+        .query(
+            "SELECT COUNT(*) FROM orders WHERE (amount > 10 AND status LIKE 'c!_%' ESCAPE '!') XOR amount < 0",
+            (),
+        )
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap();
+    assert_eq!(xor, expected_xor, "scan with the XOR of a partial child");
     let mut streamed = rows(
         &db,
         "SELECT u.id, COUNT(o.id) FROM users u INNER JOIN orders o ON u.id = o.user_id WHERE (o.amount > 10 AND o.status LIKE 'c!_%' ESCAPE '!') OR o.amount < 0 GROUP BY u.id LIMIT 1000",

--- a/tests/grouped_join_stream_test.rs
+++ b/tests/grouped_join_stream_test.rs
@@ -256,3 +256,40 @@ fn test_grouped_join_where_nested_subquery() {
         check(&db, "u.id, COUNT(o.id)", from_where, "GROUP BY u.id", 7);
     }
 }
+
+#[test]
+fn test_grouped_join_right_filters() {
+    let db = setup("grouped_join_right_filters");
+    let inner = "users u INNER JOIN orders o ON u.id = o.user_id";
+    for (from_where, group) in [
+        (
+            format!("{inner} WHERE o.status IN ('completed', 'shipped') AND o.amount > 300"),
+            "GROUP BY u.id, u.name HAVING COUNT(o.id) > 1",
+        ),
+        (
+            format!("{inner} WHERE LENGTH(o.status) > 7"),
+            "GROUP BY u.id, u.name",
+        ),
+        (
+            format!("{inner} WHERE o.status = 'completed' AND o.amount > u.id * 10 + 1"),
+            "GROUP BY u.id, u.name",
+        ),
+        (
+            format!("{inner} WHERE o.status LIKE 'c%' AND u.id > 20"),
+            "GROUP BY u.id",
+        ),
+        (
+            format!("{inner} WHERE o.status <> 'shipped' OR o.amount < 100"),
+            "GROUP BY u.id",
+        ),
+    ] {
+        check(
+            &db,
+            "u.name, COUNT(o.id), SUM(o.amount)",
+            &from_where,
+            group,
+            1000,
+        );
+        check(&db, "u.name, COUNT(o.id)", &from_where, group, 9);
+    }
+}


### PR DESCRIPTION
## Why

After #90 the benchmark's `Complex JOIN+GROUP+HAVING` gives the complete answer at about 53 us against 45 us for the incomplete one it used to give. A sample of the streaming path on that query put a fifth of the time in the right-side `status IN (...)` predicate, evaluated on every joined row through the join filter's expression machine, and another tenth in building the full twelve-column joined row for groups that read four of its columns.

## What

- The right-side WHERE goes to the storage layer as the predicate of the inner fetch, through a new `with_inner_filter` on the index nested loop operator. It is converted by the same schema-aware pushdown a scan uses, against the inner table's schema, and only a predicate the pushdown takes whole replaces the residual filter; a partial or refused conversion (a function call, for one) keeps the residual on the joined row as before. For the benchmark's `status IN (...)` a non-matching order is never materialised.
- Without a cross-table filter the operator's projection pushdown builds only the columns the group keys and the aggregates read, in that order, so the group boundary check and the accumulators index a four-column row instead of a twelve-column one.

- Found on the way and fixed in the pushdown registry, which scans use as well: the OR, NOT and XOR rules converted their children with a helper that drops the partial flag, so `(amount > 10 AND status LIKE 'c!_%' ESCAPE '!') OR amount < 0` came back as a whole conversion of `(amount > 10) OR amount < 0` and the caller dropped its memory filter. The three rules now take a child only when it converted whole.

The join changes are inside the streaming grouped path; the plain limited join is untouched.

## Measurements

Random benchmark-shaped data (`join_rand` probe, 10k users, 30k orders, unseeded), best of 6 interleaved runs against main at #90, in us:

| Query | main | this PR |
|---|---|---|
| INNER JOIN + GROUP BY + HAVING, LIMIT 50 | 48 | 35 |
| LEFT JOIN + GROUP BY, LIMIT 100 | 44 | 37 |
| INNER JOIN, LIMIT 100 | 11 | 11 |
| Self JOIN, LIMIT 100 | 6 | 6 |

`examples/benchmark` rows, three interleaved runs against main at #90 on the same machine, median in us:

| Row | main | this PR |
|---|---|---|
| INNER JOIN | 15.9 | 15.2 |
| LEFT JOIN + GROUP BY | 51.7 | 41.2 |
| CTE + JOIN | 45.7 | 41.7 |
| Complex JOIN+GROUP+HAVING | 78.9 | 57.2 |
| Self JOIN (same age) | 9.1 | 8.7 |

The Complex row averages 20 executions with no warmup; read it from several runs.

## Tests

`grouped_join_stream_test` gained a right-filter test: an IN list with a range, a function call the storage layer cannot take, a right filter next to a cross-table filter (projection off), LIKE with a left filter, and an OR of two right-side predicates, each with and without an early stop, all against the general path. A second test with its own tables checks a `TIMESTAMP '...'` comparison and a `LIKE ... ESCAPE` on the right side, the two shapes the plain converter gets wrong. A third test computes the rows and groups of the OR with a partial child from the generated data and checks a plain scan and the grouped stream against them. Join and shortfall targets pass, plus both full suites.
