### PR TITLE
fix(window): read the column a window argument names through its table

### DIFF
--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -2315,8 +2315,7 @@ impl Executor {
 
         // OPTIMIZATION: Pre-compute column index for function argument
         let arg_col_idx: Option<usize> = if !wf_info.arguments.is_empty() {
-            self.extract_column_from_arg(&wf_info.arguments[0])
-                .and_then(|col_name| col_index_map.get(&col_name.to_lowercase()).copied())
+            self.resolve_column_index(&wf_info.arguments[0], col_index_map)
         } else {
             None
         };
@@ -2529,8 +2528,7 @@ impl Executor {
 
         // Pre-compute column index for function argument
         let arg_col_idx: Option<usize> = if !wf_info.arguments.is_empty() {
-            self.extract_column_from_arg(&wf_info.arguments[0])
-                .and_then(|col_name| col_index_map.get(&col_name.to_lowercase()).copied())
+            self.resolve_column_index(&wf_info.arguments[0], col_index_map)
         } else {
             None
         };
@@ -2735,8 +2733,7 @@ impl Executor {
 
         // Pre-compute column index for function argument
         let arg_col_idx: Option<usize> = if !wf_info.arguments.is_empty() {
-            self.extract_column_from_arg(&wf_info.arguments[0])
-                .and_then(|col_name| col_index_map.get(&col_name.to_lowercase()).copied())
+            self.resolve_column_index(&wf_info.arguments[0], col_index_map)
         } else {
             None
         };
@@ -3257,23 +3254,6 @@ impl Executor {
                 (0, peer_group_end)
             }
         }
-    }
-
-    /// Extract column name from expression
-    fn extract_column_from_expr(&self, expr: &Expression) -> Option<String> {
-        match expr {
-            Expression::Identifier(id) => Some(id.value.to_string()),
-            Expression::QualifiedIdentifier(qid) => {
-                // Return fully qualified name "qualifier.column" for JOIN results
-                Some(format!("{}.{}", qid.qualifier.value, qid.name.value))
-            }
-            _ => None,
-        }
-    }
-
-    /// Extract column name from function argument
-    fn extract_column_from_arg(&self, arg: &Expression) -> Option<String> {
-        self.extract_column_from_expr(arg)
     }
 
     /// Resolve column index from expression, trying both qualified and unqualified names

--- a/tests/window_qualified_argument_test.rs
+++ b/tests/window_qualified_argument_test.rs
@@ -1,0 +1,121 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A window function reads the same column whether its argument names the
+//! column on its own or through the table it comes from. On one table the
+//! rows carry the bare name, so a qualified argument has to fall back to it.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, city TEXT)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount INTEGER)",
+        (),
+    )
+    .unwrap();
+    for id in 1..=4i64 {
+        db.execute(
+            "INSERT INTO users VALUES ($1, $2)",
+            (id, if id % 2 == 0 { "a" } else { "b" }),
+        )
+        .unwrap();
+        db.execute("INSERT INTO orders VALUES ($1, $2, $3)", (id, id, id * 10))
+            .unwrap();
+    }
+    db
+}
+
+fn column(db: &Database, sql: &str) -> Vec<String> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            row.get::<Option<String>>(0)
+                .unwrap()
+                .unwrap_or_else(|| "NULL".into())
+        })
+        .collect()
+}
+
+/// Every window function that reads a column reads it through an alias too
+#[test]
+fn test_qualified_argument_matches_the_bare_one() {
+    let db = setup("window_qualified_argument");
+    for (bare, qualified) in [
+        (
+            "SELECT LAG(id, 1) OVER (ORDER BY id) FROM users ORDER BY id",
+            "SELECT LAG(u.id, 1) OVER (ORDER BY u.id) FROM users u ORDER BY u.id",
+        ),
+        (
+            "SELECT LAG(id) OVER (ORDER BY id) FROM users ORDER BY id",
+            "SELECT LAG(u.id) OVER (ORDER BY u.id) FROM users u ORDER BY u.id",
+        ),
+        (
+            "SELECT LEAD(id, 1) OVER (ORDER BY id) FROM users ORDER BY id",
+            "SELECT LEAD(u.id, 1) OVER (ORDER BY u.id) FROM users u ORDER BY u.id",
+        ),
+        (
+            "SELECT FIRST_VALUE(id) OVER (ORDER BY id) FROM users ORDER BY id",
+            "SELECT FIRST_VALUE(u.id) OVER (ORDER BY u.id) FROM users u ORDER BY u.id",
+        ),
+        (
+            "SELECT LAST_VALUE(id) OVER (ORDER BY id) FROM users ORDER BY id",
+            "SELECT LAST_VALUE(u.id) OVER (ORDER BY u.id) FROM users u ORDER BY u.id",
+        ),
+        (
+            "SELECT NTH_VALUE(id, 2) OVER (ORDER BY id) FROM users ORDER BY id",
+            "SELECT NTH_VALUE(u.id, 2) OVER (ORDER BY u.id) FROM users u ORDER BY u.id",
+        ),
+        (
+            "SELECT LAG(id, 1) OVER (PARTITION BY city ORDER BY id) FROM users ORDER BY id",
+            "SELECT LAG(u.id, 1) OVER (PARTITION BY u.city ORDER BY u.id) FROM users u ORDER BY u.id",
+        ),
+    ] {
+        let expected = column(&db, bare);
+        assert_eq!(column(&db, qualified), expected, "{qualified}");
+        assert!(
+            expected.iter().any(|value| value != "NULL"),
+            "the bare form itself reads nothing: {bare}"
+        );
+    }
+}
+
+/// The table's own name qualifies a column the same way an alias does
+#[test]
+fn test_table_name_qualifies_a_window_argument() {
+    let db = setup("window_qualified_by_table");
+    assert_eq!(
+        column(
+            &db,
+            "SELECT LAG(users.id, 1) OVER (ORDER BY users.id) FROM users ORDER BY users.id"
+        ),
+        ["NULL", "1", "2", "3"]
+    );
+}
+
+/// A join carries qualified column names, which still resolve
+#[test]
+fn test_qualified_argument_over_a_join() {
+    let db = setup("window_qualified_join");
+    assert_eq!(
+        column(
+            &db,
+            "SELECT LAG(o.amount, 1) OVER (ORDER BY o.id) FROM users u JOIN orders o ON o.user_id = u.id ORDER BY o.id"
+        ),
+        ["NULL", "10", "20", "30"]
+    );
+}


### PR DESCRIPTION
`LAG`, `LEAD`, `FIRST_VALUE`, `LAST_VALUE` and `NTH_VALUE` return NULL on every row when their argument names the column through the table it comes from and the query reads one table.

```sql
SELECT LAG(id, 1)   OVER (ORDER BY u.id) FROM users u;  -- NULL, 1, 2, 3
SELECT LAG(u.id, 1) OVER (ORDER BY u.id) FROM users u;  -- NULL, NULL, NULL, NULL
```

The OVER clause is not involved: the same shape with a bare argument and a qualified ORDER BY is right, and the qualified argument is wrong however the ORDER BY is written. The table's own name fails the same way as an alias. A join hides it, since a join's rows carry the qualified name. SQLite answers NULL, 1, 2, 3 for both forms.

The three partition paths looked the argument up by the name as written, while the aggregate window path next to them used `resolve_column_index`, which tries the qualified name and then the bare one. They call it now, and the pair of helpers that only did the first is gone, three lines in and twenty three out.

`tests/window_qualified_argument_test.rs` compares the bare and qualified forms of all six functions, plus PARTITION BY, the table name as qualifier, and a join. Two of the three fail on `c96d2017`.
