### PR TITLE
fix(executor): resolve a WHERE subquery wherever it sits, on every join path

### DIFF
--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -405,20 +405,23 @@ impl Executor {
         // back as a column, since an aggregate cannot resolve one itself
         let lifted_stmt;
         let lifted_columns;
-        let (stmt, base_rows, base_columns) = match stmt
-            .columns
-            .iter()
-            .any(Self::has_subqueries)
-            .then(|| Self::lift_subqueries_in_aggregates(&stmt.columns))
+        let (stmt, base_rows, base_columns) = match Self::aggregates_hold_subquery(stmt)
+            .then(|| Self::lift_subqueries_in_aggregates(stmt))
             .flatten()
         {
-            Some((columns, lifted)) => {
-                let (rows, all_columns) =
-                    self.materialize_lifted_subqueries(&lifted, ctx, base_rows, base_columns)?;
-                lifted_stmt = SelectStatement {
-                    columns,
-                    ..stmt.clone()
-                };
+            Some((rewritten, lifted)) => {
+                let qualifier = stmt
+                    .table_expr
+                    .as_deref()
+                    .and_then(super::utils::get_table_alias_from_expr);
+                let (rows, all_columns) = self.materialize_lifted_subqueries(
+                    &lifted,
+                    ctx,
+                    base_rows,
+                    base_columns,
+                    qualifier.as_deref(),
+                )?;
+                lifted_stmt = rewritten;
                 lifted_columns = all_columns;
                 (&lifted_stmt, rows, lifted_columns.as_slice())
             }
@@ -5221,6 +5224,9 @@ impl Executor {
         classification: &std::sync::Arc<QueryClassification>,
     ) -> Result<Option<Box<dyn crate::storage::traits::QueryResult>>> {
         // classification is passed from caller to avoid redundant cache lookups
+        if Self::aggregates_hold_subquery(stmt) {
+            return Ok(None);
+        }
 
         // Quick eligibility checks using cached classification
         if classification.has_where {
@@ -5419,6 +5425,10 @@ impl Executor {
     ) -> Result<Option<Box<dyn crate::storage::traits::QueryResult>>> {
         use crate::storage::mvcc::version_store::AggregateOp;
 
+        if Self::aggregates_hold_subquery(stmt) {
+            return Ok(None);
+        }
+
         // --- Eligibility checks ---
 
         if !classification.has_where {
@@ -5598,7 +5608,7 @@ impl Executor {
         classification: &std::sync::Arc<QueryClassification>,
     ) -> Result<Option<Box<dyn crate::storage::traits::QueryResult>>> {
         // Quick eligibility checks using cached classification
-        if classification.has_where {
+        if classification.has_where || Self::aggregates_hold_subquery(stmt) {
             return Ok(None);
         }
         if classification.has_group_by {
@@ -5963,6 +5973,10 @@ impl Executor {
     ) -> Result<Option<Box<dyn QueryResult>>> {
         use crate::common::SmartString;
         use smallvec::SmallVec;
+
+        if Self::aggregates_hold_subquery(stmt) {
+            return Ok(None);
+        }
 
         // Quick eligibility checks
         if !classification.has_group_by {
@@ -6352,6 +6366,10 @@ impl Executor {
     ) -> Option<Box<dyn QueryResult>> {
         use crate::parser::ast::GroupByModifier;
         use crate::storage::mvcc::version_store::AggregateOp;
+
+        if Self::aggregates_hold_subquery(stmt) {
+            return None;
+        }
 
         // Only for GROUP BY without WHERE or HAVING
         if classification.has_where || !classification.has_group_by || classification.has_having {

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -401,6 +401,30 @@ impl Executor {
         base_rows: RowVec,
         base_columns: &[String],
     ) -> Result<Box<dyn QueryResult>> {
+        // A subquery inside an aggregate is resolved per input row and read
+        // back as a column, since an aggregate cannot resolve one itself
+        let lifted_stmt;
+        let lifted_columns;
+        let (stmt, base_rows, base_columns) = match stmt
+            .columns
+            .iter()
+            .any(Self::has_subqueries)
+            .then(|| Self::lift_subqueries_in_aggregates(&stmt.columns))
+            .flatten()
+        {
+            Some((columns, lifted)) => {
+                let (rows, all_columns) =
+                    self.materialize_lifted_subqueries(&lifted, ctx, base_rows, base_columns)?;
+                lifted_stmt = SelectStatement {
+                    columns,
+                    ..stmt.clone()
+                };
+                lifted_columns = all_columns;
+                (&lifted_stmt, rows, lifted_columns.as_slice())
+            }
+            None => (stmt, base_rows, base_columns),
+        };
+
         // Parse aggregations and group by columns
         let (aggregations, _non_agg_columns) = self.parse_aggregations(stmt)?;
         let group_by_columns = self.parse_group_by(stmt, base_columns)?;

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -1298,17 +1298,16 @@ impl Executor {
         None
     }
 
-    /// Execute GROUP BY aggregation and return raw columns/rows for window function processing
-    /// This is used when both GROUP BY and window functions are present in the query.
-    /// Window functions operate on the aggregated result.
-    pub(crate) fn execute_aggregation_for_window(
+    /// Aggregate, then run the window functions over the aggregate's output.
+    /// A subquery inside an aggregate is resolved per input row first, and
+    /// both stages read the same rewritten statement
+    pub(crate) fn execute_aggregation_then_windows(
         &self,
         stmt: &SelectStatement,
         ctx: &ExecutionContext,
         base_rows: &[(i64, Row)],
         base_columns: &[String],
-    ) -> Result<(Vec<String>, RowVec)> {
-        // A subquery inside an aggregate is resolved per input row first
+    ) -> Result<Box<dyn QueryResult>> {
         let lifted_stmt;
         let lifted_rows;
         let lifted_columns;
@@ -1340,7 +1339,21 @@ impl Executor {
             }
             None => (stmt, base_rows, base_columns),
         };
+        let (agg_columns, agg_rows) =
+            self.execute_aggregation_for_window(stmt, ctx, base_rows, base_columns)?;
+        self.execute_select_with_window_functions(stmt, ctx, &agg_rows, &agg_columns)
+    }
 
+    /// Execute GROUP BY aggregation and return raw columns/rows for window function processing
+    /// This is used when both GROUP BY and window functions are present in the query.
+    /// Window functions operate on the aggregated result.
+    fn execute_aggregation_for_window(
+        &self,
+        stmt: &SelectStatement,
+        ctx: &ExecutionContext,
+        base_rows: &[(i64, Row)],
+        base_columns: &[String],
+    ) -> Result<(Vec<String>, RowVec)> {
         // Parse aggregations and group by columns
         let (aggregations, _non_agg_columns) = self.parse_aggregations(stmt)?;
         let group_by_columns = self.parse_group_by(stmt, base_columns)?;

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -406,18 +406,19 @@ impl Executor {
         let lifted_stmt;
         let lifted_columns;
         let (stmt, base_rows, base_columns) = match Self::aggregates_hold_subquery(stmt)
-            .then(|| Self::lift_subqueries_in_aggregates(stmt))
+            .then(|| Self::lift_subqueries_in_aggregates(stmt, base_columns))
             .flatten()
         {
-            Some((rewritten, lifted)) => {
+            Some((rewritten, lifted, names)) => {
                 let qualifier = stmt
                     .table_expr
                     .as_deref()
                     .and_then(super::utils::get_table_alias_from_expr);
                 let (rows, all_columns) = self.materialize_lifted_subqueries(
                     &lifted,
+                    &names,
                     ctx,
-                    base_rows,
+                    &base_rows,
                     base_columns,
                     qualifier.as_deref(),
                 )?;
@@ -1307,6 +1308,39 @@ impl Executor {
         base_rows: &[(i64, Row)],
         base_columns: &[String],
     ) -> Result<(Vec<String>, RowVec)> {
+        // A subquery inside an aggregate is resolved per input row first
+        let lifted_stmt;
+        let lifted_rows;
+        let lifted_columns;
+        let (stmt, base_rows, base_columns) = match Self::aggregates_hold_subquery(stmt)
+            .then(|| Self::lift_subqueries_in_aggregates(stmt, base_columns))
+            .flatten()
+        {
+            Some((rewritten, lifted, names)) => {
+                let qualifier = stmt
+                    .table_expr
+                    .as_deref()
+                    .and_then(super::utils::get_table_alias_from_expr);
+                let (rows, all_columns) = self.materialize_lifted_subqueries(
+                    &lifted,
+                    &names,
+                    ctx,
+                    base_rows,
+                    base_columns,
+                    qualifier.as_deref(),
+                )?;
+                lifted_stmt = rewritten;
+                lifted_rows = rows;
+                lifted_columns = all_columns;
+                (
+                    &lifted_stmt,
+                    lifted_rows.as_slice(),
+                    lifted_columns.as_slice(),
+                )
+            }
+            None => (stmt, base_rows, base_columns),
+        };
+
         // Parse aggregations and group by columns
         let (aggregations, _non_agg_columns) = self.parse_aggregations(stmt)?;
         let group_by_columns = self.parse_group_by(stmt, base_columns)?;

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -1298,6 +1298,20 @@ impl Executor {
         None
     }
 
+    /// The ORDER BY of an aggregate that orders its own input, with the
+    /// NULLS placement the query asked for
+    pub(crate) fn aggregate_order_keys(
+        order_by: &[crate::parser::ast::OrderByExpression],
+    ) -> Vec<crate::functions::AggregateOrder> {
+        order_by
+            .iter()
+            .map(|order| crate::functions::AggregateOrder {
+                ascending: order.ascending,
+                nulls_first: order.nulls_first,
+            })
+            .collect()
+    }
+
     /// Aggregate, then run the window functions over the aggregate's output.
     /// A subquery inside an aggregate is resolved per input row first, and
     /// both stages read the same rewritten statement
@@ -2243,12 +2257,7 @@ impl Executor {
                 for (i, agg) in aggregations.iter().enumerate() {
                     if !agg.order_by.is_empty() {
                         if let Some(ref mut func) = agg_funcs[i] {
-                            let directions: Vec<bool> = agg
-                                .order_by
-                                .iter()
-                                .map(|o| o.ascending) // true = ASC, false = DESC
-                                .collect();
-                            func.set_order_by(directions);
+                            func.set_order_by(Self::aggregate_order_keys(&agg.order_by));
                         }
                     }
                 }
@@ -4192,12 +4201,7 @@ impl Executor {
             for (i, agg) in aggregations.iter().enumerate() {
                 if !agg.order_by.is_empty() {
                     if let Some(ref mut func) = agg_funcs[i] {
-                        let directions: Vec<bool> = agg
-                            .order_by
-                            .iter()
-                            .map(|o| o.ascending) // true = ASC, false = DESC
-                            .collect();
-                        func.set_order_by(directions);
+                        func.set_order_by(Self::aggregate_order_keys(&agg.order_by));
                     }
                 }
             }

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3913,8 +3913,18 @@ impl Executor {
         // side's scan; one left after the join is evaluated per joined row
         let correlated_where = classification.where_has_correlated_subqueries;
         let where_for_join: Option<Expression> = match &stmt.where_clause {
-            Some(where_clause) if !correlated_where && classification.where_has_subqueries => {
-                Some(self.process_where_subqueries(where_clause, ctx)?)
+            Some(where_clause) if classification.where_has_subqueries => {
+                // Each conjunct folds on its own, so an uncorrelated one folds
+                // next to a correlated one
+                let mut folded = Vec::new();
+                for pred in flatten_and_predicates(where_clause) {
+                    if Self::has_subqueries(&pred) && !Self::has_correlated_subqueries(&pred) {
+                        folded.push(self.process_where_subqueries(&pred, ctx)?);
+                    } else {
+                        folded.push(pred);
+                    }
+                }
+                combine_predicates_with_and(folded)
             }
             Some(where_clause) => Some((**where_clause).clone()),
             None => None,

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -5170,7 +5170,9 @@ impl Executor {
                 let outer_columns = CompactArc::new(all_columns.clone());
                 let mut filtered = RowVec::with_capacity(result_rows.len());
                 for (id, row) in result_rows {
-                    let mut outer: FxHashMap<CompactArc<str>, Value> = FxHashMap::default();
+                    // The row of a query around this one stays visible to the subqueries
+                    let mut outer: FxHashMap<CompactArc<str>, Value> =
+                        ctx.outer_row().cloned().unwrap_or_default();
                     for key in &keys {
                         if let Some(value) = row.get(key.index) {
                             if let Some(unqualified) = &key.unqualified_part {
@@ -5182,7 +5184,13 @@ impl Executor {
                     let row_ctx = ctx.with_outer_row(outer, outer_columns.clone());
                     let processed = self.process_correlated_where(where_clause, &row_ctx)?;
                     ctx.check_cancelled()?;
-                    if RowFilter::new(&processed, &all_columns)?
+                    // A column of the query around this one is not in the joined
+                    // row, so every reference takes its value from the context
+                    let bound = match row_ctx.outer_row() {
+                        Some(outer) => super::utils::substitute_outer_references(&processed, outer),
+                        None => processed,
+                    };
+                    if RowFilter::new(&bound, &all_columns)?
                         .with_context(&row_ctx)
                         .matches_checked(&row)?
                     {

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -311,6 +311,12 @@ impl Executor {
             }
         }
 
+        // Check for CTEs (WITH clause). A statement with one keeps every
+        // subquery for the aggregation entry, which runs with the CTEs bound
+        if self.has_cte(stmt) {
+            return self.execute_select_with_ctes(stmt, ctx);
+        }
+
         // OPTIMIZATION: Get cached query classification ONCE at entry point
         // This classification is passed through the call chain to avoid
         // redundant hash computations and cache lookups (was 10+ calls per query)
@@ -341,11 +347,6 @@ impl Executor {
         } else {
             stmt
         };
-
-        // Check for CTEs (WITH clause)
-        if self.has_cte(stmt) {
-            return self.execute_select_with_ctes(stmt, ctx);
-        }
 
         // Evaluate LIMIT/OFFSET early (needed for set operations optimization)
         // Literal fast path: `LIMIT 10` needs no compile/cache/VM round trip
@@ -10388,6 +10389,10 @@ impl Executor {
         ctx: &ExecutionContext,
     ) -> Result<Option<(Box<dyn QueryResult>, CompactArc<Vec<String>>)>> {
         use crate::core::IndexType;
+
+        if Self::aggregates_hold_subquery(stmt) {
+            return Ok(None);
+        }
 
         // Only single-column GROUP BY is supported for now
         if stmt.group_by.columns.len() != 1 {

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -1607,6 +1607,11 @@ impl Executor {
         if let Some(where_clause) = &stmt.where_clause {
             // Pre-process subqueries in WHERE clause (EXISTS, IN, ALL/ANY, scalar subqueries)
             let processed_where = self.process_where_subqueries(where_clause, ctx)?;
+            // A parent row binds the outer references of a FROM-less subquery
+            let processed_where = match ctx.outer_row() {
+                Some(outer) => super::utils::substitute_outer_references(&processed_where, outer),
+                None => processed_where,
+            };
             let where_result = ExpressionEval::compile(&processed_where, &[])?
                 .with_context(ctx)
                 .eval_slice(&Row::new())?;
@@ -1663,8 +1668,11 @@ impl Executor {
             };
             columns.push(col_name);
 
-            // Evaluate expression
-            let value = ExpressionEval::compile(col_expr, &[])?
+            // Evaluate expression, with the parent row binding outer references
+            let bound = ctx
+                .outer_row()
+                .map(|outer| super::utils::substitute_outer_references(col_expr, outer));
+            let value = ExpressionEval::compile(bound.as_ref().unwrap_or(col_expr), &[])?
                 .with_context(ctx)
                 .eval_slice(&Row::new())?;
             values.push(value);
@@ -3501,7 +3509,7 @@ impl Executor {
                         // NOTE: Cannot use this optimization if there's a top-level ORDER BY
                         // because we need all rows to sort before applying LIMIT
                         let has_order_by = !stmt.order_by.is_empty();
-                        if !has_order_by {
+                        if !has_order_by && !Self::windows_hold_subquery(stmt) {
                             if let Some(limit_val) = Self::literal_fetch_limit(stmt) {
                                 // Use lazy partition fetching - returns early!
                                 let result = self
@@ -3661,13 +3669,7 @@ impl Executor {
             // Both aggregation and window functions:
             // 1. First apply GROUP BY aggregation
             // 2. Then apply window functions on the aggregated result
-            let agg_result = self.execute_aggregation_for_window(stmt, ctx, &rows, &all_columns)?;
-            let agg_columns = agg_result.0.clone();
-            let agg_rows = agg_result.1;
-
-            // Apply window functions on aggregated rows
-            let result =
-                self.execute_select_with_window_functions(stmt, ctx, &agg_rows, &agg_columns)?;
+            let result = self.execute_aggregation_then_windows(stmt, ctx, &rows, &all_columns)?;
             let columns = CompactArc::new(result.columns().to_vec());
             return Ok((result, columns, false, None));
         }
@@ -5306,14 +5308,8 @@ impl Executor {
         if has_agg && has_window {
             // 1. First apply GROUP BY aggregation
             // 2. Then apply window functions on the aggregated result
-            let agg_result =
-                self.execute_aggregation_for_window(stmt, ctx, &final_rows, &final_columns)?;
-            let agg_columns = agg_result.0.clone();
-            let agg_rows = agg_result.1;
-
-            // Apply window functions on aggregated rows (agg_rows is already RowVec with IDs)
             let result =
-                self.execute_select_with_window_functions(stmt, ctx, &agg_rows, &agg_columns)?;
+                self.execute_aggregation_then_windows(stmt, ctx, &final_rows, &final_columns)?;
             let columns = CompactArc::new(result.columns().to_vec());
             return Ok((result, columns, false, None));
         }
@@ -5678,12 +5674,8 @@ impl Executor {
 
             if classification.has_aggregation {
                 // Aggregation + window functions: aggregate first, then apply window functions
-                let agg_result =
-                    self.execute_aggregation_for_window(stmt, ctx, &rows, &view_columns)?;
-                let agg_columns = agg_result.0.clone();
-                let agg_rows = agg_result.1;
                 let result =
-                    self.execute_select_with_window_functions(stmt, ctx, &agg_rows, &agg_columns)?;
+                    self.execute_aggregation_then_windows(stmt, ctx, &rows, &view_columns)?;
                 let columns = CompactArc::new(result.columns().to_vec());
                 return Ok((result, columns, false, None));
             }

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -311,11 +311,6 @@ impl Executor {
             }
         }
 
-        // Check for CTEs (WITH clause)
-        if self.has_cte(stmt) {
-            return self.execute_select_with_ctes(stmt, ctx);
-        }
-
         // OPTIMIZATION: Get cached query classification ONCE at entry point
         // This classification is passed through the call chain to avoid
         // redundant hash computations and cache lookups (was 10+ calls per query)
@@ -324,12 +319,13 @@ impl Executor {
             None => get_classification(stmt),
         };
 
-        // A subquery inside an aggregate's FILTER or argument is resolved
-        // before the aggregates are parsed, since every aggregation path
-        // reads the statement's own columns
+        // An uncorrelated subquery inside an aggregate's FILTER or argument
+        // folds before the aggregates are parsed, since every aggregation
+        // path reads the statement's own columns; a correlated one is
+        // resolved per input row at the aggregation entry
         let bound_stmt;
         let stmt = if classification.has_aggregation
-            && classification.select_has_scalar_subqueries
+            && stmt.columns.iter().any(Self::has_subqueries)
             && !Self::has_correlated_select_subqueries(&stmt.columns)
         {
             match self.try_process_select_subqueries(&stmt.columns, ctx)? {
@@ -345,6 +341,11 @@ impl Executor {
         } else {
             stmt
         };
+
+        // Check for CTEs (WITH clause)
+        if self.has_cte(stmt) {
+            return self.execute_select_with_ctes(stmt, ctx);
+        }
 
         // Evaluate LIMIT/OFFSET early (needed for set operations optimization)
         // Literal fast path: `LIMIT 10` needs no compile/cache/VM round trip

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -167,7 +167,9 @@ fn partition_where_for_join(
         let refs_left = qualifiers.contains(&left_alias_lower);
         let refs_right = qualifiers.contains(&right_alias_lower);
 
-        if refs_left && refs_right {
+        // The qualifiers inside a subquery are not collected, so a correlated
+        // one may read either side and is evaluated on the joined row
+        if (refs_left && refs_right) || Executor::has_correlated_subqueries(&pred) {
             // References both tables - must be applied post-join
             cross_preds.push(pred);
         } else if refs_left {
@@ -3861,8 +3863,13 @@ impl Executor {
         // classification is passed from caller to avoid redundant cache lookups
 
         // Short-circuit: if WHERE is constant-false (e.g., 1=0), skip all join
-        // materialization and return an empty result immediately.
-        if let Some(ref where_clause) = stmt.where_clause {
+        // materialization and return an empty result immediately. A subquery
+        // has no value in this evaluator, so a WHERE holding one is not judged
+        if let Some(where_clause) = stmt
+            .where_clause
+            .as_ref()
+            .filter(|_| !classification.where_has_subqueries)
+        {
             if let Ok(eval) = ExpressionEval::compile(where_clause, &[]) {
                 if let Ok(Value::Boolean(false)) = eval.with_context(ctx).eval_slice(&Row::new()) {
                     // Derive output column names from SELECT clause
@@ -3900,8 +3907,20 @@ impl Executor {
         // - LEFT JOIN: Can push filters to left (preserved), but NOT to right (may have NULLs)
         // - RIGHT JOIN: Can push filters to right (preserved), but NOT to left
         // - FULL OUTER JOIN: Cannot push filters to either side
+        // Uncorrelated subqueries in the WHERE fold to their values before
+        // the filters are split, so every join path sees a plain predicate. A
+        // correlated one pushed to one side is evaluated per row by that
+        // side's scan; one left after the join is evaluated per joined row
+        let correlated_where = classification.where_has_correlated_subqueries;
+        let where_for_join: Option<Expression> = match &stmt.where_clause {
+            Some(where_clause) if !correlated_where && classification.where_has_subqueries => {
+                Some(self.process_where_subqueries(where_clause, ctx)?)
+            }
+            Some(where_clause) => Some((**where_clause).clone()),
+            None => None,
+        };
         let (left_filter, right_filter, cross_filter) =
-            if let Some(ref where_clause) = stmt.where_clause {
+            if let Some(where_clause) = where_for_join.as_ref() {
                 if let (Some(left_a), Some(right_a)) = (&left_alias, &right_alias) {
                     let (l, r, c) = partition_where_for_join(where_clause, left_a, right_a);
 
@@ -3939,7 +3958,7 @@ impl Executor {
 
                     (safe_left, safe_right, remaining)
                 } else {
-                    (None, None, Some((**where_clause).clone()))
+                    (None, None, Some(where_clause.clone()))
                 }
             } else {
                 (None, None, None)
@@ -3953,14 +3972,18 @@ impl Executor {
             Expression::TableSource(ts) => Some(ts.name.value.as_str()),
             _ => None,
         };
-        let semijoin_limit = self.get_semijoin_reduction_limit(
-            &join_type,
-            stmt,
-            left_alias.as_deref(),
-            left_table,
-            &join_source.condition,
-            classification,
-        );
+        let semijoin_limit = if correlated_where {
+            None
+        } else {
+            self.get_semijoin_reduction_limit(
+                &join_type,
+                stmt,
+                left_alias.as_deref(),
+                left_table,
+                &join_source.condition,
+                classification,
+            )
+        };
 
         let (left_rows, left_columns, right_rows, right_columns) = if let Some(plan) =
             semijoin_limit
@@ -4048,7 +4071,7 @@ impl Executor {
             // This optimization avoids materializing the right side entirely
             // NOTE: Don't use Index NL for aggregation/window queries - they need full results
             // and the current implementation falls through to standard path, causing double execution
-            let index_nl_info = if has_agg || has_window {
+            let index_nl_info = if has_agg || has_window || correlated_where {
                 None
             } else {
                 self.check_index_nested_loop_opportunity(
@@ -4066,6 +4089,7 @@ impl Executor {
             let (index_nl_info, force_swap) = if index_nl_info.is_none()
                 && !has_agg
                 && !has_window
+                && !correlated_where
                 && (join_type == "INNER" || join_type == "LEFT")
                 && !matches!(join_source.right.as_ref(), Expression::TableSource(_))
                 && !matches!(
@@ -4103,6 +4127,7 @@ impl Executor {
                 )
             } else if !has_agg
                     && !has_window
+                    && !correlated_where
                     && join_type == "INNER"
                     && right_filter.is_some()  // Right side has a filter
                     && left_filter.is_none()
@@ -5125,7 +5150,7 @@ impl Executor {
             cross_filter.clone()
         } else {
             // No pushdown - apply full WHERE clause
-            stmt.where_clause.as_ref().map(|wc| (**wc).clone())
+            where_for_join.clone()
         };
 
         let resolved_where_clause = if !alias_map.is_empty() {
@@ -5138,24 +5163,44 @@ impl Executor {
 
         // Apply WHERE clause if present
         let filtered_rows = if let Some(ref where_clause) = resolved_where_clause {
-            // Process subqueries (EXISTS, scalar subqueries) before evaluation
-            // Use cached classification to avoid AST traversal
-            let processed_where = if classification.where_has_subqueries {
-                self.process_where_subqueries(where_clause, ctx)?
-            } else {
-                (**where_clause).clone()
-            };
-
-            // Create RowFilter once and reuse
-            let where_filter = RowFilter::new(&processed_where, &all_columns)?.with_context(ctx);
-
-            let mut filtered = RowVec::with_capacity(result_rows.len());
-            for (id, row) in result_rows {
-                if where_filter.matches_checked(&row)? {
-                    filtered.push((id, row));
+            if correlated_where {
+                // Each joined row is the outer row of the subqueries in the
+                // WHERE, so they are resolved and the predicate compiled per row
+                let keys = ColumnKeyMapping::build_mappings(&all_columns, None);
+                let outer_columns = CompactArc::new(all_columns.clone());
+                let mut filtered = RowVec::with_capacity(result_rows.len());
+                for (id, row) in result_rows {
+                    let mut outer: FxHashMap<CompactArc<str>, Value> = FxHashMap::default();
+                    for key in &keys {
+                        if let Some(value) = row.get(key.index) {
+                            if let Some(unqualified) = &key.unqualified_part {
+                                outer.insert(unqualified.clone(), value.clone());
+                            }
+                            outer.insert(key.col_lower.clone(), value.clone());
+                        }
+                    }
+                    let row_ctx = ctx.with_outer_row(outer, outer_columns.clone());
+                    let processed = self.process_correlated_where(where_clause, &row_ctx)?;
+                    ctx.check_cancelled()?;
+                    if RowFilter::new(&processed, &all_columns)?
+                        .with_context(&row_ctx)
+                        .matches_checked(&row)?
+                    {
+                        filtered.push((id, row));
+                    }
                 }
+                filtered
+            } else {
+                // Uncorrelated subqueries were folded before the filters were split
+                let where_filter = RowFilter::new(where_clause, &all_columns)?.with_context(ctx);
+                let mut filtered = RowVec::with_capacity(result_rows.len());
+                for (id, row) in result_rows {
+                    if where_filter.matches_checked(&row)? {
+                        filtered.push((id, row));
+                    }
+                }
+                filtered
             }
-            filtered
         } else {
             result_rows
         };

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -330,7 +330,7 @@ impl Executor {
         // path reads the statement's own columns; a correlated one is
         // resolved per input row at the aggregation entry
         let bound_stmt;
-        let stmt = if classification.has_aggregation
+        let stmt = if (classification.has_aggregation || classification.has_window_functions)
             && stmt.columns.iter().any(Self::has_subqueries)
             && !Self::has_correlated_select_subqueries(&stmt.columns)
         {

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -324,6 +324,28 @@ impl Executor {
             None => get_classification(stmt),
         };
 
+        // A subquery inside an aggregate's FILTER or argument is resolved
+        // before the aggregates are parsed, since every aggregation path
+        // reads the statement's own columns
+        let bound_stmt;
+        let stmt = if classification.has_aggregation
+            && classification.select_has_scalar_subqueries
+            && !Self::has_correlated_select_subqueries(&stmt.columns)
+        {
+            match self.try_process_select_subqueries(&stmt.columns, ctx)? {
+                Some(columns) => {
+                    bound_stmt = SelectStatement {
+                        columns,
+                        ..stmt.clone()
+                    };
+                    &bound_stmt
+                }
+                None => stmt,
+            }
+        } else {
+            stmt
+        };
+
         // Evaluate LIMIT/OFFSET early (needed for set operations optimization)
         // Literal fast path: `LIMIT 10` needs no compile/cache/VM round trip
         let limit = if let Some(Expression::IntegerLiteral(lit)) = stmt.limit.as_deref() {

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -1071,6 +1071,9 @@ impl QueryClassification {
                         .as_ref()
                         .is_some_and(|e| Self::has_outer_column_reference(e, inner_tables))
             }
+            Expression::AllAny(all_any) => {
+                Self::has_outer_column_reference(&all_any.left, inner_tables)
+            }
             Expression::Cast(cast) => Self::has_outer_column_reference(&cast.expr, inner_tables),
             Expression::Like(like) => {
                 Self::has_outer_column_reference(&like.left, inner_tables)

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -642,6 +642,15 @@ impl QueryClassification {
                 .iter()
                 .any(Self::expression_has_scalar_subquery),
             Expression::Distinct(distinct) => Self::expression_has_scalar_subquery(&distinct.expr),
+            Expression::Window(window) => window
+                .function
+                .arguments
+                .iter()
+                .chain(window.function.filter.as_deref())
+                .chain(window.function.order_by.iter().map(|o| &o.expression))
+                .chain(window.partition_by.iter())
+                .chain(window.order_by.iter().map(|o| &o.expression))
+                .any(Self::expression_has_scalar_subquery),
             _ => false,
         }
     }
@@ -972,6 +981,15 @@ impl QueryClassification {
             Expression::Distinct(distinct) => {
                 Self::expression_has_correlated_subqueries(&distinct.expr)
             }
+            Expression::Window(window) => window
+                .function
+                .arguments
+                .iter()
+                .chain(window.function.filter.as_deref())
+                .chain(window.function.order_by.iter().map(|o| &o.expression))
+                .chain(window.partition_by.iter())
+                .chain(window.order_by.iter().map(|o| &o.expression))
+                .any(Self::expression_has_correlated_subqueries),
             _ => false,
         }
     }
@@ -1122,6 +1140,15 @@ impl QueryClassification {
             Expression::ExpressionList(list) => list
                 .expressions
                 .iter()
+                .any(|e| Self::has_outer_column_reference(e, inner_tables)),
+            Expression::Window(window) => window
+                .function
+                .arguments
+                .iter()
+                .chain(window.function.filter.as_deref())
+                .chain(window.function.order_by.iter().map(|o| &o.expression))
+                .chain(window.partition_by.iter())
+                .chain(window.order_by.iter().map(|o| &o.expression))
                 .any(|e| Self::has_outer_column_reference(e, inner_tables)),
             _ => false,
         }

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -374,8 +374,15 @@ impl QueryClassification {
             Expression::Exists(_) => {
                 *has_exists = true;
             }
-            Expression::AllAny(_) => {
+            Expression::AllAny(all_any) => {
                 *has_all_any = true;
+                Self::analyze_where_expr_recursive(
+                    &all_any.left,
+                    has_exists,
+                    has_in_subquery,
+                    has_scalar_subquery,
+                    has_all_any,
+                );
             }
             Expression::ScalarSubquery(_) => {
                 *has_scalar_subquery = true;
@@ -428,7 +435,7 @@ impl QueryClassification {
                 );
             }
             Expression::FunctionCall(func) => {
-                for arg in &func.arguments {
+                for arg in func.arguments.iter().chain(func.filter.as_deref()) {
                     Self::analyze_where_expr_recursive(
                         arg,
                         has_exists,
@@ -576,10 +583,16 @@ impl QueryClassification {
                     || Self::expression_has_scalar_subquery(&infix.right)
             }
             Expression::Prefix(prefix) => Self::expression_has_scalar_subquery(&prefix.right),
-            Expression::FunctionCall(func) => func
-                .arguments
-                .iter()
-                .any(Self::expression_has_scalar_subquery),
+            Expression::FunctionCall(func) => {
+                func.arguments
+                    .iter()
+                    .any(Self::expression_has_scalar_subquery)
+                    || func
+                        .filter
+                        .as_deref()
+                        .is_some_and(Self::expression_has_scalar_subquery)
+            }
+            Expression::AllAny(all_any) => Self::expression_has_scalar_subquery(&all_any.left),
             Expression::Case(case) => {
                 case.value
                     .as_deref()
@@ -874,7 +887,10 @@ impl QueryClassification {
             Expression::ScalarSubquery(subquery) => {
                 Self::is_subquery_correlated(&subquery.subquery)
             }
-            Expression::AllAny(all_any) => Self::is_subquery_correlated(&all_any.subquery),
+            Expression::AllAny(all_any) => {
+                Self::is_subquery_correlated(&all_any.subquery)
+                    || Self::expression_has_correlated_subqueries(&all_any.left)
+            }
             Expression::Prefix(prefix) => {
                 // Handle NOT EXISTS
                 if let Expression::Exists(exists) = prefix.right.as_ref() {
@@ -901,10 +917,15 @@ impl QueryClassification {
             Expression::Aliased(aliased) => {
                 Self::expression_has_correlated_subqueries(&aliased.expression)
             }
-            Expression::FunctionCall(func) => func
-                .arguments
-                .iter()
-                .any(Self::expression_has_correlated_subqueries),
+            Expression::FunctionCall(func) => {
+                func.arguments
+                    .iter()
+                    .any(Self::expression_has_correlated_subqueries)
+                    || func
+                        .filter
+                        .as_deref()
+                        .is_some_and(Self::expression_has_correlated_subqueries)
+            }
             Expression::Case(case) => {
                 case.value
                     .as_deref()
@@ -1028,10 +1049,15 @@ impl QueryClassification {
             Expression::Prefix(prefix) => {
                 Self::has_outer_column_reference(&prefix.right, inner_tables)
             }
-            Expression::FunctionCall(func) => func
-                .arguments
-                .iter()
-                .any(|a| Self::has_outer_column_reference(a, inner_tables)),
+            Expression::FunctionCall(func) => {
+                func.arguments
+                    .iter()
+                    .any(|a| Self::has_outer_column_reference(a, inner_tables))
+                    || func
+                        .filter
+                        .as_deref()
+                        .is_some_and(|f| Self::has_outer_column_reference(f, inner_tables))
+            }
             Expression::Case(case) => {
                 case.value
                     .as_ref()

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -488,6 +488,69 @@ impl QueryClassification {
                     has_all_any,
                 );
             }
+            Expression::Cast(cast) => {
+                Self::analyze_where_expr_recursive(
+                    &cast.expr,
+                    has_exists,
+                    has_in_subquery,
+                    has_scalar_subquery,
+                    has_all_any,
+                );
+            }
+            Expression::Like(like) => {
+                for part in [Some(&like.left), Some(&like.pattern), like.escape.as_ref()]
+                    .into_iter()
+                    .flatten()
+                {
+                    Self::analyze_where_expr_recursive(
+                        part,
+                        has_exists,
+                        has_in_subquery,
+                        has_scalar_subquery,
+                        has_all_any,
+                    );
+                }
+            }
+            Expression::List(list) => {
+                for element in &list.elements {
+                    Self::analyze_where_expr_recursive(
+                        element,
+                        has_exists,
+                        has_in_subquery,
+                        has_scalar_subquery,
+                        has_all_any,
+                    );
+                }
+            }
+            Expression::ExpressionList(list) => {
+                for element in &list.expressions {
+                    Self::analyze_where_expr_recursive(
+                        element,
+                        has_exists,
+                        has_in_subquery,
+                        has_scalar_subquery,
+                        has_all_any,
+                    );
+                }
+            }
+            Expression::Distinct(distinct) => {
+                Self::analyze_where_expr_recursive(
+                    &distinct.expr,
+                    has_exists,
+                    has_in_subquery,
+                    has_scalar_subquery,
+                    has_all_any,
+                );
+            }
+            Expression::Aliased(aliased) => {
+                Self::analyze_where_expr_recursive(
+                    &aliased.expression,
+                    has_exists,
+                    has_in_subquery,
+                    has_scalar_subquery,
+                    has_all_any,
+                );
+            }
             _ => {}
         }
     }
@@ -809,6 +872,26 @@ impl QueryClassification {
                     .else_value
                     .as_ref()
                     .is_some_and(|e| Self::expression_has_correlated_subqueries(e))
+            }
+            Expression::Cast(cast) => Self::expression_has_correlated_subqueries(&cast.expr),
+            Expression::Like(like) => {
+                Self::expression_has_correlated_subqueries(&like.left)
+                    || Self::expression_has_correlated_subqueries(&like.pattern)
+                    || like
+                        .escape
+                        .as_deref()
+                        .is_some_and(Self::expression_has_correlated_subqueries)
+            }
+            Expression::List(list) => list
+                .elements
+                .iter()
+                .any(Self::expression_has_correlated_subqueries),
+            Expression::ExpressionList(list) => list
+                .expressions
+                .iter()
+                .any(Self::expression_has_correlated_subqueries),
+            Expression::Distinct(distinct) => {
+                Self::expression_has_correlated_subqueries(&distinct.expr)
             }
             _ => false,
         }

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -435,7 +435,12 @@ impl QueryClassification {
                 );
             }
             Expression::FunctionCall(func) => {
-                for arg in func.arguments.iter().chain(func.filter.as_deref()) {
+                for arg in func
+                    .arguments
+                    .iter()
+                    .chain(func.filter.as_deref())
+                    .chain(func.order_by.iter().map(|o| &o.expression))
+                {
                     Self::analyze_where_expr_recursive(
                         arg,
                         has_exists,
@@ -591,6 +596,10 @@ impl QueryClassification {
                         .filter
                         .as_deref()
                         .is_some_and(Self::expression_has_scalar_subquery)
+                    || func
+                        .order_by
+                        .iter()
+                        .any(|o| Self::expression_has_scalar_subquery(&o.expression))
             }
             Expression::AllAny(all_any) => Self::expression_has_scalar_subquery(&all_any.left),
             Expression::Case(case) => {
@@ -925,6 +934,10 @@ impl QueryClassification {
                         .filter
                         .as_deref()
                         .is_some_and(Self::expression_has_correlated_subqueries)
+                    || func
+                        .order_by
+                        .iter()
+                        .any(|o| Self::expression_has_correlated_subqueries(&o.expression))
             }
             Expression::Case(case) => {
                 case.value
@@ -1057,6 +1070,10 @@ impl QueryClassification {
                         .filter
                         .as_deref()
                         .is_some_and(|f| Self::has_outer_column_reference(f, inner_tables))
+                    || func
+                        .order_by
+                        .iter()
+                        .any(|o| Self::has_outer_column_reference(&o.expression, inner_tables))
             }
             Expression::Case(case) => {
                 case.value

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -439,6 +439,15 @@ impl QueryClassification {
                 }
             }
             Expression::Case(case) => {
+                if let Some(ref value) = case.value {
+                    Self::analyze_where_expr_recursive(
+                        value,
+                        has_exists,
+                        has_in_subquery,
+                        has_scalar_subquery,
+                        has_all_any,
+                    );
+                }
                 for wc in &case.when_clauses {
                     Self::analyze_where_expr_recursive(
                         &wc.condition,
@@ -572,13 +581,17 @@ impl QueryClassification {
                 .iter()
                 .any(Self::expression_has_scalar_subquery),
             Expression::Case(case) => {
-                case.when_clauses.iter().any(|w| {
-                    Self::expression_has_scalar_subquery(&w.condition)
-                        || Self::expression_has_scalar_subquery(&w.then_result)
-                }) || case
-                    .else_value
-                    .as_ref()
-                    .is_some_and(|e| Self::expression_has_scalar_subquery(e))
+                case.value
+                    .as_deref()
+                    .is_some_and(Self::expression_has_scalar_subquery)
+                    || case.when_clauses.iter().any(|w| {
+                        Self::expression_has_scalar_subquery(&w.condition)
+                            || Self::expression_has_scalar_subquery(&w.then_result)
+                    })
+                    || case
+                        .else_value
+                        .as_ref()
+                        .is_some_and(|e| Self::expression_has_scalar_subquery(e))
             }
             _ => false,
         }
@@ -865,13 +878,17 @@ impl QueryClassification {
                 .iter()
                 .any(Self::expression_has_correlated_subqueries),
             Expression::Case(case) => {
-                case.when_clauses.iter().any(|w| {
-                    Self::expression_has_correlated_subqueries(&w.condition)
-                        || Self::expression_has_correlated_subqueries(&w.then_result)
-                }) || case
-                    .else_value
-                    .as_ref()
-                    .is_some_and(|e| Self::expression_has_correlated_subqueries(e))
+                case.value
+                    .as_deref()
+                    .is_some_and(Self::expression_has_correlated_subqueries)
+                    || case.when_clauses.iter().any(|w| {
+                        Self::expression_has_correlated_subqueries(&w.condition)
+                            || Self::expression_has_correlated_subqueries(&w.then_result)
+                    })
+                    || case
+                        .else_value
+                        .as_ref()
+                        .is_some_and(|e| Self::expression_has_correlated_subqueries(e))
             }
             Expression::Cast(cast) => Self::expression_has_correlated_subqueries(&cast.expr),
             Expression::Like(like) => {

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -593,6 +593,33 @@ impl QueryClassification {
                         .as_ref()
                         .is_some_and(|e| Self::expression_has_scalar_subquery(e))
             }
+            Expression::In(in_expr) => {
+                Self::expression_has_scalar_subquery(&in_expr.left)
+                    || Self::expression_has_scalar_subquery(&in_expr.right)
+            }
+            Expression::Between(between) => {
+                Self::expression_has_scalar_subquery(&between.expr)
+                    || Self::expression_has_scalar_subquery(&between.lower)
+                    || Self::expression_has_scalar_subquery(&between.upper)
+            }
+            Expression::Cast(cast) => Self::expression_has_scalar_subquery(&cast.expr),
+            Expression::Like(like) => {
+                Self::expression_has_scalar_subquery(&like.left)
+                    || Self::expression_has_scalar_subquery(&like.pattern)
+                    || like
+                        .escape
+                        .as_deref()
+                        .is_some_and(Self::expression_has_scalar_subquery)
+            }
+            Expression::List(list) => list
+                .elements
+                .iter()
+                .any(Self::expression_has_scalar_subquery),
+            Expression::ExpressionList(list) => list
+                .expressions
+                .iter()
+                .any(Self::expression_has_scalar_subquery),
+            Expression::Distinct(distinct) => Self::expression_has_scalar_subquery(&distinct.expr),
             _ => false,
         }
     }
@@ -864,6 +891,7 @@ impl QueryClassification {
                     return Self::is_subquery_correlated(&subquery.subquery);
                 }
                 Self::expression_has_correlated_subqueries(&in_expr.left)
+                    || Self::expression_has_correlated_subqueries(&in_expr.right)
             }
             Expression::Between(between) => {
                 Self::expression_has_correlated_subqueries(&between.expr)
@@ -1005,13 +1033,29 @@ impl QueryClassification {
                 .iter()
                 .any(|a| Self::has_outer_column_reference(a, inner_tables)),
             Expression::Case(case) => {
-                case.when_clauses.iter().any(|w| {
-                    Self::has_outer_column_reference(&w.condition, inner_tables)
-                        || Self::has_outer_column_reference(&w.then_result, inner_tables)
-                }) || case
-                    .else_value
+                case.value
                     .as_ref()
-                    .is_some_and(|e| Self::has_outer_column_reference(e, inner_tables))
+                    .is_some_and(|v| Self::has_outer_column_reference(v, inner_tables))
+                    || case.when_clauses.iter().any(|w| {
+                        Self::has_outer_column_reference(&w.condition, inner_tables)
+                            || Self::has_outer_column_reference(&w.then_result, inner_tables)
+                    })
+                    || case
+                        .else_value
+                        .as_ref()
+                        .is_some_and(|e| Self::has_outer_column_reference(e, inner_tables))
+            }
+            Expression::Cast(cast) => Self::has_outer_column_reference(&cast.expr, inner_tables),
+            Expression::Like(like) => {
+                Self::has_outer_column_reference(&like.left, inner_tables)
+                    || Self::has_outer_column_reference(&like.pattern, inner_tables)
+                    || like
+                        .escape
+                        .as_ref()
+                        .is_some_and(|e| Self::has_outer_column_reference(e, inner_tables))
+            }
+            Expression::Distinct(distinct) => {
+                Self::has_outer_column_reference(&distinct.expr, inner_tables)
             }
             Expression::In(in_expr) => {
                 Self::has_outer_column_reference(&in_expr.left, inner_tables)

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -2769,33 +2769,65 @@ impl Executor {
                 .any(|order| Self::has_subqueries(&order.expression))
     }
 
+    /// Whether a window function, its OVER clause or a named window holds a subquery
+    pub(crate) fn windows_hold_subquery(stmt: &SelectStatement) -> bool {
+        stmt.columns.iter().any(Self::has_subqueries)
+            || stmt.window_defs.iter().any(|window| {
+                window.partition_by.iter().any(Self::has_subqueries)
+                    || window
+                        .order_by
+                        .iter()
+                        .any(|order| Self::has_subqueries(&order.expression))
+            })
+    }
+
+    /// The column a lifted subquery lands in: its own text, so the result
+    /// column keeps its name, shared by an identical subquery, and never an
+    /// input column's name, qualified or not
+    fn lifted_column_name(
+        expr: &Expression,
+        lifted: &mut Vec<(Expression, String)>,
+        base_columns: &[String],
+    ) -> String {
+        let text = expr.to_string();
+        if let Some((_, name)) = lifted.iter().find(|(e, _)| e.to_string() == text) {
+            return name.clone();
+        }
+        let mut name = text;
+        // A qualifier holds no dot, the name after it may
+        while base_columns.iter().any(|column| {
+            column.eq_ignore_ascii_case(&name)
+                || column
+                    .split_once('.')
+                    .is_some_and(|(_, bare)| bare.eq_ignore_ascii_case(&name))
+        }) {
+            name.push('_');
+        }
+        lifted.push((expr.clone(), name.clone()));
+        name
+    }
+
     /// The statement with every subquery inside an aggregate call, in the
     /// SELECT list, HAVING or ORDER BY, replaced by a column, and the
     /// subqueries taken out in that order. None when no aggregate holds one.
+    /// Window functions are left alone: they run over the aggregate's output
     pub(crate) fn lift_subqueries_in_aggregates(
         stmt: &SelectStatement,
         base_columns: &[String],
     ) -> Option<(SelectStatement, Vec<Expression>, Vec<String>)> {
-        // The lifted columns take a name no input column starts with
-        let mut prefix = String::from("__agg_subquery");
-        while base_columns
-            .iter()
-            .any(|column| column.to_lowercase().starts_with(&prefix))
-        {
-            prefix.push('_');
-        }
         let mut lifted = Vec::new();
         let columns: Vec<Expression> = stmt
             .columns
             .iter()
-            .map(|column| Self::lift_subqueries_in(column, false, &mut lifted, &prefix))
+            .map(|column| Self::lift_subqueries_in(column, false, false, &mut lifted, base_columns))
             .collect();
         let having = stmt.having.as_ref().map(|having| {
             Box::new(Self::lift_subqueries_in(
                 having,
                 false,
+                false,
                 &mut lifted,
-                &prefix,
+                base_columns,
             ))
         });
         let order_by: Vec<OrderByExpression> = stmt
@@ -2805,8 +2837,9 @@ impl Executor {
                 expression: Self::lift_subqueries_in(
                     &order.expression,
                     false,
+                    false,
                     &mut lifted,
-                    &prefix,
+                    base_columns,
                 ),
                 ..order.clone()
             })
@@ -2814,7 +2847,7 @@ impl Executor {
         if lifted.is_empty() {
             return None;
         }
-        let names = (0..lifted.len()).map(|i| format!("{prefix}_{i}")).collect();
+        let (lifted, names) = lifted.into_iter().unzip();
         Some((
             SelectStatement {
                 columns,
@@ -2827,42 +2860,114 @@ impl Executor {
         ))
     }
 
+    /// The statement with every subquery in the SELECT list, the OVER clauses
+    /// and the named windows replaced by a column, and the subqueries taken
+    /// out in that order. None when there is none
+    pub(crate) fn lift_subqueries_in_windows(
+        stmt: &SelectStatement,
+        base_columns: &[String],
+    ) -> Option<(SelectStatement, Vec<Expression>, Vec<String>)> {
+        let mut lifted = Vec::new();
+        // Every SELECT expression beside a window function is read per row
+        let columns: Vec<Expression> = stmt
+            .columns
+            .iter()
+            .map(|column| Self::lift_subqueries_in(column, true, true, &mut lifted, base_columns))
+            .collect();
+        let window_defs: Vec<crate::parser::ast::WindowDefinition> = stmt
+            .window_defs
+            .iter()
+            .map(|window| crate::parser::ast::WindowDefinition {
+                name: window.name.clone(),
+                partition_by: window
+                    .partition_by
+                    .iter()
+                    .map(|e| Self::lift_subqueries_in(e, true, true, &mut lifted, base_columns))
+                    .collect(),
+                order_by: window
+                    .order_by
+                    .iter()
+                    .map(|order| OrderByExpression {
+                        expression: Self::lift_subqueries_in(
+                            &order.expression,
+                            true,
+                            true,
+                            &mut lifted,
+                            base_columns,
+                        ),
+                        ..order.clone()
+                    })
+                    .collect(),
+                frame: window.frame.clone(),
+            })
+            .collect();
+        if lifted.is_empty() {
+            return None;
+        }
+        let (lifted, names) = lifted.into_iter().unzip();
+        Some((
+            SelectStatement {
+                columns,
+                window_defs,
+                ..stmt.clone()
+            },
+            lifted,
+            names,
+        ))
+    }
+
     fn lift_subqueries_in_call(
         func: &FunctionCall,
         inside_aggregate: bool,
-        lifted: &mut Vec<Expression>,
-        prefix: &str,
+        windows: bool,
+        lifted: &mut Vec<(Expression, String)>,
+        base_columns: &[String],
     ) -> FunctionCall {
-        let inside = inside_aggregate || super::utils::is_aggregate_function(&func.function);
+        let inside =
+            inside_aggregate || (!windows && super::utils::is_aggregate_function(&func.function));
         FunctionCall {
             token: func.token.clone(),
             function: func.function.clone(),
             arguments: func
                 .arguments
                 .iter()
-                .map(|a| Self::lift_subqueries_in(a, inside, lifted, prefix))
+                .map(|a| Self::lift_subqueries_in(a, inside, windows, lifted, base_columns))
                 .collect(),
             is_distinct: func.is_distinct,
             order_by: func
                 .order_by
                 .iter()
                 .map(|order| OrderByExpression {
-                    expression: Self::lift_subqueries_in(&order.expression, inside, lifted, prefix),
+                    expression: Self::lift_subqueries_in(
+                        &order.expression,
+                        inside,
+                        windows,
+                        lifted,
+                        base_columns,
+                    ),
                     ..order.clone()
                 })
                 .collect(),
-            filter: func
-                .filter
-                .as_ref()
-                .map(|f| Box::new(Self::lift_subqueries_in(f, inside, lifted, prefix))),
+            filter: func.filter.as_ref().map(|f| {
+                Box::new(Self::lift_subqueries_in(
+                    f,
+                    inside,
+                    windows,
+                    lifted,
+                    base_columns,
+                ))
+            }),
         }
     }
 
+    /// `windows` selects the scope: aggregate calls, or window functions
+    /// with their OVER clauses
     fn lift_subqueries_in(
         expr: &Expression,
         inside_aggregate: bool,
-        lifted: &mut Vec<Expression>,
-        prefix: &str,
+        windows: bool,
+        lifted: &mut Vec<(Expression, String)>,
+        base_columns: &[String],
     ) -> Expression {
         let is_subquery = matches!(
             expr,
@@ -2870,41 +2975,51 @@ impl Executor {
         ) || matches!(expr, Expression::In(in_expr)
             if matches!(in_expr.right.as_ref(), Expression::ScalarSubquery(_)));
         if inside_aggregate && is_subquery {
-            lifted.push(expr.clone());
-            let name = format!("{prefix}_{}", lifted.len() - 1);
+            let name = Self::lifted_column_name(expr, lifted, base_columns);
             return Expression::Identifier(crate::parser::ast::Identifier::new(
                 dummy_token(&name, TokenType::Identifier),
                 name.as_str(),
             ));
         }
-        let lift = |e: &Expression, lifted: &mut Vec<Expression>| {
-            Self::lift_subqueries_in(e, inside_aggregate, lifted, prefix)
+        let lift = |e: &Expression, lifted: &mut Vec<(Expression, String)>| {
+            Self::lift_subqueries_in(e, inside_aggregate, windows, lifted, base_columns)
         };
         match expr {
-            Expression::FunctionCall(func) => Expression::FunctionCall(Box::new(
-                Self::lift_subqueries_in_call(func, inside_aggregate, lifted, prefix),
-            )),
-            // A window aggregate reads its argument per row like any other
+            Expression::FunctionCall(func) => {
+                Expression::FunctionCall(Box::new(Self::lift_subqueries_in_call(
+                    func,
+                    inside_aggregate,
+                    windows,
+                    lifted,
+                    base_columns,
+                )))
+            }
+            Expression::Window(_) if !windows => expr.clone(),
+            // A window function and its OVER clause read every input row
             Expression::Window(window) => {
+                let per_row = |e: &Expression, lifted: &mut Vec<(Expression, String)>| {
+                    Self::lift_subqueries_in(e, true, windows, lifted, base_columns)
+                };
                 Expression::Window(Box::new(crate::parser::ast::WindowExpression {
                     token: window.token.clone(),
                     function: Box::new(Self::lift_subqueries_in_call(
                         &window.function,
                         true,
+                        windows,
                         lifted,
-                        prefix,
+                        base_columns,
                     )),
                     window_ref: window.window_ref.clone(),
                     partition_by: window
                         .partition_by
                         .iter()
-                        .map(|e| lift(e, lifted))
+                        .map(|e| per_row(e, lifted))
                         .collect(),
                     order_by: window
                         .order_by
                         .iter()
                         .map(|order| OrderByExpression {
-                            expression: lift(&order.expression, lifted),
+                            expression: per_row(&order.expression, lifted),
                             ..order.clone()
                         })
                         .collect(),

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -2775,7 +2775,9 @@ impl Executor {
     /// The cache key of a subquery that reads no outer row: its text and the
     /// bindings behind it, since a parameter prints as its marker and one
     /// text would otherwise answer for two executions. None when the text
-    /// holds an anonymous marker, which two bindings of one statement share
+    /// holds an anonymous marker, which two bindings of one statement share.
+    /// The bindings go in debug form: it carries the type a value prints
+    /// without, and escapes a separator a text could otherwise hold
     pub(crate) fn subquery_cache_key(
         subquery: &SelectStatement,
         ctx: &ExecutionContext,
@@ -2786,13 +2788,13 @@ impl Executor {
             return None;
         }
         for value in ctx.params() {
-            let _ = write!(key, "\u{1}{value}");
+            let _ = write!(key, "\u{1}{value:?}");
         }
         if !ctx.named_params().is_empty() {
             let mut named: Vec<(&String, &Value)> = ctx.named_params().iter().collect();
             named.sort_unstable_by_key(|(name, _)| *name);
             for (name, value) in named {
-                let _ = write!(key, "\u{1}{name}={value}");
+                let _ = write!(key, "\u{1}{name:?}={value:?}");
             }
         }
         Some(key)
@@ -2952,10 +2954,36 @@ impl Executor {
         ))
     }
 
+    /// A navigation function reads its control argument off no row, so a
+    /// subquery there answers for the whole partition. The lift leaves it
+    /// where it is; this resolves the ones that read no row either, before
+    /// the argument is compiled against no columns at all
+    pub(crate) fn fold_window_control_arguments(
+        &self,
+        window_functions: &mut [super::window::WindowFunctionInfo],
+        ctx: &ExecutionContext,
+    ) -> Result<()> {
+        for window in window_functions {
+            let Some(index) = Self::window_control_argument(&window.name) else {
+                continue;
+            };
+            let Some(argument) = window.arguments.get(index) else {
+                continue;
+            };
+            if !Self::has_subqueries(argument) || Self::has_correlated_subqueries(argument) {
+                continue;
+            }
+            if let Some(folded) = self.try_process_expression_subqueries(argument, ctx)? {
+                window.arguments[index] = folded;
+            }
+        }
+        Ok(())
+    }
+
     /// The argument a navigation window function reads once, off no row:
     /// the offset of LEAD and LAG, the group count of NTILE, the n of
     /// NTH_VALUE
-    fn window_control_argument(function: &str) -> Option<usize> {
+    pub(crate) fn window_control_argument(function: &str) -> Option<usize> {
         if function.eq_ignore_ascii_case("NTILE") {
             Some(0)
         } else if function.eq_ignore_ascii_case("LEAD")

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -247,11 +247,11 @@ impl Executor {
                     }
                 }
 
-                // If not a subquery, just return the original with processed left
+                // Not a subquery on the right: a list may still hold one
                 Ok(Expression::In(InExpression {
                     token: in_expr.token.clone(),
                     left: Box::new(processed_left),
-                    right: in_expr.right.clone(),
+                    right: Box::new(self.process_where_subqueries(&in_expr.right, ctx)?),
                     not: in_expr.not,
                 }))
             }
@@ -372,6 +372,45 @@ impl Executor {
                     filter: func.filter.clone(),
                 })))
             }
+
+            Expression::Like(like) => {
+                let escape = match &like.escape {
+                    Some(escape) => Some(Box::new(self.process_where_subqueries(escape, ctx)?)),
+                    None => None,
+                };
+                Ok(Expression::Like(LikeExpression {
+                    token: like.token.clone(),
+                    left: Box::new(self.process_where_subqueries(&like.left, ctx)?),
+                    pattern: Box::new(self.process_where_subqueries(&like.pattern, ctx)?),
+                    operator: like.operator.clone(),
+                    escape,
+                }))
+            }
+
+            Expression::List(list) => Ok(Expression::List(Box::new(ListExpression {
+                token: list.token.clone(),
+                elements: list
+                    .elements
+                    .iter()
+                    .map(|element| self.process_where_subqueries(element, ctx))
+                    .collect::<Result<Vec<_>>>()?,
+            }))),
+
+            Expression::ExpressionList(list) => {
+                Ok(Expression::ExpressionList(Box::new(ExpressionList {
+                    token: list.token.clone(),
+                    expressions: list
+                        .expressions
+                        .iter()
+                        .map(|element| self.process_where_subqueries(element, ctx))
+                        .collect::<Result<Vec<_>>>()?,
+                })))
+            }
+
+            Expression::Distinct(distinct) => Ok(Expression::Distinct(DistinctExpression {
+                token: distinct.token.clone(),
+                expr: Box::new(self.process_where_subqueries(&distinct.expr, ctx)?),
+            })),
 
             // For all other expression types, return as-is
             _ => Ok(expr.clone()),
@@ -2171,6 +2210,7 @@ impl Executor {
             Expression::ScalarSubquery(subquery) => {
                 Self::is_subquery_correlated(&subquery.subquery)
             }
+            Expression::AllAny(all_any) => Self::is_subquery_correlated(&all_any.subquery),
             Expression::Prefix(prefix) => {
                 // Handle NOT EXISTS
                 if let Expression::Exists(exists) = prefix.right.as_ref() {
@@ -2619,7 +2659,7 @@ impl Executor {
                 Ok(Expression::In(InExpression {
                     token: in_expr.token.clone(),
                     left: Box::new(processed_left),
-                    right: in_expr.right.clone(),
+                    right: Box::new(self.process_correlated_where(&in_expr.right, ctx)?),
                     not: in_expr.not,
                 }))
             }
@@ -2707,6 +2747,35 @@ impl Executor {
                 token: aliased.token.clone(),
                 expression: Box::new(self.process_correlated_where(&aliased.expression, ctx)?),
                 alias: aliased.alias.clone(),
+            })),
+
+            // ALL and ANY run their subquery under this row's context and
+            // fold to a plain comparison
+            Expression::AllAny(_) => self.process_where_subqueries(expr, ctx),
+
+            Expression::List(list) => Ok(Expression::List(Box::new(ListExpression {
+                token: list.token.clone(),
+                elements: list
+                    .elements
+                    .iter()
+                    .map(|element| self.process_correlated_where(element, ctx))
+                    .collect::<Result<Vec<_>>>()?,
+            }))),
+
+            Expression::ExpressionList(list) => {
+                Ok(Expression::ExpressionList(Box::new(ExpressionList {
+                    token: list.token.clone(),
+                    expressions: list
+                        .expressions
+                        .iter()
+                        .map(|element| self.process_correlated_where(element, ctx))
+                        .collect::<Result<Vec<_>>>()?,
+                })))
+            }
+
+            Expression::Distinct(distinct) => Ok(Expression::Distinct(DistinctExpression {
+                token: distinct.token.clone(),
+                expr: Box::new(self.process_correlated_where(&distinct.expr, ctx)?),
             })),
 
             // For all other expression types, return as-is

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -2000,6 +2000,15 @@ impl Executor {
             Expression::List(list) => list.elements.iter().any(Self::has_subqueries),
             Expression::ExpressionList(list) => list.expressions.iter().any(Self::has_subqueries),
             Expression::Distinct(distinct) => Self::has_subqueries(&distinct.expr),
+            Expression::Window(window) => window
+                .function
+                .arguments
+                .iter()
+                .chain(window.function.filter.as_deref())
+                .chain(window.function.order_by.iter().map(|o| &o.expression))
+                .chain(window.partition_by.iter())
+                .chain(window.order_by.iter().map(|o| &o.expression))
+                .any(Self::has_subqueries),
             _ => false,
         }
     }
@@ -2333,6 +2342,46 @@ impl Executor {
                     })
                 })),
 
+            Expression::Window(window) => {
+                let function = match self.try_process_expression_subqueries(
+                    &Expression::FunctionCall(window.function.clone()),
+                    ctx,
+                )? {
+                    Some(Expression::FunctionCall(function)) => Some(function),
+                    _ => None,
+                };
+                let partition_by = self.try_process_expression_list(&window.partition_by, ctx)?;
+                let order_exprs: Vec<Expression> = window
+                    .order_by
+                    .iter()
+                    .map(|o| o.expression.clone())
+                    .collect();
+                let order_by = self.try_process_expression_list(&order_exprs, ctx)?;
+                if function.is_none() && partition_by.is_none() && order_by.is_none() {
+                    return Ok(None);
+                }
+                Ok(Some(Expression::Window(Box::new(
+                    crate::parser::ast::WindowExpression {
+                        token: window.token.clone(),
+                        function: function.unwrap_or_else(|| window.function.clone()),
+                        window_ref: window.window_ref.clone(),
+                        partition_by: partition_by.unwrap_or_else(|| window.partition_by.clone()),
+                        order_by: match order_by {
+                            Some(expressions) => expressions
+                                .into_iter()
+                                .zip(window.order_by.iter())
+                                .map(|(expression, order)| OrderByExpression {
+                                    expression,
+                                    ..order.clone()
+                                })
+                                .collect(),
+                            None => window.order_by.clone(),
+                        },
+                        frame: window.frame.clone(),
+                    },
+                ))))
+            }
+
             // No subqueries possible in other expression types
             _ => Ok(None),
         }
@@ -2440,6 +2489,15 @@ impl Executor {
                 list.expressions.iter().any(Self::has_correlated_subqueries)
             }
             Expression::Distinct(distinct) => Self::has_correlated_subqueries(&distinct.expr),
+            Expression::Window(window) => window
+                .function
+                .arguments
+                .iter()
+                .chain(window.function.filter.as_deref())
+                .chain(window.function.order_by.iter().map(|o| &o.expression))
+                .chain(window.partition_by.iter())
+                .chain(window.order_by.iter().map(|o| &o.expression))
+                .any(Self::has_correlated_subqueries),
             _ => false,
         }
     }
@@ -2661,6 +2719,40 @@ impl Executor {
             })),
 
             // For all other expression types, return as-is
+            Expression::Window(window) => {
+                let function = match self.process_correlated_expression(
+                    &Expression::FunctionCall(window.function.clone()),
+                    ctx,
+                )? {
+                    Expression::FunctionCall(function) => function,
+                    _ => window.function.clone(),
+                };
+                Ok(Expression::Window(Box::new(
+                    crate::parser::ast::WindowExpression {
+                        token: window.token.clone(),
+                        function,
+                        window_ref: window.window_ref.clone(),
+                        partition_by: window
+                            .partition_by
+                            .iter()
+                            .map(|e| self.process_correlated_expression(e, ctx))
+                            .collect::<Result<Vec<_>>>()?,
+                        order_by: window
+                            .order_by
+                            .iter()
+                            .map(|order| {
+                                Ok(OrderByExpression {
+                                    expression: self
+                                        .process_correlated_expression(&order.expression, ctx)?,
+                                    ..order.clone()
+                                })
+                            })
+                            .collect::<Result<Vec<_>>>()?,
+                        frame: window.frame.clone(),
+                    },
+                )))
+            }
+
             _ => Ok(expr.clone()),
         }
     }
@@ -2682,28 +2774,47 @@ impl Executor {
     /// subqueries taken out in that order. None when no aggregate holds one.
     pub(crate) fn lift_subqueries_in_aggregates(
         stmt: &SelectStatement,
-    ) -> Option<(SelectStatement, Vec<Expression>)> {
+        base_columns: &[String],
+    ) -> Option<(SelectStatement, Vec<Expression>, Vec<String>)> {
+        // The lifted columns take a name no input column starts with
+        let mut prefix = String::from("__agg_subquery");
+        while base_columns
+            .iter()
+            .any(|column| column.to_lowercase().starts_with(&prefix))
+        {
+            prefix.push('_');
+        }
         let mut lifted = Vec::new();
         let columns: Vec<Expression> = stmt
             .columns
             .iter()
-            .map(|column| Self::lift_subqueries_in(column, false, &mut lifted))
+            .map(|column| Self::lift_subqueries_in(column, false, &mut lifted, &prefix))
             .collect();
-        let having = stmt
-            .having
-            .as_ref()
-            .map(|having| Box::new(Self::lift_subqueries_in(having, false, &mut lifted)));
+        let having = stmt.having.as_ref().map(|having| {
+            Box::new(Self::lift_subqueries_in(
+                having,
+                false,
+                &mut lifted,
+                &prefix,
+            ))
+        });
         let order_by: Vec<OrderByExpression> = stmt
             .order_by
             .iter()
             .map(|order| OrderByExpression {
-                expression: Self::lift_subqueries_in(&order.expression, false, &mut lifted),
+                expression: Self::lift_subqueries_in(
+                    &order.expression,
+                    false,
+                    &mut lifted,
+                    &prefix,
+                ),
                 ..order.clone()
             })
             .collect();
         if lifted.is_empty() {
             return None;
         }
+        let names = (0..lifted.len()).map(|i| format!("{prefix}_{i}")).collect();
         Some((
             SelectStatement {
                 columns,
@@ -2712,17 +2823,46 @@ impl Executor {
                 ..stmt.clone()
             },
             lifted,
+            names,
         ))
     }
 
-    fn lifted_column_name(index: usize) -> String {
-        format!("__agg_subquery_{index}")
+    fn lift_subqueries_in_call(
+        func: &FunctionCall,
+        inside_aggregate: bool,
+        lifted: &mut Vec<Expression>,
+        prefix: &str,
+    ) -> FunctionCall {
+        let inside = inside_aggregate || super::utils::is_aggregate_function(&func.function);
+        FunctionCall {
+            token: func.token.clone(),
+            function: func.function.clone(),
+            arguments: func
+                .arguments
+                .iter()
+                .map(|a| Self::lift_subqueries_in(a, inside, lifted, prefix))
+                .collect(),
+            is_distinct: func.is_distinct,
+            order_by: func
+                .order_by
+                .iter()
+                .map(|order| OrderByExpression {
+                    expression: Self::lift_subqueries_in(&order.expression, inside, lifted, prefix),
+                    ..order.clone()
+                })
+                .collect(),
+            filter: func
+                .filter
+                .as_ref()
+                .map(|f| Box::new(Self::lift_subqueries_in(f, inside, lifted, prefix))),
+        }
     }
 
     fn lift_subqueries_in(
         expr: &Expression,
         inside_aggregate: bool,
         lifted: &mut Vec<Expression>,
+        prefix: &str,
     ) -> Expression {
         let is_subquery = matches!(
             expr,
@@ -2731,40 +2871,44 @@ impl Executor {
             if matches!(in_expr.right.as_ref(), Expression::ScalarSubquery(_)));
         if inside_aggregate && is_subquery {
             lifted.push(expr.clone());
-            let name = Self::lifted_column_name(lifted.len() - 1);
+            let name = format!("{prefix}_{}", lifted.len() - 1);
             return Expression::Identifier(crate::parser::ast::Identifier::new(
                 dummy_token(&name, TokenType::Identifier),
                 name.as_str(),
             ));
         }
         let lift = |e: &Expression, lifted: &mut Vec<Expression>| {
-            Self::lift_subqueries_in(e, inside_aggregate, lifted)
+            Self::lift_subqueries_in(e, inside_aggregate, lifted, prefix)
         };
         match expr {
-            Expression::FunctionCall(func) => {
-                let inside =
-                    inside_aggregate || super::utils::is_aggregate_function(&func.function);
-                Expression::FunctionCall(Box::new(FunctionCall {
-                    token: func.token.clone(),
-                    function: func.function.clone(),
-                    arguments: func
-                        .arguments
+            Expression::FunctionCall(func) => Expression::FunctionCall(Box::new(
+                Self::lift_subqueries_in_call(func, inside_aggregate, lifted, prefix),
+            )),
+            // A window aggregate reads its argument per row like any other
+            Expression::Window(window) => {
+                Expression::Window(Box::new(crate::parser::ast::WindowExpression {
+                    token: window.token.clone(),
+                    function: Box::new(Self::lift_subqueries_in_call(
+                        &window.function,
+                        true,
+                        lifted,
+                        prefix,
+                    )),
+                    window_ref: window.window_ref.clone(),
+                    partition_by: window
+                        .partition_by
                         .iter()
-                        .map(|a| Self::lift_subqueries_in(a, inside, lifted))
+                        .map(|e| lift(e, lifted))
                         .collect(),
-                    is_distinct: func.is_distinct,
-                    order_by: func
+                    order_by: window
                         .order_by
                         .iter()
                         .map(|order| OrderByExpression {
-                            expression: Self::lift_subqueries_in(&order.expression, inside, lifted),
+                            expression: lift(&order.expression, lifted),
                             ..order.clone()
                         })
                         .collect(),
-                    filter: func
-                        .filter
-                        .as_ref()
-                        .map(|f| Box::new(Self::lift_subqueries_in(f, inside, lifted))),
+                    frame: window.frame.clone(),
                 }))
             }
             Expression::Infix(infix) => Expression::Infix(InfixExpression {
@@ -2848,8 +2992,9 @@ impl Executor {
     pub(crate) fn materialize_lifted_subqueries(
         &self,
         lifted: &[Expression],
+        names: &[String],
         ctx: &ExecutionContext,
-        base_rows: crate::core::RowVec,
+        base_rows: &[(i64, crate::core::Row)],
         base_columns: &[String],
         qualifier: Option<&str>,
     ) -> Result<(crate::core::RowVec, Vec<String>)> {
@@ -2885,14 +3030,14 @@ impl Executor {
                 let bound = self.process_correlated_expression(node, &row_ctx)?;
                 let value = super::expression::ExpressionEval::compile(&bound, base_columns)?
                     .with_context(&row_ctx)
-                    .eval_slice(&row)?;
+                    .eval_slice(row)?;
                 values.push(value);
             }
             ctx.check_cancelled()?;
-            rows.push((id, crate::core::Row::from_values(values)));
+            rows.push((*id, crate::core::Row::from_values(values)));
         }
         let mut columns = base_columns.to_vec();
-        columns.extend((0..lifted.len()).map(Self::lifted_column_name));
+        columns.extend(names.iter().cloned());
         Ok((rows, columns))
     }
 
@@ -3065,6 +3210,15 @@ impl Executor {
             Expression::ExpressionList(list) => list
                 .expressions
                 .iter()
+                .any(|e| Self::references_outer_columns(e, subquery_tables)),
+            Expression::Window(window) => window
+                .function
+                .arguments
+                .iter()
+                .chain(window.function.filter.as_deref())
+                .chain(window.function.order_by.iter().map(|o| &o.expression))
+                .chain(window.partition_by.iter())
+                .chain(window.order_by.iter().map(|o| &o.expression))
                 .any(|e| Self::references_outer_columns(e, subquery_tables)),
             _ => false,
         }

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -1911,6 +1911,22 @@ impl Executor {
             }
             Expression::Aliased(aliased) => Self::has_subqueries(&aliased.expression),
             Expression::FunctionCall(func) => func.arguments.iter().any(Self::has_subqueries),
+            Expression::Case(case) => {
+                case.value.as_deref().is_some_and(Self::has_subqueries)
+                    || case.when_clauses.iter().any(|w| {
+                        Self::has_subqueries(&w.condition) || Self::has_subqueries(&w.then_result)
+                    })
+                    || case.else_value.as_deref().is_some_and(Self::has_subqueries)
+            }
+            Expression::Cast(cast) => Self::has_subqueries(&cast.expr),
+            Expression::Like(like) => {
+                Self::has_subqueries(&like.left)
+                    || Self::has_subqueries(&like.pattern)
+                    || like.escape.as_deref().is_some_and(Self::has_subqueries)
+            }
+            Expression::List(list) => list.elements.iter().any(Self::has_subqueries),
+            Expression::ExpressionList(list) => list.expressions.iter().any(Self::has_subqueries),
+            Expression::Distinct(distinct) => Self::has_subqueries(&distinct.expr),
             _ => false,
         }
     }
@@ -2181,6 +2197,33 @@ impl Executor {
             Expression::FunctionCall(func) => {
                 func.arguments.iter().any(Self::has_correlated_subqueries)
             }
+            Expression::Case(case) => {
+                case.value
+                    .as_deref()
+                    .is_some_and(Self::has_correlated_subqueries)
+                    || case.when_clauses.iter().any(|w| {
+                        Self::has_correlated_subqueries(&w.condition)
+                            || Self::has_correlated_subqueries(&w.then_result)
+                    })
+                    || case
+                        .else_value
+                        .as_deref()
+                        .is_some_and(Self::has_correlated_subqueries)
+            }
+            Expression::Cast(cast) => Self::has_correlated_subqueries(&cast.expr),
+            Expression::Like(like) => {
+                Self::has_correlated_subqueries(&like.left)
+                    || Self::has_correlated_subqueries(&like.pattern)
+                    || like
+                        .escape
+                        .as_deref()
+                        .is_some_and(Self::has_correlated_subqueries)
+            }
+            Expression::List(list) => list.elements.iter().any(Self::has_correlated_subqueries),
+            Expression::ExpressionList(list) => {
+                list.expressions.iter().any(Self::has_correlated_subqueries)
+            }
+            Expression::Distinct(distinct) => Self::has_correlated_subqueries(&distinct.expr),
             _ => false,
         }
     }
@@ -2594,6 +2637,77 @@ impl Executor {
                     upper: Box::new(processed_upper),
                 }))
             }
+
+            Expression::FunctionCall(func) => {
+                let arguments = func
+                    .arguments
+                    .iter()
+                    .map(|arg| self.process_correlated_where(arg, ctx))
+                    .collect::<Result<Vec<_>>>()?;
+                let filter = match &func.filter {
+                    Some(filter) => Some(Box::new(self.process_correlated_where(filter, ctx)?)),
+                    None => None,
+                };
+                Ok(Expression::FunctionCall(Box::new(FunctionCall {
+                    token: func.token.clone(),
+                    function: func.function.clone(),
+                    arguments,
+                    is_distinct: func.is_distinct,
+                    order_by: func.order_by.clone(),
+                    filter,
+                })))
+            }
+
+            Expression::Case(case) => {
+                let value = match &case.value {
+                    Some(value) => Some(Box::new(self.process_correlated_where(value, ctx)?)),
+                    None => None,
+                };
+                let mut when_clauses = Vec::with_capacity(case.when_clauses.len());
+                for when in &case.when_clauses {
+                    when_clauses.push(WhenClause {
+                        token: when.token.clone(),
+                        condition: self.process_correlated_where(&when.condition, ctx)?,
+                        then_result: self.process_correlated_where(&when.then_result, ctx)?,
+                    });
+                }
+                let else_value = match &case.else_value {
+                    Some(value) => Some(Box::new(self.process_correlated_where(value, ctx)?)),
+                    None => None,
+                };
+                Ok(Expression::Case(Box::new(CaseExpression {
+                    token: case.token.clone(),
+                    value,
+                    when_clauses,
+                    else_value,
+                })))
+            }
+
+            Expression::Cast(cast) => Ok(Expression::Cast(CastExpression {
+                token: cast.token.clone(),
+                expr: Box::new(self.process_correlated_where(&cast.expr, ctx)?),
+                type_name: cast.type_name.clone(),
+            })),
+
+            Expression::Like(like) => {
+                let escape = match &like.escape {
+                    Some(escape) => Some(Box::new(self.process_correlated_where(escape, ctx)?)),
+                    None => None,
+                };
+                Ok(Expression::Like(LikeExpression {
+                    token: like.token.clone(),
+                    left: Box::new(self.process_correlated_where(&like.left, ctx)?),
+                    pattern: Box::new(self.process_correlated_where(&like.pattern, ctx)?),
+                    operator: like.operator.clone(),
+                    escape,
+                }))
+            }
+
+            Expression::Aliased(aliased) => Ok(Expression::Aliased(AliasedExpression {
+                token: aliased.token.clone(),
+                expression: Box::new(self.process_correlated_where(&aliased.expression, ctx)?),
+                alias: aliased.alias.clone(),
+            })),
 
             // For all other expression types, return as-is
             _ => Ok(expr.clone()),

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -2118,6 +2118,14 @@ impl Executor {
                     }
                     processed_args.push(processed);
                 }
+                // The FILTER of an aggregate may hold a subquery as well
+                let processed_filter = match &func.filter {
+                    Some(filter) => self.try_process_expression_subqueries(filter, ctx)?,
+                    None => None,
+                };
+                if processed_filter.is_some() {
+                    any_changed = true;
+                }
 
                 if any_changed {
                     let final_args: Vec<Expression> = func
@@ -2133,7 +2141,10 @@ impl Executor {
                         arguments: final_args,
                         is_distinct: func.is_distinct,
                         order_by: func.order_by.clone(),
-                        filter: func.filter.clone(),
+                        filter: match processed_filter {
+                            Some(filter) => Some(Box::new(filter)),
+                            None => func.filter.clone(),
+                        },
                     }))))
                 } else {
                     Ok(None)
@@ -2215,11 +2226,22 @@ impl Executor {
             }
 
             Expression::AllAny(all_any) => {
+                // The left operand may hold a subquery of its own
+                let left = self
+                    .try_process_expression_subqueries(&all_any.left, ctx)?
+                    .unwrap_or_else(|| (*all_any.left).clone());
+                let bound = AllAnyExpression {
+                    token: all_any.token.clone(),
+                    left: Box::new(left),
+                    operator: all_any.operator.clone(),
+                    all_any_type: all_any.all_any_type,
+                    subquery: all_any.subquery.clone(),
+                };
                 // Execute the subquery to get all values
-                let values = self.execute_in_subquery(&all_any.subquery, ctx)?;
+                let values = self.execute_in_subquery(&bound.subquery, ctx)?;
 
                 // Convert ALL/ANY to an equivalent expression that the evaluator can handle
-                Ok(Some(self.convert_all_any_to_expression(all_any, values)?))
+                Ok(Some(self.convert_all_any_to_expression(&bound, values)?))
             }
 
             // No subqueries possible in other expression types
@@ -2614,6 +2636,9 @@ impl Executor {
             }
             Expression::Aliased(aliased) => {
                 Self::references_outer_columns(&aliased.expression, subquery_tables)
+            }
+            Expression::AllAny(all_any) => {
+                Self::references_outer_columns(&all_any.left, subquery_tables)
             }
             Expression::Cast(cast) => Self::references_outer_columns(&cast.expr, subquery_tables),
             Expression::Like(like) => {

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -2657,6 +2657,192 @@ impl Executor {
         }
     }
 
+    /// The SELECT list with every subquery inside an aggregate call replaced
+    /// by a column, and the subqueries taken out, in column order. None
+    /// when no aggregate holds one.
+    pub(crate) fn lift_subqueries_in_aggregates(
+        columns: &[Expression],
+    ) -> Option<(Vec<Expression>, Vec<Expression>)> {
+        let mut lifted = Vec::new();
+        let rewritten: Vec<Expression> = columns
+            .iter()
+            .map(|column| Self::lift_subqueries_in(column, false, &mut lifted))
+            .collect();
+        if lifted.is_empty() {
+            None
+        } else {
+            Some((rewritten, lifted))
+        }
+    }
+
+    fn lifted_column_name(index: usize) -> String {
+        format!("__agg_subquery_{index}")
+    }
+
+    fn lift_subqueries_in(
+        expr: &Expression,
+        inside_aggregate: bool,
+        lifted: &mut Vec<Expression>,
+    ) -> Expression {
+        let is_subquery = matches!(
+            expr,
+            Expression::ScalarSubquery(_) | Expression::Exists(_) | Expression::AllAny(_)
+        ) || matches!(expr, Expression::In(in_expr)
+            if matches!(in_expr.right.as_ref(), Expression::ScalarSubquery(_)));
+        if inside_aggregate && is_subquery {
+            lifted.push(expr.clone());
+            let name = Self::lifted_column_name(lifted.len() - 1);
+            return Expression::Identifier(crate::parser::ast::Identifier::new(
+                dummy_token(&name, TokenType::Identifier),
+                name.as_str(),
+            ));
+        }
+        let lift = |e: &Expression, lifted: &mut Vec<Expression>| {
+            Self::lift_subqueries_in(e, inside_aggregate, lifted)
+        };
+        match expr {
+            Expression::FunctionCall(func) => {
+                let inside =
+                    inside_aggregate || super::utils::is_aggregate_function(&func.function);
+                Expression::FunctionCall(Box::new(FunctionCall {
+                    token: func.token.clone(),
+                    function: func.function.clone(),
+                    arguments: func
+                        .arguments
+                        .iter()
+                        .map(|a| Self::lift_subqueries_in(a, inside, lifted))
+                        .collect(),
+                    is_distinct: func.is_distinct,
+                    order_by: func.order_by.clone(),
+                    filter: func
+                        .filter
+                        .as_ref()
+                        .map(|f| Box::new(Self::lift_subqueries_in(f, inside, lifted))),
+                }))
+            }
+            Expression::Infix(infix) => Expression::Infix(InfixExpression {
+                token: infix.token.clone(),
+                left: Box::new(lift(&infix.left, lifted)),
+                operator: infix.operator.clone(),
+                op_type: infix.op_type,
+                right: Box::new(lift(&infix.right, lifted)),
+            }),
+            Expression::Prefix(prefix) => Expression::Prefix(PrefixExpression {
+                token: prefix.token.clone(),
+                operator: prefix.operator.clone(),
+                op_type: prefix.op_type,
+                right: Box::new(lift(&prefix.right, lifted)),
+            }),
+            Expression::Aliased(aliased) => Expression::Aliased(AliasedExpression {
+                token: aliased.token.clone(),
+                expression: Box::new(lift(&aliased.expression, lifted)),
+                alias: aliased.alias.clone(),
+            }),
+            Expression::Cast(cast) => Expression::Cast(CastExpression {
+                token: cast.token.clone(),
+                expr: Box::new(lift(&cast.expr, lifted)),
+                type_name: cast.type_name.clone(),
+            }),
+            Expression::Case(case) => Expression::Case(Box::new(CaseExpression {
+                token: case.token.clone(),
+                value: case.value.as_ref().map(|v| Box::new(lift(v, lifted))),
+                when_clauses: case
+                    .when_clauses
+                    .iter()
+                    .map(|when| WhenClause {
+                        token: when.token.clone(),
+                        condition: lift(&when.condition, lifted),
+                        then_result: lift(&when.then_result, lifted),
+                    })
+                    .collect(),
+                else_value: case.else_value.as_ref().map(|e| Box::new(lift(e, lifted))),
+            })),
+            Expression::In(in_expr) => Expression::In(InExpression {
+                token: in_expr.token.clone(),
+                left: Box::new(lift(&in_expr.left, lifted)),
+                right: Box::new(lift(&in_expr.right, lifted)),
+                not: in_expr.not,
+            }),
+            Expression::Between(between) => Expression::Between(BetweenExpression {
+                token: between.token.clone(),
+                expr: Box::new(lift(&between.expr, lifted)),
+                lower: Box::new(lift(&between.lower, lifted)),
+                upper: Box::new(lift(&between.upper, lifted)),
+                not: between.not,
+            }),
+            Expression::Like(like) => Expression::Like(LikeExpression {
+                token: like.token.clone(),
+                left: Box::new(lift(&like.left, lifted)),
+                pattern: Box::new(lift(&like.pattern, lifted)),
+                operator: like.operator.clone(),
+                escape: like.escape.as_ref().map(|e| Box::new(lift(e, lifted))),
+            }),
+            Expression::List(list) => Expression::List(Box::new(ListExpression {
+                token: list.token.clone(),
+                elements: list.elements.iter().map(|e| lift(e, lifted)).collect(),
+            })),
+            Expression::ExpressionList(list) => {
+                Expression::ExpressionList(Box::new(ExpressionList {
+                    token: list.token.clone(),
+                    expressions: list.expressions.iter().map(|e| lift(e, lifted)).collect(),
+                }))
+            }
+            Expression::Distinct(distinct) => Expression::Distinct(DistinctExpression {
+                token: distinct.token.clone(),
+                expr: Box::new(lift(&distinct.expr, lifted)),
+            }),
+            _ => expr.clone(),
+        }
+    }
+
+    /// Every input row extended with the value of each lifted subquery,
+    /// resolved with that row as the outer row, and the column names to go
+    /// with them
+    pub(crate) fn materialize_lifted_subqueries(
+        &self,
+        lifted: &[Expression],
+        ctx: &ExecutionContext,
+        base_rows: crate::core::RowVec,
+        base_columns: &[String],
+    ) -> Result<(crate::core::RowVec, Vec<String>)> {
+        let keys: Vec<(CompactArc<str>, Option<CompactArc<str>>)> = base_columns
+            .iter()
+            .map(|name| {
+                let lower = name.to_lowercase();
+                let short = lower
+                    .rfind('.')
+                    .map(|dot| CompactArc::from(&lower[dot + 1..]));
+                (CompactArc::from(lower.as_str()), short)
+            })
+            .collect();
+        let outer_columns = CompactArc::new(base_columns.to_vec());
+        let mut rows = crate::core::RowVec::with_capacity(base_rows.len());
+        for (id, row) in base_rows {
+            let mut outer: rustc_hash::FxHashMap<CompactArc<str>, Value> =
+                ctx.outer_row().cloned().unwrap_or_default();
+            for ((full, short), value) in keys.iter().zip(row.as_slice()) {
+                if let Some(short) = short {
+                    outer.insert(short.clone(), value.clone());
+                }
+                outer.insert(full.clone(), value.clone());
+            }
+            let row_ctx = ctx.with_outer_row(outer, outer_columns.clone());
+            let mut values: Vec<Value> = row.as_slice().to_vec();
+            for node in lifted {
+                let bound = self.process_correlated_expression(node, &row_ctx)?;
+                let value = super::expression::ExpressionEval::compile(&bound, base_columns)?
+                    .with_context(&row_ctx)
+                    .eval_slice(&row)?;
+                values.push(value);
+            }
+            ctx.check_cancelled()?;
+            rows.push((id, crate::core::Row::from_values(values)));
+        }
+        let mut columns = base_columns.to_vec();
+        columns.extend((0..lifted.len()).map(Self::lifted_column_name));
+        Ok((rows, columns))
+    }
+
     /// Check if a subquery is correlated (references outer columns)
     pub(crate) fn is_subquery_correlated(subquery: &SelectStatement) -> bool {
         // Get table/alias names defined in the subquery's FROM clause

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -1784,18 +1784,15 @@ impl Executor {
         // as key; bypassed inside explicit transactions (see
         // execute_in_subquery for the ROLLBACK rationale)
         let cache_key = if is_non_correlated && ctx.transaction_id().is_none() {
-            match Self::subquery_cache_key(subquery, ctx) {
-                Some(key) => {
-                    if let Some(cached_value) = get_cached_scalar_subquery(&key) {
-                        return Ok(cached_value);
-                    }
-                    Some(key)
-                }
-                None => None,
-            }
+            Self::subquery_cache_key(subquery, ctx)
         } else {
             None
         };
+        if let Some(key) = &cache_key {
+            if let Some(cached_value) = get_cached_scalar_subquery(key) {
+                return Ok(cached_value);
+            }
+        }
 
         // OPTIMIZATION: For correlated scalar subqueries with LIMIT, index-based is faster
         // because it only checks rows for the limited outer rows.
@@ -1902,18 +1899,15 @@ impl Executor {
         // entirely: an in-transaction execution sees uncommitted rows, and
         // caching that view would survive a ROLLBACK
         let cache_key = if is_non_correlated && ctx.transaction_id().is_none() {
-            match Self::subquery_cache_key(subquery, ctx) {
-                Some(key) => {
-                    if let Some(cached_values) = get_cached_in_subquery(&key) {
-                        return Ok(cached_values);
-                    }
-                    Some(key)
-                }
-                None => None,
-            }
+            Self::subquery_cache_key(subquery, ctx)
         } else {
             None
         };
+        if let Some(key) = &cache_key {
+            if let Some(cached_values) = get_cached_in_subquery(key) {
+                return Ok(cached_values);
+            }
+        }
 
         // Execute the subquery with incremented depth to avoid creating new TimeoutGuard
         let subquery_ctx = ctx.with_incremented_query_depth();

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -1979,6 +1979,10 @@ impl Executor {
             Expression::FunctionCall(func) => {
                 func.arguments.iter().any(Self::has_subqueries)
                     || func.filter.as_deref().is_some_and(Self::has_subqueries)
+                    || func
+                        .order_by
+                        .iter()
+                        .any(|order| Self::has_subqueries(&order.expression))
             }
             Expression::Case(case) => {
                 case.value.as_deref().is_some_and(Self::has_subqueries)
@@ -2404,6 +2408,10 @@ impl Executor {
                         .filter
                         .as_deref()
                         .is_some_and(Self::has_correlated_subqueries)
+                    || func
+                        .order_by
+                        .iter()
+                        .any(|order| Self::has_correlated_subqueries(&order.expression))
             }
             Expression::Case(case) => {
                 case.value
@@ -2657,22 +2665,54 @@ impl Executor {
         }
     }
 
-    /// The SELECT list with every subquery inside an aggregate call replaced
-    /// by a column, and the subqueries taken out, in column order. None
-    /// when no aggregate holds one.
+    /// True when the SELECT list, HAVING or ORDER BY still holds a subquery;
+    /// an aggregation path that reads them raw must leave the statement to
+    /// the general entry, which lifts them
+    pub(crate) fn aggregates_hold_subquery(stmt: &SelectStatement) -> bool {
+        stmt.columns.iter().any(Self::has_subqueries)
+            || stmt.having.as_deref().is_some_and(Self::has_subqueries)
+            || stmt
+                .order_by
+                .iter()
+                .any(|order| Self::has_subqueries(&order.expression))
+    }
+
+    /// The statement with every subquery inside an aggregate call, in the
+    /// SELECT list, HAVING or ORDER BY, replaced by a column, and the
+    /// subqueries taken out in that order. None when no aggregate holds one.
     pub(crate) fn lift_subqueries_in_aggregates(
-        columns: &[Expression],
-    ) -> Option<(Vec<Expression>, Vec<Expression>)> {
+        stmt: &SelectStatement,
+    ) -> Option<(SelectStatement, Vec<Expression>)> {
         let mut lifted = Vec::new();
-        let rewritten: Vec<Expression> = columns
+        let columns: Vec<Expression> = stmt
+            .columns
             .iter()
             .map(|column| Self::lift_subqueries_in(column, false, &mut lifted))
             .collect();
+        let having = stmt
+            .having
+            .as_ref()
+            .map(|having| Box::new(Self::lift_subqueries_in(having, false, &mut lifted)));
+        let order_by: Vec<OrderByExpression> = stmt
+            .order_by
+            .iter()
+            .map(|order| OrderByExpression {
+                expression: Self::lift_subqueries_in(&order.expression, false, &mut lifted),
+                ..order.clone()
+            })
+            .collect();
         if lifted.is_empty() {
-            None
-        } else {
-            Some((rewritten, lifted))
+            return None;
         }
+        Some((
+            SelectStatement {
+                columns,
+                having,
+                order_by,
+                ..stmt.clone()
+            },
+            lifted,
+        ))
     }
 
     fn lifted_column_name(index: usize) -> String {
@@ -2713,7 +2753,14 @@ impl Executor {
                         .map(|a| Self::lift_subqueries_in(a, inside, lifted))
                         .collect(),
                     is_distinct: func.is_distinct,
-                    order_by: func.order_by.clone(),
+                    order_by: func
+                        .order_by
+                        .iter()
+                        .map(|order| OrderByExpression {
+                            expression: Self::lift_subqueries_in(&order.expression, inside, lifted),
+                            ..order.clone()
+                        })
+                        .collect(),
                     filter: func
                         .filter
                         .as_ref()
@@ -2804,15 +2851,21 @@ impl Executor {
         ctx: &ExecutionContext,
         base_rows: crate::core::RowVec,
         base_columns: &[String],
+        qualifier: Option<&str>,
     ) -> Result<(crate::core::RowVec, Vec<String>)> {
+        // Each column under its own name, its bare name when qualified, and
+        // its qualified name when the source's name or alias is known
         let keys: Vec<(CompactArc<str>, Option<CompactArc<str>>)> = base_columns
             .iter()
             .map(|name| {
                 let lower = name.to_lowercase();
-                let short = lower
-                    .rfind('.')
-                    .map(|dot| CompactArc::from(&lower[dot + 1..]));
-                (CompactArc::from(lower.as_str()), short)
+                let other = match lower.rfind('.') {
+                    Some(dot) => Some(CompactArc::from(&lower[dot + 1..])),
+                    None => qualifier.map(|q| {
+                        CompactArc::from(format!("{}.{}", q.to_lowercase(), lower).as_str())
+                    }),
+                };
+                (CompactArc::from(lower.as_str()), other)
             })
             .collect();
         let outer_columns = CompactArc::new(base_columns.to_vec());
@@ -2953,6 +3006,10 @@ impl Executor {
                         .filter
                         .as_deref()
                         .is_some_and(|f| Self::references_outer_columns(f, subquery_tables))
+                    || func
+                        .order_by
+                        .iter()
+                        .any(|o| Self::references_outer_columns(&o.expression, subquery_tables))
             }
             Expression::In(in_expr) => {
                 Self::references_outer_columns(&in_expr.left, subquery_tables)

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -233,7 +233,8 @@ impl Executor {
                             && !Self::is_subquery_correlated(&subquery.subquery)
                             && ctx.transaction_id().is_none();
                         let cached_set = if is_non_correlated {
-                            get_cached_in_subquery_set(&subquery.subquery.to_string())
+                            Self::subquery_cache_key(&subquery.subquery, ctx)
+                                .and_then(|key| get_cached_in_subquery_set(&key))
                         } else {
                             None
                         };
@@ -1783,11 +1784,15 @@ impl Executor {
         // as key; bypassed inside explicit transactions (see
         // execute_in_subquery for the ROLLBACK rationale)
         let cache_key = if is_non_correlated && ctx.transaction_id().is_none() {
-            let key = subquery.to_string();
-            if let Some(cached_value) = get_cached_scalar_subquery(&key) {
-                return Ok(cached_value);
+            match Self::subquery_cache_key(subquery, ctx) {
+                Some(key) => {
+                    if let Some(cached_value) = get_cached_scalar_subquery(&key) {
+                        return Ok(cached_value);
+                    }
+                    Some(key)
+                }
+                None => None,
             }
-            Some(key)
         } else {
             None
         };
@@ -1897,11 +1902,15 @@ impl Executor {
         // entirely: an in-transaction execution sees uncommitted rows, and
         // caching that view would survive a ROLLBACK
         let cache_key = if is_non_correlated && ctx.transaction_id().is_none() {
-            let key = subquery.to_string();
-            if let Some(cached_values) = get_cached_in_subquery(&key) {
-                return Ok(cached_values);
+            match Self::subquery_cache_key(subquery, ctx) {
+                Some(key) => {
+                    if let Some(cached_values) = get_cached_in_subquery(&key) {
+                        return Ok(cached_values);
+                    }
+                    Some(key)
+                }
+                None => None,
             }
-            Some(key)
         } else {
             None
         };
@@ -2769,6 +2778,32 @@ impl Executor {
                 .any(|order| Self::has_subqueries(&order.expression))
     }
 
+    /// The cache key of a subquery that reads no outer row: its text and the
+    /// bindings behind it, since a parameter prints as its marker and one
+    /// text would otherwise answer for two executions. None when the text
+    /// holds an anonymous marker, which two bindings of one statement share
+    pub(crate) fn subquery_cache_key(
+        subquery: &SelectStatement,
+        ctx: &ExecutionContext,
+    ) -> Option<String> {
+        use std::fmt::Write;
+        let mut key = subquery.to_string();
+        if key.contains('?') {
+            return None;
+        }
+        for value in ctx.params() {
+            let _ = write!(key, "\u{1}{value}");
+        }
+        if !ctx.named_params().is_empty() {
+            let mut named: Vec<(&String, &Value)> = ctx.named_params().iter().collect();
+            named.sort_unstable_by_key(|(name, _)| *name);
+            for (name, value) in named {
+                let _ = write!(key, "\u{1}{name}={value}");
+            }
+        }
+        Some(key)
+    }
+
     /// Whether a window function, its OVER clause or a named window holds a subquery
     pub(crate) fn windows_hold_subquery(stmt: &SelectStatement) -> bool {
         stmt.columns.iter().any(Self::has_subqueries)
@@ -2790,8 +2825,12 @@ impl Executor {
         base_columns: &[String],
     ) -> String {
         let text = expr.to_string();
-        if let Some((_, name)) = lifted.iter().find(|(e, _)| e.to_string() == text) {
-            return name.clone();
+        // An anonymous parameter prints as a bare marker, so one text can
+        // stand for two bindings and only a distinct text may be shared
+        if !text.contains('?') {
+            if let Some((_, name)) = lifted.iter().find(|(e, _)| e.to_string() == text) {
+                return name.clone();
+            }
         }
         let mut name = text;
         // A qualifier holds no dot, the name after it may
@@ -2800,7 +2839,10 @@ impl Executor {
                 || column
                     .split_once('.')
                     .is_some_and(|(_, bare)| bare.eq_ignore_ascii_case(&name))
-        }) {
+        }) || lifted
+            .iter()
+            .any(|(_, taken)| taken.eq_ignore_ascii_case(&name))
+        {
             name.push('_');
         }
         lifted.push((expr.clone(), name.clone()));
@@ -2916,6 +2958,22 @@ impl Executor {
         ))
     }
 
+    /// The argument a navigation window function reads once, off no row:
+    /// the offset of LEAD and LAG, the group count of NTILE, the n of
+    /// NTH_VALUE
+    fn window_control_argument(function: &str) -> Option<usize> {
+        if function.eq_ignore_ascii_case("NTILE") {
+            Some(0)
+        } else if function.eq_ignore_ascii_case("LEAD")
+            || function.eq_ignore_ascii_case("LAG")
+            || function.eq_ignore_ascii_case("NTH_VALUE")
+        {
+            Some(1)
+        } else {
+            None
+        }
+    }
+
     fn lift_subqueries_in_call(
         func: &FunctionCall,
         inside_aggregate: bool,
@@ -2925,13 +2983,25 @@ impl Executor {
     ) -> FunctionCall {
         let inside =
             inside_aggregate || (!windows && super::utils::is_aggregate_function(&func.function));
+        // A navigation window function reads its control argument off no row
+        // at all, so a column put there would never resolve
+        let control = windows
+            .then(|| Self::window_control_argument(&func.function))
+            .flatten();
         FunctionCall {
             token: func.token.clone(),
             function: func.function.clone(),
             arguments: func
                 .arguments
                 .iter()
-                .map(|a| Self::lift_subqueries_in(a, inside, windows, lifted, base_columns))
+                .enumerate()
+                .map(|(i, a)| {
+                    if control == Some(i) {
+                        a.clone()
+                    } else {
+                        Self::lift_subqueries_in(a, inside, windows, lifted, base_columns)
+                    }
+                })
                 .collect(),
             is_distinct: func.is_distinct,
             order_by: func

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -1940,8 +1940,7 @@ impl Executor {
                 Self::has_subqueries(&infix.left) || Self::has_subqueries(&infix.right)
             }
             Expression::In(in_expr) => {
-                Self::has_subqueries(&in_expr.left)
-                    || matches!(in_expr.right.as_ref(), Expression::ScalarSubquery(_))
+                Self::has_subqueries(&in_expr.left) || Self::has_subqueries(&in_expr.right)
             }
             Expression::Between(between) => {
                 Self::has_subqueries(&between.expr)
@@ -2227,6 +2226,7 @@ impl Executor {
                     return Self::is_subquery_correlated(&subquery.subquery);
                 }
                 Self::has_correlated_subqueries(&in_expr.left)
+                    || Self::has_correlated_subqueries(&in_expr.right)
             }
             Expression::Between(between) => {
                 Self::has_correlated_subqueries(&between.expr)
@@ -2573,6 +2573,25 @@ impl Executor {
                 Self::references_outer_columns(&aliased.expression, subquery_tables)
             }
             Expression::Cast(cast) => Self::references_outer_columns(&cast.expr, subquery_tables),
+            Expression::Like(like) => {
+                Self::references_outer_columns(&like.left, subquery_tables)
+                    || Self::references_outer_columns(&like.pattern, subquery_tables)
+                    || like
+                        .escape
+                        .as_deref()
+                        .is_some_and(|e| Self::references_outer_columns(e, subquery_tables))
+            }
+            Expression::Distinct(distinct) => {
+                Self::references_outer_columns(&distinct.expr, subquery_tables)
+            }
+            Expression::List(list) => list
+                .elements
+                .iter()
+                .any(|e| Self::references_outer_columns(e, subquery_tables)),
+            Expression::ExpressionList(list) => list
+                .expressions
+                .iter()
+                .any(|e| Self::references_outer_columns(e, subquery_tables)),
             _ => false,
         }
     }

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -129,11 +129,19 @@ impl Executor {
             }
 
             Expression::AllAny(all_any) => {
+                // The left operand may hold a subquery of its own
+                let bound = AllAnyExpression {
+                    token: all_any.token.clone(),
+                    left: Box::new(self.process_where_subqueries(&all_any.left, ctx)?),
+                    operator: all_any.operator.clone(),
+                    all_any_type: all_any.all_any_type,
+                    subquery: all_any.subquery.clone(),
+                };
                 // Execute the subquery to get all values
-                let values = self.execute_in_subquery(&all_any.subquery, ctx)?;
+                let values = self.execute_in_subquery(&bound.subquery, ctx)?;
 
                 // Convert ALL/ANY to an equivalent expression that the evaluator can handle
-                self.convert_all_any_to_expression(all_any, values)
+                self.convert_all_any_to_expression(&bound, values)
             }
 
             Expression::Prefix(prefix) => {
@@ -1616,12 +1624,45 @@ impl Executor {
             };
         }
 
+        // A NULL among the values makes the comparison with it UNKNOWN, so an
+        // ALL that holds on the others and an ANY that fails on the others are
+        // UNKNOWN: the folded predicate carries a NULL beside it
+        let has_null = values.iter().any(|v| v.is_null());
+        let non_null_values: Vec<&crate::core::Value> =
+            values.iter().filter(|v| !v.is_null()).collect();
+        let unknown = || {
+            Expression::NullLiteral(NullLiteral {
+                token: dummy_token("NULL", TokenType::Keyword),
+            })
+        };
+        let with_unknown = |predicate: Expression| -> Expression {
+            if !has_null {
+                return predicate;
+            }
+            let logical = match all_any.all_any_type {
+                AllAnyType::All => "AND",
+                AllAnyType::Any => "OR",
+            };
+            Expression::Infix(InfixExpression::new(
+                all_any.token.clone(),
+                Box::new(predicate),
+                logical.to_string(),
+                Box::new(unknown()),
+            ))
+        };
+        if non_null_values.is_empty() {
+            return Ok(unknown());
+        }
+
         // Convert values to expressions
-        let value_exprs: Vec<Expression> = values.iter().map(value_to_expression).collect();
+        let value_exprs: Vec<Expression> = non_null_values
+            .iter()
+            .map(|v| value_to_expression(v))
+            .collect();
 
         // Special case: = ANY is equivalent to IN
         if op == "=" && matches!(all_any.all_any_type, AllAnyType::Any) {
-            return Ok(Expression::In(InExpression {
+            return Ok(with_unknown(Expression::In(InExpression {
                 token: all_any.token.clone(),
                 left: all_any.left.clone(),
                 right: Box::new(Expression::ExpressionList(Box::new(ExpressionList {
@@ -1629,12 +1670,12 @@ impl Executor {
                     expressions: value_exprs,
                 }))),
                 not: false,
-            }));
+            })));
         }
 
         // Special case: <> ALL is equivalent to NOT IN
         if (op == "<>" || op == "!=") && matches!(all_any.all_any_type, AllAnyType::All) {
-            return Ok(Expression::In(InExpression {
+            return Ok(with_unknown(Expression::In(InExpression {
                 token: all_any.token.clone(),
                 left: all_any.left.clone(),
                 right: Box::new(Expression::ExpressionList(Box::new(ExpressionList {
@@ -1642,7 +1683,7 @@ impl Executor {
                     expressions: value_exprs,
                 }))),
                 not: true,
-            }));
+            })));
         }
 
         // For comparison operators, we can optimize using MIN/MAX:
@@ -1654,19 +1695,6 @@ impl Executor {
         // - x >= ANY (values) → x >= MIN(values)
         // - x < ANY (values) → x < MAX(values)
         // - x <= ANY (values) → x <= MAX(values)
-
-        // Filter out NULL values for comparison
-        let non_null_values: Vec<&crate::core::Value> =
-            values.iter().filter(|v| !v.is_null()).collect();
-
-        // If all values are NULL, result depends on semantics
-        if non_null_values.is_empty() {
-            // Comparison with all NULLs is UNKNOWN, which filters as FALSE
-            return Ok(Expression::BooleanLiteral(BooleanLiteral {
-                token: dummy_token("FALSE", TokenType::Keyword),
-                value: false,
-            }));
-        }
 
         // Find min and max
         let min_val = non_null_values
@@ -1693,12 +1721,12 @@ impl Executor {
 
         if let Some(cmp_val) = comparison_value {
             // Build simple comparison: left op value
-            return Ok(Expression::Infix(InfixExpression::new(
+            return Ok(with_unknown(Expression::Infix(InfixExpression::new(
                 all_any.token.clone(),
                 all_any.left.clone(),
                 op.to_string(),
                 Box::new(value_to_expression(cmp_val)),
-            )));
+            ))));
         }
 
         // Fallback: build compound expression with AND/OR
@@ -1730,12 +1758,12 @@ impl Executor {
             });
         }
 
-        Ok(result_expr.unwrap_or_else(|| {
+        Ok(with_unknown(result_expr.unwrap_or_else(|| {
             Expression::BooleanLiteral(BooleanLiteral {
                 token: dummy_token("TRUE", TokenType::Keyword),
                 value: true,
             })
-        }))
+        })))
     }
 
     /// Execute a scalar subquery and return its single value.
@@ -1948,7 +1976,10 @@ impl Executor {
                     || Self::has_subqueries(&between.upper)
             }
             Expression::Aliased(aliased) => Self::has_subqueries(&aliased.expression),
-            Expression::FunctionCall(func) => func.arguments.iter().any(Self::has_subqueries),
+            Expression::FunctionCall(func) => {
+                func.arguments.iter().any(Self::has_subqueries)
+                    || func.filter.as_deref().is_some_and(Self::has_subqueries)
+            }
             Expression::Case(case) => {
                 case.value.as_deref().is_some_and(Self::has_subqueries)
                     || case.when_clauses.iter().any(|w| {
@@ -2209,7 +2240,10 @@ impl Executor {
             Expression::ScalarSubquery(subquery) => {
                 Self::is_subquery_correlated(&subquery.subquery)
             }
-            Expression::AllAny(all_any) => Self::is_subquery_correlated(&all_any.subquery),
+            Expression::AllAny(all_any) => {
+                Self::is_subquery_correlated(&all_any.subquery)
+                    || Self::has_correlated_subqueries(&all_any.left)
+            }
             Expression::Prefix(prefix) => {
                 // Handle NOT EXISTS
                 if let Expression::Exists(exists) = prefix.right.as_ref() {
@@ -2236,6 +2270,10 @@ impl Executor {
             Expression::Aliased(aliased) => Self::has_correlated_subqueries(&aliased.expression),
             Expression::FunctionCall(func) => {
                 func.arguments.iter().any(Self::has_correlated_subqueries)
+                    || func
+                        .filter
+                        .as_deref()
+                        .is_some_and(Self::has_correlated_subqueries)
             }
             Expression::Case(case) => {
                 case.value
@@ -2536,10 +2574,15 @@ impl Executor {
             Expression::Prefix(prefix) => {
                 Self::references_outer_columns(&prefix.right, subquery_tables)
             }
-            Expression::FunctionCall(func) => func
-                .arguments
-                .iter()
-                .any(|arg| Self::references_outer_columns(arg, subquery_tables)),
+            Expression::FunctionCall(func) => {
+                func.arguments
+                    .iter()
+                    .any(|arg| Self::references_outer_columns(arg, subquery_tables))
+                    || func
+                        .filter
+                        .as_deref()
+                        .is_some_and(|f| Self::references_outer_columns(f, subquery_tables))
+            }
             Expression::In(in_expr) => {
                 Self::references_outer_columns(&in_expr.left, subquery_tables)
                     || Self::references_outer_columns(&in_expr.right, subquery_tables)

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -2244,9 +2244,117 @@ impl Executor {
                 Ok(Some(self.convert_all_any_to_expression(&bound, values)?))
             }
 
+            Expression::In(in_expr) => {
+                // A subquery on the right folds to its values as in a WHERE
+                if matches!(in_expr.right.as_ref(), Expression::ScalarSubquery(_)) {
+                    return Ok(Some(self.process_where_subqueries(expr, ctx)?));
+                }
+                let left = self.try_process_expression_subqueries(&in_expr.left, ctx)?;
+                let right = self.try_process_expression_subqueries(&in_expr.right, ctx)?;
+                if left.is_none() && right.is_none() {
+                    return Ok(None);
+                }
+                Ok(Some(Expression::In(InExpression {
+                    token: in_expr.token.clone(),
+                    left: Box::new(left.unwrap_or_else(|| (*in_expr.left).clone())),
+                    right: Box::new(right.unwrap_or_else(|| (*in_expr.right).clone())),
+                    not: in_expr.not,
+                })))
+            }
+
+            Expression::Between(between) => {
+                let expr_p = self.try_process_expression_subqueries(&between.expr, ctx)?;
+                let lower = self.try_process_expression_subqueries(&between.lower, ctx)?;
+                let upper = self.try_process_expression_subqueries(&between.upper, ctx)?;
+                if expr_p.is_none() && lower.is_none() && upper.is_none() {
+                    return Ok(None);
+                }
+                Ok(Some(Expression::Between(BetweenExpression {
+                    token: between.token.clone(),
+                    expr: Box::new(expr_p.unwrap_or_else(|| (*between.expr).clone())),
+                    lower: Box::new(lower.unwrap_or_else(|| (*between.lower).clone())),
+                    upper: Box::new(upper.unwrap_or_else(|| (*between.upper).clone())),
+                    not: between.not,
+                })))
+            }
+
+            Expression::Like(like) => {
+                let left = self.try_process_expression_subqueries(&like.left, ctx)?;
+                let pattern = self.try_process_expression_subqueries(&like.pattern, ctx)?;
+                let escape = match &like.escape {
+                    Some(escape) => self.try_process_expression_subqueries(escape, ctx)?,
+                    None => None,
+                };
+                if left.is_none() && pattern.is_none() && escape.is_none() {
+                    return Ok(None);
+                }
+                Ok(Some(Expression::Like(LikeExpression {
+                    token: like.token.clone(),
+                    left: Box::new(left.unwrap_or_else(|| (*like.left).clone())),
+                    pattern: Box::new(pattern.unwrap_or_else(|| (*like.pattern).clone())),
+                    operator: like.operator.clone(),
+                    escape: match escape {
+                        Some(escape) => Some(Box::new(escape)),
+                        None => like.escape.clone(),
+                    },
+                })))
+            }
+
+            Expression::List(list) => {
+                let processed = self.try_process_expression_list(&list.elements, ctx)?;
+                Ok(processed.map(|elements| {
+                    Expression::List(Box::new(ListExpression {
+                        token: list.token.clone(),
+                        elements,
+                    }))
+                }))
+            }
+
+            Expression::ExpressionList(list) => {
+                let processed = self.try_process_expression_list(&list.expressions, ctx)?;
+                Ok(processed.map(|expressions| {
+                    Expression::ExpressionList(Box::new(ExpressionList {
+                        token: list.token.clone(),
+                        expressions,
+                    }))
+                }))
+            }
+
+            Expression::Distinct(distinct) => Ok(self
+                .try_process_expression_subqueries(&distinct.expr, ctx)?
+                .map(|inner| {
+                    Expression::Distinct(DistinctExpression {
+                        token: distinct.token.clone(),
+                        expr: Box::new(inner),
+                    })
+                })),
+
             // No subqueries possible in other expression types
             _ => Ok(None),
         }
+    }
+
+    /// The elements of a list with their subqueries resolved, or None when
+    /// none held one
+    fn try_process_expression_list(
+        &self,
+        elements: &[Expression],
+        ctx: &ExecutionContext,
+    ) -> Result<Option<Vec<Expression>>> {
+        let mut processed: Vec<Option<Expression>> = Vec::with_capacity(elements.len());
+        for element in elements {
+            processed.push(self.try_process_expression_subqueries(element, ctx)?);
+        }
+        if processed.iter().all(Option::is_none) {
+            return Ok(None);
+        }
+        Ok(Some(
+            processed
+                .into_iter()
+                .zip(elements.iter())
+                .map(|(new, old)| new.unwrap_or_else(|| old.clone()))
+                .collect(),
+        ))
     }
 
     // ============================================================================
@@ -2488,6 +2596,61 @@ impl Executor {
                     type_name: cast.type_name.clone(),
                 }))
             }
+
+            // ALL and ANY run their subquery under this row's context; the
+            // left operand is resolved first
+            Expression::AllAny(all_any) => {
+                let bound = AllAnyExpression {
+                    token: all_any.token.clone(),
+                    left: Box::new(self.process_correlated_expression(&all_any.left, ctx)?),
+                    operator: all_any.operator.clone(),
+                    all_any_type: all_any.all_any_type,
+                    subquery: all_any.subquery.clone(),
+                };
+                let values = self.execute_in_subquery(&bound.subquery, ctx)?;
+                self.convert_all_any_to_expression(&bound, values)
+            }
+
+            Expression::Like(like) => {
+                let escape = match &like.escape {
+                    Some(escape) => {
+                        Some(Box::new(self.process_correlated_expression(escape, ctx)?))
+                    }
+                    None => None,
+                };
+                Ok(Expression::Like(LikeExpression {
+                    token: like.token.clone(),
+                    left: Box::new(self.process_correlated_expression(&like.left, ctx)?),
+                    pattern: Box::new(self.process_correlated_expression(&like.pattern, ctx)?),
+                    operator: like.operator.clone(),
+                    escape,
+                }))
+            }
+
+            Expression::List(list) => Ok(Expression::List(Box::new(ListExpression {
+                token: list.token.clone(),
+                elements: list
+                    .elements
+                    .iter()
+                    .map(|element| self.process_correlated_expression(element, ctx))
+                    .collect::<Result<Vec<_>>>()?,
+            }))),
+
+            Expression::ExpressionList(list) => {
+                Ok(Expression::ExpressionList(Box::new(ExpressionList {
+                    token: list.token.clone(),
+                    expressions: list
+                        .expressions
+                        .iter()
+                        .map(|element| self.process_correlated_expression(element, ctx))
+                        .collect::<Result<Vec<_>>>()?,
+                })))
+            }
+
+            Expression::Distinct(distinct) => Ok(Expression::Distinct(DistinctExpression {
+                token: distinct.token.clone(),
+                expr: Box::new(self.process_correlated_expression(&distinct.expr, ctx)?),
+            })),
 
             // For all other expression types, return as-is
             _ => Ok(expr.clone()),

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -368,6 +368,16 @@ fn substitute_outer_references_inner(
             }
         }
 
+        Expression::InHashSet(in_set) => {
+            substitute_outer_references_inner(&in_set.column, outer_row, scope).map(|column| {
+                Expression::InHashSet(InHashSetExpression {
+                    token: in_set.token.clone(),
+                    column: Box::new(column),
+                    values: in_set.values.clone(),
+                    not: in_set.not,
+                })
+            })
+        }
         Expression::Cast(cast) => substitute_outer_references_inner(&cast.expr, outer_row, scope)
             .map(|expr| {
                 Expression::Cast(CastExpression {

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -36,8 +36,9 @@ use crate::core::{DataType, Operator, Row, Schema, Value};
 use crate::executor::operators::index_nested_loop::ColumnSource;
 use crate::parser::ast::{
     BetweenExpression, BooleanLiteral, Expression, FloatLiteral, FunctionCall, Identifier,
-    InExpression, InfixExpression, InfixOperator, IntegerLiteral, LikeExpression, ListExpression,
-    NullLiteral, PrefixExpression, QualifiedIdentifier, StringLiteral, WindowFrameBound,
+    InExpression, InHashSetExpression, InfixExpression, InfixOperator, IntegerLiteral,
+    LikeExpression, ListExpression, NullLiteral, PrefixExpression, QualifiedIdentifier,
+    StringLiteral, WindowFrameBound,
 };
 use crate::parser::token::{Position, Token, TokenType};
 
@@ -990,6 +991,9 @@ fn collect_table_qualifiers_impl(expr: &Expression, qualifiers: &mut FxHashSet<S
                 }
             }
         }
+        Expression::InHashSet(in_set) => {
+            collect_table_qualifiers_impl(&in_set.column, qualifiers);
+        }
         Expression::Between(between) => {
             collect_table_qualifiers_impl(&between.expr, qualifiers);
             collect_table_qualifiers_impl(&between.lower, qualifiers);
@@ -1098,6 +1102,12 @@ pub fn strip_table_qualifier(expr: &Expression, table_alias: &str) -> Expression
                 not: in_expr.not,
             })
         }
+        Expression::InHashSet(in_set) => Expression::InHashSet(InHashSetExpression {
+            token: in_set.token.clone(),
+            column: Box::new(strip_table_qualifier(&in_set.column, table_alias)),
+            values: in_set.values.clone(),
+            not: in_set.not,
+        }),
         Expression::Between(between) => Expression::Between(BetweenExpression {
             token: between.token.clone(),
             expr: Box::new(strip_table_qualifier(&between.expr, table_alias)),
@@ -1182,6 +1192,12 @@ pub fn add_table_qualifier(expr: &Expression, table_alias: &str) -> Expression {
                 not: in_expr.not,
             })
         }
+        Expression::InHashSet(in_set) => Expression::InHashSet(InHashSetExpression {
+            token: in_set.token.clone(),
+            column: Box::new(add_table_qualifier(&in_set.column, table_alias)),
+            values: in_set.values.clone(),
+            not: in_set.not,
+        }),
         Expression::Between(between) => Expression::Between(BetweenExpression {
             token: between.token.clone(),
             expr: Box::new(add_table_qualifier(&between.expr, table_alias)),

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -35,10 +35,11 @@ use crate::core::value::NULL_VALUE;
 use crate::core::{DataType, Operator, Row, Schema, Value};
 use crate::executor::operators::index_nested_loop::ColumnSource;
 use crate::parser::ast::{
-    BetweenExpression, BooleanLiteral, Expression, FloatLiteral, FunctionCall, Identifier,
-    InExpression, InHashSetExpression, InfixExpression, InfixOperator, IntegerLiteral,
-    LikeExpression, ListExpression, NullLiteral, PrefixExpression, QualifiedIdentifier,
-    StringLiteral, WindowFrameBound,
+    BetweenExpression, BooleanLiteral, CaseExpression, CastExpression, DistinctExpression,
+    Expression, ExpressionList, FloatLiteral, FunctionCall, Identifier, InExpression,
+    InHashSetExpression, InfixExpression, InfixOperator, IntegerLiteral, LikeExpression,
+    ListExpression, NullLiteral, PrefixExpression, QualifiedIdentifier, StringLiteral, WhenClause,
+    WindowFrameBound,
 };
 use crate::parser::token::{Position, Token, TokenType};
 
@@ -365,6 +366,88 @@ fn substitute_outer_references_inner(
             } else {
                 None
             }
+        }
+
+        Expression::Cast(cast) => substitute_outer_references_inner(&cast.expr, outer_row, scope)
+            .map(|expr| {
+                Expression::Cast(CastExpression {
+                    token: cast.token.clone(),
+                    expr: Box::new(expr),
+                    type_name: cast.type_name.clone(),
+                })
+            }),
+        Expression::Distinct(distinct) => {
+            substitute_outer_references_inner(&distinct.expr, outer_row, scope).map(|expr| {
+                Expression::Distinct(DistinctExpression {
+                    token: distinct.token.clone(),
+                    expr: Box::new(expr),
+                })
+            })
+        }
+        Expression::ExpressionList(list) => {
+            let new_items: Vec<Option<Expression>> = list
+                .expressions
+                .iter()
+                .map(|item| substitute_outer_references_inner(item, outer_row, scope))
+                .collect();
+            if new_items.iter().any(Option::is_some) {
+                Some(Expression::ExpressionList(Box::new(ExpressionList {
+                    token: list.token.clone(),
+                    expressions: new_items
+                        .into_iter()
+                        .zip(list.expressions.iter())
+                        .map(|(new, old)| new.unwrap_or_else(|| old.clone()))
+                        .collect(),
+                })))
+            } else {
+                None
+            }
+        }
+        Expression::Case(case) => {
+            let new_value = case
+                .value
+                .as_ref()
+                .and_then(|value| substitute_outer_references_inner(value, outer_row, scope));
+            let new_whens: Vec<(Option<Expression>, Option<Expression>)> = case
+                .when_clauses
+                .iter()
+                .map(|when| {
+                    (
+                        substitute_outer_references_inner(&when.condition, outer_row, scope),
+                        substitute_outer_references_inner(&when.then_result, outer_row, scope),
+                    )
+                })
+                .collect();
+            let new_else = case
+                .else_value
+                .as_ref()
+                .and_then(|value| substitute_outer_references_inner(value, outer_row, scope));
+            let changed = new_value.is_some()
+                || new_else.is_some()
+                || new_whens.iter().any(|(c, t)| c.is_some() || t.is_some());
+            if !changed {
+                return None;
+            }
+            Some(Expression::Case(Box::new(CaseExpression {
+                token: case.token.clone(),
+                value: match new_value {
+                    Some(value) => Some(Box::new(value)),
+                    None => case.value.clone(),
+                },
+                when_clauses: new_whens
+                    .into_iter()
+                    .zip(case.when_clauses.iter())
+                    .map(|((condition, then_result), when)| WhenClause {
+                        token: when.token.clone(),
+                        condition: condition.unwrap_or_else(|| when.condition.clone()),
+                        then_result: then_result.unwrap_or_else(|| when.then_result.clone()),
+                    })
+                    .collect(),
+                else_value: match new_else {
+                    Some(value) => Some(Box::new(value)),
+                    None => case.else_value.clone(),
+                },
+            })))
         }
 
         // Literals and other expressions that don't need substitution

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -392,6 +392,39 @@ impl Executor {
         pre_sorted: Option<WindowPreSortedState>,
         pre_grouped: Option<WindowPreGroupedState>,
     ) -> Result<Box<dyn QueryResult>> {
+        // A subquery inside a window function is resolved per input row first
+        let lifted_stmt;
+        let lifted_rows;
+        let lifted_columns;
+        let (stmt, base_rows, base_columns) = match Self::aggregates_hold_subquery(stmt)
+            .then(|| Self::lift_subqueries_in_aggregates(stmt, base_columns))
+            .flatten()
+        {
+            Some((rewritten, lifted, names)) => {
+                let qualifier = stmt
+                    .table_expr
+                    .as_deref()
+                    .and_then(super::utils::get_table_alias_from_expr);
+                let (rows, all_columns) = self.materialize_lifted_subqueries(
+                    &lifted,
+                    &names,
+                    ctx,
+                    base_rows,
+                    base_columns,
+                    qualifier.as_deref(),
+                )?;
+                lifted_stmt = rewritten;
+                lifted_rows = rows;
+                lifted_columns = all_columns;
+                (
+                    &lifted_stmt,
+                    lifted_rows.as_slice(),
+                    lifted_columns.as_slice(),
+                )
+            }
+            None => (stmt, base_rows, base_columns),
+        };
+
         // Parse window functions from the SELECT list
         let window_functions = self.parse_window_functions(stmt, base_columns)?;
 

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -466,7 +466,8 @@ impl Executor {
         };
 
         // Parse window functions from the SELECT list
-        let window_functions = self.parse_window_functions(stmt, base_columns)?;
+        let mut window_functions = self.parse_window_functions(stmt, base_columns)?;
+        self.fold_window_control_arguments(&mut window_functions, ctx)?;
 
         if window_functions.is_empty() {
             // No window functions found, return base result
@@ -1074,7 +1075,8 @@ impl Executor {
         limit: usize,
     ) -> Result<Box<dyn QueryResult>> {
         // Parse window functions from SELECT list
-        let window_functions = self.parse_window_functions(stmt, base_columns)?;
+        let mut window_functions = self.parse_window_functions(stmt, base_columns)?;
+        self.fold_window_control_arguments(&mut window_functions, ctx)?;
         if window_functions.is_empty() {
             return Err(Error::internal(
                 "No window functions found for lazy partition fetch",

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -42,6 +42,40 @@ use crate::core::value::NULL_VALUE;
 /// Stack constant for COUNT(*) accumulation by reference
 const COUNT_ONE: Value = Value::Integer(1);
 
+/// The value a window aggregate reads from one row: its argument column,
+/// the argument expression evaluated up front, or one per row for COUNT(*)
+#[inline(always)]
+fn window_argument_value<'a>(
+    rows: &'a [(i64, Row)],
+    idx: usize,
+    arg_col_idx: Option<usize>,
+    expression_values: &'a [Value],
+) -> &'a Value {
+    if let Some(col_idx) = arg_col_idx {
+        rows[idx].1.get(col_idx).unwrap_or(&NULL_VALUE)
+    } else if !expression_values.is_empty() {
+        &expression_values[idx]
+    } else {
+        &COUNT_ONE
+    }
+}
+
+/// One frame of an aggregate that orders its own input
+fn accumulate_ordered_frame(
+    agg_func: &mut Box<dyn crate::functions::AggregateFunction>,
+    frame: &[usize],
+    rows: &[(i64, Row)],
+    arg_col_idx: Option<usize>,
+    expression_values: &[Value],
+    keys: &[Vec<Value>],
+    is_distinct: bool,
+) {
+    for &idx in frame {
+        let value = window_argument_value(rows, idx, arg_col_idx, expression_values);
+        agg_func.accumulate_with_sort_key(value, keys[idx].clone(), is_distinct);
+    }
+}
+
 /// A window-function argument that cannot reference row columns:
 /// compiled once, evaluated once when deterministic and per call when
 /// volatile (RANDOM and friends keep their per-row behavior)
@@ -199,6 +233,10 @@ pub struct WindowFunctionInfo {
     pub column_name: String,
     /// Whether DISTINCT was specified (for COUNT(DISTINCT col) OVER())
     pub is_distinct: bool,
+    /// The aggregate's FILTER (WHERE ...) clause
+    pub filter: Option<Box<Expression>>,
+    /// The aggregate's own ORDER BY, for an aggregate that orders its input
+    pub call_order_by: Box<[OrderByExpression]>,
 }
 
 /// Information about a SELECT list item for window function processing
@@ -392,12 +430,14 @@ impl Executor {
         pre_sorted: Option<WindowPreSortedState>,
         pre_grouped: Option<WindowPreGroupedState>,
     ) -> Result<Box<dyn QueryResult>> {
-        // A subquery inside a window function is resolved per input row first
+        // A subquery inside a window function or its OVER clause is resolved
+        // per input row first; the columns it adds stay out of SELECT *
+        let visible_columns = base_columns.len();
         let lifted_stmt;
         let lifted_rows;
         let lifted_columns;
-        let (stmt, base_rows, base_columns) = match Self::aggregates_hold_subquery(stmt)
-            .then(|| Self::lift_subqueries_in_aggregates(stmt, base_columns))
+        let (stmt, base_rows, base_columns) = match Self::windows_hold_subquery(stmt)
+            .then(|| Self::lift_subqueries_in_windows(stmt, base_columns))
             .flatten()
         {
             Some((rewritten, lifted, names)) => {
@@ -460,6 +500,7 @@ impl Executor {
                                 ctx,
                                 base_rows,
                                 base_columns,
+                                visible_columns,
                                 &window_functions,
                                 limit_val as usize,
                             );
@@ -543,7 +584,12 @@ impl Executor {
         let mut result_columns = Vec::new();
 
         // Parse the SELECT list to determine output column order
-        let select_items = self.parse_select_list_for_window(stmt, base_columns, &window_functions);
+        let select_items = self.parse_select_list_for_window(
+            stmt,
+            base_columns,
+            visible_columns,
+            &window_functions,
+        );
 
         for item in &select_items {
             result_columns.push(item.output_name.clone());
@@ -783,12 +829,14 @@ impl Executor {
 
     /// Streaming execution for window functions with LIMIT pushdown
     /// Processes partitions one at a time and stops early when LIMIT is reached
+    #[allow(clippy::too_many_arguments)]
     fn execute_select_with_window_functions_streaming(
         &self,
         stmt: &SelectStatement,
         ctx: &ExecutionContext,
         base_rows: &[(i64, Row)],
         base_columns: &[String],
+        visible_columns: usize,
         window_functions: &[WindowFunctionInfo],
         limit: usize,
     ) -> Result<Box<dyn QueryResult>> {
@@ -806,7 +854,12 @@ impl Executor {
             Self::build_partition_map(primary_wf, base_rows, base_columns, &col_index_map, ctx)?;
 
         // Build result columns from SELECT list
-        let select_items = self.parse_select_list_for_window(stmt, base_columns, window_functions);
+        let select_items = self.parse_select_list_for_window(
+            stmt,
+            base_columns,
+            visible_columns,
+            window_functions,
+        );
         let result_columns: Vec<String> =
             select_items.iter().map(|i| i.output_name.clone()).collect();
 
@@ -1046,7 +1099,12 @@ impl Executor {
             .collect();
 
         // Build result columns from SELECT list
-        let select_items = self.parse_select_list_for_window(stmt, base_columns, &window_functions);
+        let select_items = self.parse_select_list_for_window(
+            stmt,
+            base_columns,
+            base_columns.len(),
+            &window_functions,
+        );
         let result_columns: Vec<String> =
             select_items.iter().map(|i| i.output_name.clone()).collect();
 
@@ -1232,6 +1290,7 @@ impl Executor {
         &self,
         stmt: &SelectStatement,
         base_columns: &[String],
+        visible_columns: usize,
         window_functions: &[WindowFunctionInfo],
     ) -> Vec<SelectItem> {
         let col_index_map = build_column_index_map(base_columns);
@@ -1391,7 +1450,7 @@ impl Executor {
                 }
                 Expression::Star(_) | Expression::QualifiedStar(_) => {
                     // SELECT * or t.* - include all base columns
-                    for (idx, col) in base_columns.iter().enumerate() {
+                    for (idx, col) in base_columns.iter().take(visible_columns).enumerate() {
                         items.push(SelectItem {
                             output_name: col.clone(),
                             source: SelectItemSource::BaseColumn(idx),
@@ -1841,6 +1900,8 @@ impl Executor {
             frame,
             column_name,
             is_distinct: func.is_distinct,
+            filter: func.filter.clone(),
+            call_order_by: func.order_by.clone().into_boxed_slice(),
         })
     }
 
@@ -3819,6 +3880,61 @@ impl Executor {
         }
     }
 
+    /// The aggregate's argument per row, NULL where its FILTER rejects the row
+    #[allow(clippy::too_many_arguments)]
+    fn window_filtered_values(
+        &self,
+        filter: &Expression,
+        rows: &[(i64, Row)],
+        columns: &[String],
+        ctx: &ExecutionContext,
+        arg_col_idx: Option<usize>,
+        expression_values: &[Value],
+    ) -> Result<Vec<Value>> {
+        let mut eval = ExpressionEval::compile(filter, columns)?.with_context(ctx);
+        let mut values = Vec::with_capacity(rows.len());
+        for (idx, (_, row)) in rows.iter().enumerate() {
+            values.push(if matches!(eval.eval(row)?, Value::Boolean(true)) {
+                window_argument_value(rows, idx, arg_col_idx, expression_values).clone()
+            } else {
+                Value::null_unknown()
+            });
+        }
+        Ok(values)
+    }
+
+    /// The keys the call's own ORDER BY gives each row, empty without one or
+    /// for an aggregate that does not order its input
+    fn window_call_sort_keys(
+        &self,
+        wf_info: &WindowFunctionInfo,
+        rows: &[(i64, Row)],
+        columns: &[String],
+        ctx: &ExecutionContext,
+    ) -> Result<Vec<Vec<Value>>> {
+        if wf_info.call_order_by.is_empty()
+            || !self
+                .function_registry
+                .get_aggregate(&wf_info.name)
+                .is_some_and(|f| f.supports_order_by())
+        {
+            return Ok(Vec::new());
+        }
+        let mut evals = Vec::with_capacity(wf_info.call_order_by.len());
+        for order in wf_info.call_order_by.iter() {
+            evals.push(ExpressionEval::compile(&order.expression, columns)?.with_context(ctx));
+        }
+        let mut sort_keys = Vec::with_capacity(rows.len());
+        for (_, row) in rows {
+            let mut key = Vec::with_capacity(evals.len());
+            for eval in evals.iter_mut() {
+                key.push(eval.eval(row)?);
+            }
+            sort_keys.push(key);
+        }
+        Ok(sort_keys)
+    }
+
     /// Compute aggregate function as window function (SUM, COUNT, AVG, MIN, MAX)
     /// cached_order_by: Optional precomputed ORDER BY values from cache to avoid redundant computation
     #[allow(clippy::too_many_arguments)]
@@ -3838,7 +3954,7 @@ impl Executor {
             !wf_info.arguments.is_empty() && matches!(wf_info.arguments[0], Expression::Star(_));
 
         // Get the column index for the aggregate argument
-        let arg_col_idx: Option<usize> = if !wf_info.arguments.is_empty() && !is_count_star {
+        let mut arg_col_idx: Option<usize> = if !wf_info.arguments.is_empty() && !is_count_star {
             self.resolve_column_index(&wf_info.arguments[0], col_index_map)
         } else {
             // COUNT(*) has no arguments or Star expression
@@ -3852,7 +3968,7 @@ impl Executor {
             !wf_info.arguments.is_empty() && !is_count_star && arg_col_idx.is_none();
 
         // Pre-compute expression values for all rows if needed
-        let expression_values: Vec<Value> = if has_expression_arg {
+        let mut expression_values: Vec<Value> = if has_expression_arg {
             let mut eval =
                 ExpressionEval::compile(&wf_info.arguments[0], columns)?.with_context(ctx);
             rows.iter()
@@ -3861,6 +3977,25 @@ impl Executor {
         } else {
             vec![]
         };
+
+        // A FILTER hides a row by handing the aggregate a NULL, which every
+        // aggregate skips, so the frames below read one plain value column
+        if let Some(filter) = wf_info.filter.as_deref() {
+            expression_values = self.window_filtered_values(
+                filter,
+                rows,
+                columns,
+                ctx,
+                arg_col_idx,
+                &expression_values,
+            )?;
+            arg_col_idx = None;
+        }
+
+        // The keys the call's own ORDER BY gives each row, empty without one
+        let sort_keys = self.window_call_sort_keys(wf_info, rows, columns, ctx)?;
+        let is_distinct = wf_info.is_distinct;
+        let keys: Option<&[Vec<Value>]> = (!sort_keys.is_empty()).then_some(&sort_keys);
 
         // Use precomputed ORDER BY values from cache if available
         let empty_order_by = ColumnarOrderByValues {
@@ -3961,6 +4096,10 @@ impl Executor {
                     .ok_or_else(|| {
                         Error::NotSupported(format!("Unknown aggregate function: {}", wf_info.name))
                     })?;
+                if keys.is_some() {
+                    agg_func
+                        .set_order_by(wf_info.call_order_by.iter().map(|o| o.ascending).collect());
+                }
 
                 // Check if we can use O(n) incremental accumulation instead of O(n²) reset.
                 // Safe when: frame start is UNBOUNDED PRECEDING (frame only grows),
@@ -4067,17 +4206,26 @@ impl Executor {
                         };
 
                         // Accumulate only the new values since prev_end
-                        for j in prev_end..frame_end {
-                            // Bind by reference: accumulate clones
-                            // internally only when it retains the value
-                            let value: &Value = if let Some(col_idx) = arg_col_idx {
-                                rows[row_indices[j]].1.get(col_idx).unwrap_or(&NULL_VALUE)
-                            } else if has_expression_arg {
-                                &expression_values[row_indices[j]]
-                            } else {
-                                &COUNT_ONE
-                            };
-                            agg_func.accumulate(value, false);
+                        if keys.is_none() {
+                            for &idx in &row_indices[prev_end..frame_end] {
+                                let value = window_argument_value(
+                                    rows,
+                                    idx,
+                                    arg_col_idx,
+                                    &expression_values,
+                                );
+                                agg_func.accumulate(value, is_distinct);
+                            }
+                        } else {
+                            accumulate_ordered_frame(
+                                &mut agg_func,
+                                &row_indices[prev_end..frame_end],
+                                rows,
+                                arg_col_idx,
+                                &expression_values,
+                                sort_keys.as_slice(),
+                                is_distinct,
+                            );
                         }
                         if frame_end > prev_end {
                             prev_end = frame_end;
@@ -4303,19 +4451,26 @@ impl Executor {
                         };
 
                         // Accumulate values within the frame
-                        for &idx in &row_indices[frame_start..frame_end] {
-                            // Bind by reference: accumulate clones
-                            // internally only when it retains the value
-                            let value: &Value = if let Some(col_idx) = arg_col_idx {
-                                rows[idx].1.get(col_idx).unwrap_or(&NULL_VALUE)
-                            } else if has_expression_arg {
-                                // Expression argument (e.g., val * 2) - use pre-computed value
-                                &expression_values[idx]
-                            } else {
-                                // COUNT(*) counts all rows
-                                &COUNT_ONE
-                            };
-                            agg_func.accumulate(value, wf_info.is_distinct);
+                        if keys.is_none() {
+                            for &idx in &row_indices[frame_start..frame_end] {
+                                let value = window_argument_value(
+                                    rows,
+                                    idx,
+                                    arg_col_idx,
+                                    &expression_values,
+                                );
+                                agg_func.accumulate(value, is_distinct);
+                            }
+                        } else {
+                            accumulate_ordered_frame(
+                                &mut agg_func,
+                                &row_indices[frame_start..frame_end],
+                                rows,
+                                arg_col_idx,
+                                &expression_values,
+                                sort_keys.as_slice(),
+                                is_distinct,
+                            );
                         }
                         results[row_idx] = Some(agg_func.result());
                     }
@@ -4328,21 +4483,28 @@ impl Executor {
                     .ok_or_else(|| {
                         Error::NotSupported(format!("Unknown aggregate function: {}", wf_info.name))
                     })?;
+                if keys.is_some() {
+                    agg_func
+                        .set_order_by(wf_info.call_order_by.iter().map(|o| o.ascending).collect());
+                }
 
                 // Accumulate all values in the partition
-                for &row_idx in row_indices {
-                    // Bind by reference: accumulate clones internally only
-                    // when it retains the value
-                    let value: &Value = if let Some(col_idx) = arg_col_idx {
-                        rows[row_idx].1.get(col_idx).unwrap_or(&NULL_VALUE)
-                    } else if has_expression_arg {
-                        // Expression argument (e.g., val * 2) - use pre-computed value
-                        &expression_values[row_idx]
-                    } else {
-                        // COUNT(*) counts all rows
-                        &COUNT_ONE
-                    };
-                    agg_func.accumulate(value, wf_info.is_distinct);
+                if keys.is_none() {
+                    for &idx in row_indices {
+                        let value =
+                            window_argument_value(rows, idx, arg_col_idx, &expression_values);
+                        agg_func.accumulate(value, is_distinct);
+                    }
+                } else {
+                    accumulate_ordered_frame(
+                        &mut agg_func,
+                        row_indices,
+                        rows,
+                        arg_col_idx,
+                        &expression_values,
+                        sort_keys.as_slice(),
+                        is_distinct,
+                    );
                 }
                 let aggregate_result = agg_func.result();
 
@@ -4588,6 +4750,8 @@ mod tests {
             frame: None,
             column_name: "rn".to_string(),
             is_distinct: false,
+            filter: None,
+            call_order_by: Box::new([]),
         };
 
         assert_eq!(info.name, "ROW_NUMBER");

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -4097,8 +4097,7 @@ impl Executor {
                         Error::NotSupported(format!("Unknown aggregate function: {}", wf_info.name))
                     })?;
                 if keys.is_some() {
-                    agg_func
-                        .set_order_by(wf_info.call_order_by.iter().map(|o| o.ascending).collect());
+                    agg_func.set_order_by(Self::aggregate_order_keys(&wf_info.call_order_by));
                 }
 
                 // Check if we can use O(n) incremental accumulation instead of O(n²) reset.
@@ -4484,8 +4483,7 @@ impl Executor {
                         Error::NotSupported(format!("Unknown aggregate function: {}", wf_info.name))
                     })?;
                 if keys.is_some() {
-                    agg_func
-                        .set_order_by(wf_info.call_order_by.iter().map(|o| o.ascending).collect());
+                    agg_func.set_order_by(Self::aggregate_order_keys(&wf_info.call_order_by));
                 }
 
                 // Accumulate all values in the partition

--- a/src/functions/aggregate/array_agg.rs
+++ b/src/functions/aggregate/array_agg.rs
@@ -44,7 +44,7 @@ pub struct ArrayAggFunction {
     /// Values with sort keys (used when ORDER BY is specified)
     ordered_entries: Vec<OrderedEntry>,
     /// Sort directions: true = ASC, false = DESC
-    order_directions: Vec<bool>,
+    order_keys: Vec<crate::functions::AggregateOrder>,
     /// Whether ORDER BY is active
     has_order_by: bool,
     distinct_tracker: Option<DistinctTracker>,
@@ -68,8 +68,8 @@ impl AggregateFunction for ArrayAggFunction {
         // No configuration options
     }
 
-    fn set_order_by(&mut self, directions: Vec<bool>) {
-        self.order_directions = directions;
+    fn set_order_by(&mut self, keys: Vec<crate::functions::AggregateOrder>) {
+        self.order_keys = keys;
         self.has_order_by = true;
     }
 
@@ -125,18 +125,9 @@ impl AggregateFunction for ArrayAggFunction {
         {
             // Sort the entries by their sort keys
             let mut entries: Vec<&OrderedEntry> = self.ordered_entries.iter().collect();
-            let directions = &self.order_directions;
+            let keys = &self.order_keys;
 
-            entries.sort_by(|a, b| {
-                for (i, (key_a, key_b)) in a.sort_keys.iter().zip(b.sort_keys.iter()).enumerate() {
-                    let is_asc = directions.get(i).copied().unwrap_or(true);
-                    let cmp = compare_values(key_a, key_b);
-                    if cmp != std::cmp::Ordering::Equal {
-                        return if is_asc { cmp } else { cmp.reverse() };
-                    }
-                }
-                std::cmp::Ordering::Equal
-            });
+            entries.sort_by(|a, b| super::compare_sort_keys(&a.sort_keys, &b.sort_keys, keys));
 
             entries.iter().map(|e| &e.value).collect()
         } else if !self.values.is_empty() {
@@ -184,32 +175,11 @@ impl AggregateFunction for ArrayAggFunction {
         self.values.clear();
         self.ordered_entries.clear();
         self.distinct_tracker = None;
-        // Note: order_directions and has_order_by are kept as they're configuration
+        // Note: order_keys and has_order_by are kept as they're configuration
     }
 
     fn clone_box(&self) -> Box<dyn AggregateFunction> {
         Box::new(ArrayAggFunction::default())
-    }
-}
-
-/// Compare two Values for sorting
-fn compare_values(a: &Value, b: &Value) -> std::cmp::Ordering {
-    match (a, b) {
-        (Value::Null(_), Value::Null(_)) => std::cmp::Ordering::Equal,
-        (Value::Null(_), _) => std::cmp::Ordering::Greater, // NULLs last
-        (_, Value::Null(_)) => std::cmp::Ordering::Less,
-        (Value::Integer(a), Value::Integer(b)) => a.cmp(b),
-        (Value::Float(a), Value::Float(b)) => a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal),
-        (Value::Integer(a), Value::Float(b)) => (*a as f64)
-            .partial_cmp(b)
-            .unwrap_or(std::cmp::Ordering::Equal),
-        (Value::Float(a), Value::Integer(b)) => a
-            .partial_cmp(&(*b as f64))
-            .unwrap_or(std::cmp::Ordering::Equal),
-        (Value::Text(a), Value::Text(b)) => a.cmp(b),
-        (Value::Boolean(a), Value::Boolean(b)) => a.cmp(b),
-        (Value::Timestamp(a), Value::Timestamp(b)) => a.cmp(b),
-        _ => std::cmp::Ordering::Equal, // Different types compare equal
     }
 }
 

--- a/src/functions/aggregate/first.rs
+++ b/src/functions/aggregate/first.rs
@@ -35,7 +35,7 @@ struct BestEntry {
 pub struct FirstFunction {
     first_value: Option<Value>,
     has_order_by: bool,
-    order_directions: Vec<bool>,
+    order_keys: Vec<crate::functions::AggregateOrder>,
     best_entry: Option<BestEntry>,
 }
 
@@ -53,8 +53,8 @@ impl AggregateFunction for FirstFunction {
         )
     }
 
-    fn set_order_by(&mut self, directions: Vec<bool>) {
-        self.order_directions = directions;
+    fn set_order_by(&mut self, keys: Vec<crate::functions::AggregateOrder>) {
+        self.order_keys = keys;
         self.has_order_by = true;
     }
 
@@ -81,7 +81,7 @@ impl AggregateFunction for FirstFunction {
         // FIRST: keep the entry that would sort first (minimum in sort order).
         // For equal keys, keep the first seen (don't replace).
         let dominated = self.best_entry.as_ref().is_some_and(|best| {
-            compare_sort_keys(&sort_keys, &best.sort_keys, &self.order_directions)
+            compare_sort_keys(&sort_keys, &best.sort_keys, &self.order_keys)
                 != std::cmp::Ordering::Less
         });
         if !dominated {
@@ -169,7 +169,10 @@ mod tests {
     #[test]
     fn test_first_with_order_by_asc() {
         let mut first = FirstFunction::default();
-        first.set_order_by(vec![true]); // ASC
+        first.set_order_by(vec![crate::functions::AggregateOrder {
+            ascending: true,
+            nulls_first: None,
+        }]);
         first.accumulate_with_sort_key(&Value::text("c_val"), vec![Value::Integer(3)], false);
         first.accumulate_with_sort_key(&Value::text("a_val"), vec![Value::Integer(1)], false);
         first.accumulate_with_sort_key(&Value::text("b_val"), vec![Value::Integer(2)], false);
@@ -180,7 +183,10 @@ mod tests {
     #[test]
     fn test_first_with_order_by_desc() {
         let mut first = FirstFunction::default();
-        first.set_order_by(vec![false]); // DESC
+        first.set_order_by(vec![crate::functions::AggregateOrder {
+            ascending: false,
+            nulls_first: None,
+        }]);
         first.accumulate_with_sort_key(&Value::text("c_val"), vec![Value::Integer(3)], false);
         first.accumulate_with_sort_key(&Value::text("a_val"), vec![Value::Integer(1)], false);
         first.accumulate_with_sort_key(&Value::text("b_val"), vec![Value::Integer(2)], false);

--- a/src/functions/aggregate/last.rs
+++ b/src/functions/aggregate/last.rs
@@ -35,7 +35,7 @@ struct BestEntry {
 pub struct LastFunction {
     last_value: Option<Value>,
     has_order_by: bool,
-    order_directions: Vec<bool>,
+    order_keys: Vec<crate::functions::AggregateOrder>,
     best_entry: Option<BestEntry>,
 }
 
@@ -53,8 +53,8 @@ impl AggregateFunction for LastFunction {
         )
     }
 
-    fn set_order_by(&mut self, directions: Vec<bool>) {
-        self.order_directions = directions;
+    fn set_order_by(&mut self, keys: Vec<crate::functions::AggregateOrder>) {
+        self.order_keys = keys;
         self.has_order_by = true;
     }
 
@@ -79,7 +79,7 @@ impl AggregateFunction for LastFunction {
         // LAST: keep the entry that would sort last (maximum in sort order).
         // For equal keys, replace (last-seen-wins, matching stable sort behavior).
         let should_replace = self.best_entry.as_ref().is_none_or(|best| {
-            compare_sort_keys(&sort_keys, &best.sort_keys, &self.order_directions)
+            compare_sort_keys(&sort_keys, &best.sort_keys, &self.order_keys)
                 != std::cmp::Ordering::Less
         });
         if should_replace {
@@ -168,7 +168,10 @@ mod tests {
     #[test]
     fn test_last_with_order_by_asc() {
         let mut last = LastFunction::default();
-        last.set_order_by(vec![true]); // ASC
+        last.set_order_by(vec![crate::functions::AggregateOrder {
+            ascending: true,
+            nulls_first: None,
+        }]);
         last.accumulate_with_sort_key(&Value::text("c_val"), vec![Value::Integer(3)], false);
         last.accumulate_with_sort_key(&Value::text("a_val"), vec![Value::Integer(1)], false);
         last.accumulate_with_sort_key(&Value::text("b_val"), vec![Value::Integer(2)], false);
@@ -179,7 +182,10 @@ mod tests {
     #[test]
     fn test_last_with_order_by_desc() {
         let mut last = LastFunction::default();
-        last.set_order_by(vec![false]); // DESC
+        last.set_order_by(vec![crate::functions::AggregateOrder {
+            ascending: false,
+            nulls_first: None,
+        }]);
         last.accumulate_with_sort_key(&Value::text("c_val"), vec![Value::Integer(3)], false);
         last.accumulate_with_sort_key(&Value::text("a_val"), vec![Value::Integer(1)], false);
         last.accumulate_with_sort_key(&Value::text("b_val"), vec![Value::Integer(2)], false);

--- a/src/functions/aggregate/mod.rs
+++ b/src/functions/aggregate/mod.rs
@@ -64,14 +64,33 @@ pub use sum::SumFunction;
 use crate::core::Value;
 use std::cmp::Ordering;
 
-/// Compare two Values for ordering (used by FIRST/LAST with ORDER BY).
-/// NULLs sort last (greater than all non-NULL values).
-pub(crate) fn compare_sort_keys(a: &[Value], b: &[Value], directions: &[bool]) -> Ordering {
+/// Compare two sort keys of an aggregate that orders its own input.
+/// A NULL goes where the key says, or where the direction implies
+pub(crate) fn compare_sort_keys(
+    a: &[Value],
+    b: &[Value],
+    keys: &[crate::functions::AggregateOrder],
+) -> Ordering {
+    const DEFAULT: crate::functions::AggregateOrder = crate::functions::AggregateOrder {
+        ascending: true,
+        nulls_first: None,
+    };
     for (i, (key_a, key_b)) in a.iter().zip(b.iter()).enumerate() {
-        let is_asc = directions.get(i).copied().unwrap_or(true);
+        let key = keys.get(i).copied().unwrap_or(DEFAULT);
+        let (a_null, b_null) = (key_a.is_null(), key_b.is_null());
+        if a_null || b_null {
+            if a_null && b_null {
+                continue;
+            }
+            return if a_null == key.nulls_first() {
+                Ordering::Less
+            } else {
+                Ordering::Greater
+            };
+        }
         let cmp = compare_values_for_sort(key_a, key_b);
         if cmp != Ordering::Equal {
-            return if is_asc { cmp } else { cmp.reverse() };
+            return if key.ascending { cmp } else { cmp.reverse() };
         }
     }
     Ordering::Equal

--- a/src/functions/aggregate/string_agg.rs
+++ b/src/functions/aggregate/string_agg.rs
@@ -42,7 +42,7 @@ pub struct StringAggFunction {
     /// Values with sort keys (used when ORDER BY is specified)
     ordered_entries: Vec<OrderedEntry>,
     /// Sort directions: true = ASC, false = DESC
-    order_directions: Vec<bool>,
+    order_keys: Vec<crate::functions::AggregateOrder>,
     /// Whether ORDER BY is active
     has_order_by: bool,
     distinct_tracker: Option<DistinctTracker>,
@@ -55,7 +55,7 @@ impl Default for StringAggFunction {
         Self {
             values: Vec::new(),
             ordered_entries: Vec::new(),
-            order_directions: Vec::new(),
+            order_keys: Vec::new(),
             has_order_by: false,
             distinct_tracker: None,
             separator: ",".to_string(),
@@ -89,8 +89,8 @@ impl AggregateFunction for StringAggFunction {
         }
     }
 
-    fn set_order_by(&mut self, directions: Vec<bool>) {
-        self.order_directions = directions;
+    fn set_order_by(&mut self, keys: Vec<crate::functions::AggregateOrder>) {
+        self.order_keys = keys;
         self.has_order_by = true;
     }
 
@@ -166,18 +166,9 @@ impl AggregateFunction for StringAggFunction {
         let values_to_output: Vec<&str> = if self.has_order_by && !self.ordered_entries.is_empty() {
             // Sort the entries by their sort keys
             let mut entries: Vec<&OrderedEntry> = self.ordered_entries.iter().collect();
-            let directions = &self.order_directions;
+            let keys = &self.order_keys;
 
-            entries.sort_by(|a, b| {
-                for (i, (key_a, key_b)) in a.sort_keys.iter().zip(b.sort_keys.iter()).enumerate() {
-                    let is_asc = directions.get(i).copied().unwrap_or(true);
-                    let cmp = compare_values(key_a, key_b);
-                    if cmp != std::cmp::Ordering::Equal {
-                        return if is_asc { cmp } else { cmp.reverse() };
-                    }
-                }
-                std::cmp::Ordering::Equal
-            });
+            entries.sort_by(|a, b| super::compare_sort_keys(&a.sort_keys, &b.sort_keys, keys));
 
             entries.iter().map(|e| e.value.as_str()).collect()
         } else if !self.values.is_empty() {
@@ -203,32 +194,11 @@ impl AggregateFunction for StringAggFunction {
         self.values.clear();
         self.ordered_entries.clear();
         self.distinct_tracker = None;
-        // Note: order_directions and has_order_by are kept as they're configuration
+        // Note: order_keys and has_order_by are kept as they're configuration
     }
 
     fn clone_box(&self) -> Box<dyn AggregateFunction> {
         Box::new(StringAggFunction::default())
-    }
-}
-
-/// Compare two Values for sorting
-fn compare_values(a: &Value, b: &Value) -> std::cmp::Ordering {
-    match (a, b) {
-        (Value::Null(_), Value::Null(_)) => std::cmp::Ordering::Equal,
-        (Value::Null(_), _) => std::cmp::Ordering::Greater, // NULLs last
-        (_, Value::Null(_)) => std::cmp::Ordering::Less,
-        (Value::Integer(a), Value::Integer(b)) => a.cmp(b),
-        (Value::Float(a), Value::Float(b)) => a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal),
-        (Value::Integer(a), Value::Float(b)) => (*a as f64)
-            .partial_cmp(b)
-            .unwrap_or(std::cmp::Ordering::Equal),
-        (Value::Float(a), Value::Integer(b)) => a
-            .partial_cmp(&(*b as f64))
-            .unwrap_or(std::cmp::Ordering::Equal),
-        (Value::Text(a), Value::Text(b)) => a.cmp(b),
-        (Value::Boolean(a), Value::Boolean(b)) => a.cmp(b),
-        (Value::Timestamp(a), Value::Timestamp(b)) => a.cmp(b),
-        _ => std::cmp::Ordering::Equal, // Different types compare equal
     }
 }
 
@@ -261,8 +231,8 @@ impl AggregateFunction for GroupConcatFunction {
         self.inner.configure(options);
     }
 
-    fn set_order_by(&mut self, directions: Vec<bool>) {
-        self.inner.set_order_by(directions);
+    fn set_order_by(&mut self, keys: Vec<crate::functions::AggregateOrder>) {
+        self.inner.set_order_by(keys);
     }
 
     fn supports_order_by(&self) -> bool {

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -194,6 +194,23 @@ impl FunctionInfo {
 }
 
 /// Trait for aggregate functions
+/// One ORDER BY key of an aggregate that orders its own input
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AggregateOrder {
+    /// true for ASC, false for DESC
+    pub ascending: bool,
+    /// None takes the SQL default: NULLS LAST for ASC, NULLS FIRST for DESC
+    pub nulls_first: Option<bool>,
+}
+
+impl AggregateOrder {
+    /// Where a NULL key goes, with the default the direction implies
+    #[inline]
+    pub fn nulls_first(&self) -> bool {
+        self.nulls_first.unwrap_or(!self.ascending)
+    }
+}
+
 pub trait AggregateFunction: Send + Sync {
     /// Get the function name
     fn name(&self) -> &str;
@@ -214,9 +231,9 @@ pub trait AggregateFunction: Send + Sync {
 
     /// Configure ORDER BY for ordered-set aggregates like ARRAY_AGG, STRING_AGG
     ///
-    /// The `directions` parameter contains true for ASC, false for DESC for each sort key.
+    /// One key per sort expression, in order.
     /// Default implementation ignores ordering.
-    fn set_order_by(&mut self, _directions: Vec<bool>) {
+    fn set_order_by(&mut self, _keys: Vec<AggregateOrder>) {
         // Default: ignore ordering
     }
 

--- a/tests/where_subquery_containers_test.rs
+++ b/tests/where_subquery_containers_test.rs
@@ -580,3 +580,61 @@ fn test_correlated_left_operand_of_all() {
         "grouped join"
     );
 }
+
+/// An outer column on the left of ALL is the only correlation of the
+/// subquery: users from 21 clear every order of user 20
+#[test]
+fn test_outer_column_on_the_left_of_all_inside_a_subquery() {
+    let db = setup("where_subquery_all_left_outer");
+    let predicate = "EXISTS (SELECT 1 FROM orders x WHERE u.id * 10 > ALL (SELECT amount FROM orders WHERE user_id = 20) AND x.user_id = 25)";
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM users u WHERE {predicate}")
+        ),
+        10,
+        "single table"
+    );
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM {JOIN} WHERE {predicate}")
+        ),
+        30,
+        "joined rows"
+    );
+    let expected: Vec<Vec<String>> = (21..=30i64)
+        .map(|user| vec![user.to_string(), "3".to_string()])
+        .collect();
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT u.id, COUNT(o.id) FROM {JOIN} WHERE {predicate} GROUP BY u.id ORDER BY u.id")
+        ),
+        expected,
+        "grouped join"
+    );
+}
+
+/// A subquery on the left of ALL in the SELECT list is resolved before the
+/// expression compiles
+#[test]
+fn test_select_list_subquery_on_the_left_of_all() {
+    let db = setup("select_subquery_all_left");
+    assert_eq!(
+        count(
+            &db,
+            "SELECT CASE WHEN (SELECT 2) > ALL (SELECT 1) THEN 1 ELSE 0 END"
+        ),
+        1,
+        "scalar left of ALL"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT CASE WHEN (SELECT MAX(amount) FROM orders) > ALL (SELECT amount FROM orders WHERE user_id = 20) THEN 1 ELSE 0 END"
+        ),
+        1,
+        "aggregate left of ALL"
+    );
+}

--- a/tests/where_subquery_containers_test.rs
+++ b/tests/where_subquery_containers_test.rs
@@ -1,0 +1,248 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A subquery nested inside a CAST, a function call or a CASE in a WHERE,
+//! and a correlated EXISTS in a join's WHERE, must give the answer the
+//! same predicate gives when written plainly. Every expected value is
+//! computed from the generated data, not from another query path.
+
+use stoolap::Database;
+
+/// 30 users, 3 orders each with amount user * 10 + k, k in 0..3
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount FLOAT)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX idx_orders_user_id ON orders(user_id)", ())
+        .unwrap();
+    let mut id = 0;
+    for user in 1..=30i64 {
+        db.execute(
+            "INSERT INTO users VALUES ($1, $2)",
+            (user, format!("user{user}")),
+        )
+        .unwrap();
+        for k in 0..3i64 {
+            id += 1;
+            db.execute(
+                "INSERT INTO orders VALUES ($1, $2, $3)",
+                (id, user, (user * 10 + k) as f64),
+            )
+            .unwrap();
+        }
+    }
+    db
+}
+
+fn amount(user: i64, k: i64) -> f64 {
+    (user * 10 + k) as f64
+}
+
+fn average_amount() -> f64 {
+    let mut sum = 0.0;
+    for user in 1..=30i64 {
+        for k in 0..3i64 {
+            sum += amount(user, k);
+        }
+    }
+    sum / 90.0
+}
+
+fn rows(db: &Database, sql: &str) -> Vec<Vec<String>> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (0..row.len())
+                .map(|i| {
+                    row.get::<Option<String>>(i)
+                        .unwrap()
+                        .unwrap_or_else(|| "NULL".into())
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn count(db: &Database, sql: &str) -> i64 {
+    db.query(sql, ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap()
+}
+
+/// Groups of users with at least one order above the average, with the
+/// number of such orders
+fn groups_above_average() -> Vec<Vec<String>> {
+    let avg = average_amount();
+    let mut groups = Vec::new();
+    for user in 1..=30i64 {
+        let n = (0..3i64).filter(|&k| amount(user, k) > avg).count();
+        if n > 0 {
+            groups.push(vec![user.to_string(), n.to_string()]);
+        }
+    }
+    groups
+}
+
+fn orders_above_average() -> i64 {
+    groups_above_average()
+        .iter()
+        .map(|g| g[1].parse::<i64>().unwrap())
+        .sum()
+}
+
+const JOIN: &str = "users u INNER JOIN orders o ON u.id = o.user_id";
+
+#[test]
+fn test_subquery_inside_cast() {
+    let db = setup("where_subquery_cast");
+    let predicate = "amount > CAST((SELECT AVG(amount) FROM orders) AS FLOAT)";
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM orders WHERE {predicate}")
+        ),
+        orders_above_average(),
+        "scan"
+    );
+    let grouped = format!(
+        "SELECT u.id, COUNT(o.id) FROM {JOIN} WHERE o.{predicate} GROUP BY u.id ORDER BY u.id"
+    );
+    assert_eq!(rows(&db, &grouped), groups_above_average(), "grouped join");
+}
+
+#[test]
+fn test_subquery_inside_case() {
+    let db = setup("where_subquery_case");
+    let predicate = "CASE WHEN o.amount > (SELECT AVG(amount) FROM orders) THEN 1 ELSE 0 END = 1";
+    let expected = groups_above_average();
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT u.id, COUNT(o.id) FROM {JOIN} WHERE {predicate} GROUP BY u.id ORDER BY u.id")
+        ),
+        expected,
+        "grouped join with ORDER BY"
+    );
+    let mut limited = rows(
+        &db,
+        &format!("SELECT u.id, COUNT(o.id) FROM {JOIN} WHERE {predicate} GROUP BY u.id LIMIT 1000"),
+    );
+    limited.sort_by_key(|g| g[0].parse::<i64>().unwrap());
+    assert_eq!(limited, expected, "grouped join with LIMIT");
+}
+
+#[test]
+fn test_correlated_subquery_inside_function() {
+    let db = setup("where_subquery_function");
+    // Users whose largest order is above 200: user * 10 + 2 > 200
+    let expected: Vec<Vec<String>> = (20..=30i64)
+        .map(|user| vec![user.to_string(), "3".to_string()])
+        .collect();
+    let predicate = "COALESCE((SELECT MAX(amount) FROM orders x WHERE x.user_id = u.id), 0) > 200";
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT u.id, COUNT(o.id) FROM {JOIN} WHERE {predicate} GROUP BY u.id ORDER BY u.id")
+        ),
+        expected,
+        "grouped join"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT u.id, (SELECT COUNT(*) FROM orders o WHERE o.user_id = u.id) FROM users u WHERE {predicate} ORDER BY u.id")
+        ),
+        expected,
+        "single table"
+    );
+}
+
+#[test]
+fn test_correlated_exists_in_join_where() {
+    let db = setup("where_subquery_exists_join");
+    let predicate = "EXISTS (SELECT 1 FROM orders x WHERE x.user_id = u.id AND x.amount > 200)";
+    let expected: Vec<Vec<String>> = (20..=30i64)
+        .map(|user| vec![user.to_string(), "3".to_string()])
+        .collect();
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT u.id, COUNT(o.id) FROM {JOIN} WHERE {predicate} GROUP BY u.id ORDER BY u.id")
+        ),
+        expected,
+        "grouped join"
+    );
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM {JOIN} WHERE {predicate}")
+        ),
+        33,
+        "joined rows"
+    );
+    let plain = rows(
+        &db,
+        &format!("SELECT u.id, o.amount FROM {JOIN} WHERE {predicate} ORDER BY u.id, o.amount"),
+    );
+    assert_eq!(plain.len(), 33, "plain join");
+    assert_eq!(plain[0], vec!["20".to_string(), "200".to_string()]);
+    let limited = rows(
+        &db,
+        &format!("SELECT u.id, o.amount FROM {JOIN} WHERE {predicate} LIMIT 10"),
+    );
+    assert_eq!(limited.len(), 10, "plain join with LIMIT");
+}
+
+/// A correlated subquery that reads both sides of the join can only be
+/// evaluated on the joined row: every order except the user's largest
+#[test]
+fn test_correlated_subquery_over_both_sides() {
+    let db = setup("where_subquery_both_sides");
+    let predicate =
+        "EXISTS (SELECT 1 FROM orders x WHERE x.user_id = u.id AND x.amount > o.amount)";
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM {JOIN} WHERE {predicate}")
+        ),
+        60,
+        "joined rows"
+    );
+    let expected: Vec<Vec<String>> = (1..=30i64)
+        .map(|user| vec![user.to_string(), "2".to_string()])
+        .collect();
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT u.id, COUNT(o.id) FROM {JOIN} WHERE {predicate} GROUP BY u.id ORDER BY u.id")
+        ),
+        expected,
+        "grouped join"
+    );
+    let limited = rows(
+        &db,
+        &format!("SELECT u.id, o.amount FROM {JOIN} WHERE {predicate} LIMIT 10"),
+    );
+    assert_eq!(limited.len(), 10, "plain join with LIMIT");
+}

--- a/tests/where_subquery_containers_test.rs
+++ b/tests/where_subquery_containers_test.rs
@@ -1267,3 +1267,94 @@ fn test_aggregate_order_by_nulls_placement() {
         "descending inside a window"
     );
 }
+
+/// The cached answer of a subquery belongs to the binding that produced it,
+/// and a NULL is not the text that spells it
+#[test]
+fn test_subquery_cache_keeps_the_binding_type() {
+    let db = setup("subquery_cache_binding_type");
+    let sql = "SELECT (SELECT $1) IS NULL FROM users LIMIT 1";
+    let read = |value: Option<&str>| -> String {
+        db.query(sql, (value,))
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .get::<String>(0)
+            .unwrap()
+    };
+    assert_eq!(read(None), "true", "a NULL binding");
+    assert_eq!(read(Some("NULL")), "false", "the text that spells it");
+
+    let number = "SELECT (SELECT $1) FROM users LIMIT 1";
+    let as_integer: String = db
+        .query(number, (7i64,))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap();
+    let as_text: String = db
+        .query(number, ("7",))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap();
+    assert_eq!((as_integer.as_str(), as_text.as_str()), ("7", "7"));
+    let is_text: String = db
+        .query("SELECT (SELECT $1) || 'x' FROM users LIMIT 1", ("7",))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap();
+    assert_eq!(is_text, "7x");
+}
+
+/// A control argument that reads no row is resolved even when a correlated
+/// column beside it keeps the SELECT list from being folded up front
+#[test]
+fn test_navigation_control_argument_beside_a_correlated_column() {
+    let db = setup("navigation_control_correlated_neighbour");
+    let correlated = "(SELECT MAX(x.user_id) FROM orders x WHERE x.user_id = u.id)";
+    let tail = "FROM users u WHERE u.id <= 4 ORDER BY u.id";
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT u.id, NTILE((SELECT 2)) OVER (ORDER BY u.id), {correlated} {tail}")
+        )
+        .iter()
+        .map(|row| row[1].clone())
+        .collect::<Vec<_>>(),
+        ["1", "1", "2", "2"],
+        "NTILE group count"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT id, LAG(id, (SELECT 1)) OVER (ORDER BY id), {correlated} {tail}")
+        )
+        .iter()
+        .map(|row| row[1].clone())
+        .collect::<Vec<_>>(),
+        ["NULL", "1", "2", "3"],
+        "LAG offset"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            &format!(
+                "SELECT id, NTH_VALUE(id, (SELECT 2)) OVER (ORDER BY id), {correlated} {tail}"
+            )
+        )
+        .iter()
+        .map(|row| row[1].clone())
+        .collect::<Vec<_>>(),
+        ["NULL", "2", "2", "2"],
+        "NTH_VALUE n"
+    );
+}

--- a/tests/where_subquery_containers_test.rs
+++ b/tests/where_subquery_containers_test.rs
@@ -863,3 +863,60 @@ fn test_subquery_inside_an_aggregate_in_having_and_order_by() {
         "ORDER BY inside the aggregate"
     );
 }
+
+/// A subquery inside an aggregate next to a window function, and inside a
+/// window aggregate, is resolved before either runs
+#[test]
+fn test_subquery_inside_an_aggregate_with_a_window() {
+    let db = setup("select_subquery_window");
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT SUM((SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id)), ROW_NUMBER() OVER () FROM users u"
+        ),
+        vec![vec!["4710".to_string(), "1".to_string()]],
+        "aggregate beside a window function"
+    );
+    let windowed = rows(&db, "SELECT SUM((SELECT 1)) OVER () FROM users");
+    assert_eq!(windowed.len(), 30, "window aggregate rows");
+    assert!(
+        windowed.iter().all(|row| row[0] == "30"),
+        "window aggregate over a constant subquery: {windowed:?}"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT u.id, SUM((SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id)) OVER () FROM users u WHERE u.id <= 3 ORDER BY u.id"
+        ),
+        vec![
+            vec!["1".to_string(), "66".to_string()],
+            vec!["2".to_string(), "66".to_string()],
+            vec!["3".to_string(), "66".to_string()],
+        ],
+        "window aggregate over a correlated subquery"
+    );
+}
+
+/// The column a lifted subquery lands in never takes a user column's name
+#[test]
+fn test_lifted_column_name_avoids_user_columns() {
+    let db = Database::open("memory://lifted_column_name").unwrap();
+    db.execute(
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, __agg_subquery_0 INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO c VALUES (1, 100), (2, 200)", ())
+        .unwrap();
+    assert_eq!(
+        count(&db, "SELECT SUM((SELECT 1)) + SUM(__agg_subquery_0) FROM c"),
+        302
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT SUM((SELECT MAX(id) FROM c d WHERE d.id = c.id)) + SUM(__agg_subquery_0) FROM c"
+        ),
+        303
+    );
+}

--- a/tests/where_subquery_containers_test.rs
+++ b/tests/where_subquery_containers_test.rs
@@ -812,4 +812,54 @@ fn test_subquery_inside_an_aggregate_over_a_cte() {
         20,
         "recursive CTE"
     );
+    // The subquery inside the aggregate reads the CTE itself: orders above 150
+    assert_eq!(
+        count(
+            &db,
+            "WITH lim AS (SELECT 150 AS v) SELECT COUNT(*) FILTER (WHERE amount > (SELECT v FROM lim)) FROM orders"
+        ),
+        47,
+        "aggregate subquery over the CTE"
+    );
+    // The correlated subquery reads the recursive CTE's column by its name
+    assert_eq!(
+        count(
+            &db,
+            "WITH RECURSIVE n(v) AS (SELECT 1 UNION ALL SELECT v + 1 FROM n WHERE v < 3) SELECT SUM((SELECT MAX(x.amount) FROM orders x WHERE x.user_id = n.v)) FROM n"
+        ),
+        66,
+        "qualified CTE column inside the aggregate's subquery"
+    );
+}
+
+/// An aggregate in HAVING or ORDER BY resolves the subquery it holds, and
+/// so does the ORDER BY inside an aggregate call
+#[test]
+fn test_subquery_inside_an_aggregate_in_having_and_order_by() {
+    let db = setup("select_subquery_in_having_order_by");
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM (SELECT user_id FROM orders GROUP BY user_id HAVING COUNT(*) FILTER (WHERE EXISTS (SELECT 1)) > 2) t"
+        ),
+        30,
+        "HAVING"
+    );
+    // Users 16 to 30 have all three orders above the average
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT user_id FROM orders GROUP BY user_id ORDER BY COUNT(*) FILTER (WHERE amount > (SELECT AVG(amount) FROM orders)) DESC, user_id LIMIT 2"
+        ),
+        vec![vec!["16".to_string()], vec!["17".to_string()]],
+        "ORDER BY"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT GROUP_CONCAT(name ORDER BY (SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id) DESC) FROM users u WHERE u.id <= 3"
+        ),
+        vec![vec!["user3,user2,user1".to_string()]],
+        "ORDER BY inside the aggregate"
+    );
 }

--- a/tests/where_subquery_containers_test.rs
+++ b/tests/where_subquery_containers_test.rs
@@ -638,3 +638,89 @@ fn test_select_list_subquery_on_the_left_of_all() {
         "aggregate left of ALL"
     );
 }
+
+/// A subquery inside an aggregate's FILTER or argument is resolved before
+/// the aggregates are parsed
+#[test]
+fn test_subquery_inside_an_aggregate() {
+    let db = setup("select_subquery_in_aggregate");
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FILTER (WHERE (SELECT 1) = 1) FROM users"
+        ),
+        30,
+        "constant subquery in FILTER"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FILTER (WHERE amount > (SELECT AVG(amount) FROM orders)) FROM orders"
+        ),
+        orders_above_average(),
+        "subquery in FILTER"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT SUM(CASE WHEN amount > (SELECT AVG(amount) FROM orders) THEN 1 ELSE 0 END) FROM orders"
+        ),
+        orders_above_average(),
+        "subquery in an argument"
+    );
+    let avg = average_amount();
+    let expected: Vec<Vec<String>> = (1..=30i64)
+        .map(|user| {
+            let n = (0..3i64).filter(|&k| amount(user, k) > avg).count();
+            vec![user.to_string(), n.to_string()]
+        })
+        .collect();
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT user_id, COUNT(*) FILTER (WHERE amount > (SELECT AVG(amount) FROM orders)) FROM orders GROUP BY user_id ORDER BY user_id"
+        ),
+        expected,
+        "subquery in FILTER, grouped"
+    );
+}
+
+/// ALL, BETWEEN, IN and LIKE in the SELECT list resolve the subqueries
+/// they hold, with and without an outer row
+#[test]
+fn test_select_list_containers_hold_subqueries() {
+    let db = setup("select_subquery_containers");
+    for (select, label) in [
+        (
+            "CASE WHEN (SELECT 1) BETWEEN 0 AND 2 THEN 1 ELSE 0 END",
+            "BETWEEN",
+        ),
+        (
+            "CASE WHEN (SELECT 1) IN (1, 2) THEN 1 ELSE 0 END",
+            "IN list",
+        ),
+        (
+            "CASE WHEN 1 IN ((SELECT 1), 2) THEN 1 ELSE 0 END",
+            "subquery in the IN list",
+        ),
+        (
+            "CASE WHEN (SELECT 'ab') LIKE 'a%' THEN 1 ELSE 0 END",
+            "LIKE",
+        ),
+    ] {
+        assert_eq!(count(&db, &format!("SELECT {select}")), 1, "{label}");
+    }
+    let expected: Vec<Vec<String>> = vec![
+        vec!["1".into(), "1".into(), "1".into()],
+        vec!["2".into(), "1".into(), "1".into()],
+        vec!["3".into(), "1".into(), "0".into()],
+    ];
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT u.id, CASE WHEN (SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id) > ALL (SELECT 0) THEN 1 ELSE 0 END, CASE WHEN (SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id) BETWEEN 10 AND 22 THEN 1 ELSE 0 END FROM users u WHERE u.id <= 3 ORDER BY u.id"
+        ),
+        expected,
+        "correlated ALL and BETWEEN"
+    );
+}

--- a/tests/where_subquery_containers_test.rs
+++ b/tests/where_subquery_containers_test.rs
@@ -1131,3 +1131,139 @@ fn test_fromless_correlated_subquery_in_where() {
         3
     );
 }
+
+/// Two subqueries whose text is the same but whose anonymous parameters are
+/// not each read their own binding, within one statement and across two
+#[test]
+fn test_subqueries_keep_their_own_parameter() {
+    let db = setup("subquery_parameters");
+    // MAX(x.amount) for user n is n * 10 + 2, summed over the 30 users
+    let row = db
+        .query(
+            "SELECT SUM((SELECT MAX(x.amount) FROM orders x WHERE x.user_id = ?)), SUM((SELECT MAX(x.amount) FROM orders x WHERE x.user_id = ?)) FROM users u",
+            (1i64, 2i64),
+        )
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        (row.get::<String>(0).unwrap(), row.get::<String>(1).unwrap()),
+        ("360".to_string(), "660".to_string()),
+        "two anonymous parameters in one statement"
+    );
+
+    let one = "SELECT (SELECT MAX(x.amount) FROM orders x WHERE x.user_id = ?) FROM users LIMIT 1";
+    let read = |p: i64| -> String {
+        db.query(one, (p,))
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .get::<String>(0)
+            .unwrap()
+    };
+    assert_eq!(
+        (read(1), read(2)),
+        ("12".to_string(), "22".to_string()),
+        "one statement, two executions"
+    );
+}
+
+/// A navigation window function reads its control argument off no row, so a
+/// subquery there stays where it is instead of becoming a column
+#[test]
+fn test_navigation_window_control_argument() {
+    let db = setup("navigation_control_argument");
+    // An unqualified argument, since a qualified one is a separate bug that
+    // predates this branch and shows the same way on main
+    let ids = "WHERE id <= 4 ORDER BY id";
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT id, LAG(id, (SELECT 1)) OVER (ORDER BY id) FROM users {ids}")
+        ),
+        [("1", "NULL"), ("2", "1"), ("3", "2"), ("4", "3")]
+            .iter()
+            .map(|(a, b)| vec![a.to_string(), b.to_string()])
+            .collect::<Vec<_>>(),
+        "LAG offset"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT id, NTILE((SELECT 2)) OVER (ORDER BY id) FROM users {ids}")
+        ),
+        [("1", "1"), ("2", "1"), ("3", "2"), ("4", "2")]
+            .iter()
+            .map(|(a, b)| vec![a.to_string(), b.to_string()])
+            .collect::<Vec<_>>(),
+        "NTILE group count"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT id, NTH_VALUE(id, (SELECT 2)) OVER (ORDER BY id) FROM users {ids}")
+        ),
+        [("1", "NULL"), ("2", "2"), ("3", "2"), ("4", "2")]
+            .iter()
+            .map(|(a, b)| vec![a.to_string(), b.to_string()])
+            .collect::<Vec<_>>(),
+        "NTH_VALUE n"
+    );
+    // A correlated control argument reads no row either, so it keeps the
+    // answer it has always given rather than failing to compile
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT u.id, NTILE((SELECT MAX(x.user_id) FROM orders x WHERE x.user_id = u.id)) OVER (ORDER BY u.id) FROM users u WHERE u.id <= 4 ORDER BY u.id"
+        )
+        .len(),
+        4,
+        "correlated control argument still runs"
+    );
+}
+
+/// An aggregate that orders its own input places NULLs where the query says
+#[test]
+fn test_aggregate_order_by_nulls_placement() {
+    let db = Database::open("memory://aggregate_order_nulls").unwrap();
+    db.execute(
+        "CREATE TABLE n (id INTEGER PRIMARY KEY, k INTEGER, v TEXT)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO n VALUES (1, 2, 'x'), (2, NULL, 'y'), (3, 1, 'z')",
+        (),
+    )
+    .unwrap();
+    let first = |sql: &str| -> String { rows(&db, sql)[0][0].clone() };
+    assert_eq!(
+        first("SELECT GROUP_CONCAT(v ORDER BY k NULLS FIRST) FROM n"),
+        "y,z,x"
+    );
+    assert_eq!(
+        first("SELECT GROUP_CONCAT(v ORDER BY k NULLS LAST) FROM n"),
+        "z,x,y"
+    );
+    assert_eq!(
+        first("SELECT GROUP_CONCAT(v ORDER BY k DESC NULLS LAST) FROM n"),
+        "x,z,y"
+    );
+    assert_eq!(
+        first("SELECT GROUP_CONCAT(v ORDER BY k DESC) FROM n"),
+        "y,x,z",
+        "DESC without a NULLS clause puts them first"
+    );
+    assert_eq!(
+        first("SELECT GROUP_CONCAT(v ORDER BY k NULLS FIRST) OVER () FROM n LIMIT 1"),
+        "y,z,x",
+        "the same inside a window"
+    );
+    assert_eq!(
+        first("SELECT GROUP_CONCAT(v ORDER BY k DESC NULLS LAST) OVER () FROM n LIMIT 1"),
+        "x,z,y",
+        "descending inside a window"
+    );
+}

--- a/tests/where_subquery_containers_test.rs
+++ b/tests/where_subquery_containers_test.rs
@@ -724,3 +724,92 @@ fn test_select_list_containers_hold_subqueries() {
         "correlated ALL and BETWEEN"
     );
 }
+
+/// An EXISTS, an ALL or a correlated subquery inside an aggregate is
+/// resolved per input row before the aggregate runs
+#[test]
+fn test_every_subquery_kind_inside_an_aggregate() {
+    let db = setup("select_subquery_kinds_in_aggregate");
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FILTER (WHERE EXISTS (SELECT 1)) FROM users"
+        ),
+        30,
+        "EXISTS in FILTER"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FILTER (WHERE 5 > ALL (SELECT 1)) FROM users"
+        ),
+        30,
+        "ALL in FILTER"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FILTER (WHERE EXISTS (SELECT 1 FROM orders x WHERE x.user_id = u.id AND x.amount > 200)) FROM users u"
+        ),
+        11,
+        "correlated EXISTS in FILTER"
+    );
+    // The largest order of every user, summed: 10 * (1 + ... + 30) + 2 * 30
+    assert_eq!(
+        count(
+            &db,
+            "SELECT SUM((SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id)) FROM users u"
+        ),
+        4710,
+        "correlated scalar as an argument"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT u.id, SUM((SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id)) FROM users u GROUP BY u.id ORDER BY u.id LIMIT 3"
+        ),
+        vec![
+            vec!["1".to_string(), "12".to_string()],
+            vec!["2".to_string(), "22".to_string()],
+            vec!["3".to_string(), "32".to_string()],
+        ],
+        "correlated scalar as an argument, grouped"
+    );
+}
+
+/// The aggregate subquery fix reaches a CTE and a recursive CTE
+#[test]
+fn test_subquery_inside_an_aggregate_over_a_cte() {
+    let db = setup("select_subquery_in_aggregate_cte");
+    assert_eq!(
+        count(
+            &db,
+            "WITH t AS (SELECT * FROM orders) SELECT COUNT(*) FILTER (WHERE amount > (SELECT AVG(amount) FROM orders)) FROM t"
+        ),
+        orders_above_average(),
+        "CTE"
+    );
+    let avg = average_amount();
+    let expected: Vec<Vec<String>> = (1..=30i64)
+        .map(|user| {
+            let n = (0..3i64).filter(|&k| amount(user, k) > avg).count();
+            vec![user.to_string(), n.to_string()]
+        })
+        .collect();
+    assert_eq!(
+        rows(
+            &db,
+            "WITH t AS (SELECT * FROM orders) SELECT user_id, COUNT(*) FILTER (WHERE amount > (SELECT AVG(amount) FROM orders)) FROM t GROUP BY user_id ORDER BY user_id"
+        ),
+        expected,
+        "CTE, grouped"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "WITH RECURSIVE n(v) AS (SELECT 1 UNION ALL SELECT v + 1 FROM n WHERE v < 30) SELECT COUNT(*) FILTER (WHERE v > (SELECT MIN(id) FROM users) + 9) FROM n"
+        ),
+        20,
+        "recursive CTE"
+    );
+}

--- a/tests/where_subquery_containers_test.rs
+++ b/tests/where_subquery_containers_test.rs
@@ -246,3 +246,113 @@ fn test_correlated_subquery_over_both_sides() {
     );
     assert_eq!(limited.len(), 10, "plain join with LIMIT");
 }
+
+/// A join inside a scalar subquery: the join's WHERE reads the row of the
+/// query around it as well as its own rows
+#[test]
+fn test_join_where_reads_the_parent_row() {
+    let db = setup("where_subquery_parent_row");
+    // Users whose largest order is above u2.id * 10: every user for 1, users from 2 for 2, from 3 for 3
+    let expected: Vec<Vec<String>> = vec![
+        vec!["1".into(), "90".into()],
+        vec!["2".into(), "87".into()],
+        vec!["3".into(), "84".into()],
+    ];
+    assert_eq!(
+        rows(
+            &db,
+            &format!(
+                "SELECT u2.id, (SELECT COUNT(*) FROM {JOIN} WHERE (SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id) > u2.id * 10) FROM users u2 WHERE u2.id <= 3 ORDER BY u2.id"
+            )
+        ),
+        expected
+    );
+}
+
+/// A subquery inside LIKE or inside an IN list is resolved like a bare one
+#[test]
+fn test_subquery_inside_like_and_in_list() {
+    let db = setup("where_subquery_like_list");
+    // user1 and user10 to user19
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM users u WHERE u.name LIKE (SELECT name FROM users WHERE id = 1) || '%'"
+        ),
+        11,
+        "LIKE over a subquery, scan"
+    );
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM {JOIN} WHERE u.name LIKE (SELECT name FROM users WHERE id = 1) || '%'")
+        ),
+        33,
+        "LIKE over a subquery, join"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM users u WHERE u.id IN ((SELECT MIN(id) FROM users), 2)"
+        ),
+        2,
+        "IN list holding a subquery, scan"
+    );
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM {JOIN} WHERE u.id IN ((SELECT MIN(id) FROM users), 2)")
+        ),
+        6,
+        "IN list holding a subquery, join"
+    );
+}
+
+/// The operand of a simple CASE may be a subquery
+#[test]
+fn test_subquery_as_case_operand() {
+    let db = setup("where_subquery_case_operand");
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM {JOIN} WHERE CASE (SELECT MIN(id) FROM users) WHEN u.id THEN 1 ELSE 0 END = 1")
+        ),
+        3,
+        "uncorrelated operand"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT u.id, COUNT(o.id) FROM {JOIN} WHERE CASE (SELECT MAX(amount) FROM orders x WHERE x.user_id = u.id) WHEN 302 THEN 1 ELSE 0 END = 1 GROUP BY u.id ORDER BY u.id")
+        ),
+        vec![vec!["30".to_string(), "3".to_string()]],
+        "correlated operand"
+    );
+}
+
+/// A correlated ALL in a join's WHERE: the largest order of every user
+#[test]
+fn test_correlated_all_in_join_where() {
+    let db = setup("where_subquery_all_join");
+    let predicate =
+        "o.amount > ALL (SELECT amount FROM orders x WHERE x.user_id = u.id AND x.id <> o.id)";
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM {JOIN} WHERE {predicate}")
+        ),
+        30,
+        "joined rows"
+    );
+    let expected: Vec<Vec<String>> = (1..=30i64)
+        .map(|user| vec![user.to_string(), amount(user, 2).to_string()])
+        .collect();
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT u.id, o.amount FROM {JOIN} WHERE {predicate} ORDER BY u.id")
+        ),
+        expected,
+        "plain join"
+    );
+}

--- a/tests/where_subquery_containers_test.rs
+++ b/tests/where_subquery_containers_test.rs
@@ -459,3 +459,124 @@ fn test_uncorrelated_next_to_correlated_on_a_derived_side() {
         "table"
     );
 }
+
+/// A column of the query around the join on the left of a correlated IN
+#[test]
+fn test_parent_column_in_a_correlated_in() {
+    let db = setup("where_subquery_parent_in");
+    let expected: Vec<Vec<String>> = (1..=3i64)
+        .map(|user| vec![user.to_string(), "3".to_string()])
+        .collect();
+    assert_eq!(
+        rows(
+            &db,
+            &format!(
+                "SELECT u2.id, (SELECT COUNT(*) FROM {JOIN} WHERE u2.id IN (SELECT x.user_id FROM orders x WHERE x.user_id = u.id)) FROM users u2 WHERE u2.id <= 3 ORDER BY u2.id"
+            )
+        ),
+        expected
+    );
+}
+
+/// ALL and ANY over a set holding a NULL follow three-valued logic
+#[test]
+fn test_all_any_with_a_null_in_the_set() {
+    let db = setup("where_subquery_all_null");
+    db.execute("INSERT INTO orders VALUES (91, 1, NULL)", ())
+        .unwrap();
+    let cases = [
+        (
+            "200 > ALL (SELECT amount FROM orders WHERE user_id = 1)",
+            0,
+            "ALL that holds on every value but sees a NULL",
+        ),
+        (
+            "200 > ALL (SELECT amount FROM orders WHERE user_id = 1 AND amount IS NOT NULL)",
+            30,
+            "ALL without the NULL",
+        ),
+        (
+            "200 > ALL (SELECT amount FROM orders WHERE user_id = 99)",
+            30,
+            "ALL over an empty set",
+        ),
+        (
+            "5 > ANY (SELECT amount FROM orders WHERE user_id = 1)",
+            0,
+            "ANY that fails on every value and sees a NULL",
+        ),
+        (
+            "NOT (5 > ANY (SELECT amount FROM orders WHERE user_id = 1))",
+            0,
+            "NOT of an unknown ANY",
+        ),
+        (
+            "11 > ANY (SELECT amount FROM orders WHERE user_id = 1)",
+            30,
+            "ANY that holds on one value",
+        ),
+        (
+            "10 = ANY (SELECT amount FROM orders WHERE user_id = 1)",
+            30,
+            "= ANY that holds",
+        ),
+        (
+            "NOT (7 = ANY (SELECT amount FROM orders WHERE user_id = 1))",
+            0,
+            "NOT of an unknown = ANY",
+        ),
+        (
+            "7 <> ALL (SELECT amount FROM orders WHERE user_id = 1)",
+            0,
+            "<> ALL that sees a NULL",
+        ),
+    ];
+    for (predicate, expected, label) in cases {
+        assert_eq!(
+            count(
+                &db,
+                &format!("SELECT COUNT(*) FROM users WHERE {predicate}")
+            ),
+            expected,
+            "{label}"
+        );
+    }
+    // The largest order of every user, except the user whose set holds a NULL
+    let predicate =
+        "o.amount > ALL (SELECT amount FROM orders x WHERE x.user_id = u.id AND x.id <> o.id)";
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM {JOIN} WHERE {predicate}")
+        ),
+        29,
+        "correlated ALL"
+    );
+}
+
+/// The left operand of ALL may itself hold a correlated subquery
+#[test]
+fn test_correlated_left_operand_of_all() {
+    let db = setup("where_subquery_all_left");
+    // Users whose largest order tops every order of user 20 (202): users from 21
+    let predicate = "(SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id) > ALL (SELECT amount FROM orders WHERE user_id = 20)";
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM {JOIN} WHERE {predicate}")
+        ),
+        30,
+        "joined rows"
+    );
+    let expected: Vec<Vec<String>> = (21..=30i64)
+        .map(|user| vec![user.to_string(), "3".to_string()])
+        .collect();
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT u.id, COUNT(o.id) FROM {JOIN} WHERE {predicate} GROUP BY u.id ORDER BY u.id")
+        ),
+        expected,
+        "grouped join"
+    );
+}

--- a/tests/where_subquery_containers_test.rs
+++ b/tests/where_subquery_containers_test.rs
@@ -897,26 +897,237 @@ fn test_subquery_inside_an_aggregate_with_a_window() {
     );
 }
 
-/// The column a lifted subquery lands in never takes a user column's name
+/// A lifted subquery keeps its text as the result column's name, an identical
+/// subquery shares its column, and a user column with that very name, bare
+/// or qualified through a join, is never shadowed
 #[test]
-fn test_lifted_column_name_avoids_user_columns() {
-    let db = Database::open("memory://lifted_column_name").unwrap();
+fn test_lifted_column_keeps_the_subquery_text() {
+    let db = setup("lifted_column_name");
+    let result = db
+        .query(
+            "SELECT SUM((SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id)), COUNT((SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id)) FROM users u",
+            (),
+        )
+        .unwrap();
+    let columns: Vec<String> = result.columns().iter().map(|c| c.to_string()).collect();
+    assert_eq!(
+        columns,
+        [
+            "SUM((SELECT MAX(x.amount) FROM orders AS x WHERE (x.user_id = u.id)))",
+            "COUNT((SELECT MAX(x.amount) FROM orders AS x WHERE (x.user_id = u.id)))",
+        ]
+    );
+    let values: Vec<Vec<String>> = result
+        .map(|row| {
+            let row = row.unwrap();
+            (0..row.len())
+                .map(|i| row.get::<String>(i).unwrap())
+                .collect()
+        })
+        .collect();
+    assert_eq!(values, vec![vec!["4710".to_string(), "30".to_string()]]);
+
+    let text = "(SELECT MAX(id) FROM c AS e WHERE (e.id = c.id))";
     db.execute(
-        "CREATE TABLE c (id INTEGER PRIMARY KEY, __agg_subquery_0 INTEGER)",
+        &format!("CREATE TABLE c (id INTEGER PRIMARY KEY, \"{text}\" INTEGER)"),
         (),
     )
     .unwrap();
+    db.execute("CREATE TABLE d (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
     db.execute("INSERT INTO c VALUES (1, 100), (2, 200)", ())
         .unwrap();
+    db.execute("INSERT INTO d VALUES (1), (2)", ()).unwrap();
     assert_eq!(
-        count(&db, "SELECT SUM((SELECT 1)) + SUM(__agg_subquery_0) FROM c"),
-        302
+        count(
+            &db,
+            &format!(
+                "SELECT SUM((SELECT MAX(id) FROM c e WHERE e.id = c.id)) + SUM(\"{text}\") FROM c"
+            )
+        ),
+        303
     );
     assert_eq!(
         count(
             &db,
-            "SELECT SUM((SELECT MAX(id) FROM c d WHERE d.id = c.id)) + SUM(__agg_subquery_0) FROM c"
+            &format!("SELECT SUM((SELECT MAX(id) FROM c e WHERE e.id = c.id)) + SUM(\"{text}\") FROM c JOIN d ON d.id = c.id")
         ),
         303
+    );
+}
+
+/// A subquery inside an aggregate next to a window function is resolved on
+/// the input rows once, and the window stage reads the rewritten statement
+#[test]
+fn test_aggregate_with_window_lifts_once() {
+    let db = setup("aggregate_window_once");
+    // MAX amount per user is user * 10 + 2: even users 2430, odd users 2280
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT u.id % 2, SUM((SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id)), ROW_NUMBER() OVER (ORDER BY u.id % 2) FROM users u GROUP BY u.id % 2 ORDER BY 1"
+        ),
+        vec![
+            vec!["0".to_string(), "2430".to_string(), "1".to_string()],
+            vec!["1".to_string(), "2280".to_string(), "2".to_string()],
+        ],
+        "grouped aggregate beside a window function"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT SUM((SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id AND u.name <> '')), ROW_NUMBER() OVER () FROM users u"
+        ),
+        vec![vec!["4710".to_string(), "1".to_string()]],
+        "a parent column the aggregate rows do not carry"
+    );
+}
+
+/// A window aggregate honours its FILTER and its own ORDER BY
+#[test]
+fn test_window_aggregate_filter_and_order_by() {
+    let db = setup("window_aggregate_filter");
+    let none = rows(
+        &db,
+        "SELECT COUNT(*) FILTER (WHERE (SELECT 0) = 1) OVER () FROM users",
+    );
+    assert_eq!(none.len(), 30);
+    assert!(none.iter().all(|row| row[0] == "0"), "{none:?}");
+    let sums = rows(
+        &db,
+        "SELECT SUM(id) FILTER (WHERE id > 27) OVER () FROM users",
+    );
+    assert!(sums.iter().all(|row| row[0] == "87"), "{sums:?}");
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT COUNT(*) FILTER (WHERE id % 2 = 0) OVER (ORDER BY id) FROM users WHERE id <= 6 ORDER BY id"
+        ),
+        ["0", "1", "1", "2", "2", "3"]
+            .iter()
+            .map(|v| vec![v.to_string()])
+            .collect::<Vec<_>>(),
+        "running filtered count"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT id, COUNT(*) FILTER (WHERE id > 3) OVER (PARTITION BY id % 2) FROM users WHERE id <= 6 ORDER BY id"
+        ),
+        [("1", "1"), ("2", "2"), ("3", "1"), ("4", "2"), ("5", "1"), ("6", "2")]
+            .iter()
+            .map(|(id, n)| vec![id.to_string(), n.to_string()])
+            .collect::<Vec<_>>(),
+        "filtered count per partition"
+    );
+    // Even users 2, 4 and 6 have MAX amounts 22, 42 and 62
+    let correlated = rows(
+        &db,
+        "SELECT SUM((SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id)) FILTER (WHERE u.id % 2 = 0) OVER () FROM users u WHERE u.id <= 6"
+    );
+    assert_eq!(correlated.len(), 6);
+    assert!(
+        correlated.iter().all(|row| row[0] == "126"),
+        "filtered correlated window aggregate: {correlated:?}"
+    );
+    let ordered = rows(
+        &db,
+        "SELECT GROUP_CONCAT(name ORDER BY id DESC) OVER () FROM users WHERE id <= 3",
+    );
+    assert_eq!(ordered.len(), 3);
+    assert!(
+        ordered.iter().all(|row| row[0] == "user3,user2,user1"),
+        "ordered window aggregate: {ordered:?}"
+    );
+}
+
+/// A subquery in an OVER clause or a named window orders and partitions the
+/// rows, and the column it lands in stays out of SELECT *
+#[test]
+fn test_subquery_in_over_clause() {
+    let db = setup("subquery_in_over");
+    let reversed: Vec<Vec<String>> = (1..=6)
+        .map(|id| vec![id.to_string(), (7 - id).to_string()])
+        .collect();
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT id, ROW_NUMBER() OVER (ORDER BY (SELECT -u.id)) FROM users u WHERE u.id <= 6 ORDER BY id"
+        ),
+        reversed,
+        "FROM-less subquery in ORDER BY"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT id, ROW_NUMBER() OVER (ORDER BY (SELECT -MAX(x.id) FROM users x WHERE x.id = u.id)) FROM users u WHERE u.id <= 6 ORDER BY id"
+        ),
+        reversed,
+        "subquery with a FROM in ORDER BY"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT id, ROW_NUMBER() OVER w FROM users u WHERE u.id <= 6 WINDOW w AS (ORDER BY (SELECT -u.id)) ORDER BY id"
+        ),
+        reversed,
+        "named window"
+    );
+    let counts = rows(
+        &db,
+        "SELECT id, COUNT(*) OVER (PARTITION BY (SELECT u.id % 2)) FROM users u WHERE u.id <= 6 ORDER BY id"
+    );
+    assert_eq!(counts.len(), 6);
+    assert!(
+        counts.iter().all(|row| row[1] == "3"),
+        "subquery in PARTITION BY: {counts:?}"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT *, ROW_NUMBER() OVER (ORDER BY (SELECT -u.id)) FROM users u WHERE u.id <= 2 ORDER BY id"
+        ),
+        vec![
+            vec!["1".to_string(), "user1".to_string(), "2".to_string()],
+            vec!["2".to_string(), "user2".to_string(), "1".to_string()],
+        ],
+        "SELECT * beside a lifted OVER clause"
+    );
+}
+
+/// A correlated subquery beside a window function is read per input row,
+/// also on the indexed partition fetch that LIMIT would take
+#[test]
+fn test_correlated_subquery_beside_a_window_function() {
+    let db = setup("subquery_beside_window");
+    let limited = rows(
+        &db,
+        "SELECT id, COUNT(*) OVER (PARTITION BY id) + (SELECT u.id * 0) FROM users u LIMIT 2",
+    );
+    assert_eq!(limited.len(), 2);
+    assert!(
+        limited.iter().all(|row| row[1] == "1"),
+        "beside a partitioned count with LIMIT: {limited:?}"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT id, SUM((SELECT u.id)) OVER (PARTITION BY id % 2) FROM users u WHERE u.id <= 6 ORDER BY id"
+        ),
+        [("1", "9"), ("2", "12"), ("3", "9"), ("4", "12"), ("5", "9"), ("6", "12")]
+            .iter()
+            .map(|(id, sum)| vec![id.to_string(), sum.to_string()])
+            .collect::<Vec<_>>(),
+        "window aggregate over a FROM-less subquery"
+    );
+}
+
+/// A FROM-less subquery in a WHERE reads the parent row
+#[test]
+fn test_fromless_correlated_subquery_in_where() {
+    let db = setup("fromless_where");
+    assert_eq!(
+        count(&db, "SELECT COUNT(*) FROM users u WHERE (SELECT u.id) > 27"),
+        3
     );
 }

--- a/tests/where_subquery_containers_test.rs
+++ b/tests/where_subquery_containers_test.rs
@@ -356,3 +356,106 @@ fn test_correlated_all_in_join_where() {
         "plain join"
     );
 }
+
+/// A subquery inside an IN list reaches the DML path too
+#[test]
+fn test_in_list_subquery_in_delete() {
+    let db = setup("where_subquery_in_list_delete");
+    db.execute(
+        "DELETE FROM orders WHERE id IN ((SELECT MIN(id) FROM orders), 2)",
+        (),
+    )
+    .unwrap();
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM orders"), 88);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM orders WHERE id <= 2"), 0);
+}
+
+/// A column of the query around the join may sit inside a CAST or a CASE
+#[test]
+fn test_join_where_reads_the_parent_row_inside_a_container() {
+    let db = setup("where_subquery_parent_row_container");
+    let expected: Vec<Vec<String>> = vec![
+        vec!["1".into(), "90".into()],
+        vec!["2".into(), "87".into()],
+        vec!["3".into(), "84".into()],
+    ];
+    assert_eq!(
+        rows(
+            &db,
+            &format!(
+                "SELECT u2.id, (SELECT COUNT(*) FROM {JOIN} WHERE (SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id) > CAST(u2.id AS FLOAT) * 10) FROM users u2 WHERE u2.id <= 3 ORDER BY u2.id"
+            )
+        ),
+        expected,
+        "CAST"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            &format!(
+                "SELECT u2.id, (SELECT COUNT(*) FROM {JOIN} WHERE (SELECT MAX(x.amount) FROM orders x WHERE x.user_id = u.id) > CASE WHEN u2.id = 1 THEN 10 WHEN u2.id = 2 THEN 20 ELSE 30 END) FROM users u2 WHERE u2.id <= 3 ORDER BY u2.id"
+            )
+        ),
+        expected,
+        "CASE"
+    );
+}
+
+/// An outer reference wrapped in a CAST still makes the subquery correlated
+#[test]
+fn test_correlated_reference_inside_cast() {
+    let db = setup("where_subquery_cast_reference");
+    let predicate =
+        "EXISTS (SELECT 1 FROM orders x WHERE x.user_id = CAST(u.id AS INTEGER) AND x.amount > 200)";
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM {JOIN} WHERE {predicate}")
+        ),
+        33,
+        "joined rows"
+    );
+    let expected: Vec<Vec<String>> = (20..=30i64)
+        .map(|user| vec![user.to_string(), "3".to_string()])
+        .collect();
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT u.id, COUNT(o.id) FROM {JOIN} WHERE {predicate} GROUP BY u.id ORDER BY u.id")
+        ),
+        expected,
+        "grouped join"
+    );
+}
+
+/// An uncorrelated subquery folds even next to a correlated one, so the
+/// conjunct pushed to a derived table or CTE side is a plain predicate
+#[test]
+fn test_uncorrelated_next_to_correlated_on_a_derived_side() {
+    let db = setup("where_subquery_mixed_derived");
+    let predicate = "EXISTS (SELECT 1 FROM orders x WHERE x.user_id = u.id AND x.amount > 200) AND o.amount > (SELECT AVG(amount) FROM orders)";
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM users u INNER JOIN (SELECT * FROM orders) o ON u.id = o.user_id WHERE {predicate}")
+        ),
+        33,
+        "derived table"
+    );
+    assert_eq!(
+        count(
+            &db,
+            &format!("WITH o AS (SELECT * FROM orders) SELECT COUNT(*) FROM users u INNER JOIN o ON u.id = o.user_id WHERE {predicate}")
+        ),
+        33,
+        "CTE"
+    );
+    assert_eq!(
+        count(
+            &db,
+            &format!("SELECT COUNT(*) FROM {JOIN} WHERE {predicate}")
+        ),
+        33,
+        "table"
+    );
+}


### PR DESCRIPTION
## Why

Writing the tests for #90 and #91 turned up four WHERE subquery shapes that return no rows on main, each verified against values computed from the generated data:

| Shape | Where it failed |
|---|---|
| `o.amount > CAST((SELECT AVG(amount) FROM orders) AS FLOAT)` | every path, scan and join |
| `CASE WHEN o.amount > (SELECT AVG(amount) FROM orders) THEN 1 ELSE 0 END = 1` | GROUP BY + LIMIT join |
| `COALESCE((SELECT MAX(amount) FROM orders x WHERE x.user_id = u.id), 0) > 200` | every path |
| `EXISTS (SELECT 1 FROM orders x WHERE x.user_id = u.id AND x.amount > 200)` | every join path |

## What

- **Detectors see every container.** The classification walker that sets `where_has_subqueries`, its correlated counterpart, and the executor's `has_subqueries` / `has_correlated_subqueries` now descend into CAST, LIKE, lists, DISTINCT and CASE, so a nested subquery is processed like a bare one.
- **The join's constant-false short-circuit skips a WHERE with a subquery.** It compiles the raw WHERE against no columns and evaluates it on an empty row; a subquery has no value there, so `EXISTS (...)` and `COALESCE((SELECT ...), 0) > 200` came out constant false and the join returned empty before running. That was the cause of the EXISTS and COALESCE rows above.
- **Uncorrelated subqueries fold before the filters are split.** The join path processes the WHERE once, then partitions it, so the reduction, the index nested loop and the grouped stream all see plain predicates instead of raw subqueries. The filter partition and the qualifier helpers learned the hashed set an IN subquery folds to, which they used to take for a constant and push to the wrong side.
- **Correlated predicates stay with the joined row.** The filter partition cannot see the qualifiers inside a subquery (a bare EXISTS was pushed to the left scan "arbitrarily", wrong as soon as it read the right side), so a correlated predicate now goes post-join, the fast paths are skipped, and the general path resolves its subqueries per joined row with that row as the outer row. The per-row processor also descends into function calls, CASE, CAST and LIKE now.

## Tests

`tests/where_subquery_containers_test.rs`: the four shapes above on the scan, the plain join, the join with LIMIT and the grouped join with ORDER BY and with LIMIT, plus a correlated EXISTS that reads both sides of the join (`x.amount > o.amount`), which can only be answered on the joined row. Every expected value is computed from the generated data. All failed on main before the fix. Join, subquery, CTE and aggregation targets pass, plus both full suites.

## Measurements

`examples/benchmark` join and subquery rows, three interleaved runs against main at #91 on the same machine, median in us. None of these queries has a subquery in a join's WHERE, so the change is not on their path; this is a parity check.

| Row | main | this PR |
|---|---|---|
| INNER JOIN | 14.0 | 14.7 |
| LEFT JOIN + GROUP BY | 40.2 | 39.2 |
| Scalar subquery | 9.3 | 9.7 |
| IN subquery | 111.8 | 110.2 |
| EXISTS subquery | 2.7 | 2.6 |
| CTE + JOIN | 39.5 | 40.3 |
| Complex JOIN+GROUP+HAVING | 54.5 | 56.2 |
| NOT IN subquery | 74.2 | 78.9 |
| NOT EXISTS subquery | 26.8 | 27.0 |
| Self JOIN (same age) | 8.3 | 8.2 |
| Nested subquery (3 lvl) | 367.5 | 370.4 |
| Correlated in SELECT | 265.5 | 266.8 |
| Compare with subquery | 5.8 | 5.8 |

