### PR TITLE
fix: correlated subqueries, CTEs, views, joins, DML and expressions answer the way SQLite and DuckDB do

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,18 @@
+# `cargo nextest run` uses the default profile, which leaves out the tests
+# that judge wall-clock time and the concurrency stress binaries: they turn
+# red under load and cost minutes. `cargo nextest run -P full` runs every
+# test, for CI and before a merge.
+
+[profile.default]
+default-filter = """
+not (
+  test(=storage::mvcc::version_store::tests::test_unique_constraint_performance_bulk_update)
+  | test(=test_fk_cascade_delete_performance_with_auto_index)
+  | binary(=concurrency_history_test)
+  | binary(=volume_concurrency_test)
+)
+"""
+slow-timeout = { period = "60s" }
+
+[profile.full]
+default-filter = "all()"

--- a/src/core/value.rs
+++ b/src/core/value.rs
@@ -600,6 +600,7 @@ impl Value {
                     Value::Integer(v) => Value::Integer(*v),
                     Value::Float(v) => Value::Integer(*v as i64),
                     Value::Text(s) => s
+                        .trim()
                         .parse::<i64>()
                         .map(Value::Integer)
                         .unwrap_or(Value::Null(target_type)),
@@ -613,6 +614,7 @@ impl Value {
                     Value::Float(v) => Value::Float(*v),
                     Value::Integer(v) => Value::Float(*v as f64),
                     Value::Text(s) => s
+                        .trim()
                         .parse::<f64>()
                         .map(Value::Float)
                         .unwrap_or(Value::Null(target_type)),

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -6181,12 +6181,21 @@ impl Executor {
         // Parse aggregations
         let (aggregations, non_agg_columns) = self.parse_aggregations(stmt)?;
 
-        // Must have only aggregations plus the GROUP BY column (no other regular columns)
-        // Non-agg columns must be exactly the GROUP BY column
-        if non_agg_columns.len() > 1 {
+        // The rows come out as the GROUP BY column and then the aggregates,
+        // so the select list has to read exactly that, in that order
+        if non_agg_columns.len() != 1 || !non_agg_columns[0].eq_ignore_ascii_case(&group_col_name) {
             return Ok(None);
         }
-        if non_agg_columns.len() == 1 && !non_agg_columns[0].eq_ignore_ascii_case(&group_col_name) {
+        let leads_with_group_column = match stmt.columns.first() {
+            Some(crate::parser::ast::Expression::Identifier(id)) => {
+                id.value_lower.eq_ignore_ascii_case(&group_col_name)
+            }
+            Some(crate::parser::ast::Expression::QualifiedIdentifier(qid)) => {
+                qid.name.value_lower.eq_ignore_ascii_case(&group_col_name)
+            }
+            _ => false,
+        };
+        if !leads_with_group_column {
             return Ok(None);
         }
 

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -3071,18 +3071,17 @@ impl Executor {
                         }
                         SimpleAgg::Sum(sum_col_idx) | SimpleAgg::Avg(sum_col_idx) => {
                             if let Some(value) = row.get(*sum_col_idx) {
-                                match value {
-                                    Value::Integer(v) => {
-                                        state.agg_values[i] += *v as f64;
-                                        state.agg_has_value[i] = true;
-                                        state.counts[i] += 1;
-                                    }
-                                    Value::Float(v) => {
-                                        state.agg_values[i] += v;
-                                        state.agg_has_value[i] = true;
-                                        state.counts[i] += 1;
-                                    }
-                                    _ => {}
+                                // A boolean counts as one or nought
+                                let numeric = match value {
+                                    Value::Integer(v) => Some(*v as f64),
+                                    Value::Float(v) => Some(*v),
+                                    Value::Boolean(b) => Some(*b as i64 as f64),
+                                    _ => None,
+                                };
+                                if let Some(v) = numeric {
+                                    state.agg_values[i] += v;
+                                    state.agg_has_value[i] = true;
+                                    state.counts[i] += 1;
                                 }
                             }
                         }
@@ -3319,18 +3318,17 @@ impl Executor {
                         }
                         SimpleAgg::Sum(sum_col_idx) | SimpleAgg::Avg(sum_col_idx) => {
                             if let Some(value) = row.get(*sum_col_idx) {
-                                match value {
-                                    Value::Integer(v) => {
-                                        state.agg_values[i] += *v as f64;
-                                        state.agg_has_value[i] = true;
-                                        state.counts[i] += 1;
-                                    }
-                                    Value::Float(v) => {
-                                        state.agg_values[i] += v;
-                                        state.agg_has_value[i] = true;
-                                        state.counts[i] += 1;
-                                    }
-                                    _ => {}
+                                // A boolean counts as one or nought
+                                let numeric = match value {
+                                    Value::Integer(v) => Some(*v as f64),
+                                    Value::Float(v) => Some(*v),
+                                    Value::Boolean(b) => Some(*b as i64 as f64),
+                                    _ => None,
+                                };
+                                if let Some(v) = numeric {
+                                    state.agg_values[i] += v;
+                                    state.agg_has_value[i] = true;
+                                    state.counts[i] += 1;
                                 }
                             }
                         }
@@ -3546,18 +3544,17 @@ impl Executor {
                     }
                     SimpleAgg::Sum(sum_col_idx) | SimpleAgg::Avg(sum_col_idx) => {
                         if let Some(value) = row.get(*sum_col_idx) {
-                            match value {
-                                Value::Integer(v) => {
-                                    state.agg_values[i] += *v as f64;
-                                    state.agg_has_value[i] = true;
-                                    state.counts[i] += 1;
-                                }
-                                Value::Float(v) => {
-                                    state.agg_values[i] += v;
-                                    state.agg_has_value[i] = true;
-                                    state.counts[i] += 1;
-                                }
-                                _ => {}
+                            // A boolean counts as one or nought
+                            let numeric = match value {
+                                Value::Integer(v) => Some(*v as f64),
+                                Value::Float(v) => Some(*v),
+                                Value::Boolean(b) => Some(*b as i64 as f64),
+                                _ => None,
+                            };
+                            if let Some(v) = numeric {
+                                state.agg_values[i] += v;
+                                state.agg_has_value[i] = true;
+                                state.counts[i] += 1;
                             }
                         }
                     }
@@ -5007,6 +5004,15 @@ impl Executor {
                                 sum_int += i;
                             }
                         }
+                        // A boolean counts as one or nought
+                        Value::Boolean(b) => {
+                            has_value = true;
+                            if has_float {
+                                sum_float += *b as i64 as f64;
+                            } else {
+                                sum_int += *b as i64;
+                            }
+                        }
                         Value::Float(f) => {
                             has_value = true;
                             if !has_float {
@@ -5031,6 +5037,14 @@ impl Executor {
                             sum_float += *i as f64;
                         } else {
                             sum_int += i;
+                        }
+                    }
+                    Value::Boolean(b) => {
+                        has_value = true;
+                        if has_float {
+                            sum_float += *b as i64 as f64;
+                        } else {
+                            sum_int += *b as i64;
                         }
                     }
                     Value::Float(f) => {
@@ -5079,6 +5093,14 @@ impl Executor {
                                     sum_float += *i as f64;
                                 } else {
                                     sum_int += i;
+                                }
+                            }
+                            Value::Boolean(b) => {
+                                has_value = true;
+                                if has_float {
+                                    sum_float += *b as i64 as f64;
+                                } else {
+                                    sum_int += *b as i64;
                                 }
                             }
                             Value::Float(f) => {
@@ -5161,6 +5183,11 @@ impl Executor {
                         sum += f;
                         count += 1;
                     }
+                    // A boolean counts as one or nought
+                    Value::Boolean(b) => {
+                        sum += *b as i64 as f64;
+                        count += 1;
+                    }
                     _ => {}
                 }
             }
@@ -5195,6 +5222,10 @@ impl Executor {
                             }
                             Value::Float(f) => {
                                 sum += f;
+                                count += 1;
+                            }
+                            Value::Boolean(b) => {
+                                sum += *b as i64 as f64;
                                 count += 1;
                             }
                             _ => {}
@@ -5909,6 +5940,8 @@ impl Executor {
                         let num = match value {
                             Value::Integer(i) => *i as f64,
                             Value::Float(f) => *f,
+                            // A boolean counts as one or nought
+                            Value::Boolean(b) => *b as i64 as f64,
                             _ => continue,
                         };
                         state.sum += num;

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -6310,6 +6310,11 @@ impl Executor {
                                             state.agg_has_value[i] = true;
                                             state.counts[i] += 1;
                                         }
+                                        Value::Boolean(v) => {
+                                            state.agg_values[i] += *v as i64 as f64;
+                                            state.agg_has_value[i] = true;
+                                            state.counts[i] += 1;
+                                        }
                                         _ => {}
                                     }
                                 }

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -514,8 +514,27 @@ impl Executor {
                 (result_columns, result_rows)
             } else {
                 // Pre-process scalar subqueries in HAVING clause
-                // This executes subqueries like (SELECT AVG(a) FROM t) and replaces them with values
-                let processed_having = self.process_where_subqueries(having, ctx)?;
+                // This executes subqueries like (SELECT AVG(a) FROM t) and replaces them with values.
+                // One that reads the group is left as written; apply_having
+                // runs it once per group with that group as the outer row
+                let has_correlated_having = Self::has_correlated_subqueries(having);
+                let processed_having = if has_correlated_having {
+                    (**having).clone()
+                } else {
+                    self.process_where_subqueries(having, ctx)?
+                };
+                let outer_table: Option<String> =
+                    stmt.table_expr.as_ref().and_then(|te| match te.as_ref() {
+                        Expression::TableSource(source) => Some(
+                            source
+                                .alias
+                                .as_ref()
+                                .map(|a| a.value_lower.to_string())
+                                .unwrap_or_else(|| source.name.value_lower.to_string()),
+                        ),
+                        Expression::Aliased(aliased) => Some(aliased.alias.value_lower.to_string()),
+                        _ => None,
+                    });
 
                 // Build aggregate expression aliases for HAVING clause
                 // IMPORTANT: Include ALL aggregates, not just aliased ones,
@@ -548,6 +567,7 @@ impl Executor {
                     &result_columns,
                     &agg_aliases,
                     &expr_aliases,
+                    outer_table.as_deref(),
                     ctx,
                 )?;
 
@@ -4925,6 +4945,7 @@ impl Executor {
     }
 
     /// Apply HAVING clause to aggregated results
+    #[allow(clippy::too_many_arguments)]
     fn apply_having(
         &self,
         result: Box<dyn QueryResult>,
@@ -4932,6 +4953,7 @@ impl Executor {
         columns: &[String],
         agg_aliases: &[(String, usize)],
         expr_aliases: &[(String, usize)],
+        outer_table: Option<&str>,
         ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
         // Materialize the result
@@ -4946,6 +4968,50 @@ impl Executor {
         // Combine all aliases for HAVING clause evaluation
         let mut all_aliases: Vec<(String, usize)> = agg_aliases.to_vec();
         all_aliases.extend_from_slice(expr_aliases);
+
+        // A subquery that reads the group it is asked about is run once per
+        // group, with the group's row standing as the outer row, the way a
+        // correlated subquery in the WHERE clause is run once per row. The
+        // group's columns are offered under their bare names and under the
+        // table's, since the subquery may name either
+        if Self::has_correlated_subqueries(having) {
+            let columns_arc = CompactArc::new(columns.to_vec());
+            let keys: Vec<(CompactArc<str>, Option<CompactArc<str>>)> = columns
+                .iter()
+                .map(|c| {
+                    let bare = c.to_lowercase();
+                    let qualified = outer_table.filter(|_| !bare.contains('.')).map(|t| {
+                        CompactArc::from(format!("{}.{}", t.to_lowercase(), bare).as_str())
+                    });
+                    (CompactArc::from(bare.as_str()), qualified)
+                })
+                .collect();
+            let mut filtered_rows = RowVec::new();
+            let mut new_id = 0i64;
+            for (_, row) in rows {
+                let mut outer_row_map: FxHashMap<CompactArc<str>, Value> = FxHashMap::default();
+                for (i, (bare, qualified)) in keys.iter().enumerate() {
+                    let value = row.get(i).cloned().unwrap_or_else(Value::null_unknown);
+                    if let Some(q) = qualified {
+                        outer_row_map.insert(q.clone(), value.clone());
+                    }
+                    outer_row_map.insert(bare.clone(), value);
+                }
+                let correlated_ctx =
+                    ctx.with_outer_row(outer_row_map, CompactArc::clone(&columns_arc));
+                let processed = self.process_correlated_where(having, &correlated_ctx)?;
+                let filter = RowFilter::with_aliases(&processed, columns, &all_aliases)?
+                    .with_context(&correlated_ctx);
+                if filter.matches_checked(&row)? {
+                    filtered_rows.push((new_id, row));
+                    new_id += 1;
+                }
+            }
+            return Ok(Box::new(ExecutorResult::new(
+                columns.to_vec(),
+                filtered_rows,
+            )));
+        }
 
         // Create RowFilter with all aliases and context
         let having_filter =

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -916,7 +916,8 @@ impl Executor {
                     Expression::FunctionCall(func) if is_aggregate_function(&func.function) => {
                         self.get_aggregate_column_name(func).to_lowercase()
                     }
-                    _ => continue, // Can't easily compare, assume mismatch
+                    // Anything else matches only as a GROUP BY expression column
+                    _ => self.expression_to_string(col_expr).to_lowercase(),
                 };
                 if i >= agg_columns.len() || agg_columns[i].to_lowercase() != expected_name {
                     columns_match = false;
@@ -993,9 +994,15 @@ impl Executor {
                             )));
                         }
                     } else {
-                        // Non-aggregate function - evaluate it
+                        // Non-aggregate function: a GROUP BY expression column is
+                        // read as it is, anything else is evaluated
+                        let expr_lower = self.expression_to_string(col_expr).to_lowercase();
                         final_columns.push(format!("{}(...)", func.function));
-                        column_sources.push(make_source(col_expr, is_correlated));
+                        if agg_col_index_map.contains_key(&expr_lower) && !is_correlated {
+                            column_sources.push(ColumnSource::AggColumn(expr_lower));
+                        } else {
+                            column_sources.push(make_source(col_expr, is_correlated));
+                        }
                     }
                 }
                 Expression::Aliased(aliased) => {

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -1501,6 +1501,17 @@ impl Executor {
                 &mut non_agg_columns,
             )?;
         }
+        // A named window a function refers to with OVER w may partition or
+        // order by an aggregate as well; it is computed like ORDER BY's
+        for window in &stmt.window_defs {
+            for expr in window
+                .partition_by
+                .iter()
+                .chain(window.order_by.iter().map(|o| &o.expression))
+            {
+                self.extract_aggregates_from_expr(expr, &mut aggregations, &mut non_agg_columns)?;
+            }
+        }
         // Mark any new aggregates (from ORDER BY) as hidden, but only if they're truly new
         // Helper to create a signature string for an aggregate including its filter
         let make_sig = |agg: &SqlAggregateFunction| -> (String, String, bool, String) {

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -1615,6 +1615,19 @@ impl Executor {
             Expression::Cast(cast) => {
                 self.extract_aggregates_from_expr(&cast.expr, aggregations, non_agg_columns)?;
             }
+            // An aggregate a window function takes as its argument, or
+            // partitions or orders by, is computed like any other
+            Expression::Window(window) => {
+                for expr in window
+                    .function
+                    .arguments
+                    .iter()
+                    .chain(window.partition_by.iter())
+                    .chain(window.order_by.iter().map(|o| &o.expression))
+                {
+                    self.extract_aggregates_from_expr(expr, aggregations, non_agg_columns)?;
+                }
+            }
             _ => {}
         }
         Ok(())

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -1927,55 +1927,10 @@ impl Executor {
         self.expression_to_string(target_expr)
     }
 
-    /// Convert an expression to a display string
-    #[allow(clippy::only_used_in_recursion)]
+    /// Convert an expression to a display string: the one stringifier, so
+    /// two aggregates over different expressions never share a name
     fn expression_to_string(&self, expr: &Expression) -> String {
-        match expr {
-            Expression::FunctionCall(func) => {
-                let args: Vec<String> = func
-                    .arguments
-                    .iter()
-                    .map(|a| self.expression_to_string(a))
-                    .collect();
-                format!("{}({})", func.function, args.join(", "))
-            }
-            Expression::Identifier(id) => id.value.to_string(),
-            Expression::QualifiedIdentifier(qid) => {
-                format!("{}.{}", qid.qualifier.value, qid.name.value)
-            }
-            Expression::StringLiteral(lit) => format!("'{}'", lit.value),
-            Expression::IntegerLiteral(lit) => lit.value.to_string(),
-            Expression::FloatLiteral(lit) => lit.value.to_string(),
-            Expression::BooleanLiteral(lit) => lit.value.to_string(),
-            Expression::Case(case) => {
-                // Use the Display implementation for CaseExpression
-                format!("{}", case)
-            }
-            Expression::Infix(infix) => {
-                format!(
-                    "{} {} {}",
-                    self.expression_to_string(&infix.left),
-                    infix.operator,
-                    self.expression_to_string(&infix.right)
-                )
-            }
-            Expression::Prefix(prefix) => {
-                format!(
-                    "{}{}",
-                    prefix.operator,
-                    self.expression_to_string(&prefix.right)
-                )
-            }
-            Expression::Cast(cast) => {
-                format!(
-                    "CAST({} AS {})",
-                    self.expression_to_string(&cast.expr),
-                    cast.type_name
-                )
-            }
-            // For any other expression type, use the Display trait if implemented
-            _ => format!("{}", expr),
-        }
+        super::utils::expression_to_string(expr)
     }
 
     /// Execute global aggregation (no GROUP BY)

--- a/src/executor/context.rs
+++ b/src/executor/context.rs
@@ -978,6 +978,16 @@ impl ExecutionContext {
         outer_row: FxHashMap<CompactArc<str>, Value>,
         outer_columns: CompactArc<Vec<String>>,
     ) -> Self {
+        // A subquery inside a subquery reads the row its grandparent sits
+        // on as well, with the nearer scope winning where both name a column
+        let outer_row = match &self.outer_row {
+            Some(grandparent) if !grandparent.is_empty() => {
+                let mut merged = grandparent.clone();
+                merged.extend(outer_row);
+                merged
+            }
+            _ => outer_row,
+        };
         Self {
             params: self.params.clone(),             // Arc clone = cheap
             named_params: self.named_params.clone(), // Arc clone = cheap

--- a/src/executor/cte.rs
+++ b/src/executor/cte.rs
@@ -114,7 +114,7 @@ fn expr_to_normalized_string(expr: &Expression) -> String {
 
 /// Hint for CTE optimization including LIMIT and optional ORDER BY pushdown
 #[derive(Clone)]
-struct CtePushdownHint {
+pub(crate) struct CtePushdownHint {
     limit: u64,
     order_by: Vec<OrderByExpression>,
 }
@@ -232,14 +232,27 @@ impl Executor {
         // This enables streaming GROUP BY early termination
         let cte_limit_hints = self.compute_cte_limit_hints(stmt, with_clause);
 
-        // Create CTE registry
+        let mut cte_registry = self.materialize_ctes(with_clause, ctx, Some(&cte_limit_hints))?;
+
+        // Execute the main query with CTE registry
+        self.execute_main_query_with_ctes(stmt, ctx, &mut cte_registry)
+    }
+
+    /// Run the CTEs of a WITH clause in order and store each result, so
+    /// the statement that follows, a SELECT or a DML, can read them
+    pub(crate) fn materialize_ctes(
+        &self,
+        with_clause: &WithClause,
+        ctx: &ExecutionContext,
+        cte_limit_hints: Option<&StringMap<CtePushdownHint>>,
+    ) -> Result<CteRegistry> {
         let mut cte_registry = CteRegistry::new();
 
         // Execute each CTE in order
         for cte in &with_clause.ctes {
             // Check if we have a pushdown hint for this CTE
             let cte_name_lower: String = cte.name.value_lower.to_string();
-            let pushdown_hint = cte_limit_hints.get(&cte_name_lower);
+            let pushdown_hint = cte_limit_hints.and_then(|hints| hints.get(&cte_name_lower));
 
             // Execute the CTE query (handles recursive CTEs)
             let (columns, rows) = if cte.is_recursive {
@@ -287,8 +300,7 @@ impl Executor {
             cte_registry.store(&cte.name.value, columns, rows);
         }
 
-        // Execute the main query with CTE registry
-        self.execute_main_query_with_ctes(stmt, ctx, &mut cte_registry)
+        Ok(cte_registry)
     }
 
     /// Execute a single CTE query

--- a/src/executor/cte.rs
+++ b/src/executor/cte.rs
@@ -1140,11 +1140,20 @@ impl Executor {
         // OPTIMIZATION: Get cached query classification to avoid repeated AST traversals
         let classification = get_classification(stmt);
 
+        let cte_alias = stmt
+            .table_expr
+            .as_deref()
+            .and_then(super::utils::get_table_alias_from_expr)
+            .map(|name| name.to_lowercase());
+
         // Apply WHERE clause filter
         let filtered_rows = if let Some(ref where_clause) = stmt.where_clause {
             // Process subqueries in WHERE clause (e.g., IN subqueries on CTEs)
-            // Use cached classification to avoid AST traversal
-            let processed_where = if classification.where_has_subqueries {
+            // Use cached classification to avoid AST traversal; a correlated
+            // one is evaluated per row below
+            let processed_where = if classification.where_has_subqueries
+                && !Self::has_correlated_subqueries(where_clause)
+            {
                 self.process_where_subqueries(where_clause, ctx)?
             } else {
                 (**where_clause).clone()
@@ -1154,14 +1163,7 @@ impl Executor {
             // CTE's own
             let processed_where = match ctx.outer_row() {
                 Some(outer) => {
-                    let inner: Vec<String> = stmt
-                        .table_expr
-                        .as_deref()
-                        .and_then(super::utils::get_table_alias_from_expr)
-                        .map(|name| name.to_lowercase())
-                        .into_iter()
-                        .collect();
-                    let inner: Vec<&str> = inner.iter().map(String::as_str).collect();
+                    let inner: Vec<&str> = cte_alias.iter().map(String::as_str).collect();
                     let scope = super::utils::InnerScope {
                         tables: &inner,
                         schema: None,
@@ -1175,19 +1177,29 @@ impl Executor {
                 None => processed_where,
             };
 
-            // Compile filter once and reuse for all rows
-            let mut eval =
-                ExpressionEval::compile(&processed_where, &cte_columns)?.with_context(ctx);
+            if Self::has_correlated_subqueries(&processed_where) {
+                self.filter_rows_by_correlated_where(
+                    &processed_where,
+                    cte_rows,
+                    &cte_columns,
+                    cte_alias.as_deref(),
+                    ctx,
+                )?
+            } else {
+                // Compile filter once and reuse for all rows
+                let mut eval =
+                    ExpressionEval::compile(&processed_where, &cte_columns)?.with_context(ctx);
 
-            let mut result = RowVec::new();
-            let mut row_id = 0i64;
-            for (_, row) in cte_rows {
-                if eval.eval_bool_checked(&row)? {
-                    result.push((row_id, row));
-                    row_id += 1;
+                let mut result = RowVec::new();
+                let mut row_id = 0i64;
+                for (_, row) in cte_rows {
+                    if eval.eval_bool_checked(&row)? {
+                        result.push((row_id, row));
+                        row_id += 1;
+                    }
                 }
+                result
             }
-            result
         } else {
             cte_rows
         };
@@ -1218,8 +1230,13 @@ impl Executor {
             return Ok((columns, rows, !skip_order_limit));
         }
 
-        // Process scalar subqueries in SELECT columns before projection
-        let processed_columns = self.try_process_select_subqueries(&stmt.columns, ctx)?;
+        // Process scalar subqueries in SELECT columns before projection; a
+        // correlated one is evaluated per row by the projection
+        let processed_columns = if Self::has_correlated_select_subqueries(&stmt.columns) {
+            None
+        } else {
+            self.try_process_select_subqueries(&stmt.columns, ctx)?
+        };
         let columns_to_use = processed_columns.as_ref().unwrap_or(&stmt.columns);
 
         // Determine output columns
@@ -1259,6 +1276,7 @@ impl Executor {
                         columns_to_use,
                         &filtered_rows,
                         &cte_columns,
+                        cte_alias.as_deref(),
                         ctx,
                     )?;
                     // Append source columns that aren't in output
@@ -1295,6 +1313,7 @@ impl Executor {
                     columns_to_use,
                     &filtered_rows,
                     &cte_columns,
+                    cte_alias.as_deref(),
                     ctx,
                 )?
             } else {
@@ -1314,7 +1333,13 @@ impl Executor {
                 // Sort on source columns first, then project
                 let sorted =
                     self.apply_order_by_to_rows(filtered_rows, &stmt.order_by, &cte_columns)?;
-                self.project_cte_rows_from_columns(columns_to_use, &sorted, &cte_columns, ctx)?
+                self.project_cte_rows_from_columns(
+                    columns_to_use,
+                    &sorted,
+                    &cte_columns,
+                    cte_alias.as_deref(),
+                    ctx,
+                )?
             } else {
                 self.apply_order_by_to_rows(filtered_rows, &stmt.order_by, &cte_columns)?
             }
@@ -1325,6 +1350,7 @@ impl Executor {
                     columns_to_use,
                     &filtered_rows,
                     &cte_columns,
+                    cte_alias.as_deref(),
                     ctx,
                 )?
             } else {
@@ -1461,9 +1487,22 @@ impl Executor {
         columns: &[Expression],
         rows: &RowVec,
         cte_columns: &[String],
+        table_alias: Option<&str>,
         ctx: &ExecutionContext,
     ) -> Result<RowVec> {
         use super::expression::{compile_expression, ExecuteContext, ExprVM, SharedProgram};
+
+        // A correlated subquery reads each row as its outer row
+        if Self::has_correlated_select_subqueries(columns) {
+            return self.project_rows_with_alias(
+                columns,
+                RowVec::from_vec((**rows).clone()),
+                cte_columns,
+                None,
+                ctx,
+                table_alias,
+            );
+        }
 
         let col_index_map = build_column_index_map(cte_columns);
 

--- a/src/executor/cte.rs
+++ b/src/executor/cte.rs
@@ -1950,19 +1950,8 @@ impl Executor {
             self.count_cte_references_in_expr(where_clause, &mut where_ref_counts);
         }
 
-        // A reference from the select list, HAVING, ORDER BY or another
-        // branch of a set operation reads the CTE by name as well
-        for expr in stmt
-            .columns
-            .iter()
-            .chain(stmt.having.as_deref())
-            .chain(stmt.order_by.iter().map(|o| &o.expression))
-        {
-            self.count_cte_references_in_expr(expr, &mut where_ref_counts);
-        }
-        for set_op in &stmt.set_operations {
-            self.count_cte_references_in_stmt(&set_op.right, &mut where_ref_counts);
-        }
+        // A reference from any other clause reads the CTE by name as well
+        self.count_cte_references_outside_from(stmt, &mut where_ref_counts);
 
         // Only inline CTEs that:
         // 1. Are used exactly once in table expressions (FROM/JOIN)
@@ -2077,12 +2066,27 @@ impl Executor {
             self.count_cte_references_in_expr(where_clause, ref_counts);
         }
 
-        // Check SELECT columns, HAVING and ORDER BY for subqueries
+        self.count_cte_references_outside_from(stmt, ref_counts);
+    }
+
+    /// Count CTE references in the clauses other than FROM and WHERE: the
+    /// select list, HAVING, ORDER BY, named windows and set-operation branches
+    fn count_cte_references_outside_from(
+        &self,
+        stmt: &SelectStatement,
+        ref_counts: &mut StringMap<usize>,
+    ) {
+        let windows = stmt.window_defs.iter().flat_map(|w| {
+            w.partition_by
+                .iter()
+                .chain(w.order_by.iter().map(|o| &o.expression))
+        });
         for expr in stmt
             .columns
             .iter()
             .chain(stmt.having.as_deref())
             .chain(stmt.order_by.iter().map(|o| &o.expression))
+            .chain(windows)
         {
             self.count_cte_references_in_expr(expr, ref_counts);
         }
@@ -2175,6 +2179,18 @@ impl Executor {
             }
             Expression::Aliased(aliased) => {
                 self.count_cte_references_in_expr(&aliased.expression, ref_counts);
+            }
+            Expression::Window(window) => {
+                for expr in window
+                    .function
+                    .arguments
+                    .iter()
+                    .chain(window.function.filter.as_deref())
+                    .chain(window.partition_by.iter())
+                    .chain(window.order_by.iter().map(|o| &o.expression))
+                {
+                    self.count_cte_references_in_expr(expr, ref_counts);
+                }
             }
             _ => {}
         }

--- a/src/executor/cte.rs
+++ b/src/executor/cte.rs
@@ -1149,6 +1149,31 @@ impl Executor {
             } else {
                 (**where_clause).clone()
             };
+            // A parent row's column named through its own table is bound
+            // first, or the bare name it would fall back to could be the
+            // CTE's own
+            let processed_where = match ctx.outer_row() {
+                Some(outer) => {
+                    let inner: Vec<String> = stmt
+                        .table_expr
+                        .as_deref()
+                        .and_then(super::utils::get_table_alias_from_expr)
+                        .map(|name| name.to_lowercase())
+                        .into_iter()
+                        .collect();
+                    let inner: Vec<&str> = inner.iter().map(String::as_str).collect();
+                    let scope = super::utils::InnerScope {
+                        tables: &inner,
+                        schema: None,
+                    };
+                    super::utils::substitute_outer_references_in_scope(
+                        &processed_where,
+                        outer,
+                        &scope,
+                    )
+                }
+                None => processed_where,
+            };
 
             // Compile filter once and reuse for all rows
             let mut eval =

--- a/src/executor/cte.rs
+++ b/src/executor/cte.rs
@@ -312,17 +312,19 @@ impl Executor {
     ) -> Result<(Vec<String>, RowVec)> {
         // Check if the CTE references another CTE
         if let Some(ref table_expr) = stmt.table_expr {
-            // First check for simple CTE reference
-            // BUT: if there are set operations (UNION, etc.), we need to fall through
-            // to execute_select which handles them properly
-            if stmt.set_operations.is_empty() {
+            // First check for simple CTE reference, when the CTE path can
+            // finish the statement on its own; otherwise fall through to
+            // execute_select, which handles set operations and the rest
+            if Self::cte_result_path_finishes(stmt) {
                 if let Some(cte_name) = self.extract_cte_name_for_lookup(table_expr) {
                     if let Some((columns, rows)) = cte_registry.get(&cte_name) {
                         // Execute query against CTE result
                         // Clone Arc data into RowVec for processing
+                        // A subquery in the statement reads the earlier
+                        // CTEs through the context
                         return self.execute_query_on_cte_result(
                             stmt,
-                            ctx,
+                            &ctx.with_cte_data(cte_registry.data()),
                             columns.to_vec(),
                             RowVec::from_vec((**rows).clone()),
                         );
@@ -526,14 +528,11 @@ impl Executor {
         let ctx_with_ctes = ctx.with_cte_data(cte_registry.data());
 
         // Check if the main query references a CTE
-        // NOTE: Skip the CTE fast path if there are set operations (UNION/INTERSECT/EXCEPT)
-        // because execute_query_on_cte_result doesn't handle set_operations
-        let has_set_operations = !stmt.set_operations.is_empty();
-
         if let Some(ref table_expr) = stmt.table_expr {
-            // First check for simple CTE reference (only when no set operations)
+            // First check for simple CTE reference, when the CTE path can
+            // finish the statement on its own
             // Use the base CTE name (not alias) for registry lookup
-            if !has_set_operations {
+            if Self::cte_result_path_finishes(stmt) {
                 if let Some(cte_name) = self.extract_cte_name_for_lookup(table_expr) {
                     if let Some((columns, rows)) = cte_registry.get(&cte_name) {
                         // Execute query against CTE result
@@ -1575,6 +1574,22 @@ impl Executor {
         stmt.with.is_some()
     }
 
+    /// Whether the query-on-CTE-result path can finish a statement by
+    /// itself: it sorts by column only, and leaves set operations and
+    /// DISTINCT to execute_select
+    fn cte_result_path_finishes(stmt: &SelectStatement) -> bool {
+        stmt.set_operations.is_empty()
+            && !stmt.distinct
+            && stmt.order_by.iter().all(|ob| {
+                matches!(
+                    &ob.expression,
+                    Expression::Identifier(_)
+                        | Expression::QualifiedIdentifier(_)
+                        | Expression::IntegerLiteral(_)
+                )
+            })
+    }
+
     /// Apply ORDER BY to rows
     fn apply_order_by_to_rows(
         &self,
@@ -1935,6 +1950,20 @@ impl Executor {
             self.count_cte_references_in_expr(where_clause, &mut where_ref_counts);
         }
 
+        // A reference from the select list, HAVING, ORDER BY or another
+        // branch of a set operation reads the CTE by name as well
+        for expr in stmt
+            .columns
+            .iter()
+            .chain(stmt.having.as_deref())
+            .chain(stmt.order_by.iter().map(|o| &o.expression))
+        {
+            self.count_cte_references_in_expr(expr, &mut where_ref_counts);
+        }
+        for set_op in &stmt.set_operations {
+            self.count_cte_references_in_stmt(&set_op.right, &mut where_ref_counts);
+        }
+
         // Only inline CTEs that:
         // 1. Are used exactly once in table expressions (FROM/JOIN)
         // 2. Are NOT used in WHERE clause subqueries (these need special handling)
@@ -2048,9 +2077,18 @@ impl Executor {
             self.count_cte_references_in_expr(where_clause, ref_counts);
         }
 
-        // Check SELECT columns for subqueries
-        for col in &stmt.columns {
-            self.count_cte_references_in_expr(col, ref_counts);
+        // Check SELECT columns, HAVING and ORDER BY for subqueries
+        for expr in stmt
+            .columns
+            .iter()
+            .chain(stmt.having.as_deref())
+            .chain(stmt.order_by.iter().map(|o| &o.expression))
+        {
+            self.count_cte_references_in_expr(expr, ref_counts);
+        }
+
+        for set_op in &stmt.set_operations {
+            self.count_cte_references_in_stmt(&set_op.right, ref_counts);
         }
     }
 
@@ -2087,17 +2125,53 @@ impl Executor {
             }
             Expression::In(in_expr) => {
                 self.count_cte_references_in_expr(&in_expr.left, ref_counts);
-                // Check if right side is a ScalarSubquery
-                if let Expression::ScalarSubquery(sq) = &*in_expr.right {
-                    self.count_cte_references_in_stmt(&sq.subquery, ref_counts);
-                }
+                self.count_cte_references_in_expr(&in_expr.right, ref_counts);
             }
             Expression::Exists(ex) => {
                 self.count_cte_references_in_stmt(&ex.subquery, ref_counts);
             }
+            Expression::AllAny(all_any) => {
+                self.count_cte_references_in_expr(&all_any.left, ref_counts);
+                self.count_cte_references_in_stmt(&all_any.subquery, ref_counts);
+            }
             Expression::Infix(infix) => {
                 self.count_cte_references_in_expr(&infix.left, ref_counts);
                 self.count_cte_references_in_expr(&infix.right, ref_counts);
+            }
+            Expression::Prefix(prefix) => {
+                self.count_cte_references_in_expr(&prefix.right, ref_counts);
+            }
+            Expression::Between(between) => {
+                self.count_cte_references_in_expr(&between.expr, ref_counts);
+                self.count_cte_references_in_expr(&between.lower, ref_counts);
+                self.count_cte_references_in_expr(&between.upper, ref_counts);
+            }
+            Expression::Cast(cast) => {
+                self.count_cte_references_in_expr(&cast.expr, ref_counts);
+            }
+            Expression::Like(like) => {
+                self.count_cte_references_in_expr(&like.left, ref_counts);
+                self.count_cte_references_in_expr(&like.pattern, ref_counts);
+            }
+            Expression::FunctionCall(func) => {
+                for arg in func.arguments.iter().chain(func.filter.as_deref()) {
+                    self.count_cte_references_in_expr(arg, ref_counts);
+                }
+            }
+            Expression::Case(case) => {
+                for expr in case
+                    .value
+                    .as_deref()
+                    .into_iter()
+                    .chain(
+                        case.when_clauses
+                            .iter()
+                            .flat_map(|w| [&w.condition, &w.then_result]),
+                    )
+                    .chain(case.else_value.as_deref())
+                {
+                    self.count_cte_references_in_expr(expr, ref_counts);
+                }
             }
             Expression::Aliased(aliased) => {
                 self.count_cte_references_in_expr(&aliased.expression, ref_counts);

--- a/src/executor/ddl.rs
+++ b/src/executor/ddl.rs
@@ -189,6 +189,18 @@ impl Executor {
             TableConstraint::PrimaryKey(cols) if cols.len() == 1 => Some(cols[0].value.as_str()),
             _ => None,
         });
+        // The columns of a composite PRIMARY KEY hold no NULL, or the
+        // unique index that keeps the key would let (NULL, 1) in twice
+        let composite_pk_columns: Vec<&str> = stmt
+            .table_constraints
+            .iter()
+            .filter_map(|c| match c {
+                TableConstraint::PrimaryKey(cols) if cols.len() > 1 => Some(cols),
+                _ => None,
+            })
+            .flatten()
+            .map(|c| c.value.as_str())
+            .collect();
 
         for col_def in &stmt.columns {
             let col_name = &col_def.name.value;
@@ -196,7 +208,10 @@ impl Executor {
             let nullable = !col_def
                 .constraints
                 .iter()
-                .any(|c| matches!(c, ColumnConstraint::NotNull));
+                .any(|c| matches!(c, ColumnConstraint::NotNull))
+                && !composite_pk_columns
+                    .iter()
+                    .any(|pk| pk.eq_ignore_ascii_case(col_name));
             let is_primary_key = col_def
                 .constraints
                 .iter()

--- a/src/executor/ddl.rs
+++ b/src/executor/ddl.rs
@@ -183,6 +183,13 @@ impl Executor {
         // Collect columns with UNIQUE constraints to create indexes after table creation
         let mut unique_columns: Vec<String> = Vec::new();
 
+        // PRIMARY KEY (col) at table level names the key column the way the
+        // column's own constraint would
+        let table_level_pk: Option<&str> = stmt.table_constraints.iter().find_map(|c| match c {
+            TableConstraint::PrimaryKey(cols) if cols.len() == 1 => Some(cols[0].value.as_str()),
+            _ => None,
+        });
+
         for col_def in &stmt.columns {
             let col_name = &col_def.name.value;
             let data_type = self.parse_data_type(&col_def.data_type)?;
@@ -193,7 +200,8 @@ impl Executor {
             let is_primary_key = col_def
                 .constraints
                 .iter()
-                .any(|c| matches!(c, ColumnConstraint::PrimaryKey));
+                .any(|c| matches!(c, ColumnConstraint::PrimaryKey))
+                || table_level_pk.is_some_and(|pk| pk.eq_ignore_ascii_case(col_name));
 
             // Validate PRIMARY KEY type - only INTEGER is supported
             if is_primary_key && data_type != DataType::Integer {
@@ -287,6 +295,12 @@ impl Executor {
         for constraint in &stmt.table_constraints {
             match constraint {
                 TableConstraint::Unique(cols) => {
+                    let col_names: Vec<String> = cols.iter().map(|c| c.value.to_string()).collect();
+                    table_unique_constraints.push(col_names);
+                }
+                // A composite PRIMARY KEY is kept unique the way a composite
+                // UNIQUE is; the row id stays the table's own
+                TableConstraint::PrimaryKey(cols) if cols.len() > 1 => {
                     let col_names: Vec<String> = cols.iter().map(|c| c.value.to_string()).collect();
                     table_unique_constraints.push(col_names);
                 }

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -2725,6 +2725,7 @@ impl Executor {
             let column_indices: Vec<usize> = (0..column_count).collect();
             let mut scanner = table.scan(&column_indices, where_expr.as_deref())?;
             let mut rows_to_delete: Vec<(Value, Option<Row>)> = Vec::new();
+            let mut rows_to_delete_by_row_id: Vec<(i64, Option<Row>)> = Vec::new();
 
             // Pre-compute column name mappings for correlated subqueries
             let column_names_arc = if has_correlated {
@@ -2838,16 +2839,20 @@ impl Executor {
                 };
 
                 if matches {
-                    // Row matches - get primary key value for deletion
-                    if let Some(pk_idx) = pk_col_idx {
-                        if let Some(pk_value) = row.get(pk_idx) {
-                            let row_data = if has_returning {
-                                Some(row.clone())
-                            } else {
-                                None
-                            };
-                            rows_to_delete.push((pk_value.clone(), row_data));
+                    let row_data = if has_returning {
+                        Some(row.clone())
+                    } else {
+                        None
+                    };
+                    // Row matches - get primary key value for deletion.
+                    // A table without one is named by its row id instead
+                    match pk_col_idx {
+                        Some(pk_idx) => {
+                            if let Some(pk_value) = row.get(pk_idx) {
+                                rows_to_delete.push((pk_value.clone(), row_data));
+                            }
                         }
+                        None => rows_to_delete_by_row_id.push((scanner.current_row_id(), row_data)),
                     }
                 }
             }
@@ -2879,6 +2884,19 @@ impl Executor {
                         }
                         delete_count += deleted;
                     }
+                }
+            } else if !rows_to_delete_by_row_id.is_empty() {
+                // A table without a primary key: the rows are named by the
+                // ids the scan read them under
+                let row_ids: Vec<i64> =
+                    rows_to_delete_by_row_id.iter().map(|(id, _)| *id).collect();
+                delete_count = table.delete_by_row_ids(&row_ids)?;
+                if has_returning {
+                    returning_rows.extend(
+                        rows_to_delete_by_row_id
+                            .into_iter()
+                            .filter_map(|(_, row)| row),
+                    );
                 }
             }
             delete_count

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -231,6 +231,8 @@ fn build_default_slots(
 struct CompiledUpsert {
     /// (column_index, column_type, vector_dimensions, compiled_program)
     compiled_updates: Vec<(usize, DataType, u16, super::expression::SharedProgram)>,
+    /// DO UPDATE ... WHERE, read against the row met and the EXCLUDED row
+    compiled_where: Option<super::expression::SharedProgram>,
     /// (column_index, column_name, check_expression_text, compiled_check_program)
     /// The program is executed with a single-column row containing the new value.
     compiled_checks: Vec<(usize, String, String, super::expression::SharedProgram)>,
@@ -3198,6 +3200,23 @@ impl Executor {
             }
         }
 
+        // DO UPDATE ... WHERE is compiled the same way, with EXCLUDED as the
+        // second row source
+        let compiled_where = match stmt.update_where.as_deref() {
+            Some(expr) => {
+                let compile_ctx = CompileContext::new(&column_names, global_registry())
+                    .with_second_row(&excluded_columns);
+                let program = ExprCompiler::new(&compile_ctx).compile(expr).map_err(|e| {
+                    Error::internal(format!(
+                        "failed to compile ON CONFLICT update condition: {}",
+                        e
+                    ))
+                })?;
+                Some(CompactArc::new(program))
+            }
+            None => None,
+        };
+
         // Compile CHECK constraints for columns being updated.
         // Store as SharedProgram (not ExpressionEval) so the struct can be shared
         // immutably — the VM used to execute the program lives in the setter closure.
@@ -3234,6 +3253,7 @@ impl Executor {
 
         Ok(CompiledUpsert {
             compiled_updates,
+            compiled_where,
             compiled_checks,
         })
     }
@@ -3330,6 +3350,20 @@ impl Executor {
 
         // Create a setter function that applies the ON DUPLICATE KEY UPDATE
         let mut setter = |mut row: Row| -> Result<(Row, bool)> {
+            // DO UPDATE ... WHERE leaves the row as it is where it does not hold
+            if let Some(program) = &effective.compiled_where {
+                let mut exec_ctx = ExecuteContext::for_join(&row, &excluded_row);
+                if !params.is_empty() {
+                    exec_ctx = exec_ctx.with_params(params);
+                }
+                if !named_params.is_empty() {
+                    exec_ctx = exec_ctx.with_named_params(named_params);
+                }
+                if !vm.execute_bool(program, &exec_ctx) {
+                    return Ok((row, false));
+                }
+            }
+
             // Collect all updates first to avoid borrow conflicts
             let updates_to_apply: Vec<(usize, Value)> = {
                 // Use for_join to make EXCLUDED columns available as row2

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -2873,9 +2873,20 @@ impl Executor {
                 )?;
             }
             // Without a primary key each key is read from the column it
-            // names, which is why the rows were kept
+            // names, which is why the rows were kept. The keys that can
+            // refuse the delete are asked first, all of them, so a refusal
+            // leaves the statement having written nothing
             if has_referencing_fks && !rows_to_delete_by_row_id.is_empty() {
-                for fk_entry in referencing_fks.iter() {
+                let mut ordered: Vec<&(String, crate::core::ForeignKeyConstraint)> =
+                    referencing_fks.iter().collect();
+                ordered.sort_by_key(|(_, fk)| {
+                    !matches!(
+                        fk.on_delete,
+                        crate::core::ForeignKeyAction::Restrict
+                            | crate::core::ForeignKeyAction::NoAction
+                    )
+                });
+                for fk_entry in ordered {
                     let referenced = fk_entry.1.referenced_column.to_lowercase();
                     let Some(idx) = schema_arc
                         .columns

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -2873,38 +2873,46 @@ impl Executor {
                 )?;
             }
             // Without a primary key each key is read from the column it
-            // names, which is why the rows were kept. The keys that can
-            // refuse the delete are asked first, all of them, so a refusal
-            // leaves the statement having written nothing
+            // names, which is why the rows were kept. Every key is asked
+            // whether it refuses before any key acts, so a refusal leaves
+            // the statement having written nothing
             if has_referencing_fks && !rows_to_delete_by_row_id.is_empty() {
-                let mut ordered: Vec<&(String, crate::core::ForeignKeyConstraint)> =
-                    referencing_fks.iter().collect();
-                ordered.sort_by_key(|(_, fk)| {
-                    !matches!(
-                        fk.on_delete,
-                        crate::core::ForeignKeyAction::Restrict
-                            | crate::core::ForeignKeyAction::NoAction
-                    )
-                });
-                for fk_entry in ordered {
-                    let referenced = fk_entry.1.referenced_column.to_lowercase();
-                    let Some(idx) = schema_arc
-                        .columns
+                let keyed_values: Vec<(&(String, crate::core::ForeignKeyConstraint), Vec<Value>)> =
+                    referencing_fks
                         .iter()
-                        .position(|c| c.name_lower == referenced)
-                    else {
-                        continue;
-                    };
-                    let values: Vec<Value> = rows_to_delete_by_row_id
-                        .iter()
-                        .filter_map(|(_, row)| row.as_ref().and_then(|r| r.get(idx).cloned()))
+                        .filter_map(|fk_entry| {
+                            let referenced = fk_entry.1.referenced_column.to_lowercase();
+                            let idx = schema_arc
+                                .columns
+                                .iter()
+                                .position(|c| c.name_lower == referenced)?;
+                            let values: Vec<Value> = rows_to_delete_by_row_id
+                                .iter()
+                                .filter_map(|(_, row)| {
+                                    row.as_ref().and_then(|r| r.get(idx).cloned())
+                                })
+                                .collect();
+                            Some((fk_entry, values))
+                        })
                         .collect();
-                    super::foreign_key::enforce_delete_actions_iter(
+                for (fk_entry, values) in &keyed_values {
+                    let refs: Vec<&Value> = values.iter().collect();
+                    super::foreign_key::pre_check_delete_keys(
                         &self.engine,
                         table.txn_id(),
                         table_name,
-                        values.iter(),
-                        std::slice::from_ref(fk_entry),
+                        &refs,
+                        std::slice::from_ref(*fk_entry),
+                    )?;
+                }
+                for (fk_entry, values) in &keyed_values {
+                    let refs: Vec<&Value> = values.iter().collect();
+                    super::foreign_key::apply_delete_actions(
+                        &self.engine,
+                        table.txn_id(),
+                        table_name,
+                        &refs,
+                        std::slice::from_ref(*fk_entry),
                     )?;
                 }
             }

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -1885,6 +1885,7 @@ impl Executor {
         //
         // OPTIMIZATION: For correlated EXISTS/IN in WHERE, try semi-join optimization first.
         // This transforms O(outer × inner) per-row subquery execution to O(inner + outer).
+        let mut where_is_correlated = false;
         let (where_expr, needs_memory_filter, memory_where_clause): (
             Option<Box<dyn StorageExpr>>,
             bool,
@@ -1916,8 +1917,11 @@ impl Executor {
                     .or(exists_optimized)
                     .unwrap_or_else(|| (**where_clause).clone());
 
-                // Process any remaining non-correlated subqueries
-                if Self::has_subqueries(&current_expr) {
+                // What the semi-join rewrite refused is bound to each row as it is met
+                if Self::has_correlated_subqueries(&current_expr) {
+                    where_is_correlated = true;
+                    current_expr
+                } else if Self::has_subqueries(&current_expr) {
                     self.process_where_subqueries(&current_expr, ctx)?
                 } else {
                     current_expr
@@ -1928,14 +1932,18 @@ impl Executor {
                 (**where_clause).clone()
             };
 
-            // Try to push down predicate to storage layer
-            let (storage_expr, needs_mem) =
-                pushdown::try_pushdown(&processed_where, schema, Some(ctx));
-            if needs_mem {
-                // Complex expression (like a + b > 100) - use in-memory filtering
-                (storage_expr, true, Some(processed_where))
+            if where_is_correlated {
+                (None, true, Some(processed_where))
             } else {
-                (storage_expr, false, None)
+                // Try to push down predicate to storage layer
+                let (storage_expr, needs_mem) =
+                    pushdown::try_pushdown(&processed_where, schema, Some(ctx));
+                if needs_mem {
+                    // Complex expression (like a + b > 100) - use in-memory filtering
+                    (storage_expr, true, Some(processed_where))
+                } else {
+                    (storage_expr, false, None)
+                }
             }
         } else {
             (None, false, None)
@@ -2070,17 +2078,7 @@ impl Executor {
             let mut scanner = table.scan(&all_col_indices, None)?;
             while scanner.next() {
                 let row = scanner.row();
-
-                // Check WHERE condition if needed
                 evaluator.set_row_array(row);
-                if needs_memory_filter {
-                    if let Some(ref where_clause) = memory_where_clause {
-                        match evaluator.evaluate_bool(where_clause) {
-                            Ok(true) => {}
-                            _ => continue,
-                        }
-                    }
-                }
 
                 // Get PK value for this row
                 let pk_value = row.get(pk_idx).cloned().unwrap_or(Value::null_unknown());
@@ -2100,6 +2098,22 @@ impl Executor {
                     std::mem::take(&mut outer_row_map),
                     CompactArc::clone(&column_names),
                 );
+
+                // Check WHERE condition if needed
+                if needs_memory_filter {
+                    if let Some(ref where_clause) = memory_where_clause {
+                        let held = if where_is_correlated {
+                            self.process_correlated_where(where_clause, &correlated_ctx)
+                                .and_then(|processed| evaluator.evaluate_bool(&processed))
+                        } else {
+                            evaluator.evaluate_bool(where_clause)
+                        };
+                        if !matches!(held, Ok(true)) {
+                            outer_row_map = correlated_ctx.outer_row.take().unwrap_or_default();
+                            continue;
+                        }
+                    }
+                }
 
                 // Evaluate all update expressions
                 let mut new_values: Vec<(usize, Value)> = Vec::with_capacity(update_indices.len());
@@ -2297,6 +2311,22 @@ impl Executor {
                     .ok()
                 });
             let transaction_id = ctx.transaction_id();
+            // A WHERE the semi-join rewrite refused is bound to each row as it is met
+            let col_name_pairs: Vec<(CompactArc<str>, CompactArc<str>)> = if where_is_correlated {
+                schema
+                    .column_names_lower_arc()
+                    .iter()
+                    .map(|col_lower| {
+                        let qualified =
+                            CompactArc::from(format!("{}.{}", table_name, col_lower).as_str());
+                        (CompactArc::from(col_lower.as_str()), qualified)
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            let mut outer_row_map: FxHashMap<CompactArc<str>, Value> =
+                FxHashMap::with_capacity_and_hasher(col_name_pairs.len() * 2, Default::default());
             let mut setter = |mut row: Row| -> Result<(Row, bool)> {
                 // Execute pre-compiled programs (no recompilation per row)
                 let updates_to_apply: Vec<(usize, Value)> = {
@@ -2313,9 +2343,29 @@ impl Executor {
                             }
                         } else if let Some(ref where_expr) = memory_where_clause {
                             evaluator.set_row_array(&row);
-                            match evaluator.evaluate_bool(where_expr) {
-                                Ok(true) => {}
-                                _ => return Ok((row, false)),
+                            let held = if where_is_correlated {
+                                outer_row_map.clear();
+                                for (i, (col_lower, qualified)) in col_name_pairs.iter().enumerate()
+                                {
+                                    if let Some(value) = row.get(i) {
+                                        outer_row_map.insert(col_lower.clone(), value.clone());
+                                        outer_row_map.insert(qualified.clone(), value.clone());
+                                    }
+                                }
+                                let mut correlated_ctx = ctx.with_outer_row(
+                                    std::mem::take(&mut outer_row_map),
+                                    CompactArc::clone(&column_names),
+                                );
+                                let held = self
+                                    .process_correlated_where(where_expr, &correlated_ctx)
+                                    .and_then(|processed| evaluator.evaluate_bool(&processed));
+                                outer_row_map = correlated_ctx.outer_row.take().unwrap_or_default();
+                                held
+                            } else {
+                                evaluator.evaluate_bool(where_expr)
+                            };
+                            if !matches!(held, Ok(true)) {
+                                return Ok((row, false));
                             }
                         }
                     }

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -2839,7 +2839,10 @@ impl Executor {
                 };
 
                 if matches {
-                    let row_data = if has_returning {
+                    // Without a primary key the row itself is what the
+                    // foreign keys are read from, so it is kept for them too
+                    let row_data = if has_returning || (has_referencing_fks && pk_col_idx.is_none())
+                    {
                         Some(row.clone())
                     } else {
                         None
@@ -2868,6 +2871,31 @@ impl Executor {
                     rows_to_delete.iter().map(|(pk, _)| pk),
                     &referencing_fks,
                 )?;
+            }
+            // Without a primary key each key is read from the column it
+            // names, which is why the rows were kept
+            if has_referencing_fks && !rows_to_delete_by_row_id.is_empty() {
+                for fk_entry in referencing_fks.iter() {
+                    let referenced = fk_entry.1.referenced_column.to_lowercase();
+                    let Some(idx) = schema_arc
+                        .columns
+                        .iter()
+                        .position(|c| c.name_lower == referenced)
+                    else {
+                        continue;
+                    };
+                    let values: Vec<Value> = rows_to_delete_by_row_id
+                        .iter()
+                        .filter_map(|(_, row)| row.as_ref().and_then(|r| r.get(idx).cloned()))
+                        .collect();
+                    super::foreign_key::enforce_delete_actions_iter(
+                        &self.engine,
+                        table.txn_id(),
+                        table_name,
+                        values.iter(),
+                        std::slice::from_ref(fk_entry),
+                    )?;
+                }
             }
 
             // Delete matching rows by primary key

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -775,12 +775,13 @@ impl Executor {
                                 ctx,
                                 has_returning,
                             ) {
-                                Ok(Some(updated_row)) => {
-                                    returning_rows.push(updated_row);
-                                    rows_affected += 1;
-                                }
-                                Ok(None) => {
-                                    rows_affected += 1;
+                                Ok((updated, returned)) => {
+                                    if let Some(updated_row) = returned {
+                                        returning_rows.push(updated_row);
+                                    }
+                                    if updated {
+                                        rows_affected += 1;
+                                    }
                                 }
                                 Err(e) => return Err(e),
                             }
@@ -824,12 +825,13 @@ impl Executor {
                                         ctx,
                                         has_returning,
                                     ) {
-                                        Ok(Some(updated_row)) => {
-                                            returning_rows.push(updated_row);
-                                            rows_affected += 1;
-                                        }
-                                        Ok(None) => {
-                                            rows_affected += 1;
+                                        Ok((updated, returned)) => {
+                                            if let Some(updated_row) = returned {
+                                                returning_rows.push(updated_row);
+                                            }
+                                            if updated {
+                                                rows_affected += 1;
+                                            }
                                         }
                                         Err(e) => return Err(e),
                                     }
@@ -1054,12 +1056,13 @@ impl Executor {
                                 ctx,
                                 has_returning,
                             ) {
-                                Ok(Some(updated_row)) => {
-                                    returning_rows.push(updated_row);
-                                    rows_affected += 1;
-                                }
-                                Ok(None) => {
-                                    rows_affected += 1;
+                                Ok((updated, returned)) => {
+                                    if let Some(updated_row) = returned {
+                                        returning_rows.push(updated_row);
+                                    }
+                                    if updated {
+                                        rows_affected += 1;
+                                    }
                                 }
                                 Err(e) => return Err(e),
                             }
@@ -1104,12 +1107,13 @@ impl Executor {
                                         ctx,
                                         has_returning,
                                     ) {
-                                        Ok(Some(updated_row)) => {
-                                            returning_rows.push(updated_row);
-                                            rows_affected += 1;
-                                        }
-                                        Ok(None) => {
-                                            rows_affected += 1;
+                                        Ok((updated, returned)) => {
+                                            if let Some(updated_row) = returned {
+                                                returning_rows.push(updated_row);
+                                            }
+                                            if updated {
+                                                rows_affected += 1;
+                                            }
                                         }
                                         Err(e) => return Err(e),
                                     }
@@ -3323,7 +3327,7 @@ impl Executor {
         compiled: Option<&CompiledUpsert>,
         ctx: &ExecutionContext,
         capture_row: bool,
-    ) -> Result<Option<Row>> {
+    ) -> Result<(bool, Option<Row>)> {
         // Build a WHERE clause to find the specific row
         // Use schema's cached pk_column_index for O(1) lookup
         let pk_col = schema
@@ -3490,13 +3494,14 @@ impl Executor {
         // Prefer direct row_id lookup when we have a concrete conflicting row_id.
         // This avoids a second scan on non-PK upserts after conflict resolution.
         // row_id < 0 means "unknown" (sentinel from UniqueConstraint error).
-        if row_id >= 0 {
-            table.update_by_row_ids(&[row_id], &mut setter)?;
+        // A row DO UPDATE ... WHERE left alone is not an updated row
+        let updated = if row_id >= 0 {
+            table.update_by_row_ids(&[row_id], &mut setter)?
         } else {
-            table.update(where_expr.as_deref(), &mut setter)?;
-        }
+            table.update(where_expr.as_deref(), &mut setter)?
+        };
 
-        Ok(captured_row)
+        Ok((updated > 0, captured_row))
     }
 
     /// Find a row by unique index value (supports single and composite unique constraints).

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -1696,6 +1696,16 @@ impl Executor {
         stmt: &UpdateStatement,
         ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        // A WITH clause is run first, so the subqueries can read it
+        let ctx_with_ctes;
+        let ctx = match &stmt.with {
+            Some(with_clause) => {
+                let registry = self.materialize_ctes(with_clause, ctx, None)?;
+                ctx_with_ctes = ctx.with_cte_data(registry.data());
+                &ctx_with_ctes
+            }
+            None => ctx,
+        };
         // OPTIMIZATION: Use pre-computed lowercase name to avoid allocation per query
         let table_name = &stmt.table_name.value_lower;
 
@@ -2642,6 +2652,16 @@ impl Executor {
         stmt: &DeleteStatement,
         ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        // A WITH clause is run first, so the subqueries can read it
+        let ctx_with_ctes;
+        let ctx = match &stmt.with {
+            Some(with_clause) => {
+                let registry = self.materialize_ctes(with_clause, ctx, None)?;
+                ctx_with_ctes = ctx.with_cte_data(registry.data());
+                &ctx_with_ctes
+            }
+            None => ctx,
+        };
         // OPTIMIZATION: Use pre-computed lowercase name to avoid allocation per query
         let table_name = &stmt.table_name.value_lower;
         // Use alias if provided, otherwise use table name

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -1699,11 +1699,12 @@ impl Executor {
             .iter()
             .find(|c| c.name.eq_ignore_ascii_case(name))
             .ok_or_else(|| Error::ColumnNotFound(name.to_string()))?;
-        if let Some(value) = &column.default_value {
-            return Ok(super::utils::value_to_expression(value));
-        }
-        match &column.default_expr {
-            Some(text) => {
+        // The expression comes first: a value kept beside it was computed
+        // once, when the column was added, and a RANDOM() default must be
+        // drawn again for every row
+        match (&column.default_expr, &column.default_value) {
+            (None, Some(value)) => Ok(super::utils::value_to_expression(value)),
+            (Some(text), _) => {
                 let statements = crate::parser::parse_sql(&format!("SELECT {}", text))
                     .map_err(|e| Error::parse(e.to_string()))?;
                 match statements.into_iter().next() {
@@ -1717,7 +1718,7 @@ impl Executor {
                     ))),
                 }
             }
-            None => Ok(super::utils::value_to_expression(&Value::null_unknown())),
+            (None, None) => Ok(super::utils::value_to_expression(&Value::null_unknown())),
         }
     }
 

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -3486,7 +3486,7 @@ impl Executor {
                 if !named_params.is_empty() {
                     exec_ctx = exec_ctx.with_named_params(named_params);
                 }
-                if !vm.execute_bool(program, &exec_ctx) {
+                if !vm.execute_bool_checked(program, &exec_ctx)? {
                     return Ok((row, false));
                 }
             }

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -1691,6 +1691,36 @@ impl Executor {
     }
 
     /// Execute an UPDATE statement
+    /// The expression a column's DEFAULT stands for in an UPDATE: its
+    /// default value, else its default expression, else NULL
+    fn column_default_expression(schema: &crate::core::Schema, name: &str) -> Result<Expression> {
+        let column = schema
+            .columns
+            .iter()
+            .find(|c| c.name.eq_ignore_ascii_case(name))
+            .ok_or_else(|| Error::ColumnNotFound(name.to_string()))?;
+        if let Some(value) = &column.default_value {
+            return Ok(super::utils::value_to_expression(value));
+        }
+        match &column.default_expr {
+            Some(text) => {
+                let statements = crate::parser::parse_sql(&format!("SELECT {}", text))
+                    .map_err(|e| Error::parse(e.to_string()))?;
+                match statements.into_iter().next() {
+                    Some(Statement::Select(select)) => select
+                        .columns
+                        .into_iter()
+                        .next()
+                        .ok_or_else(|| Error::parse(format!("the default of {name} is empty"))),
+                    _ => Err(Error::parse(format!(
+                        "the default of {name} is not an expression"
+                    ))),
+                }
+            }
+            None => Ok(super::utils::value_to_expression(&Value::null_unknown())),
+        }
+    }
+
     pub(crate) fn execute_update(
         &self,
         stmt: &UpdateStatement,
@@ -1742,6 +1772,29 @@ impl Executor {
 
         // Pre-compute column names and indices to avoid schema borrow conflicts
         let schema = table.schema();
+
+        // SET col = DEFAULT reads the column's default
+        let defaulted_stmt;
+        let stmt = if stmt
+            .updates
+            .values()
+            .any(|e| matches!(e, Expression::Default(_)))
+        {
+            let mut updates = stmt.updates.clone();
+            for (name, expr) in updates.iter_mut() {
+                if matches!(expr, Expression::Default(_)) {
+                    *expr = Self::column_default_expression(schema, name.as_str())?;
+                }
+            }
+            defaulted_stmt = UpdateStatement {
+                updates,
+                ..stmt.clone()
+            };
+            &defaulted_stmt
+        } else {
+            stmt
+        };
+
         // OPTIMIZATION: Use CompactArc<Vec<String>> to share column names without cloning
         let column_names = schema.column_names_arc();
 

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -2009,13 +2009,49 @@ impl Executor {
                 .any(|fks| super::foreign_key::fk_tree_needs_precheck(&self.engine, fks));
             if any_needs_precheck {
                 let parent_rows = table.collect_all_rows(where_expr.as_deref())?;
+                // A WHERE the semi-join rewrite refused is bound to each
+                // row here as it is in the update itself, or the check
+                // would look at rows the update does not touch
+                let bound_pairs: Vec<(CompactArc<str>, CompactArc<str>)> = if where_is_correlated {
+                    schema
+                        .column_names_lower_arc()
+                        .iter()
+                        .map(|col_lower| {
+                            let qualified =
+                                CompactArc::from(format!("{}.{}", table_name, col_lower).as_str());
+                            (CompactArc::from(col_lower.as_str()), qualified)
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                };
                 for (_rid, row) in parent_rows.iter() {
                     if needs_memory_filter {
                         if let Some(ref mem_where) = memory_where_clause {
                             evaluator.set_row_array(row);
-                            match evaluator.evaluate_bool(mem_where) {
-                                Ok(true) => {}
-                                _ => continue,
+                            let held = if where_is_correlated {
+                                let mut outer_row_map: FxHashMap<CompactArc<str>, Value> =
+                                    FxHashMap::with_capacity_and_hasher(
+                                        bound_pairs.len() * 2,
+                                        Default::default(),
+                                    );
+                                for (i, (col_lower, qualified)) in bound_pairs.iter().enumerate() {
+                                    if let Some(value) = row.get(i) {
+                                        outer_row_map.insert(col_lower.clone(), value.clone());
+                                        outer_row_map.insert(qualified.clone(), value.clone());
+                                    }
+                                }
+                                let correlated_ctx = ctx.with_outer_row(
+                                    outer_row_map,
+                                    CompactArc::clone(&column_names),
+                                );
+                                self.process_correlated_where(mem_where, &correlated_ctx)
+                                    .and_then(|processed| evaluator.evaluate_bool(&processed))
+                            } else {
+                                evaluator.evaluate_bool(mem_where)
+                            };
+                            if !matches!(held, Ok(true)) {
+                                continue;
                             }
                         }
                     }

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -454,6 +454,17 @@ impl Executor {
         // Check if there's an active explicit transaction
         let mut active_tx = self.active_transaction.lock().unwrap();
 
+        // INSERT is dispatched before the dispatcher puts the transaction
+        // id in the context, so the expressions are given it here
+        let ctx_with_txn;
+        let ctx = match (*active_tx).as_ref().map(|t| t.transaction.id()) {
+            Some(txn_id) => {
+                ctx_with_txn = ctx.with_transaction_id(txn_id as u64);
+                &ctx_with_txn
+            }
+            None => ctx,
+        };
+
         let (mut table, should_auto_commit, standalone_tx) =
             if let Some(ref mut tx_state) = *active_tx {
                 // Use the active transaction
@@ -3380,6 +3391,7 @@ impl Executor {
         // Extract params from execution context for use in the setter closure
         let params = ctx.params();
         let named_params = ctx.named_params();
+        let transaction_id = ctx.transaction_id();
 
         // Capture the post-update row for RETURNING clause
         let mut captured_row: Option<Row> = None;
@@ -3388,7 +3400,8 @@ impl Executor {
         let mut setter = |mut row: Row| -> Result<(Row, bool)> {
             // DO UPDATE ... WHERE leaves the row as it is where it does not hold
             if let Some(program) = &effective.compiled_where {
-                let mut exec_ctx = ExecuteContext::for_join(&row, &excluded_row);
+                let mut exec_ctx = ExecuteContext::for_join(&row, &excluded_row)
+                    .with_transaction_id(transaction_id);
                 if !params.is_empty() {
                     exec_ctx = exec_ctx.with_params(params);
                 }
@@ -3403,7 +3416,8 @@ impl Executor {
             // Collect all updates first to avoid borrow conflicts
             let updates_to_apply: Vec<(usize, Value)> = {
                 // Use for_join to make EXCLUDED columns available as row2
-                let mut exec_ctx = ExecuteContext::for_join(&row, &excluded_row);
+                let mut exec_ctx = ExecuteContext::for_join(&row, &excluded_row)
+                    .with_transaction_id(transaction_id);
                 if !params.is_empty() {
                     exec_ctx = exec_ctx.with_params(params);
                 }

--- a/src/executor/expression/compiler.rs
+++ b/src/executor/expression/compiler.rs
@@ -1334,19 +1334,18 @@ impl<'a> ExprCompiler<'a> {
 
         while let Some(c) = chars.next() {
             if c == escape {
-                // Next character should be treated literally
-                if let Some(&next) = chars.peek() {
-                    if next == '%' || next == '_' || next == escape {
-                        // Escape the wildcard - use regex escape sequence
-                        result.push('\\');
-                        result.push(chars.next().unwrap());
-                    } else {
-                        // Not escaping a special character, keep the escape char
-                        result.push(c);
+                // Whatever follows stands for itself. A wildcard and the
+                // backslash the pattern reads as its own marker keep that
+                // marker in front of them; anything else is already itself
+                match chars.next() {
+                    Some(next) => {
+                        if next == '%' || next == '_' || next == '\\' {
+                            result.push('\\');
+                        }
+                        result.push(next);
                     }
-                } else {
-                    // Escape at end of pattern
-                    result.push(c);
+                    // Nothing follows, so the escape stands for itself
+                    None => result.push(c),
                 }
             } else {
                 result.push(c);

--- a/src/executor/expression/compiler.rs
+++ b/src/executor/expression/compiler.rs
@@ -1374,8 +1374,8 @@ impl<'a> ExprCompiler<'a> {
 
         for when_clause in &case.when_clauses {
             if is_simple {
-                // Simple CASE: compare operand with WHEN value
-                builder.emit(Op::Dup); // Keep operand on stack
+                // Simple CASE: compare the operand, which CaseCompare reads
+                // without taking, so it is there for the branch after this
                 self.compile_expr(&when_clause.condition, builder)?;
                 builder.emit(Op::CaseCompare);
             } else {
@@ -1389,7 +1389,7 @@ impl<'a> ExprCompiler<'a> {
 
             // Compile THEN result
             if is_simple {
-                builder.emit(Op::Pop); // Remove operand copy
+                builder.emit(Op::Pop); // The operand has served its purpose
             }
             self.compile_expr(&when_clause.then_result, builder)?;
 

--- a/src/executor/expression/compiler.rs
+++ b/src/executor/expression/compiler.rs
@@ -1175,7 +1175,13 @@ impl<'a> ExprCompiler<'a> {
                 for item in &items {
                     self.compile_expr(item, builder)?;
                 }
-                builder.emit(Op::InList(items.len() as u16));
+                let count = u32::try_from(items.len()).map_err(|_| {
+                    CompileError::UnsupportedExpression(format!(
+                        "IN list holds {} items, more than an expression can hold",
+                        items.len()
+                    ))
+                })?;
+                builder.emit(Op::InList(count));
                 if in_expr.not {
                     builder.emit(Op::Not);
                 }

--- a/src/executor/expression/compiler.rs
+++ b/src/executor/expression/compiler.rs
@@ -1154,11 +1154,56 @@ impl<'a> ExprCompiler<'a> {
                 }
             }
         } else {
-            // Fallback: evaluate each item (less efficient)
-            // For now, return error - would need runtime set building
-            return Err(CompileError::UnsupportedExpression(
-                "Dynamic IN list not yet supported in VM".to_string(),
-            ));
+            // An item that is not a constant is compared in turn:
+            // left = item OR left = item ..., with IN's NULL rule falling
+            // out of OR's
+            let items: Vec<&Expression> = match &*in_expr.right {
+                Expression::List(list) => list.elements.iter().collect(),
+                Expression::ExpressionList(list) => list.expressions.iter().collect(),
+                _ => {
+                    return Err(CompileError::UnsupportedExpression(
+                        "IN over something that is not a list".to_string(),
+                    ))
+                }
+            };
+            let operator = |op: &str| {
+                crate::parser::token::Token::new(
+                    crate::parser::token::TokenType::Operator,
+                    op,
+                    crate::parser::token::Position::default(),
+                )
+            };
+            let mut chain: Option<Expression> = None;
+            for item in items {
+                let equal = Expression::Infix(InfixExpression::new(
+                    operator("="),
+                    Box::new((*in_expr.left).clone()),
+                    "=",
+                    Box::new(item.clone()),
+                ));
+                chain = Some(match chain {
+                    None => equal,
+                    Some(previous) => Expression::Infix(InfixExpression::new(
+                        crate::parser::token::Token::new(
+                            crate::parser::token::TokenType::Keyword,
+                            "OR",
+                            crate::parser::token::Position::default(),
+                        ),
+                        Box::new(previous),
+                        "OR",
+                        Box::new(equal),
+                    )),
+                });
+            }
+            match chain {
+                Some(chain) => {
+                    self.compile_expr(&chain, builder)?;
+                    if in_expr.not {
+                        builder.emit(Op::Not);
+                    }
+                }
+                None => builder.emit(Op::LoadConst(Value::Boolean(in_expr.not))),
+            }
         }
 
         Ok(())

--- a/src/executor/expression/compiler.rs
+++ b/src/executor/expression/compiler.rs
@@ -1166,43 +1166,19 @@ impl<'a> ExprCompiler<'a> {
                     ))
                 }
             };
-            let operator = |op: &str| {
-                crate::parser::token::Token::new(
-                    crate::parser::token::TokenType::Operator,
-                    op,
-                    crate::parser::token::Position::default(),
-                )
-            };
-            let mut chain: Option<Expression> = None;
-            for item in items {
-                let equal = Expression::Infix(InfixExpression::new(
-                    operator("="),
-                    Box::new((*in_expr.left).clone()),
-                    "=",
-                    Box::new(item.clone()),
-                ));
-                chain = Some(match chain {
-                    None => equal,
-                    Some(previous) => Expression::Infix(InfixExpression::new(
-                        crate::parser::token::Token::new(
-                            crate::parser::token::TokenType::Keyword,
-                            "OR",
-                            crate::parser::token::Position::default(),
-                        ),
-                        Box::new(previous),
-                        "OR",
-                        Box::new(equal),
-                    )),
-                });
-            }
-            match chain {
-                Some(chain) => {
-                    self.compile_expr(&chain, builder)?;
-                    if in_expr.not {
-                        builder.emit(Op::Not);
-                    }
+            // The value is evaluated once and judged against every item,
+            // so a volatile left side rolls a single time
+            if items.is_empty() {
+                builder.emit(Op::LoadConst(Value::Boolean(in_expr.not)));
+            } else {
+                self.compile_expr(&in_expr.left, builder)?;
+                for item in &items {
+                    self.compile_expr(item, builder)?;
                 }
-                None => builder.emit(Op::LoadConst(Value::Boolean(in_expr.not))),
+                builder.emit(Op::InList(items.len() as u16));
+                if in_expr.not {
+                    builder.emit(Op::Not);
+                }
             }
         }
 

--- a/src/executor/expression/evaluator_bridge.rs
+++ b/src/executor/expression/evaluator_bridge.rs
@@ -812,6 +812,8 @@ pub struct JoinFilter {
     params: CompactArc<ParamVec>,
     /// Named parameters (shared Arc to avoid cloning)
     named_params: Arc<FxHashMap<String, Value>>,
+    /// Transaction ID for CURRENT_TRANSACTION_ID()
+    transaction_id: Option<u64>,
 }
 
 impl JoinFilter {
@@ -837,15 +839,18 @@ impl JoinFilter {
             program: CompactArc::new(program),
             params: EMPTY_PARAMS.clone(),
             named_params: EMPTY_NAMED_PARAMS.clone(),
+            transaction_id: None,
         })
     }
 
-    /// Set parameters from execution context.
-    /// This is required when the join condition contains parameter placeholders ($1, $2, etc.).
+    /// Set parameters and the transaction from the execution context.
+    /// Required when the join condition holds parameter placeholders
+    /// ($1, $2, ...) or reads CURRENT_TRANSACTION_ID().
     #[inline]
     pub fn with_context(mut self, ctx: &ExecutionContext) -> Self {
         self.params = CompactArc::clone(ctx.params_arc());
         self.named_params = Arc::clone(ctx.named_params_arc());
+        self.transaction_id = ctx.transaction_id();
         self
     }
 
@@ -866,6 +871,7 @@ impl JoinFilter {
             if !self.named_params.is_empty() {
                 ctx = ctx.with_named_params(&self.named_params);
             }
+            ctx = ctx.with_transaction_id(self.transaction_id);
 
             // Use try_borrow_mut to avoid panic on recursive calls (e.g., nested subqueries).
             // If the VM is already borrowed, create a temporary one for this call.
@@ -1821,8 +1827,16 @@ impl<'a> CompiledEvaluator<'a> {
                 // order, so each of the two independent keys sees the members
                 // themselves. Folding them into one 64-bit value first would
                 // hand both keys the same collision.
-                let mut members: Vec<&Value> = in_hash.values.iter().collect();
-                members.sort_unstable();
+                // Sorted through Ord, which puts a NULL first and is total.
+                // The plain sort clippy asks for reads PartialOrd, whose
+                // NULL is neither below nor above anything, and the sort
+                // trips on the broken order once the set is large enough
+                #[allow(clippy::unnecessary_sort_by)]
+                let members = {
+                    let mut members: Vec<&Value> = in_hash.values.iter().collect();
+                    members.sort_unstable_by(|a, b| a.cmp(b));
+                    members
+                };
                 for value in members {
                     value.hash(hasher);
                 }

--- a/src/executor/expression/ops.rs
+++ b/src/executor/expression/ops.rs
@@ -617,7 +617,7 @@ pub enum Op {
 
     /// IN over items evaluated at run time; the value is judged once
     /// Stack: [value, item_1, ..., item_n] -> [bool]
-    InList(u16), // item count
+    InList(u32), // item count
 
     /// BETWEEN check: value BETWEEN low AND high
     /// Stack: [value, low, high] -> [bool]

--- a/src/executor/expression/ops.rs
+++ b/src/executor/expression/ops.rs
@@ -615,6 +615,10 @@ pub enum Op {
     /// Stack: [value] -> [bool]
     NotInSet(CompactArc<ValueSet>, bool), // set, has_null
 
+    /// IN over items evaluated at run time; the value is judged once
+    /// Stack: [value, item_1, ..., item_n] -> [bool]
+    InList(u16), // item count
+
     /// BETWEEN check: value BETWEEN low AND high
     /// Stack: [value, low, high] -> [bool]
     Between,
@@ -943,6 +947,7 @@ impl std::fmt::Debug for Op {
             Op::NotInSet(set, has_null) => {
                 write!(f, "NotInSet(len={}, has_null={})", set.len(), has_null)
             }
+            Op::InList(count) => write!(f, "InList({})", count),
             Op::Between => write!(f, "Between"),
             Op::NotBetween => write!(f, "NotBetween"),
             Op::InTupleSet {

--- a/src/executor/expression/program.rs
+++ b/src/executor/expression/program.rs
@@ -270,7 +270,7 @@ impl Program {
                 // Pop 3, push 1 (-2)
                 Op::Between | Op::NotBetween => -2,
                 // Pop the value and its items, push 1
-                Op::InList(count) => -(*count as i32),
+                Op::InList(count) => -i32::try_from(*count).unwrap_or(i32::MAX),
 
                 // Dynamic pattern ops: Pop 2, push 1 (-1)
                 Op::LikeDynamic(_)

--- a/src/executor/expression/program.rs
+++ b/src/executor/expression/program.rs
@@ -269,6 +269,8 @@ impl Program {
 
                 // Pop 3, push 1 (-2)
                 Op::Between | Op::NotBetween => -2,
+                // Pop the value and its items, push 1
+                Op::InList(count) => -(*count as i32),
 
                 // Dynamic pattern ops: Pop 2, push 1 (-1)
                 Op::LikeDynamic(_)

--- a/src/executor/expression/vm.rs
+++ b/src/executor/expression/vm.rs
@@ -2714,13 +2714,18 @@ impl ExprVM {
         // Pattern: [GtColumnConst(idx, val), Return]
         if ops.len() == 2 {
             if let Op::Return = &ops[1] {
-                return Self::eval_single_op_bool(&ops[0], ctx);
+                if Self::is_single_op_predicate(&ops[0]) {
+                    return Self::eval_single_op_bool(&ops[0], ctx);
+                }
             }
         }
 
         // Fast path: Two comparisons with AND (range filter)
         // Pattern: [Compare1, And(_), Compare2, AndFinalize, Return]
-        if ops.len() == 5 {
+        if ops.len() == 5
+            && Self::is_single_op_predicate(&ops[0])
+            && Self::is_single_op_predicate(&ops[2])
+        {
             if let (Op::And(_), Op::AndFinalize, Op::Return) = (&ops[1], &ops[3], &ops[4]) {
                 let a = Self::eval_single_op_tribool(&ops[0], ctx);
                 // Short-circuit: if first is false, result is false
@@ -2768,12 +2773,17 @@ impl ExprVM {
         // Fast path: Single comparison + Return (most common filter)
         if ops.len() == 2 {
             if let Op::Return = &ops[1] {
-                return Ok(Self::eval_single_op_bool(&ops[0], ctx));
+                if Self::is_single_op_predicate(&ops[0]) {
+                    return Ok(Self::eval_single_op_bool(&ops[0], ctx));
+                }
             }
         }
 
         // Fast path: Two comparisons with AND/OR
-        if ops.len() == 5 {
+        if ops.len() == 5
+            && Self::is_single_op_predicate(&ops[0])
+            && Self::is_single_op_predicate(&ops[2])
+        {
             if let (Op::And(_), Op::AndFinalize, Op::Return) = (&ops[1], &ops[3], &ops[4]) {
                 let a = Self::eval_single_op_tribool(&ops[0], ctx);
                 if a == Some(false) {
@@ -2800,6 +2810,30 @@ impl ExprVM {
             Ok(_) => Ok(false),
             Err(e) => Err(e),
         }
+    }
+
+    /// The ops the two single-op paths below answer for themselves. They
+    /// report a NULL as false, which is what a filter wants, so an op they
+    /// do not know has to go to the full VM rather than be read the same
+    /// way: a bare column load is a value to be read as a condition, not a
+    /// comparison that came out unknown.
+    #[inline]
+    fn is_single_op_predicate(op: &Op) -> bool {
+        matches!(
+            op,
+            Op::GtColumnConst(..)
+                | Op::LtColumnConst(..)
+                | Op::GeColumnConst(..)
+                | Op::LeColumnConst(..)
+                | Op::EqColumnConst(..)
+                | Op::NeColumnConst(..)
+                | Op::IsNullColumn(..)
+                | Op::IsNotNullColumn(..)
+                | Op::BetweenColumnConst(..)
+                | Op::InSetColumn(..)
+                | Op::LikeColumn(..)
+                | Op::LoadConst(..)
+        )
     }
 
     /// Evaluate a single comparison op and return bool (for fast path)

--- a/src/executor/expression/vm.rs
+++ b/src/executor/expression/vm.rs
@@ -431,13 +431,7 @@ impl ExprVM {
                         (Value::Float(x), Value::Integer(y)) => {
                             Value::Boolean(crate::core::value::i64_ge_f64(*y, *x))
                         }
-                        _ => match a.partial_cmp(&b) {
-                            Some(std::cmp::Ordering::Less) | Some(std::cmp::Ordering::Equal) => {
-                                Value::Boolean(true)
-                            }
-                            Some(std::cmp::Ordering::Greater) => Value::Boolean(false),
-                            None => Value::Null(DataType::Boolean),
-                        },
+                        _ => self.compare_values_or_equal(&a, &b, std::cmp::Ordering::Less),
                     };
                     self.stack.push(result);
                     pc += 1;
@@ -475,13 +469,7 @@ impl ExprVM {
                         (Value::Float(x), Value::Integer(y)) => {
                             Value::Boolean(crate::core::value::i64_le_f64(*y, *x))
                         }
-                        _ => match a.partial_cmp(&b) {
-                            Some(std::cmp::Ordering::Greater) | Some(std::cmp::Ordering::Equal) => {
-                                Value::Boolean(true)
-                            }
-                            Some(std::cmp::Ordering::Less) => Value::Boolean(false),
-                            None => Value::Null(DataType::Boolean),
-                        },
+                        _ => self.compare_values_or_equal(&a, &b, std::cmp::Ordering::Greater),
                     };
                     self.stack.push(result);
                     pc += 1;
@@ -605,13 +593,7 @@ impl ExprVM {
                     let result = match val {
                         Value::Integer(threshold) => Self::le_int(col_val, *threshold),
                         Value::Float(threshold) => Self::le_float(col_val, *threshold),
-                        _ => match col_val.partial_cmp(val) {
-                            Some(std::cmp::Ordering::Less) | Some(std::cmp::Ordering::Equal) => {
-                                Value::Boolean(true)
-                            }
-                            Some(std::cmp::Ordering::Greater) => Value::Boolean(false),
-                            None => Value::Null(DataType::Boolean),
-                        },
+                        _ => self.compare_values_or_equal(col_val, val, std::cmp::Ordering::Less),
                     };
                     self.stack.push(result);
                     pc += 1;
@@ -641,13 +623,9 @@ impl ExprVM {
                     let result = match val {
                         Value::Integer(threshold) => Self::ge_int(col_val, *threshold),
                         Value::Float(threshold) => Self::ge_float(col_val, *threshold),
-                        _ => match col_val.partial_cmp(val) {
-                            Some(std::cmp::Ordering::Greater) | Some(std::cmp::Ordering::Equal) => {
-                                Value::Boolean(true)
-                            }
-                            Some(std::cmp::Ordering::Less) => Value::Boolean(false),
-                            None => Value::Null(DataType::Boolean),
-                        },
+                        _ => {
+                            self.compare_values_or_equal(col_val, val, std::cmp::Ordering::Greater)
+                        }
                     };
                     self.stack.push(result);
                     pc += 1;
@@ -2183,13 +2161,7 @@ impl ExprVM {
                         (Value::Float(x), Value::Integer(y)) => {
                             Value::Boolean(crate::core::value::i64_ge_f64(*y, *x))
                         }
-                        _ => match (*a).partial_cmp(&*b) {
-                            Some(std::cmp::Ordering::Less) | Some(std::cmp::Ordering::Equal) => {
-                                Value::Boolean(true)
-                            }
-                            Some(std::cmp::Ordering::Greater) => Value::Boolean(false),
-                            None => Value::Null(DataType::Boolean),
-                        },
+                        _ => self.compare_values_or_equal(&a, &b, std::cmp::Ordering::Less),
                     };
                     stack.push(Cow::Owned(result));
                     pc += 1;
@@ -2225,13 +2197,7 @@ impl ExprVM {
                         (Value::Float(x), Value::Integer(y)) => {
                             Value::Boolean(crate::core::value::i64_le_f64(*y, *x))
                         }
-                        _ => match (*a).partial_cmp(&*b) {
-                            Some(std::cmp::Ordering::Greater) | Some(std::cmp::Ordering::Equal) => {
-                                Value::Boolean(true)
-                            }
-                            Some(std::cmp::Ordering::Less) => Value::Boolean(false),
-                            None => Value::Null(DataType::Boolean),
-                        },
+                        _ => self.compare_values_or_equal(&a, &b, std::cmp::Ordering::Greater),
                     };
                     stack.push(Cow::Owned(result));
                     pc += 1;
@@ -3237,8 +3203,28 @@ impl ExprVM {
 
     #[inline]
     fn compare_values(&self, a: &Value, b: &Value, expected: std::cmp::Ordering) -> Value {
+        // Two NULLs order equal so an index can hold them; asked whether one
+        // is below or above the other, SQL answers that it does not know
+        if a.is_null() || b.is_null() {
+            return Value::Null(DataType::Boolean);
+        }
         match a.partial_cmp(b) {
             Some(ord) if ord == expected => Value::Boolean(true),
+            Some(_) => Value::Boolean(false),
+            None => Value::Null(DataType::Boolean),
+        }
+    }
+
+    /// Answer `<=` or `>=`: `expected` is the strict half of the operator.
+    #[inline]
+    fn compare_values_or_equal(&self, a: &Value, b: &Value, expected: std::cmp::Ordering) -> Value {
+        if a.is_null() || b.is_null() {
+            return Value::Null(DataType::Boolean);
+        }
+        match a.partial_cmp(b) {
+            Some(ord) if ord == expected || ord == std::cmp::Ordering::Equal => {
+                Value::Boolean(true)
+            }
             Some(_) => Value::Boolean(false),
             None => Value::Null(DataType::Boolean),
         }

--- a/src/executor/expression/vm.rs
+++ b/src/executor/expression/vm.rs
@@ -668,7 +668,11 @@ impl ExprVM {
                         .row
                         .get(*idx as usize)
                         .unwrap_or(&Value::Null(DataType::Null));
-                    let result = if col_val.is_null() {
+                    // A set holding nothing matches nothing, whatever it is
+                    // asked about, so NOT IN over it holds for every row
+                    let result = if set.is_empty() && !*has_null {
+                        Value::Boolean(false)
+                    } else if col_val.is_null() {
                         Value::Null(DataType::Boolean)
                     } else if set.contains(col_val) {
                         Value::Boolean(true)
@@ -1335,7 +1339,11 @@ impl ExprVM {
                 // =============================================================
                 Op::InSet(set, has_null) => {
                     let v = self.stack.pop().unwrap_or_else(Value::null_unknown);
-                    let result = if v.is_null() {
+                    // A set holding nothing matches nothing, whatever it is
+                    // asked about, so NOT IN over it holds for every row
+                    let result = if set.is_empty() && !*has_null {
+                        Value::Boolean(false)
+                    } else if v.is_null() {
                         Value::Null(DataType::Boolean)
                     } else if set.contains(&v) {
                         Value::Boolean(true)
@@ -1350,7 +1358,9 @@ impl ExprVM {
 
                 Op::NotInSet(set, has_null) => {
                     let v = self.stack.pop().unwrap_or_else(Value::null_unknown);
-                    let result = if v.is_null() {
+                    let result = if set.is_empty() && !*has_null {
+                        Value::Boolean(true)
+                    } else if v.is_null() {
                         Value::Null(DataType::Boolean)
                     } else if set.contains(&v) {
                         Value::Boolean(false)
@@ -3121,6 +3131,11 @@ impl ExprVM {
                 None => None,
             },
             Op::InSetColumn(idx, set, has_null) => {
+                // A set holding nothing matches nothing, whatever it is
+                // asked about
+                if set.is_empty() && !*has_null {
+                    return Some(false);
+                }
                 match ctx.row.get(*idx as usize) {
                     Some(v) if v.is_null() => None, // NULL IN set -> NULL
                     Some(v) if set.contains(v) => Some(true),

--- a/src/executor/expression/vm.rs
+++ b/src/executor/expression/vm.rs
@@ -1356,6 +1356,23 @@ impl ExprVM {
                     pc += 1;
                 }
 
+                Op::InList(count) => {
+                    let start = self.stack.len().saturating_sub(*count as usize);
+                    let items: Vec<Value> = self.stack.drain(start..).collect();
+                    let v = self.stack.pop().unwrap_or_else(Value::null_unknown);
+                    let result = if v.is_null() {
+                        Value::Null(DataType::Boolean)
+                    } else if items.iter().any(|item| !item.is_null() && *item == v) {
+                        Value::Boolean(true)
+                    } else if items.iter().any(Value::is_null) {
+                        Value::Null(DataType::Boolean)
+                    } else {
+                        Value::Boolean(false)
+                    };
+                    self.stack.push(result);
+                    pc += 1;
+                }
+
                 Op::NotInSet(set, has_null) => {
                     let v = self.stack.pop().unwrap_or_else(Value::null_unknown);
                     let result = if set.is_empty() && !*has_null {

--- a/src/executor/foreign_key.rs
+++ b/src/executor/foreign_key.rs
@@ -186,35 +186,148 @@ pub(crate) fn enforce_delete_actions_iter<'a>(
     }
 
     let values: Vec<&Value> = deleted_pk_values.collect();
+    pre_check_delete_keys(engine, txn_id, parent_table, &values, referencing_fks)?;
+    apply_delete_actions(engine, txn_id, parent_table, &values, referencing_fks)
+}
 
-    // Every key that can refuse the delete is asked before the first change,
-    // so a refusal leaves the statement having written nothing. Otherwise a
-    // key that cascades and a key that restricts, in that order, would take
-    // the children of the first away and then refuse the parent
-    for pk_value in &values {
-        for (child_table_name, fk) in referencing_fks {
-            if matches!(
-                fk.on_delete,
-                ForeignKeyAction::Restrict | ForeignKeyAction::NoAction
-            ) && child_rows_exist(engine, txn_id, child_table_name, fk, pk_value)?
-            {
-                return Err(Error::foreign_key_violation(
-                    child_table_name,
-                    &fk.column_name,
-                    parent_table,
-                    &fk.referenced_column,
-                    format!(
-                        "cannot delete row with {} = {} — still referenced by table '{}'",
-                        fk.referenced_column, pk_value, child_table_name
-                    ),
-                ));
+/// Ask every key that can refuse the delete before the first change is
+/// made, so a refusal leaves the statement having written nothing.
+///
+/// The walk follows CASCADE and SET NULL down to the keys beneath them: a
+/// RESTRICT on a grandchild refuses the delete just as one on a child does,
+/// and asking only the children would let the first parent's child go
+/// before the second parent's grandchild refused. The walk is skipped when
+/// the tree holds nothing that can refuse.
+pub(crate) fn pre_check_delete_keys(
+    engine: &MVCCEngine,
+    txn_id: i64,
+    parent_table: &str,
+    values: &[&Value],
+    referencing_fks: &[(String, ForeignKeyConstraint)],
+) -> Result<()> {
+    if !fk_tree_can_refuse_delete(engine, referencing_fks, 0) {
+        return Ok(());
+    }
+    for pk_value in values {
+        pre_check_delete_recursive(engine, txn_id, parent_table, pk_value, referencing_fks, 0)?;
+    }
+    Ok(())
+}
+
+/// Whether a delete of a row this tree points at can be refused anywhere
+/// in it: a key that restricts, at any depth below the keys that cascade,
+/// or a cascade deep enough to hit the depth limit. Reads the metadata
+/// only, so a tree of nothing but CASCADE and SET NULL skips the row walk.
+fn fk_tree_can_refuse_delete(
+    engine: &MVCCEngine,
+    referencing_fks: &[(String, ForeignKeyConstraint)],
+    depth: usize,
+) -> bool {
+    if depth >= MAX_CASCADE_DEPTH {
+        return true;
+    }
+    for (child_table_name, fk) in referencing_fks {
+        match fk.on_delete {
+            ForeignKeyAction::Restrict | ForeignKeyAction::NoAction => return true,
+            // A cascade removes whole child rows, so every key pointing at
+            // the child table is asked, the way the cascade itself asks them
+            ForeignKeyAction::Cascade => {
+                let grandchild_fks = find_referencing_fks(engine, child_table_name);
+                if fk_tree_can_refuse_delete(engine, &grandchild_fks[..], depth + 1) {
+                    return true;
+                }
             }
+            // The child rows stay, so nothing below them changes
+            ForeignKeyAction::SetNull => {}
         }
     }
+    false
+}
 
+/// Walk the keys a delete of `value` would set off, the way the cascade
+/// walks them, and refuse at the first key that refuses. Nothing is
+/// written, so the caller can ask this of every value before acting.
+fn pre_check_delete_recursive(
+    engine: &MVCCEngine,
+    txn_id: i64,
+    parent_table: &str,
+    value: &Value,
+    referencing_fks: &[(String, ForeignKeyConstraint)],
+    depth: usize,
+) -> Result<()> {
+    for (child_table_name, fk) in referencing_fks {
+        match fk.on_delete {
+            ForeignKeyAction::Restrict | ForeignKeyAction::NoAction => {
+                if child_rows_exist(engine, txn_id, child_table_name, fk, value)? {
+                    return Err(Error::foreign_key_violation(
+                        child_table_name,
+                        &fk.column_name,
+                        parent_table,
+                        &fk.referenced_column,
+                        format!(
+                            "cannot delete row with {} = {} — still referenced by table '{}'",
+                            fk.referenced_column, value, child_table_name
+                        ),
+                    ));
+                }
+            }
+            ForeignKeyAction::Cascade => {
+                if depth >= MAX_CASCADE_DEPTH {
+                    return Err(Error::internal(format!(
+                        "foreign key CASCADE depth limit ({}) exceeded — possible circular reference",
+                        MAX_CASCADE_DEPTH
+                    )));
+                }
+                let grandchild_fks = find_referencing_fks(engine, child_table_name);
+                if grandchild_fks.is_empty() {
+                    continue;
+                }
+                // The child rows that would go are named by their primary
+                // key, which is what the keys beneath them point at
+                let child_schema = engine.get_table_schema(child_table_name)?;
+                let Some(pk_idx) = child_schema.pk_column_index() else {
+                    continue;
+                };
+                let child_handle = engine.get_table_for_txn(txn_id, child_table_name)?;
+                let col_name = &child_schema.columns[fk.column_index].name;
+                let mut filter = crate::storage::expression::ComparisonExpr::new(
+                    col_name.as_str(),
+                    crate::core::Operator::Eq,
+                    value.clone(),
+                );
+                filter.prepare_for_schema(&child_schema);
+                let rows = child_handle.collect_all_rows(Some(&filter))?;
+                for (_, row) in rows.iter() {
+                    if let Some(child_pk) = row.get(pk_idx) {
+                        pre_check_delete_recursive(
+                            engine,
+                            txn_id,
+                            child_table_name,
+                            child_pk,
+                            &grandchild_fks[..],
+                            depth + 1,
+                        )?;
+                    }
+                }
+            }
+            ForeignKeyAction::SetNull => {}
+        }
+    }
+    Ok(())
+}
+
+/// Carry out the CASCADE and SET NULL keys for rows already found free to
+/// go. Run after `pre_check_delete_keys` for every key of the table.
+pub(crate) fn apply_delete_actions(
+    engine: &MVCCEngine,
+    txn_id: i64,
+    _parent_table: &str,
+    values: &[&Value],
+    referencing_fks: &[(String, ForeignKeyConstraint)],
+) -> Result<i32> {
     let mut total_affected = 0i32;
 
-    for pk_value in &values {
+    for pk_value in values {
         for (child_table_name, fk) in referencing_fks {
             match fk.on_delete {
                 // Asked above, before anything was written

--- a/src/executor/foreign_key.rs
+++ b/src/executor/foreign_key.rs
@@ -185,28 +185,40 @@ pub(crate) fn enforce_delete_actions_iter<'a>(
         return Ok(0);
     }
 
+    let values: Vec<&Value> = deleted_pk_values.collect();
+
+    // Every key that can refuse the delete is asked before the first change,
+    // so a refusal leaves the statement having written nothing. Otherwise a
+    // key that cascades and a key that restricts, in that order, would take
+    // the children of the first away and then refuse the parent
+    for pk_value in &values {
+        for (child_table_name, fk) in referencing_fks {
+            if matches!(
+                fk.on_delete,
+                ForeignKeyAction::Restrict | ForeignKeyAction::NoAction
+            ) && child_rows_exist(engine, txn_id, child_table_name, fk, pk_value)?
+            {
+                return Err(Error::foreign_key_violation(
+                    child_table_name,
+                    &fk.column_name,
+                    parent_table,
+                    &fk.referenced_column,
+                    format!(
+                        "cannot delete row with {} = {} — still referenced by table '{}'",
+                        fk.referenced_column, pk_value, child_table_name
+                    ),
+                ));
+            }
+        }
+    }
+
     let mut total_affected = 0i32;
 
-    for pk_value in deleted_pk_values {
+    for pk_value in &values {
         for (child_table_name, fk) in referencing_fks {
-            let action = fk.on_delete;
-
-            match action {
-                ForeignKeyAction::Restrict | ForeignKeyAction::NoAction => {
-                    // Check if any child rows reference this PK value
-                    if child_rows_exist(engine, txn_id, child_table_name, fk, pk_value)? {
-                        return Err(Error::foreign_key_violation(
-                            child_table_name,
-                            &fk.column_name,
-                            parent_table,
-                            &fk.referenced_column,
-                            format!(
-                                "cannot delete row with {} = {} — still referenced by table '{}'",
-                                fk.referenced_column, pk_value, child_table_name
-                            ),
-                        ));
-                    }
-                }
+            match fk.on_delete {
+                // Asked above, before anything was written
+                ForeignKeyAction::Restrict | ForeignKeyAction::NoAction => {}
                 ForeignKeyAction::Cascade => {
                     // Delete matching child rows within the caller's transaction
                     let affected = cascade_delete(engine, txn_id, child_table_name, fk, pk_value)?;

--- a/src/executor/foreign_key.rs
+++ b/src/executor/foreign_key.rs
@@ -282,12 +282,10 @@ fn pre_check_delete_recursive(
                 if grandchild_fks.is_empty() {
                     continue;
                 }
-                // The child rows that would go are named by their primary
-                // key, which is what the keys beneath them point at
+                // Each key beneath the child names the column it points at,
+                // and the child rows that would go are read through that
+                // column, whether or not it is the child's primary key
                 let child_schema = engine.get_table_schema(child_table_name)?;
-                let Some(pk_idx) = child_schema.pk_column_index() else {
-                    continue;
-                };
                 let child_handle = engine.get_table_for_txn(txn_id, child_table_name)?;
                 let col_name = &child_schema.columns[fk.column_index].name;
                 let mut filter = crate::storage::expression::ComparisonExpr::new(
@@ -297,16 +295,29 @@ fn pre_check_delete_recursive(
                 );
                 filter.prepare_for_schema(&child_schema);
                 let rows = child_handle.collect_all_rows(Some(&filter))?;
-                for (_, row) in rows.iter() {
-                    if let Some(child_pk) = row.get(pk_idx) {
-                        pre_check_delete_recursive(
-                            engine,
-                            txn_id,
-                            child_table_name,
-                            child_pk,
-                            &grandchild_fks[..],
-                            depth + 1,
-                        )?;
+                for gfk_entry in grandchild_fks.iter() {
+                    let referenced = gfk_entry.1.referenced_column.to_lowercase();
+                    let Some(ref_idx) = child_schema
+                        .columns
+                        .iter()
+                        .position(|c| c.name_lower == referenced)
+                    else {
+                        continue;
+                    };
+                    for (_, row) in rows.iter() {
+                        if let Some(child_value) = row.get(ref_idx) {
+                            if child_value.is_null() {
+                                continue;
+                            }
+                            pre_check_delete_recursive(
+                                engine,
+                                txn_id,
+                                child_table_name,
+                                child_value,
+                                std::slice::from_ref(gfk_entry),
+                                depth + 1,
+                            )?;
+                        }
                     }
                 }
             }
@@ -573,29 +584,40 @@ fn cascade_delete_recursive(
         )));
     }
 
-    // Before deleting child rows, collect their PK values for recursive CASCADE.
-    // This is needed because the child table may itself be a parent with CASCADE children.
+    // Before deleting child rows, read what the keys beneath the child point
+    // at. Each such key names a column of the child, its primary key or
+    // any other, so the child rows about to go are read through that
+    // column, once per key
     let grandchild_fks = find_referencing_fks(engine, child_table);
-    let mut deleted_child_pks: Vec<Value> = Vec::new();
+    let mut deleted_child_keys: Vec<(usize, Vec<Value>)> = Vec::new();
 
     if !grandchild_fks.is_empty() {
-        // Need to collect PK values of rows about to be deleted
         let child_schema = engine.get_table_schema(child_table)?;
-        if let Some(pk_idx) = child_schema.pk_column_index() {
-            let child_handle = engine.get_table_for_txn(txn_id, child_table)?;
-            // Use filtered scan instead of full table scan
-            let col_name = &child_schema.columns[fk.column_index].name;
-            let mut filter = crate::storage::expression::ComparisonExpr::new(
-                col_name.as_str(),
-                crate::core::Operator::Eq,
-                parent_pk_value.clone(),
-            );
-            filter.prepare_for_schema(&child_schema);
-            let rows = child_handle.collect_all_rows(Some(&filter))?;
-            for (_, row) in rows.iter() {
-                if let Some(pk_val) = row.get(pk_idx) {
-                    deleted_child_pks.push(pk_val.clone());
-                }
+        let child_handle = engine.get_table_for_txn(txn_id, child_table)?;
+        // Use filtered scan instead of full table scan
+        let col_name = &child_schema.columns[fk.column_index].name;
+        let mut filter = crate::storage::expression::ComparisonExpr::new(
+            col_name.as_str(),
+            crate::core::Operator::Eq,
+            parent_pk_value.clone(),
+        );
+        filter.prepare_for_schema(&child_schema);
+        let rows = child_handle.collect_all_rows(Some(&filter))?;
+        for (gfk_idx, (_, grandchild_fk)) in grandchild_fks.iter().enumerate() {
+            let referenced = grandchild_fk.referenced_column.to_lowercase();
+            let Some(ref_idx) = child_schema
+                .columns
+                .iter()
+                .position(|c| c.name_lower == referenced)
+            else {
+                continue;
+            };
+            let values: Vec<Value> = rows
+                .iter()
+                .filter_map(|(_, row)| row.get(ref_idx).filter(|v| !v.is_null()).cloned())
+                .collect();
+            if !values.is_empty() {
+                deleted_child_keys.push((gfk_idx, values));
             }
         }
     }
@@ -603,25 +625,26 @@ fn cascade_delete_recursive(
     // Pre-check: verify grandchild RESTRICT constraints BEFORE deleting child rows.
     // If we deleted children first and a grandchild RESTRICT check fails, the child
     // deletions would remain in the transaction state (orphaning data in explicit txns).
-    if !grandchild_fks.is_empty() && !deleted_child_pks.is_empty() {
-        for child_pk in &deleted_child_pks {
-            for (grandchild_table, grandchild_fk) in grandchild_fks.iter() {
-                if matches!(
-                    grandchild_fk.on_delete,
-                    ForeignKeyAction::Restrict | ForeignKeyAction::NoAction
-                ) && child_rows_exist(engine, txn_id, grandchild_table, grandchild_fk, child_pk)?
-                {
-                    return Err(Error::foreign_key_violation(
-                        grandchild_table,
-                        &grandchild_fk.column_name,
-                        child_table,
-                        &grandchild_fk.referenced_column,
-                        format!(
-                            "cannot cascade-delete row with {} = {} — still referenced by table '{}'",
-                            grandchild_fk.referenced_column, child_pk, grandchild_table
-                        ),
-                    ));
-                }
+    for (gfk_idx, values) in &deleted_child_keys {
+        let (grandchild_table, grandchild_fk) = &grandchild_fks[*gfk_idx];
+        if !matches!(
+            grandchild_fk.on_delete,
+            ForeignKeyAction::Restrict | ForeignKeyAction::NoAction
+        ) {
+            continue;
+        }
+        for child_value in values {
+            if child_rows_exist(engine, txn_id, grandchild_table, grandchild_fk, child_value)? {
+                return Err(Error::foreign_key_violation(
+                    grandchild_table,
+                    &grandchild_fk.column_name,
+                    child_table,
+                    &grandchild_fk.referenced_column,
+                    format!(
+                        "cannot cascade-delete row with {} = {} — still referenced by table '{}'",
+                        grandchild_fk.referenced_column, child_value, grandchild_table
+                    ),
+                ));
             }
         }
     }
@@ -644,34 +667,33 @@ fn cascade_delete_recursive(
     let mut total = count;
 
     // Recursively enforce CASCADE/SET NULL on grandchild tables (RESTRICT already checked above)
-    if !grandchild_fks.is_empty() && !deleted_child_pks.is_empty() {
-        for child_pk in &deleted_child_pks {
-            for (grandchild_table, grandchild_fk) in grandchild_fks.iter() {
-                match grandchild_fk.on_delete {
-                    ForeignKeyAction::Restrict | ForeignKeyAction::NoAction => {
-                        // Already checked above — skip
-                    }
-                    ForeignKeyAction::Cascade => {
-                        let affected = cascade_delete_recursive(
-                            engine,
-                            txn_id,
-                            grandchild_table,
-                            grandchild_fk,
-                            child_pk,
-                            depth + 1,
-                        )?;
-                        total = total.saturating_add(affected);
-                    }
-                    ForeignKeyAction::SetNull => {
-                        let affected = set_null_on_delete(
-                            engine,
-                            txn_id,
-                            grandchild_table,
-                            grandchild_fk,
-                            child_pk,
-                        )?;
-                        total = total.saturating_add(affected);
-                    }
+    for (gfk_idx, values) in &deleted_child_keys {
+        let (grandchild_table, grandchild_fk) = &grandchild_fks[*gfk_idx];
+        for child_value in values {
+            match grandchild_fk.on_delete {
+                ForeignKeyAction::Restrict | ForeignKeyAction::NoAction => {
+                    // Already checked above — skip
+                }
+                ForeignKeyAction::Cascade => {
+                    let affected = cascade_delete_recursive(
+                        engine,
+                        txn_id,
+                        grandchild_table,
+                        grandchild_fk,
+                        child_value,
+                        depth + 1,
+                    )?;
+                    total = total.saturating_add(affected);
+                }
+                ForeignKeyAction::SetNull => {
+                    let affected = set_null_on_delete(
+                        engine,
+                        txn_id,
+                        grandchild_table,
+                        grandchild_fk,
+                        child_value,
+                    )?;
+                    total = total.saturating_add(affected);
                 }
             }
         }

--- a/src/executor/join_executor.rs
+++ b/src/executor/join_executor.rs
@@ -109,6 +109,7 @@ use crate::executor::planner::{RuntimeJoinAlgorithm, RuntimeJoinDecision};
 use crate::executor::utils::{extract_join_keys_and_residual, is_sorted_on_keys};
 use crate::optimizer::bloom::RuntimeBloomFilter;
 use crate::parser::ast::Expression;
+use ahash::AHashSet as HashSet;
 
 /// LIMIT threshold below which streaming execution is preferred over parallel.
 ///
@@ -967,7 +968,7 @@ impl JoinExecutor {
     #[allow(clippy::too_many_arguments)]
     fn apply_residual_post_join(
         &self,
-        mut rows: RowVec,
+        rows: RowVec,
         residual: &[Expression],
         all_columns: &[String],
         join_type: &str,
@@ -975,49 +976,72 @@ impl JoinExecutor {
         right_col_count: usize,
         ctx: &ExecutionContext,
     ) -> Result<RowVec> {
-        let is_left_outer = join_type.contains("LEFT");
-        let is_right_outer = join_type.contains("RIGHT");
-        let is_full_outer = join_type.contains("FULL");
+        let is_left_outer = join_type.contains("LEFT") || join_type.contains("FULL");
+        let is_right_outer = join_type.contains("RIGHT") || join_type.contains("FULL");
 
+        let mut filters = Vec::with_capacity(residual.len());
         for cond in residual {
-            let filter = RowFilter::new(cond, all_columns)?.with_context(ctx);
+            filters.push(RowFilter::new(cond, all_columns)?.with_context(ctx));
+        }
 
-            if is_left_outer || is_right_outer || is_full_outer {
-                // For OUTER joins, replace non-matching rows with NULL-padded versions
-                let mut new_rows = RowVec::with_capacity(rows.len());
-                for (row_id, row) in rows {
-                    if filter.matches_checked(&row)? {
-                        new_rows.push((row_id, row));
-                    } else {
-                        // Convert to NULL-padded row
-                        if is_left_outer {
-                            // Keep left, NULL right
-                            let mut new_values: CompactVec<Value> =
-                                CompactVec::with_capacity(left_col_count + right_col_count);
-                            new_values.extend(row.iter().take(left_col_count).cloned());
-                            new_values.extend(std::iter::repeat_n(NULL_VALUE, right_col_count));
-                            new_rows.push((row_id, Row::from_compact_vec(new_values)));
-                        } else if is_right_outer {
-                            // NULL left, keep right
-                            let mut new_values: CompactVec<Value> =
-                                CompactVec::with_capacity(left_col_count + right_col_count);
-                            new_values.extend(std::iter::repeat_n(NULL_VALUE, left_col_count));
-                            new_values.extend(row.iter().skip(left_col_count).cloned());
-                            new_rows.push((row_id, Row::from_compact_vec(new_values)));
-                        } else {
-                            // FULL OUTER - keep original for now
-                            new_rows.push((row_id, row));
-                        }
-                    }
+        // A row the condition rejects is not a row of the join. The side the
+        // join preserves keeps a row of its own only where the whole
+        // condition matched nothing for it, and one row however many pairs
+        // it rejected
+        let mut kept = RowVec::with_capacity(rows.len());
+        let mut matched_left: HashSet<Vec<Value>> = HashSet::default();
+        let mut matched_right: HashSet<Vec<Value>> = HashSet::default();
+        let mut rejected: Vec<Row> = Vec::new();
+        for (row_id, row) in rows {
+            let mut passes = true;
+            for filter in &filters {
+                if !filter.matches_checked(&row)? {
+                    passes = false;
+                    break;
                 }
-                rows = new_rows;
+            }
+            if passes {
+                if is_left_outer {
+                    matched_left.insert(row.iter().take(left_col_count).cloned().collect());
+                }
+                if is_right_outer {
+                    matched_right.insert(row.iter().skip(left_col_count).cloned().collect());
+                }
+                kept.push((row_id, row));
             } else {
-                // INNER join - just filter
-                filter.retain_checked(&mut rows)?;
+                rejected.push(row);
             }
         }
 
-        Ok(rows)
+        let mut next_row_id = kept.len() as i64;
+        let mut seen_left: HashSet<Vec<Value>> = HashSet::default();
+        let mut seen_right: HashSet<Vec<Value>> = HashSet::default();
+        for row in rejected {
+            if is_left_outer {
+                let left: Vec<Value> = row.iter().take(left_col_count).cloned().collect();
+                if !matched_left.contains(&left) && seen_left.insert(left.clone()) {
+                    let mut values: CompactVec<Value> =
+                        CompactVec::with_capacity(left_col_count + right_col_count);
+                    values.extend(left);
+                    values.extend(std::iter::repeat_n(NULL_VALUE, right_col_count));
+                    kept.push((next_row_id, Row::from_compact_vec(values)));
+                    next_row_id += 1;
+                }
+            }
+            if is_right_outer {
+                let right: Vec<Value> = row.iter().skip(left_col_count).cloned().collect();
+                if !matched_right.contains(&right) && seen_right.insert(right.clone()) {
+                    let mut values: CompactVec<Value> =
+                        CompactVec::with_capacity(left_col_count + right_col_count);
+                    values.extend(std::iter::repeat_n(NULL_VALUE, left_col_count));
+                    values.extend(right);
+                    kept.push((next_row_id, Row::from_compact_vec(values)));
+                    next_row_id += 1;
+                }
+            }
+        }
+
+        Ok(kept)
     }
 }
 

--- a/src/executor/join_executor.rs
+++ b/src/executor/join_executor.rs
@@ -92,9 +92,8 @@
 //! The optimizer has bloom filter propagation logic, but runtime bloom filter
 //! checks are not yet integrated into the streaming operators.
 
-use crate::common::{CompactArc, CompactVec};
-use crate::core::value::NULL_VALUE;
-use crate::core::{Result, Row, RowVec, Value};
+use crate::common::CompactArc;
+use crate::core::{Result, Row, RowVec};
 use crate::executor::context::ExecutionContext;
 use crate::executor::expression::RowFilter;
 use crate::executor::hash_table::JoinHashTable;
@@ -109,7 +108,6 @@ use crate::executor::planner::{RuntimeJoinAlgorithm, RuntimeJoinDecision};
 use crate::executor::utils::{extract_join_keys_and_residual, is_sorted_on_keys};
 use crate::optimizer::bloom::RuntimeBloomFilter;
 use crate::parser::ast::Expression;
-use ahash::AHashSet as HashSet;
 
 /// LIMIT threshold below which streaming execution is preferred over parallel.
 ///
@@ -292,6 +290,7 @@ impl JoinExecutor {
                 request.right_columns,
                 &analysis,
                 request.limit,
+                request.ctx,
             )?,
             RuntimeJoinAlgorithm::NestedLoop => self.execute_nested_loop(
                 request.left_rows,
@@ -396,41 +395,30 @@ impl JoinExecutor {
             )
         };
 
-        // Compile residual filters for inline application (INNER JOINs only)
+        // Compile the non-equality part of the ON clause
         let is_inner = !analysis.join_type_str.contains("LEFT")
             && !analysis.join_type_str.contains("RIGHT")
             && !analysis.join_type_str.contains("FULL");
 
-        let residual_filters: Vec<RowFilter> = if is_inner {
-            analysis
-                .residual_conditions
-                .iter()
-                .map(|cond| RowFilter::new(cond, &all_columns).map(|f| f.with_context(request.ctx)))
-                .collect::<Result<Vec<_>>>()?
+        let residual_filters: Vec<RowFilter> = analysis
+            .residual_conditions
+            .iter()
+            .map(|cond| RowFilter::new(cond, &all_columns).map(|f| f.with_context(request.ctx)))
+            .collect::<Result<Vec<_>>>()?;
+
+        // OUTER joins have to reject a pair inside the operator so the row it
+        // came from still counts as unmatched; INNER joins can filter the
+        // output rows, which avoids materializing a candidate per pair.
+        let inline_filters: &[RowFilter] = if is_inner {
+            &residual_filters
         } else {
-            Vec::new()
+            join_op = join_op.with_residual(residual_filters);
+            &[]
         };
 
         // Execute with Volcano model - this is where true streaming happens!
         let rows =
-            self.execute_operator_with_filter(&mut join_op, request.limit, &residual_filters)?;
-
-        // Apply residual conditions for OUTER joins (after iteration)
-        let left_col_count = left_columns.len();
-        let right_col_count = right_columns.len();
-        let rows = if !is_inner && !analysis.residual_conditions.is_empty() {
-            self.apply_residual_post_join(
-                rows,
-                &analysis.residual_conditions,
-                &all_columns,
-                &analysis.join_type_str,
-                left_col_count,
-                right_col_count,
-                request.ctx,
-            )?
-        } else {
-            rows
-        };
+            self.execute_operator_with_filter(&mut join_op, request.limit, inline_filters)?;
 
         Ok(JoinResult {
             rows,
@@ -600,8 +588,14 @@ impl JoinExecutor {
         } else {
             right_rows.len()
         };
+        // OUTER joins with a non-equality ON condition need the residual applied
+        // per candidate pair, which only the streaming operator does.
+        let is_outer = analysis.join_type_str.contains("LEFT")
+            || analysis.join_type_str.contains("RIGHT")
+            || analysis.join_type_str.contains("FULL");
         let use_parallel = build_row_count >= DEFAULT_PARALLEL_JOIN_THRESHOLD
-            && limit.is_none_or(|l| l > STREAMING_LIMIT_THRESHOLD);
+            && limit.is_none_or(|l| l > STREAMING_LIMIT_THRESHOLD)
+            && !(is_outer && !analysis.residual_conditions.is_empty());
 
         if use_parallel {
             // Parallel execution path
@@ -624,8 +618,6 @@ impl JoinExecutor {
                 analysis,
                 left_columns,
                 right_columns,
-                left_col_count,
-                right_col_count,
                 &all_columns,
                 build_left,
                 limit,
@@ -703,30 +695,12 @@ impl JoinExecutor {
             .collect();
 
         // Apply residual conditions FIRST (before LIMIT)
-        // This ensures correct semantics: filter matching rows, then limit
-        let is_inner = !analysis.join_type_str.contains("LEFT")
-            && !analysis.join_type_str.contains("RIGHT")
-            && !analysis.join_type_str.contains("FULL");
-
-        if !analysis.residual_conditions.is_empty() {
-            if is_inner {
-                // For INNER joins, simply filter rows
-                for cond in &analysis.residual_conditions {
-                    let filter = RowFilter::new(cond, all_columns)?.with_context(ctx);
-                    filter.retain_checked(&mut rows)?;
-                }
-            } else {
-                // For OUTER joins, need special NULL-padding handling
-                rows = self.apply_residual_post_join(
-                    rows,
-                    &analysis.residual_conditions,
-                    all_columns,
-                    &analysis.join_type_str,
-                    left_col_count,
-                    right_col_count,
-                    ctx,
-                )?;
-            }
+        // This ensures correct semantics: filter matching rows, then limit.
+        // Only INNER joins reach this path: execute_hash_join() routes OUTER
+        // joins carrying a residual to the streaming operator.
+        for cond in &analysis.residual_conditions {
+            let filter = RowFilter::new(cond, all_columns)?.with_context(ctx);
+            filter.retain_checked(&mut rows)?;
         }
 
         // Apply LIMIT after filtering (correct order)
@@ -749,8 +723,6 @@ impl JoinExecutor {
         analysis: &JoinAnalysis,
         left_columns: &[String],
         right_columns: &[String],
-        left_col_count: usize,
-        right_col_count: usize,
         all_columns: &[String],
         build_left: bool,
         limit: Option<u64>,
@@ -780,43 +752,33 @@ impl JoinExecutor {
             build_side,
         );
 
-        // Compile residual filters for inline application (INNER JOINs only)
+        // Compile the non-equality part of the ON clause
         let is_inner = !analysis.join_type_str.contains("LEFT")
             && !analysis.join_type_str.contains("RIGHT")
             && !analysis.join_type_str.contains("FULL");
 
-        let residual_filters: Vec<RowFilter> = if is_inner {
-            analysis
-                .residual_conditions
-                .iter()
-                .map(|cond| RowFilter::new(cond, all_columns).map(|f| f.with_context(ctx)))
-                .collect::<Result<Vec<_>>>()?
+        let residual_filters: Vec<RowFilter> = analysis
+            .residual_conditions
+            .iter()
+            .map(|cond| RowFilter::new(cond, all_columns).map(|f| f.with_context(ctx)))
+            .collect::<Result<Vec<_>>>()?;
+
+        // OUTER joins have to reject a pair inside the operator so the row it
+        // came from still counts as unmatched; INNER joins can filter the
+        // output rows, which avoids materializing a candidate per pair.
+        let inline_filters: &[RowFilter] = if is_inner {
+            &residual_filters
         } else {
-            Vec::new()
+            join_op = join_op.with_residual(residual_filters);
+            &[]
         };
 
         // Execute with Volcano model
-        let rows = self.execute_operator_with_filter(&mut join_op, limit, &residual_filters)?;
-
-        // Apply residual conditions for OUTER joins (after iteration)
-        let rows = if !is_inner && !analysis.residual_conditions.is_empty() {
-            self.apply_residual_post_join(
-                rows,
-                &analysis.residual_conditions,
-                all_columns,
-                &analysis.join_type_str,
-                left_col_count,
-                right_col_count,
-                ctx,
-            )?
-        } else {
-            rows
-        };
-
-        Ok(rows)
+        self.execute_operator_with_filter(&mut join_op, limit, inline_filters)
     }
 
     /// Execute merge join for pre-sorted inputs using MergeJoinOperator.
+    #[allow(clippy::too_many_arguments)]
     fn execute_merge_join(
         &self,
         left_rows: CompactArc<Vec<Row>>,
@@ -825,6 +787,7 @@ impl JoinExecutor {
         right_columns: &[String],
         analysis: &JoinAnalysis,
         limit: Option<u64>,
+        ctx: &ExecutionContext,
     ) -> Result<RowVec> {
         // Build schema for operators
         let left_schema: Vec<ColumnInfo> = left_columns.iter().map(ColumnInfo::new).collect();
@@ -847,7 +810,20 @@ impl JoinExecutor {
             analysis.right_key_indices.clone(),
         );
 
-        // Execute with Volcano model (no residual filters for merge join currently)
+        // The non-equality part of the ON clause decides whether a pair is a
+        // match, so the operator applies it while it walks the two runs.
+        if !analysis.residual_conditions.is_empty() {
+            let mut all_columns = left_columns.to_vec();
+            all_columns.extend(right_columns.iter().cloned());
+            let residual_filters: Vec<RowFilter> = analysis
+                .residual_conditions
+                .iter()
+                .map(|cond| RowFilter::new(cond, &all_columns).map(|f| f.with_context(ctx)))
+                .collect::<Result<Vec<_>>>()?;
+            merge_op = merge_op.with_residual(residual_filters);
+        }
+
+        // Execute with Volcano model
         self.execute_operator_with_filter(&mut merge_op, limit, &[])
     }
 
@@ -960,89 +936,6 @@ impl JoinExecutor {
         op.close()?;
         Ok(rows)
     }
-
-    /// Apply residual conditions for OUTER joins.
-    ///
-    /// For OUTER joins, residual conditions need special handling:
-    /// matched rows that fail residual should produce NULL-padded output.
-    #[allow(clippy::too_many_arguments)]
-    fn apply_residual_post_join(
-        &self,
-        rows: RowVec,
-        residual: &[Expression],
-        all_columns: &[String],
-        join_type: &str,
-        left_col_count: usize,
-        right_col_count: usize,
-        ctx: &ExecutionContext,
-    ) -> Result<RowVec> {
-        let is_left_outer = join_type.contains("LEFT") || join_type.contains("FULL");
-        let is_right_outer = join_type.contains("RIGHT") || join_type.contains("FULL");
-
-        let mut filters = Vec::with_capacity(residual.len());
-        for cond in residual {
-            filters.push(RowFilter::new(cond, all_columns)?.with_context(ctx));
-        }
-
-        // A row the condition rejects is not a row of the join. The side the
-        // join preserves keeps a row of its own only where the whole
-        // condition matched nothing for it, and one row however many pairs
-        // it rejected
-        let mut kept = RowVec::with_capacity(rows.len());
-        let mut matched_left: HashSet<Vec<Value>> = HashSet::default();
-        let mut matched_right: HashSet<Vec<Value>> = HashSet::default();
-        let mut rejected: Vec<Row> = Vec::new();
-        for (row_id, row) in rows {
-            let mut passes = true;
-            for filter in &filters {
-                if !filter.matches_checked(&row)? {
-                    passes = false;
-                    break;
-                }
-            }
-            if passes {
-                if is_left_outer {
-                    matched_left.insert(row.iter().take(left_col_count).cloned().collect());
-                }
-                if is_right_outer {
-                    matched_right.insert(row.iter().skip(left_col_count).cloned().collect());
-                }
-                kept.push((row_id, row));
-            } else {
-                rejected.push(row);
-            }
-        }
-
-        let mut next_row_id = kept.len() as i64;
-        let mut seen_left: HashSet<Vec<Value>> = HashSet::default();
-        let mut seen_right: HashSet<Vec<Value>> = HashSet::default();
-        for row in rejected {
-            if is_left_outer {
-                let left: Vec<Value> = row.iter().take(left_col_count).cloned().collect();
-                if !matched_left.contains(&left) && seen_left.insert(left.clone()) {
-                    let mut values: CompactVec<Value> =
-                        CompactVec::with_capacity(left_col_count + right_col_count);
-                    values.extend(left);
-                    values.extend(std::iter::repeat_n(NULL_VALUE, right_col_count));
-                    kept.push((next_row_id, Row::from_compact_vec(values)));
-                    next_row_id += 1;
-                }
-            }
-            if is_right_outer {
-                let right: Vec<Value> = row.iter().skip(left_col_count).cloned().collect();
-                if !matched_right.contains(&right) && seen_right.insert(right.clone()) {
-                    let mut values: CompactVec<Value> =
-                        CompactVec::with_capacity(left_col_count + right_col_count);
-                    values.extend(std::iter::repeat_n(NULL_VALUE, left_col_count));
-                    values.extend(right);
-                    kept.push((next_row_id, Row::from_compact_vec(values)));
-                    next_row_id += 1;
-                }
-            }
-        }
-
-        Ok(kept)
-    }
 }
 
 impl Default for JoinExecutor {
@@ -1054,6 +947,7 @@ impl Default for JoinExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::Value;
 
     fn make_rows(data: Vec<Vec<i64>>) -> Vec<Row> {
         data.into_iter()

--- a/src/executor/operators/hash_join.rs
+++ b/src/executor/operators/hash_join.rs
@@ -35,6 +35,7 @@
 use crate::common::CompactArc;
 use crate::core::value::NULL_VALUE;
 use crate::core::{Result, Row};
+use crate::executor::expression::RowFilter;
 use crate::executor::hash_table::{hash_row_keys, verify_key_equality, JoinHashTable};
 use crate::executor::operator::{ColumnInfo, Operator, RowRef};
 
@@ -230,6 +231,10 @@ pub struct HashJoinOperator {
     current_matches: Vec<usize>,
     probe_had_match: bool,
 
+    // Non-equality ON conditions, applied to each candidate pair before it
+    // counts as a match. Empty when the whole ON clause is equi-keys.
+    residual: Vec<RowFilter>,
+
     // For OUTER joins: track which build rows were matched
     build_matched: Vec<bool>,
     returning_unmatched_build: bool,
@@ -296,6 +301,7 @@ impl HashJoinOperator {
             current_match_idx: 0,
             current_matches: Vec::new(),
             probe_had_match: false,
+            residual: Vec::new(),
             build_matched: Vec::new(),
             returning_unmatched_build: false,
             unmatched_build_idx: 0,
@@ -406,6 +412,7 @@ impl HashJoinOperator {
             current_match_idx: 0,
             current_matches: Vec::new(),
             probe_had_match: false,
+            residual: Vec::new(),
             build_matched,
             returning_unmatched_build: false,
             unmatched_build_idx: 0,
@@ -453,6 +460,7 @@ impl HashJoinOperator {
             current_match_idx: 0,
             current_matches: Vec::new(),
             probe_had_match: false,
+            residual: Vec::new(),
             build_matched: Vec::new(),
             returning_unmatched_build: false,
             unmatched_build_idx: 0,
@@ -463,6 +471,32 @@ impl HashJoinOperator {
             opened: false,
             probe_exhausted: false,
         }
+    }
+
+    /// Attach the non-equality part of the ON clause.
+    ///
+    /// The filters are compiled against the joined column layout
+    /// (left columns followed by right columns). A pair that fails them is
+    /// not a match: it is neither emitted nor counted when deciding which
+    /// rows an OUTER join has to NULL-pad.
+    pub fn with_residual(mut self, residual: Vec<RowFilter>) -> Self {
+        self.residual = residual;
+        self
+    }
+
+    /// Test a candidate pair against the residual ON conditions.
+    fn residual_matches(&self, build_idx: usize) -> Result<bool> {
+        let probe_row = match self.current_probe_row.as_ref() {
+            Some(row) => row.clone(),
+            None => return Ok(true),
+        };
+        let candidate = self.combine_rows_direct(probe_row, build_idx).into_owned();
+        for filter in &self.residual {
+            if !filter.matches_checked(&candidate)? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 
     /// Get the key indices based on which side is build vs probe.
@@ -674,6 +708,10 @@ impl Operator for HashJoinOperator {
                     self.probe_key_indices(),
                     self.build_key_indices(),
                 ) {
+                    if !self.residual.is_empty() && !self.residual_matches(build_idx)? {
+                        continue;
+                    }
+
                     self.probe_had_match = true;
 
                     // SEMI JOIN: Return probe row only (no build columns), then skip remaining matches

--- a/src/executor/operators/merge_join.rs
+++ b/src/executor/operators/merge_join.rs
@@ -24,6 +24,7 @@ use std::cmp::Ordering;
 
 use crate::core::value::NULL_VALUE;
 use crate::core::{Result, Row};
+use crate::executor::expression::RowFilter;
 use crate::executor::operator::{ColumnInfo, Operator, RowRef};
 use crate::executor::utils::compare_values;
 
@@ -64,6 +65,11 @@ pub struct MergeJoinOperator {
     current_left_in_group: usize,
     current_right_in_group: usize,
     in_cartesian_product: bool,
+    current_left_matched: bool,
+
+    // Non-equality ON conditions, applied to each candidate pair before it
+    // counts as a match. Empty when the whole ON clause is equi-keys.
+    residual: Vec<RowFilter>,
 
     // Track matched rows for OUTER joins
     right_matched: Vec<bool>,
@@ -133,6 +139,8 @@ impl MergeJoinOperator {
             current_left_in_group: 0,
             current_right_in_group: 0,
             in_cartesian_product: false,
+            current_left_matched: false,
+            residual: Vec::new(),
             right_matched: Vec::new(),
             returning_unmatched_right: false,
             unmatched_right_idx: 0,
@@ -140,6 +148,27 @@ impl MergeJoinOperator {
             cached_null_right: Row::new(), // Initialized in open()
             opened: false,
         }
+    }
+
+    /// Attach the non-equality part of the ON clause.
+    ///
+    /// The filters are compiled against the joined column layout
+    /// (left columns followed by right columns). A pair that fails them is
+    /// not a match: it is neither emitted nor counted when deciding which
+    /// rows an OUTER join has to NULL-pad.
+    pub fn with_residual(mut self, residual: Vec<RowFilter>) -> Self {
+        self.residual = residual;
+        self
+    }
+
+    /// Test a combined candidate row against the residual ON conditions.
+    fn residual_matches(&self, combined: &Row) -> Result<bool> {
+        for filter in &self.residual {
+            if !filter.matches_checked(combined)? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 
     /// Compare two rows on their respective join keys.
@@ -280,40 +309,51 @@ impl Operator for MergeJoinOperator {
         // Phase 1: Merge join with cartesian product for duplicate key groups
         loop {
             // If we're in a cartesian product of matching groups
-            if self.in_cartesian_product {
+            while self.in_cartesian_product && self.current_left_in_group < self.left_idx {
                 // Try to emit next pair from current groups
-                if self.current_left_in_group < self.left_idx
-                    && self.current_right_in_group < self.current_right_group_end
-                {
-                    let left_row = &self.left_rows[self.current_left_in_group];
-                    let right_row = &self.right_rows[self.current_right_in_group];
+                if self.current_right_in_group < self.current_right_group_end {
+                    let left_idx = self.current_left_in_group;
+                    let right_idx = self.current_right_in_group;
+                    self.current_right_in_group += 1;
+
+                    let combined =
+                        self.combine(&self.left_rows[left_idx], &self.right_rows[right_idx]);
+                    if !self.residual.is_empty() && !self.residual_matches(&combined)? {
+                        continue;
+                    }
 
                     // Mark right row as matched
                     if is_right_outer {
-                        self.right_matched[self.current_right_in_group] = true;
+                        self.right_matched[right_idx] = true;
                     }
+                    self.current_left_matched = true;
 
-                    self.current_right_in_group += 1;
-
-                    // If we've exhausted right group, move to next left row
-                    if self.current_right_in_group >= self.current_right_group_end {
-                        self.current_left_in_group += 1;
-                        self.current_right_in_group = self.current_right_group_start;
-
-                        // If we've exhausted left group, exit cartesian product mode
-                        if self.current_left_in_group >= self.left_idx {
-                            self.in_cartesian_product = false;
-                            self.right_idx = self.current_right_group_end;
-                        }
-                    }
-
-                    let combined = self.combine(left_row, right_row);
                     return Ok(Some(RowRef::Owned(combined)));
                 }
 
-                // Shouldn't reach here, but safety exit
-                self.in_cartesian_product = false;
+                // Right group exhausted for this left row - move to the next one
+                let left_idx = self.current_left_in_group;
+                let left_unmatched = !self.current_left_matched;
+                self.current_left_in_group += 1;
+                self.current_right_in_group = self.current_right_group_start;
+                self.current_left_matched = false;
+
+                // If we've exhausted left group, exit cartesian product mode
+                if self.current_left_in_group >= self.left_idx {
+                    self.in_cartesian_product = false;
+                    self.right_idx = self.current_right_group_end;
+                }
+
+                // A left row whose every pair failed the residual is unmatched
+                if left_unmatched && is_left_outer {
+                    let null_right = self.null_right_row();
+                    let combined = self.combine(&self.left_rows[left_idx], &null_right);
+                    return Ok(Some(RowRef::Owned(combined)));
+                }
             }
+
+            // Safety exit: empty group leaves cartesian mode without emitting
+            self.in_cartesian_product = false;
 
             // Check if either side is exhausted
             if self.left_idx >= self.left_rows.len() {
@@ -414,6 +454,7 @@ impl Operator for MergeJoinOperator {
                     self.current_left_in_group = left_start;
                     self.current_right_in_group = right_start;
                     self.in_cartesian_product = true;
+                    self.current_left_matched = false;
 
                     // Continue loop to emit first match
                 }

--- a/src/executor/pushdown/mod.rs
+++ b/src/executor/pushdown/mod.rs
@@ -207,6 +207,17 @@ impl PushdownRegistry {
         expr: &ast::Expression,
         ctx: &PushdownContext<'_>,
     ) -> (Option<Box<dyn StorageExpr>>, bool) {
+        // A volatile function is judged once, in memory: pushed beside a
+        // conjunct the memory filter re-evaluates, it would roll twice
+        let is_logical = matches!(
+            expr,
+            ast::Expression::Infix(infix)
+                if matches!(infix.op_type, ast::InfixOperator::And | ast::InfixOperator::Or)
+        );
+        if !is_logical && rules::contains_non_deterministic_volatile(expr) {
+            return (None, true);
+        }
+
         for rule in &self.rules {
             match rule.try_convert(expr, ctx) {
                 PushdownResult::Converted(storage_expr) => {

--- a/src/executor/pushdown/rules.rs
+++ b/src/executor/pushdown/rules.rs
@@ -139,6 +139,10 @@ pub(crate) fn contains_non_deterministic_volatile(expr: &ast::Expression) -> boo
             .elements
             .iter()
             .any(contains_non_deterministic_volatile),
+        ast::Expression::ExpressionList(list) => list
+            .expressions
+            .iter()
+            .any(contains_non_deterministic_volatile),
         _ => false,
     }
 }

--- a/src/executor/pushdown/rules.rs
+++ b/src/executor/pushdown/rules.rs
@@ -106,6 +106,39 @@ pub(crate) fn contains_non_deterministic_volatile(expr: &ast::Expression) -> boo
         }
         ast::Expression::Prefix(prefix) => contains_non_deterministic_volatile(&prefix.right),
         ast::Expression::Cast(cast) => contains_non_deterministic_volatile(&cast.expr),
+        ast::Expression::Aliased(aliased) => {
+            contains_non_deterministic_volatile(&aliased.expression)
+        }
+        ast::Expression::Case(case) => {
+            case.value
+                .as_deref()
+                .is_some_and(contains_non_deterministic_volatile)
+                || case.when_clauses.iter().any(|w| {
+                    contains_non_deterministic_volatile(&w.condition)
+                        || contains_non_deterministic_volatile(&w.then_result)
+                })
+                || case
+                    .else_value
+                    .as_deref()
+                    .is_some_and(contains_non_deterministic_volatile)
+        }
+        ast::Expression::Between(between) => {
+            contains_non_deterministic_volatile(&between.expr)
+                || contains_non_deterministic_volatile(&between.lower)
+                || contains_non_deterministic_volatile(&between.upper)
+        }
+        ast::Expression::Like(like) => {
+            contains_non_deterministic_volatile(&like.left)
+                || contains_non_deterministic_volatile(&like.pattern)
+        }
+        ast::Expression::In(in_expr) => {
+            contains_non_deterministic_volatile(&in_expr.left)
+                || contains_non_deterministic_volatile(&in_expr.right)
+        }
+        ast::Expression::List(list) => list
+            .elements
+            .iter()
+            .any(contains_non_deterministic_volatile),
         _ => false,
     }
 }

--- a/src/executor/pushdown/rules.rs
+++ b/src/executor/pushdown/rules.rs
@@ -86,7 +86,7 @@ fn extract_literal_with_ctx(expr: &ast::Expression, ctx: &PushdownContext<'_>) -
 /// Stable-within-query functions (NOW, CURRENT_DATE, CURRENT_TIMESTAMP) are NOT
 /// considered volatile here — they return the same value for every row in a single
 /// query execution, so pushing them down as a frozen literal is correct.
-fn contains_non_deterministic_volatile(expr: &ast::Expression) -> bool {
+pub(crate) fn contains_non_deterministic_volatile(expr: &ast::Expression) -> bool {
     match expr {
         ast::Expression::FunctionCall(func) => {
             let upper = func.function.to_uppercase();

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -5562,17 +5562,43 @@ impl Executor {
             return Ok((result, out_columns, false, None));
         }
 
-        // Project rows according to SELECT expressions
-        let projected_rows =
-            self.project_rows_with_alias(&stmt.columns, filtered_rows, &columns, None, ctx, None)?;
-
-        // Determine output column names
         let subquery_alias = subquery_source
             .alias
             .as_ref()
             .map(|a| a.value_lower.as_str());
-        let output_columns =
-            CompactArc::new(self.get_output_column_names(&stmt.columns, &columns, subquery_alias));
+
+        // Project rows according to SELECT expressions; a column ORDER BY
+        // or DISTINCT ON reads that the select list leaves out rides along
+        let (projected_rows, output_columns) = if self.order_by_needs_extra_columns(stmt, &columns)
+        {
+            let (projected_rows, extra_names) = self.project_rows_with_order_by(
+                &stmt.columns,
+                &stmt.order_by,
+                &stmt.distinct_on,
+                filtered_rows,
+                &columns,
+                ctx,
+            )?;
+            let mut output_columns =
+                self.get_output_column_names(&stmt.columns, &columns, subquery_alias);
+            output_columns.extend(extra_names);
+            (projected_rows, CompactArc::new(output_columns))
+        } else {
+            let projected_rows = self.project_rows_with_alias(
+                &stmt.columns,
+                filtered_rows,
+                &columns,
+                None,
+                ctx,
+                None,
+            )?;
+            let output_columns = CompactArc::new(self.get_output_column_names(
+                &stmt.columns,
+                &columns,
+                subquery_alias,
+            ));
+            (projected_rows, output_columns)
+        };
 
         let result =
             ExecutorResult::with_arc_columns(CompactArc::clone(&output_columns), projected_rows);
@@ -5721,6 +5747,38 @@ impl Executor {
             // For SELECT *, just return the view result with WHERE applied
             // DISTINCT, ORDER BY, LIMIT/OFFSET are handled by execute_select
             return Ok((result, CompactArc::new(view_columns), false, None));
+        }
+
+        // A column ORDER BY or DISTINCT ON reads that the select list leaves
+        // out rides along, the way it does for a derived table
+        if self.order_by_needs_extra_columns(stmt, &view_columns) {
+            let mut result = result;
+            let mut rows = RowVec::new();
+            let mut row_id = 0i64;
+            while result.next() {
+                rows.push((row_id, result.take_row()));
+                row_id += 1;
+            }
+            if let Some(err) = result.last_error() {
+                return Err(err);
+            }
+            let (projected_rows, extra_names) = self.project_rows_with_order_by(
+                &stmt.columns,
+                &stmt.order_by,
+                &stmt.distinct_on,
+                rows,
+                &view_columns,
+                ctx,
+            )?;
+            let mut output_columns =
+                self.get_output_column_names(&stmt.columns, &view_columns, None);
+            output_columns.extend(extra_names);
+            let output_columns = CompactArc::new(output_columns);
+            let result = ExecutorResult::with_arc_columns(
+                CompactArc::clone(&output_columns),
+                projected_rows,
+            );
+            return Ok((Box::new(result), output_columns, false, None));
         }
 
         // Determine if we have any complex expressions (not just column references)

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -5359,7 +5359,13 @@ impl Executor {
 
                 (filtered_columns, filtered_rows)
             } else {
-                (all_columns.clone(), filtered_rows)
+                // An explicit select list finds the join column by its
+                // bare name too, as `a` or as `x.a`
+                let mut renamed = all_columns.clone();
+                for (idx, base_name) in &join_col_renames {
+                    renamed[*idx] = base_name.clone();
+                }
+                (renamed, filtered_rows)
             }
         } else {
             (all_columns.clone(), filtered_rows)

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3958,6 +3958,18 @@ impl Executor {
         let left_alias = get_table_alias_from_expr(&join_source.left);
         let right_alias = get_table_alias_from_expr(&join_source.right);
 
+        // A subquery in the ON clause is read once, the way the WHERE clause
+        // reads one, so every path below compares each pair against a value
+        // rather than against something it never evaluated
+        let processed_on: Option<Expression> = match join_source.condition.as_deref() {
+            Some(cond) if Self::has_subqueries(cond) && !Self::has_correlated_subqueries(cond) => {
+                Some(self.process_where_subqueries(cond, ctx)?)
+            }
+            _ => None,
+        };
+        let on_condition: Option<&Expression> =
+            processed_on.as_ref().or(join_source.condition.as_deref());
+
         // Determine join type early for filter pushdown decisions
         let join_type = join_source.join_type.to_uppercase();
 
@@ -4145,7 +4157,7 @@ impl Executor {
             } else {
                 self.check_index_nested_loop_opportunity(
                     &join_source.right,
-                    join_source.condition.as_ref().map(|c| c.as_ref()),
+                    on_condition,
                     &join_type,
                     left_alias.as_deref(),
                     right_alias.as_deref(),
@@ -4171,7 +4183,7 @@ impl Executor {
                 // Right is subquery/CTE - check if left side has Index NL opportunity
                 let left_as_inner = self.check_index_nested_loop_opportunity(
                     &join_source.left,
-                    join_source.condition.as_ref().map(|c| c.as_ref()),
+                    on_condition,
                     &join_type,
                     right_alias.as_deref(), // Swap aliases for the check
                     left_alias.as_deref(),
@@ -4209,7 +4221,7 @@ impl Executor {
                 // (which is more efficient than secondary index lookup)
                 let swapped_info = self.check_index_nested_loop_opportunity(
                     &join_source.left, // Left becomes inner (right)
-                    join_source.condition.as_ref().map(|c| c.as_ref()),
+                    on_condition,
                     &join_type,
                     right_alias.as_deref(), // Swap aliases
                     left_alias.as_deref(),
@@ -4420,13 +4432,30 @@ impl Executor {
                         all
                     };
 
-                    // Residual filter from nl_right_filter, re-qualified with the
-                    // inner alias; built per pass since the operator owns it
+                    // The probe answers one equality out of the ON clause, so
+                    // the whole clause is asked of each pair it returns, next
+                    // to the filter the WHERE put on the inner table. The
+                    // operator asks it where the pair is formed, so a pair it
+                    // turns away leaves an outer row still unmatched. The
+                    // filter is built per pass since the operator owns it
                     let build_residual_filter = || {
-                        nl_right_filter.as_ref().and_then(|rf| {
-                            let qualified_rf = add_table_qualifier(rf, inner_alias);
+                        let inner_filter = nl_right_filter
+                            .as_ref()
+                            .map(|rf| add_table_qualifier(rf, inner_alias));
+                        let combined = match (on_condition, inner_filter) {
+                            (Some(on), Some(f)) => Some(Expression::Infix(InfixExpression::new(
+                                Token::new(TokenType::Operator, "AND", Position::default()),
+                                Box::new(on.clone()),
+                                "AND".to_string(),
+                                Box::new(f),
+                            ))),
+                            (Some(on), None) => Some(on.clone()),
+                            (None, Some(f)) => Some(f),
+                            (None, None) => None,
+                        };
+                        combined.and_then(|expr| {
                             JoinFilter::new(
-                                &qualified_rf,
+                                &expr,
                                 &outer_cols,
                                 &inner_cols,
                                 &self.function_registry,
@@ -4865,12 +4894,12 @@ impl Executor {
                     )?;
 
                     // Extract join keys BEFORE moving columns (uses original left/right positions)
-                    let (left_key_indices, right_key_indices, _) =
-                        if let Some(cond) = join_source.condition.as_ref() {
-                            extract_join_keys_and_residual(cond, &left_cols, &right_cols)
-                        } else {
-                            (Vec::new(), Vec::new(), Vec::new())
-                        };
+                    let (left_key_indices, right_key_indices, _) = if let Some(cond) = on_condition
+                    {
+                        extract_join_keys_and_residual(cond, &left_cols, &right_cols)
+                    } else {
+                        (Vec::new(), Vec::new(), Vec::new())
+                    };
 
                     // Build combined columns (always left-first for consistent output schema)
                     let mut all_cols = left_cols.clone();
@@ -4953,7 +4982,7 @@ impl Executor {
                         build_columns: &build_cols,
                         probe_source,
                         probe_columns: probe_cols.clone(),
-                        condition: join_source.condition.as_ref().map(|c| c.as_ref()),
+                        condition: on_condition,
                         join_type: &join_type,
                         build_is_left,
                         limit: Some(limit),
@@ -5115,20 +5144,9 @@ impl Executor {
         // Destructure the tuple: (condition, excluded_column_indices, column_renames)
         let (natural_join_cond, excluded_column_indices, join_col_renames) = natural_join_condition;
 
-        // Use natural join condition if present, otherwise use explicit condition
-        let effective_condition = natural_join_cond
-            .as_ref()
-            .or(join_source.condition.as_ref().map(|c| c.as_ref()));
-
-        // A subquery in the ON clause is read once, the way the WHERE clause
-        // reads one, so the join has a value to compare each pair against
-        let processed_join_cond: Option<Expression> = match effective_condition {
-            Some(cond) if Self::has_subqueries(cond) && !Self::has_correlated_subqueries(cond) => {
-                Some(self.process_where_subqueries(cond, ctx)?)
-            }
-            _ => None,
-        };
-        let effective_condition = processed_join_cond.as_ref().or(effective_condition);
+        // Use natural join condition if present, otherwise use explicit
+        // condition, whose subqueries were read at the top of the function
+        let effective_condition = natural_join_cond.as_ref().or(on_condition);
 
         // =================================================================
         // Execute JOIN using streaming JoinExecutor

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3736,16 +3736,30 @@ impl Executor {
             // Get base column names
             let mut output_columns =
                 self.get_output_column_names(&stmt.columns, &all_columns, table_alias.as_deref());
-            // Append ORDER BY columns not in SELECT
+            // Append ORDER BY columns not in SELECT. A qualified one is
+            // appended to the rows the same way, so it needs a name here or
+            // the sort key rides out with them
             // OPTIMIZATION: Use eq_ignore_ascii_case to avoid allocations
             for ob in &stmt.order_by {
-                if let Expression::Identifier(id) = &ob.expression {
-                    if !output_columns
-                        .iter()
-                        .any(|c| c.eq_ignore_ascii_case(&id.value_lower))
+                match &ob.expression {
+                    Expression::Identifier(id)
+                        if !output_columns
+                            .iter()
+                            .any(|c| c.eq_ignore_ascii_case(&id.value_lower)) =>
                     {
                         output_columns.push(id.value.to_string());
                     }
+                    Expression::QualifiedIdentifier(qi) => {
+                        let full = format!("{}.{}", qi.qualifier.value_lower, qi.name.value_lower);
+                        if !output_columns.iter().any(|c| {
+                            c.eq_ignore_ascii_case(&full)
+                                || c.eq_ignore_ascii_case(&qi.name.value_lower)
+                        }) {
+                            output_columns
+                                .push(format!("{}.{}", qi.qualifier.value, qi.name.value));
+                        }
+                    }
+                    _ => {}
                 }
             }
             // Append DISTINCT ON columns not already in output

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -1948,8 +1948,10 @@ impl Executor {
             return None;
         }
 
-        // No DISTINCT ON — deferred projection would bypass the DISTINCT ON step
-        if classification.has_distinct_on {
+        // No DISTINCT — it reads the columns the SELECT asked for, and
+        // deferring the projection would leave it reading the whole source
+        // row, where rows that project alike are still telling apart
+        if classification.has_distinct_on || classification.has_distinct {
             return None;
         }
 
@@ -4157,7 +4159,10 @@ impl Executor {
                 && !has_agg
                 && !has_window
                 && !correlated_where
-                && (join_type == "INNER" || join_type == "LEFT")
+                // Only an INNER join reads the same with its sides
+                // exchanged; a LEFT join would go on preserving the side it
+                // was given, which after the swap is the wrong one
+                && join_type == "INNER"
                 && !matches!(join_source.right.as_ref(), Expression::TableSource(_))
                 && !matches!(
                     join_source.right.as_ref(),
@@ -5114,6 +5119,16 @@ impl Executor {
         let effective_condition = natural_join_cond
             .as_ref()
             .or(join_source.condition.as_ref().map(|c| c.as_ref()));
+
+        // A subquery in the ON clause is read once, the way the WHERE clause
+        // reads one, so the join has a value to compare each pair against
+        let processed_join_cond: Option<Expression> = match effective_condition {
+            Some(cond) if Self::has_subqueries(cond) && !Self::has_correlated_subqueries(cond) => {
+                Some(self.process_where_subqueries(cond, ctx)?)
+            }
+            _ => None,
+        };
+        let effective_condition = processed_join_cond.as_ref().or(effective_condition);
 
         // =================================================================
         // Execute JOIN using streaming JoinExecutor

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -465,8 +465,21 @@ impl Executor {
             limit_offset_applied = all_union_all && set_limit.is_some();
         }
 
-        // Count expected SELECT columns (before any extra ORDER BY columns)
-        let expected_columns = self.count_select_columns(stmt);
+        // Count expected SELECT columns (before any extra ORDER BY columns).
+        // Beside a star the count is unknown, but the only columns past
+        // the visible ones are then the window functions ORDER BY had
+        // computed for it, so those are counted off the end
+        let expected_columns = match self.count_select_columns(stmt) {
+            0 if classification.has_window_functions => {
+                let hidden = Self::hidden_order_by_windows(stmt).len();
+                if hidden > 0 {
+                    columns.len().saturating_sub(hidden)
+                } else {
+                    0
+                }
+            }
+            counted => counted,
+        };
 
         // Apply DISTINCT (skip for DISTINCT ON — it's applied after ORDER BY)
         // When ORDER BY references columns not in SELECT, we add extra columns for sorting.

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -2543,7 +2543,11 @@ impl Executor {
         // FAST PATH: MIN/MAX index optimization
         // For queries like `SELECT MIN(col) FROM table` or `SELECT MAX(col) FROM table`
         // without WHERE or GROUP BY, use the index directly (O(1) instead of O(n))
-        if storage_expr.is_none() && !needs_memory_filter && !classification.has_group_by {
+        if storage_expr.is_none()
+            && !needs_memory_filter
+            && !classification.has_group_by
+            && stmt.having.is_none()
+        {
             if let Some((result, columns)) =
                 self.try_min_max_index_optimization(stmt, &*table, &all_columns)?
             {
@@ -2554,7 +2558,11 @@ impl Executor {
         // FAST PATH: COUNT(*) pushdown optimization
         // For queries like `SELECT COUNT(*) FROM table` without WHERE or GROUP BY,
         // use the table's row_count() method instead of scanning all rows
-        if storage_expr.is_none() && !needs_memory_filter && !classification.has_group_by {
+        if storage_expr.is_none()
+            && !needs_memory_filter
+            && !classification.has_group_by
+            && stmt.having.is_none()
+        {
             if let Some((result, columns)) = self.try_count_star_optimization(stmt, &*table)? {
                 return Ok((result, columns, false, None));
             }

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -2584,11 +2584,15 @@ impl Executor {
         // FAST PATH: IN subquery index optimization
         // For queries like `SELECT * FROM table WHERE id IN (SELECT col FROM other_table WHERE ...)`
         // where 'id' has an index or is PRIMARY KEY, probe directly instead of scanning all rows
-        // Skip if query has aggregation: projection cannot compile aggregate functions
+        // Left to the normal pipeline: aggregation and window functions (this
+        // projection cannot compile them) and an ORDER BY key that is not
+        // projected (the sorter would not find it).
         if needs_memory_filter
             && !has_outer_context
             && !classification.has_group_by
             && !classification.has_aggregation
+            && !classification.has_window_functions
+            && !order_by_needs_extra_columns
         {
             if let Some(where_expr) = where_to_use {
                 if let Some((result, columns, limit_applied)) = self
@@ -2939,7 +2943,19 @@ impl Executor {
                         // For LIMIT queries, the streaming InHashSet path is faster due to early termination
                         let has_limit = outer_limit.is_some()
                             && outer_limit.unwrap() < ANTI_JOIN_LIMIT_THRESHOLD;
-                        let use_anti_join = is_pure_not_exists && !has_limit;
+
+                        // This path projects the anti-join rows and returns
+                        // them, so it can only answer a plain projection:
+                        // anything that shapes the result afterwards belongs
+                        // to the general path
+                        let is_plain_projection = !classification.has_aggregation
+                            && !classification.has_window_functions
+                            && !classification.has_group_by
+                            && !classification.has_having
+                            && !classification.has_order_by
+                            && !classification.has_distinct
+                            && !classification.has_distinct_on;
+                        let use_anti_join = is_pure_not_exists && !has_limit && is_plain_projection;
 
                         if use_anti_join {
                             // Materialize outer table rows
@@ -3068,7 +3084,9 @@ impl Executor {
             if !has_correlated
                 && !classification.has_group_by
                 && !classification.has_aggregation
+                && !classification.has_window_functions
                 && !classification.select_has_correlated_subqueries
+                && !self.order_by_needs_extra_columns(stmt, &all_columns)
             {
                 if let Some(ref where_expr) = processed_where {
                     if let Some((result, columns, limit_applied)) = self

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -632,7 +632,11 @@ impl Executor {
                                 }
                             }
                         }
-                        None
+                        // The projection puts an expression the SELECT list
+                        // leaves out in a column named after it
+                        columns
+                            .iter()
+                            .position(|c| c.eq_ignore_ascii_case(&order_expr_str))
                     }
                 }
             };
@@ -1813,6 +1817,25 @@ impl Executor {
                                 || c.eq_ignore_ascii_case(qi.name.value_lower.as_str())
                         })
                     {
+                        return true;
+                    }
+                }
+                Expression::IntegerLiteral(_) => {}
+                // An expression is read from a column of its own, unless the
+                // SELECT list already has it under a name. A subquery reads
+                // the parent row per row, which the sort does for itself
+                other
+                    if !matches!(
+                        other,
+                        Expression::Identifier(_) | Expression::QualifiedIdentifier(_)
+                    ) && !Self::has_subqueries(other) =>
+                {
+                    let name = other.to_string();
+                    let aliased = stmt.columns.iter().any(|expr| match expr {
+                        Expression::Aliased(a) => a.expression.to_string() == name,
+                        _ => false,
+                    });
+                    if !aliased && !select_columns.contains(name.to_lowercase().as_str()) {
                         return true;
                     }
                 }
@@ -3725,7 +3748,7 @@ impl Executor {
             // 1. Include those columns in the output (appended at end)
             // 2. Sort will happen in execute_select
             // 3. Extra columns will be projected out after sorting
-            let (projected_rows, _) = self.project_rows_with_order_by(
+            let (projected_rows, extra_names) = self.project_rows_with_order_by(
                 &stmt.columns,
                 &stmt.order_by,
                 &stmt.distinct_on,
@@ -3733,69 +3756,11 @@ impl Executor {
                 &all_columns,
                 ctx,
             )?;
-            // Get base column names
+            // Get base column names, then the ones the projection appended,
+            // which it names in the order it appends them
             let mut output_columns =
                 self.get_output_column_names(&stmt.columns, &all_columns, table_alias.as_deref());
-            // Append ORDER BY columns not in SELECT. A qualified one is
-            // appended to the rows the same way, so it needs a name here or
-            // the sort key rides out with them
-            // OPTIMIZATION: Use eq_ignore_ascii_case to avoid allocations
-            for ob in &stmt.order_by {
-                match &ob.expression {
-                    Expression::Identifier(id)
-                        if !output_columns
-                            .iter()
-                            .any(|c| c.eq_ignore_ascii_case(&id.value_lower)) =>
-                    {
-                        output_columns.push(id.value.to_string());
-                    }
-                    Expression::QualifiedIdentifier(qi) => {
-                        let full = format!("{}.{}", qi.qualifier.value_lower, qi.name.value_lower);
-                        if !output_columns.iter().any(|c| {
-                            c.eq_ignore_ascii_case(&full)
-                                || c.eq_ignore_ascii_case(&qi.name.value_lower)
-                        }) {
-                            output_columns
-                                .push(format!("{}.{}", qi.qualifier.value, qi.name.value));
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            // Append DISTINCT ON columns not already in output
-            for expr in &stmt.distinct_on {
-                match expr {
-                    Expression::Identifier(id)
-                        if !output_columns
-                            .iter()
-                            .any(|c| c.eq_ignore_ascii_case(&id.value_lower)) =>
-                    {
-                        output_columns.push(id.value.to_string());
-                    }
-                    Expression::QualifiedIdentifier(qi) => {
-                        let full_name =
-                            format!("{}.{}", qi.qualifier.value_lower, qi.name.value_lower);
-                        // Only match full qualified name to avoid ambiguity
-                        if !output_columns
-                            .iter()
-                            .any(|c| c.eq_ignore_ascii_case(&full_name))
-                        {
-                            output_columns
-                                .push(format!("{}.{}", qi.qualifier.value, qi.name.value));
-                        }
-                    }
-                    _ => {
-                        // Computed expression — use Display representation as column name
-                        let expr_name = expr.to_string();
-                        if !output_columns
-                            .iter()
-                            .any(|c| c.eq_ignore_ascii_case(&expr_name))
-                        {
-                            output_columns.push(expr_name);
-                        }
-                    }
-                }
-            }
+            output_columns.extend(extra_names);
             (projected_rows, output_columns, None)
         } else if let Some((col_indices, output_names)) = deferred_projection_info {
             // DEFERRED PROJECTION: Skip projection now, do it after ORDER BY + LIMIT
@@ -5350,7 +5315,7 @@ impl Executor {
         // Project rows according to SELECT expressions
         let (projected_rows, output_columns) = if join_needs_extra_columns {
             // Use projection that preserves extra ORDER BY / DISTINCT ON columns
-            let (projected_rows, _) = self.project_rows_with_order_by(
+            let (projected_rows, extra_names) = self.project_rows_with_order_by(
                 &stmt.columns,
                 &stmt.order_by,
                 &stmt.distinct_on,
@@ -5360,83 +5325,7 @@ impl Executor {
             )?;
             let mut output_columns =
                 self.get_output_column_names(&stmt.columns, &final_columns, None);
-            // Build a set of qualified names from SELECT for accurate "already present" checks.
-            // This mirrors the select_column_names logic in project_rows_with_order_by.
-            let mut select_qualified_names: Vec<String> = Vec::new();
-            for expr in &stmt.columns {
-                match expr {
-                    Expression::QualifiedIdentifier(qi) => {
-                        select_qualified_names.push(format!(
-                            "{}.{}",
-                            qi.qualifier.value_lower, qi.name.value_lower
-                        ));
-                    }
-                    Expression::Aliased(a) => {
-                        if let Expression::QualifiedIdentifier(qi) = &*a.expression {
-                            select_qualified_names.push(format!(
-                                "{}.{}",
-                                qi.qualifier.value_lower, qi.name.value_lower
-                            ));
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            // Append extra ORDER BY columns not in SELECT
-            for ob in &stmt.order_by {
-                match &ob.expression {
-                    Expression::Identifier(id)
-                        if !output_columns
-                            .iter()
-                            .any(|c| c.eq_ignore_ascii_case(&id.value_lower)) =>
-                    {
-                        output_columns.push(id.value.to_string());
-                    }
-                    Expression::QualifiedIdentifier(qi) => {
-                        let full = format!("{}.{}", qi.qualifier.value_lower, qi.name.value_lower);
-                        // Check both output_columns and select qualified names
-                        if !output_columns.iter().any(|c| c.eq_ignore_ascii_case(&full))
-                            && !select_qualified_names.contains(&full)
-                        {
-                            output_columns
-                                .push(format!("{}.{}", qi.qualifier.value, qi.name.value));
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            // Append extra DISTINCT ON columns not in SELECT
-            for expr in &stmt.distinct_on {
-                match expr {
-                    Expression::Identifier(id) => {
-                        if !output_columns
-                            .iter()
-                            .any(|c| c.eq_ignore_ascii_case(&id.value_lower))
-                        {
-                            output_columns.push(id.value.to_string());
-                        }
-                    }
-                    Expression::QualifiedIdentifier(qi) => {
-                        let full = format!("{}.{}", qi.qualifier.value_lower, qi.name.value_lower);
-                        // Check both output_columns and select qualified names
-                        if !output_columns.iter().any(|c| c.eq_ignore_ascii_case(&full))
-                            && !select_qualified_names.contains(&full)
-                        {
-                            output_columns
-                                .push(format!("{}.{}", qi.qualifier.value, qi.name.value));
-                        }
-                    }
-                    _ => {
-                        let expr_name = expr.to_string();
-                        if !output_columns
-                            .iter()
-                            .any(|c| c.eq_ignore_ascii_case(&expr_name))
-                        {
-                            output_columns.push(expr_name);
-                        }
-                    }
-                }
-            }
+            output_columns.extend(extra_names);
             (projected_rows, CompactArc::new(output_columns))
         } else {
             let projected_rows = self.project_rows_with_alias(
@@ -8340,6 +8229,9 @@ impl Executor {
 
         // Find ORDER BY columns not in SELECT
         let mut extra_order_indices: Vec<usize> = Vec::new();
+        // An ORDER BY expression is read from a column of its own, so the
+        // sort has something to read once the projection has run
+        let mut computed_order_by: Vec<&Expression> = Vec::new();
         for ob in order_by {
             match &ob.expression {
                 Expression::Identifier(id)
@@ -8366,6 +8258,23 @@ impl Executor {
                                 extra_order_indices.push(idx);
                             }
                         }
+                    }
+                }
+                // A subquery is read per row against the parent, which the
+                // sort does for itself, so it is not read from a column here
+                other
+                    if !matches!(
+                        other,
+                        Expression::Identifier(_) | Expression::QualifiedIdentifier(_)
+                    ) && !Self::has_subqueries(other) =>
+                {
+                    let name = other.to_string();
+                    if !select_column_names
+                        .iter()
+                        .any(|s| s.eq_ignore_ascii_case(&name))
+                        && !computed_order_by.iter().any(|e| e.to_string() == name)
+                    {
+                        computed_order_by.push(other);
                     }
                 }
                 _ => {}
@@ -8451,9 +8360,19 @@ impl Executor {
             }
         }
 
+        // The names of the columns appended below, in the order they are
+        // appended, so the caller can put them on the end of its own list
+        let mut extra_names: Vec<String> = extra_order_indices
+            .iter()
+            .map(|idx| all_columns[*idx].clone())
+            .collect();
+        extra_names.extend(computed_order_by.iter().map(|expr| expr.to_string()));
+        extra_names.extend(computed_distinct_on.iter().map(|expr| expr.to_string()));
+
         // Check if we can use fast path (all simple column refs, no computed DISTINCT ON)
         let all_simple = select_column_indices.iter().all(|idx| idx.is_some())
-            && computed_distinct_on.is_empty();
+            && computed_distinct_on.is_empty()
+            && computed_order_by.is_empty();
 
         if all_simple {
             // Fast path
@@ -8479,7 +8398,7 @@ impl Executor {
             }
 
             // Output column names will be computed in caller
-            Ok((projected, vec![]))
+            Ok((projected, extra_names))
         } else {
             // Slow path: Use Evaluator for complex expressions
             let mut projected = RowVec::with_capacity(rows.len());
@@ -8489,7 +8408,8 @@ impl Executor {
             evaluator = evaluator.with_context(ctx);
             evaluator.init_columns(all_columns);
 
-            let total_extra = extra_order_indices.len() + computed_distinct_on.len();
+            let total_extra =
+                extra_order_indices.len() + computed_order_by.len() + computed_distinct_on.len();
 
             // OPTIMIZATION: Reuse col_index_map_lower for O(1) lookup
             for (row_id, row) in rows.drain_rows().enumerate() {
@@ -8513,6 +8433,14 @@ impl Executor {
                     values.push(row.get(idx).cloned().unwrap_or(Value::null_unknown()));
                 }
 
+                // Evaluate computed ORDER BY expressions
+                for expr in &computed_order_by {
+                    let value = evaluator
+                        .evaluate(expr)
+                        .unwrap_or_else(|_| Value::null_unknown());
+                    values.push(value);
+                }
+
                 // Evaluate computed DISTINCT ON expressions
                 for expr in &computed_distinct_on {
                     let value = evaluator
@@ -8524,7 +8452,7 @@ impl Executor {
                 projected.push((row_id as i64, Row::from_values(values)));
             }
 
-            Ok((projected, vec![]))
+            Ok((projected, extra_names))
         }
     }
 

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -616,7 +616,13 @@ impl Executor {
                                 }
                             }
                         }
-                        None
+                        // A function of anything but a bare column is named
+                        // after the whole call, the way the projection names
+                        // the column it puts an unselected expression in
+                        let order_expr_str = ob.expression.to_string();
+                        columns
+                            .iter()
+                            .position(|c| c.eq_ignore_ascii_case(&order_expr_str))
                     }
                     _ => {
                         // For any other expression (Infix, Prefix, Cast, etc.),
@@ -8195,6 +8201,55 @@ impl Executor {
 
     /// Project rows including ORDER BY columns not in SELECT
     /// Returns rows with SELECT columns followed by ORDER BY columns
+    /// True when an expression names a SELECT alias that no source column
+    /// carries. Inside an expression a source column wins over an alias of
+    /// the same name, so only a name the source lacks counts here.
+    fn reads_a_select_alias(
+        expr: &Expression,
+        aliases: &FxHashSet<String>,
+        source_columns: &crate::common::StringMap<usize>,
+    ) -> bool {
+        let check = |e: &Expression| Self::reads_a_select_alias(e, aliases, source_columns);
+        let only_an_alias =
+            |name: &str| aliases.contains(name) && !source_columns.contains_key(name);
+
+        match expr {
+            Expression::Identifier(id) => only_an_alias(id.value_lower.as_str()),
+            // An alias is never qualified
+            Expression::QualifiedIdentifier(_) => false,
+            Expression::IntegerLiteral(_)
+            | Expression::FloatLiteral(_)
+            | Expression::StringLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_)
+            | Expression::IntervalLiteral(_)
+            | Expression::Parameter(_)
+            | Expression::Star(_)
+            | Expression::QualifiedStar(_)
+            | Expression::Default(_) => false,
+            Expression::Prefix(p) => check(&p.right),
+            Expression::Infix(inf) => check(&inf.left) || check(&inf.right),
+            Expression::FunctionCall(fc) => fc.arguments.iter().any(check),
+            Expression::Cast(c) => check(&c.expr),
+            Expression::Aliased(a) => check(&a.expression),
+            Expression::Case(case) => {
+                case.value.as_ref().is_some_and(|v| check(v))
+                    || case
+                        .when_clauses
+                        .iter()
+                        .any(|w| check(&w.condition) || check(&w.then_result))
+                    || case.else_value.as_ref().is_some_and(|e| check(e))
+            }
+            Expression::Between(b) => check(&b.expr) || check(&b.lower) || check(&b.upper),
+            Expression::In(i) => check(&i.left),
+            Expression::Like(l) => check(&l.left) || check(&l.pattern),
+            Expression::Distinct(d) => check(&d.expr),
+            Expression::Window(w) => w.function.arguments.iter().any(check),
+            // Anything else is left to the sort, which reads the projected row
+            _ => true,
+        }
+    }
+
     fn project_rows_with_order_by(
         &self,
         select_exprs: &[Expression],
@@ -8245,6 +8300,15 @@ impl Executor {
             })
             .collect();
 
+        // The names the projection alone brings into scope
+        let select_aliases: FxHashSet<String> = select_exprs
+            .iter()
+            .filter_map(|e| match e {
+                Expression::Aliased(a) => Some(a.alias.value_lower.to_string()),
+                _ => None,
+            })
+            .collect();
+
         // Find ORDER BY columns not in SELECT
         let mut extra_order_indices: Vec<usize> = Vec::new();
         // An ORDER BY expression is read from a column of its own, so the
@@ -8279,12 +8343,19 @@ impl Executor {
                     }
                 }
                 // A subquery is read per row against the parent, which the
-                // sort does for itself, so it is not read from a column here
+                // sort does for itself, so it is not read from a column here.
+                // Neither is an expression naming an alias, which the row
+                // only carries once the projection has run
                 other
                     if !matches!(
                         other,
                         Expression::Identifier(_) | Expression::QualifiedIdentifier(_)
-                    ) && !Self::has_subqueries(other) =>
+                    ) && !Self::has_subqueries(other)
+                        && !Self::reads_a_select_alias(
+                            other,
+                            &select_aliases,
+                            &col_index_map_lower,
+                        ) =>
                 {
                     let name = other.to_string();
                     if !select_column_names

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -2388,10 +2388,10 @@ impl Executor {
                 // Example: WHERE o.user_id = u.id -> WHERE o.user_id = 42
                 if let Some(outer_row) = ctx.outer_row() {
                     let schema = table.schema();
+                    let inner = [table_alias.as_deref().unwrap_or(table_name)];
                     let scope = super::utils::InnerScope {
-                        table: table_name,
-                        alias: table_alias.as_deref(),
-                        schema,
+                        tables: &inner,
+                        schema: Some(schema),
                     };
                     let substituted_expr = super::utils::substitute_outer_references_in_scope(
                         where_expr, outer_row, &scope,

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -688,6 +688,23 @@ impl Executor {
                 // This avoids O(n * row_size) cloning overhead.
                 let num_order_cols = stmt.order_by.len();
 
+                // A subquery that reads nothing of the row is run once here:
+                // its compiled placeholder cannot run on its own
+                let order_exprs: Vec<std::borrow::Cow<Expression>> = stmt
+                    .order_by
+                    .iter()
+                    .map(|ob| {
+                        if Self::has_subqueries(&ob.expression)
+                            && !Self::has_correlated_subqueries(&ob.expression)
+                        {
+                            self.process_where_subqueries(&ob.expression, ctx)
+                                .map(std::borrow::Cow::Owned)
+                        } else {
+                            Ok(std::borrow::Cow::Borrowed(&ob.expression))
+                        }
+                    })
+                    .collect::<Result<_>>()?;
+
                 // Compute sort keys for each row: Vec<Vec<Value>>
                 // Each inner Vec contains the evaluated ORDER BY expressions for that row
                 let sort_keys: Vec<Vec<Value>> = if has_correlated_order_by {
@@ -747,7 +764,8 @@ impl Executor {
                             evaluator.set_row_array(row);
                             stmt.order_by
                                 .iter()
-                                .map(|ob| {
+                                .zip(order_exprs.iter())
+                                .map(|(ob, order_expr)| {
                                     // A key the projection already put in a
                                     // column is read from it
                                     if let Some(idx) = try_map_to_column(ob) {
@@ -776,7 +794,7 @@ impl Executor {
                                         }
                                     } else {
                                         evaluator
-                                            .evaluate(&ob.expression)
+                                            .evaluate(order_expr)
                                             .unwrap_or_else(|_| Value::null_unknown())
                                     }
                                 })
@@ -795,9 +813,10 @@ impl Executor {
                     )> = stmt
                         .order_by
                         .iter()
-                        .map(|ob| match try_map_to_column(ob) {
+                        .zip(order_exprs.iter())
+                        .map(|(ob, order_expr)| match try_map_to_column(ob) {
                             Some(idx) => (Some(idx), None),
-                            None => (None, evaluator.compile_cached(&ob.expression).ok()),
+                            None => (None, evaluator.compile_cached(order_expr).ok()),
                         })
                         .collect();
                     rows.iter()
@@ -1830,6 +1849,16 @@ impl Executor {
                 }
                 _ => {}
             }
+        }
+
+        // A correlated subquery in ORDER BY reads the parent row, all of
+        // it, so every column is carried until the sort has run
+        if stmt
+            .order_by
+            .iter()
+            .any(|ob| Self::has_correlated_subqueries(&ob.expression))
+        {
+            return true;
         }
 
         // Check if any ORDER BY column is not in SELECT
@@ -8444,6 +8473,19 @@ impl Executor {
                     }
                 }
                 _ => {}
+            }
+        }
+
+        // A correlated subquery in ORDER BY reads the parent row, so every
+        // column rides along until the sort has run
+        if order_by
+            .iter()
+            .any(|ob| Self::has_correlated_subqueries(&ob.expression))
+        {
+            for idx in 0..all_columns.len() {
+                if !extra_order_indices.contains(&idx) {
+                    extra_order_indices.push(idx);
+                }
             }
         }
 

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -6841,6 +6841,16 @@ impl Executor {
                     .unwrap_or_else(|| agg.get_expression_name()),
             );
         }
+        // A HAVING that reads the group it is asked about has to be run once
+        // per group with that group as the outer row, which the general
+        // aggregation does and this streaming path does not
+        if stmt
+            .having
+            .as_deref()
+            .is_some_and(Self::has_correlated_subqueries)
+        {
+            return Ok(None);
+        }
         let having = match &stmt.having {
             Some(having) => {
                 let processed = self.process_where_subqueries(having, ctx)?;

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -10676,18 +10676,18 @@ impl Executor {
                                 }
                                 StreamingAgg::Sum(col_idx) | StreamingAgg::Avg(col_idx) => {
                                     if let Some(value) = row.get(*col_idx) {
-                                        match value {
-                                            Value::Integer(v) => {
-                                                agg_sums[i] += *v as f64;
-                                                counts[i] += 1;
-                                                agg_has_value[i] = true;
-                                            }
-                                            Value::Float(v) => {
-                                                agg_sums[i] += v;
-                                                counts[i] += 1;
-                                                agg_has_value[i] = true;
-                                            }
-                                            _ => {}
+                                        // A boolean counts as one or nought,
+                                        // as the aggregate itself reads it
+                                        let numeric = match value {
+                                            Value::Integer(v) => Some(*v as f64),
+                                            Value::Float(v) => Some(*v),
+                                            Value::Boolean(b) => Some(*b as i64 as f64),
+                                            _ => None,
+                                        };
+                                        if let Some(v) = numeric {
+                                            agg_sums[i] += v;
+                                            counts[i] += 1;
+                                            agg_has_value[i] = true;
                                         }
                                     }
                                 }

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -10317,6 +10317,19 @@ impl Executor {
         let mut result = Vec::new();
 
         for col in &stmt.columns {
+            // A FILTER or DISTINCT narrows what the aggregate reads, and the
+            // streaming path below reads the column whole
+            let call = match col {
+                Expression::FunctionCall(fc) => Some(fc),
+                Expression::Aliased(aliased) => match aliased.expression.as_ref() {
+                    Expression::FunctionCall(fc) => Some(fc),
+                    _ => None,
+                },
+                _ => None,
+            };
+            if call.is_some_and(|fc| fc.filter.is_some() || fc.is_distinct) {
+                return Vec::new();
+            }
             match col {
                 Expression::FunctionCall(fc) => {
                     let func_upper = fc.function.to_uppercase();

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -503,6 +503,19 @@ impl Executor {
                 }
             };
 
+            // The projection names a column after the whole expression it
+            // holds. Identifiers inside it are matched whatever their case,
+            // but a string literal is not, so an exact name wins over one
+            // that only reads the same: ABS(g, 'a') and ABS(g, 'A') are two
+            // expressions and get two columns
+            let find_column_named_after = |expr: &Expression| -> Option<usize> {
+                let name = expr.to_string();
+                columns
+                    .iter()
+                    .position(|c| *c == name)
+                    .or_else(|| columns.iter().position(|c| c.eq_ignore_ascii_case(&name)))
+            };
+
             // Check if ORDER BY expression can be mapped to existing column (handles aggregates)
             let try_map_to_column = |ob: &crate::parser::ast::OrderByExpression| -> Option<usize> {
                 match &ob.expression {
@@ -619,10 +632,7 @@ impl Executor {
                         // A function of anything but a bare column is named
                         // after the whole call, the way the projection names
                         // the column it puts an unselected expression in
-                        let order_expr_str = ob.expression.to_string();
-                        columns
-                            .iter()
-                            .position(|c| c.eq_ignore_ascii_case(&order_expr_str))
+                        find_column_named_after(&ob.expression)
                     }
                     _ => {
                         // For any other expression (Infix, Prefix, Cast, etc.),
@@ -640,9 +650,7 @@ impl Executor {
                         }
                         // The projection puts an expression the SELECT list
                         // leaves out in a column named after it
-                        columns
-                            .iter()
-                            .position(|c| c.eq_ignore_ascii_case(&order_expr_str))
+                        find_column_named_after(&ob.expression)
                     }
                 }
             };
@@ -740,6 +748,14 @@ impl Executor {
                             stmt.order_by
                                 .iter()
                                 .map(|ob| {
+                                    // A key the projection already put in a
+                                    // column is read from it
+                                    if let Some(idx) = try_map_to_column(ob) {
+                                        return row
+                                            .get(idx)
+                                            .cloned()
+                                            .unwrap_or_else(Value::null_unknown);
+                                    }
                                     // Try processing correlated subqueries first
                                     if Self::has_correlated_subqueries(&ob.expression) {
                                         match self.process_correlated_expression(
@@ -768,22 +784,34 @@ impl Executor {
                         })
                         .collect()
                 } else {
-                    // Pre-compile each ORDER BY expression once; per row
+                    // A key the projection already put in a column is read
+                    // from it: the row no longer carries what it was
+                    // computed from. The rest are compiled once, so per row
                     // only the VM runs (no row clone, no expression re-hash)
-                    let programs: Vec<Option<super::expression::SharedProgram>> = stmt
+                    #[allow(clippy::type_complexity)]
+                    let key_sources: Vec<(
+                        Option<usize>,
+                        Option<super::expression::SharedProgram>,
+                    )> = stmt
                         .order_by
                         .iter()
-                        .map(|ob| evaluator.compile_cached(&ob.expression).ok())
+                        .map(|ob| match try_map_to_column(ob) {
+                            Some(idx) => (Some(idx), None),
+                            None => (None, evaluator.compile_cached(&ob.expression).ok()),
+                        })
                         .collect();
                     rows.iter()
                         .map(|(_, row)| {
-                            programs
+                            key_sources
                                 .iter()
-                                .map(|p| match p {
-                                    Some(p) => evaluator
+                                .map(|source| match source {
+                                    (Some(idx), _) => {
+                                        row.get(*idx).cloned().unwrap_or_else(Value::null_unknown)
+                                    }
+                                    (None, Some(p)) => evaluator
                                         .evaluate_program(p, row)
                                         .unwrap_or_else(|_| Value::null_unknown()),
-                                    None => Value::null_unknown(),
+                                    (None, None) => Value::null_unknown(),
                                 })
                                 .collect()
                         })

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -2387,6 +2387,26 @@ impl Executor {
         // Check if this query might reference outer columns (correlated)
         let has_outer_context = ctx.outer_row().is_some();
 
+        // A parent row's columns are bound into a WHERE holding subqueries,
+        // the subqueries included, so one that reads only the parent row
+        // folds once instead of running for every row of this table
+        let bound_where: Option<Expression> = match (where_to_use, ctx.outer_row()) {
+            (Some(where_expr), Some(outer_row)) if classification.where_has_subqueries => {
+                let inner = [table_alias.as_deref().unwrap_or(table_name)];
+                let scope = super::utils::InnerScope {
+                    tables: &inner,
+                    schema: Some(table.schema()),
+                };
+                Some(super::utils::substitute_outer_references_in_scope(
+                    where_expr, outer_row, &scope,
+                ))
+            }
+            _ => None,
+        };
+        let where_to_use: Option<&Expression> = bound_where.as_ref().or(where_to_use);
+        let where_still_correlated = classification.where_has_correlated_subqueries
+            && where_to_use.is_some_and(Self::has_correlated_subqueries);
+
         // SEMANTIC CACHE: Check if we can serve this query from cache
         // Eligible queries: simple column projections with WHERE, no aggregation/window/grouping, no outer context
         // Use cached classification for is_select_star check
@@ -2998,8 +3018,7 @@ impl Executor {
 
             // Check if WHERE contains correlated subqueries
             // Use cached classification to avoid expensive AST traversal
-            let has_correlated = classification.where_has_subqueries
-                && classification.where_has_correlated_subqueries;
+            let has_correlated = where_still_correlated;
 
             // Check if WHERE contains any subqueries (correlated or not)
             // Use cached classification to avoid redundant traversal of the expression tree

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -8719,8 +8719,23 @@ impl Executor {
         )?;
         let mut columns = all_columns.to_vec();
         let mut exprs = select_exprs.to_vec();
-        for (n, &i) in correlated.iter().enumerate() {
-            let name = format!("__correlated_{n}");
+        // A source column may carry any name, so the bound column takes the
+        // first name no source column has, qualified or bare
+        let taken = |name: &str, columns: &[String]| {
+            columns.iter().any(|column| {
+                let bare = column.rsplit('.').next().unwrap_or(column);
+                column.eq_ignore_ascii_case(name) || bare.eq_ignore_ascii_case(name)
+            })
+        };
+        let mut next = 0usize;
+        for &i in &correlated {
+            let name = loop {
+                let candidate = format!("__correlated_{next}");
+                next += 1;
+                if !taken(&candidate, &columns) {
+                    break candidate;
+                }
+            };
             let column = Expression::Identifier(Identifier::new(
                 dummy_token(&name, TokenType::Identifier),
                 name.clone(),

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -4070,11 +4070,9 @@ impl Executor {
         // A predicate holding a subquery is left for the per-row path
         let where_for_join = match (where_for_join, ctx.outer_row()) {
             (Some(where_clause), Some(outer)) => {
-                let inner: Vec<String> = [&left_alias, &right_alias]
-                    .into_iter()
-                    .flatten()
-                    .map(|alias| alias.to_lowercase())
-                    .collect();
+                let mut inner = Vec::new();
+                super::utils::collect_table_aliases(&join_source.left, &mut inner);
+                super::utils::collect_table_aliases(&join_source.right, &mut inner);
                 let inner: Vec<&str> = inner.iter().map(String::as_str).collect();
                 let scope = super::utils::InnerScope {
                     tables: &inner,

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -5559,6 +5559,50 @@ impl Executor {
         Ok((Box::new(result), output_columns, false, None))
     }
 
+    /// Keep the rows of an in-memory source that pass a WHERE holding a
+    /// correlated subquery, each row bound as the subquery's outer row
+    pub(crate) fn filter_rows_by_correlated_where(
+        &self,
+        where_expr: &Expression,
+        rows: RowVec,
+        columns: &[String],
+        table_alias: Option<&str>,
+        ctx: &ExecutionContext,
+    ) -> Result<RowVec> {
+        let mut evaluator = CompiledEvaluator::new(&self.function_registry).with_context(ctx);
+        evaluator.init_columns(columns);
+        let column_keys = ColumnKeyMapping::build_mappings(columns, table_alias);
+        let columns_arc = CompactArc::new(columns.to_vec());
+        let mut outer_row_map: FxHashMap<CompactArc<str>, Value> = FxHashMap::default();
+        let mut kept = RowVec::with_capacity(rows.len());
+        for (id, row) in rows {
+            outer_row_map.clear();
+            for mapping in &column_keys {
+                if let Some(value) = row.get(mapping.index) {
+                    if let Some(ref upart) = mapping.unqualified_part {
+                        outer_row_map.insert(upart.clone(), value.clone());
+                    }
+                    if let Some(ref qname) = mapping.qualified_name {
+                        outer_row_map.insert(qname.clone(), value.clone());
+                    }
+                    outer_row_map.insert(mapping.col_lower.clone(), value.clone());
+                }
+            }
+            let mut correlated_ctx =
+                ctx.with_outer_row(std::mem::take(&mut outer_row_map), columns_arc.clone());
+            let processed = self.process_correlated_where(where_expr, &correlated_ctx)?;
+            ctx.check_cancelled()?;
+            evaluator.set_outer_row_owned(correlated_ctx.outer_row.take().unwrap_or_default());
+            evaluator.set_row_array(&row);
+            let keep = evaluator.evaluate_bool(&processed)?;
+            outer_row_map = evaluator.take_outer_row();
+            if keep {
+                kept.push((id, row));
+            }
+        }
+        Ok(kept)
+    }
+
     /// Execute a subquery source
     fn execute_subquery_source(
         &self,
@@ -5646,15 +5690,23 @@ impl Executor {
                 }
                 None => where_clause,
             };
-            let where_filter = RowFilter::new(where_clause, &columns)?.with_context(ctx);
+            if Self::has_correlated_subqueries(where_clause) {
+                let alias = subquery_source
+                    .alias
+                    .as_ref()
+                    .map(|a| a.value_lower.as_str());
+                self.filter_rows_by_correlated_where(where_clause, rows, &columns, alias, ctx)?
+            } else {
+                let where_filter = RowFilter::new(where_clause, &columns)?.with_context(ctx);
 
-            let mut filtered = RowVec::with_capacity(rows.len());
-            for (id, row) in rows {
-                if where_filter.matches_checked(&row)? {
-                    filtered.push((id, row));
+                let mut filtered = RowVec::with_capacity(rows.len());
+                for (id, row) in rows {
+                    if where_filter.matches_checked(&row)? {
+                        filtered.push((id, row));
+                    }
                 }
+                filtered
             }
-            filtered
         } else {
             rows
         };
@@ -5797,6 +5849,11 @@ impl Executor {
         // avoiding repeated expression compilation per row.
         // CRITICAL: Must pass ctx for parameter resolution ($1, named params, etc.)
         let mut result: Box<dyn QueryResult> = result;
+        let view_alias = stmt
+            .table_expr
+            .as_deref()
+            .and_then(super::utils::get_table_alias_from_expr)
+            .map(|name| name.to_lowercase());
         if let Some(ref where_clause) = stmt.where_clause {
             // A parent row's column named through its own table is bound
             // first, or the bare name it would fall back to could be the
@@ -5825,8 +5882,45 @@ impl Executor {
                 }
                 None => where_clause,
             };
-            let filter = RowFilter::new(where_clause, &view_columns)?.with_context(ctx);
-            result = Box::new(FilteredResult::from_filter(result, filter));
+            if Self::has_correlated_subqueries(where_clause) {
+                let rows = Self::materialize_result(result)?;
+                let rows = self.filter_rows_by_correlated_where(
+                    where_clause,
+                    rows,
+                    &view_columns,
+                    view_alias.as_deref(),
+                    ctx,
+                )?;
+                result = Box::new(ExecutorResult::new(view_columns.clone(), rows));
+            } else {
+                let filter = RowFilter::new(where_clause, &view_columns)?.with_context(ctx);
+                result = Box::new(FilteredResult::from_filter(result, filter));
+            }
+        }
+
+        // A correlated subquery in the select list reads each view row as
+        // its outer row, the way it does over a derived table
+        if Self::has_correlated_select_subqueries(&stmt.columns)
+            && !classification.has_aggregation
+            && !classification.has_window_functions
+            && !self.order_by_needs_extra_columns(stmt, &view_columns)
+        {
+            let rows = Self::materialize_result(result)?;
+            let projected_rows = self.project_rows_with_alias(
+                &stmt.columns,
+                rows,
+                &view_columns,
+                None,
+                ctx,
+                view_alias.as_deref(),
+            )?;
+            let output_columns =
+                CompactArc::new(self.get_output_column_names(&stmt.columns, &view_columns, None));
+            let result = ExecutorResult::with_arc_columns(
+                CompactArc::clone(&output_columns),
+                projected_rows,
+            );
+            return Ok((Box::new(result), output_columns, false, None));
         }
 
         // Handle aggregation: if outer query has aggregates, materialize view result and aggregate

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -2515,7 +2515,11 @@ impl Executor {
             // If there are subqueries, we must filter in memory
             // Use cached classification to avoid AST traversal
             if classification.where_has_subqueries {
-                (None, true)
+                // The conjuncts without a subquery still narrow the scan;
+                // the whole WHERE is evaluated in memory afterwards
+                let (storage_expr, _) =
+                    pushdown::try_pushdown(where_expr, table.schema(), Some(ctx));
+                (storage_expr, true)
             } else if has_outer_context {
                 // If we have outer row context, this is a correlated subquery
                 // OPTIMIZATION: Substitute outer references with their actual values

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -5800,6 +5800,33 @@ impl Executor {
         // CRITICAL: Must pass ctx for parameter resolution ($1, named params, etc.)
         let mut result: Box<dyn QueryResult> = result;
         if let Some(ref where_clause) = stmt.where_clause {
+            // A parent row's column named through its own table is bound
+            // first, or the bare name it would fall back to could be the
+            // view's own
+            let bound_where;
+            let where_clause: &Expression = match ctx.outer_row() {
+                Some(outer) => {
+                    let inner: Vec<String> = stmt
+                        .table_expr
+                        .as_deref()
+                        .and_then(super::utils::get_table_alias_from_expr)
+                        .map(|name| name.to_lowercase())
+                        .into_iter()
+                        .collect();
+                    let inner: Vec<&str> = inner.iter().map(String::as_str).collect();
+                    let scope = super::utils::InnerScope {
+                        tables: &inner,
+                        schema: None,
+                    };
+                    bound_where = super::utils::substitute_outer_references_in_scope(
+                        where_clause,
+                        outer,
+                        &scope,
+                    );
+                    &bound_where
+                }
+                None => where_clause,
+            };
             let filter = RowFilter::new(where_clause, &view_columns)?.with_context(ctx);
             result = Box::new(FilteredResult::from_filter(result, filter));
         }

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -5410,12 +5410,18 @@ impl Executor {
                 (filtered_columns, filtered_rows)
             } else {
                 // An explicit select list finds the join column by its
-                // bare name too, as `a` or as `x.a`
-                let mut renamed = all_columns.clone();
+                // bare name too, as a column of its own beside the
+                // qualified ones, so `a`, `x.a` and `x.*` all see it
+                let mut columns = all_columns.clone();
+                let mut rows = filtered_rows;
                 for (idx, base_name) in &join_col_renames {
-                    renamed[*idx] = base_name.clone();
+                    columns.push(base_name.clone());
+                    for (_, row) in rows.iter_mut() {
+                        let value = row.get(*idx).cloned().unwrap_or_else(Value::null_unknown);
+                        row.push(value);
+                    }
                 }
-                (renamed, filtered_rows)
+                (columns, rows)
             }
         } else {
             (all_columns.clone(), filtered_rows)

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -6505,6 +6505,16 @@ impl Executor {
                         .iter()
                         .map(|col| format!("{}.{}", table_alias, col))
                         .collect();
+                    // The filter pushed to this side applies to the view's
+                    // rows the way it does to a CTE's
+                    let result: Box<dyn QueryResult> = match filter {
+                        Some(filter_expr) => {
+                            let row_filter =
+                                RowFilter::new(filter_expr, &qualified_columns)?.with_context(ctx);
+                            Box::new(FilteredResult::from_filter(result, row_filter))
+                        }
+                        None => result,
+                    };
                     return Ok((result, qualified_columns));
                 }
 

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -440,8 +440,22 @@ impl Executor {
         // Execute the main query
         // The third return value indicates if LIMIT/OFFSET was already applied (by storage-level pushdown)
         // The fourth return value contains deferred projection info if applicable
+        // ORDER BY, LIMIT and OFFSET belong to the whole set operation, so
+        // the first branch runs without them
+        let branch_stmt;
+        let branch = if stmt.set_operations.is_empty() {
+            stmt
+        } else {
+            branch_stmt = SelectStatement {
+                order_by: Vec::new(),
+                limit: None,
+                offset: None,
+                ..stmt.clone()
+            };
+            &branch_stmt
+        };
         let (mut result, columns, limit_offset_applied, deferred_projection) =
-            self.execute_select_internal(stmt, ctx, &classification)?;
+            self.execute_select_internal(branch, ctx, &classification)?;
 
         // Apply set operations (UNION, INTERSECT, EXCEPT)
         // Pass limit+offset to enable early termination for UNION ALL
@@ -460,9 +474,9 @@ impl Executor {
             };
             result = self.execute_set_operations(result, &stmt.set_operations, ctx, set_limit)?;
 
-            // After set operations, reset limit_offset_applied since we have a new result
-            // For UNION ALL with limit, we've already incorporated the limit
-            limit_offset_applied = all_union_all && set_limit.is_some();
+            // The set operation gathers LIMIT + OFFSET rows at most; the
+            // OFFSET is skipped and the LIMIT cut below, on the whole
+            limit_offset_applied = false;
         }
 
         // Count expected SELECT columns (before any extra ORDER BY columns).

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -4064,6 +4064,36 @@ impl Executor {
             Some(where_clause) => Some((**where_clause).clone()),
             None => None,
         };
+        // A parent row's column named through the parent's table is bound
+        // before the predicates are split, or the side a predicate is
+        // pushed to would read the bare name it falls back to as its own.
+        // A predicate holding a subquery is left for the per-row path
+        let where_for_join = match (where_for_join, ctx.outer_row()) {
+            (Some(where_clause), Some(outer)) => {
+                let inner: Vec<String> = [&left_alias, &right_alias]
+                    .into_iter()
+                    .flatten()
+                    .map(|alias| alias.to_lowercase())
+                    .collect();
+                let inner: Vec<&str> = inner.iter().map(String::as_str).collect();
+                let scope = super::utils::InnerScope {
+                    tables: &inner,
+                    schema: None,
+                };
+                let bound: Vec<Expression> = flatten_and_predicates(&where_clause)
+                    .into_iter()
+                    .map(|pred| {
+                        if Self::has_subqueries(&pred) {
+                            pred
+                        } else {
+                            super::utils::substitute_outer_references_in_scope(&pred, outer, &scope)
+                        }
+                    })
+                    .collect();
+                combine_predicates_with_and(bound)
+            }
+            (where_clause, _) => where_clause,
+        };
         let (left_filter, right_filter, cross_filter) =
             if let Some(where_clause) = where_for_join.as_ref() {
                 if let (Some(left_a), Some(right_a)) = (&left_alias, &right_alias) {
@@ -5332,6 +5362,17 @@ impl Executor {
                 // WHERE, so they are resolved and the predicate compiled per row
                 let keys = ColumnKeyMapping::build_mappings(&all_columns, None);
                 let outer_columns = CompactArc::new(all_columns.clone());
+                let joined_qualifiers: Vec<String> = {
+                    let mut qualifiers: Vec<String> = all_columns
+                        .iter()
+                        .filter_map(|c| c.split_once('.').map(|(q, _)| q.to_lowercase()))
+                        .collect();
+                    qualifiers.sort_unstable();
+                    qualifiers.dedup();
+                    qualifiers
+                };
+                let joined_qualifiers: Vec<&str> =
+                    joined_qualifiers.iter().map(String::as_str).collect();
                 let mut filtered = RowVec::with_capacity(result_rows.len());
                 for (id, row) in result_rows {
                     // The row of a query around this one stays visible to the subqueries
@@ -5349,9 +5390,19 @@ impl Executor {
                     let processed = self.process_correlated_where(where_clause, &row_ctx)?;
                     ctx.check_cancelled()?;
                     // A column of the query around this one is not in the joined
-                    // row, so every reference takes its value from the context
+                    // row, so a reference through the parent's table takes its
+                    // value from the context; one through a joined table's name
+                    // is the row's own, whatever bare name it shares
                     let bound = match row_ctx.outer_row() {
-                        Some(outer) => super::utils::substitute_outer_references(&processed, outer),
+                        Some(outer) => {
+                            let scope = super::utils::InnerScope {
+                                tables: &joined_qualifiers,
+                                schema: None,
+                            };
+                            super::utils::substitute_outer_references_in_scope(
+                                &processed, outer, &scope,
+                            )
+                        }
                         None => processed,
                     };
                     if RowFilter::new(&bound, &all_columns)?

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3872,6 +3872,7 @@ impl Executor {
                 &stmt.distinct_on,
                 rows,
                 &all_columns,
+                table_alias.as_deref(),
                 ctx,
             )?;
             // Get base column names, then the ones the projection appended,
@@ -5531,6 +5532,7 @@ impl Executor {
                 &stmt.distinct_on,
                 final_rows,
                 &final_columns,
+                None,
                 ctx,
             )?;
             let mut output_columns =
@@ -5742,6 +5744,7 @@ impl Executor {
                 &stmt.distinct_on,
                 filtered_rows,
                 &columns,
+                subquery_alias,
                 ctx,
             )?;
             let mut output_columns =
@@ -6002,6 +6005,7 @@ impl Executor {
                 &stmt.distinct_on,
                 rows,
                 &view_columns,
+                view_alias.as_deref(),
                 ctx,
             )?;
             let mut output_columns =
@@ -8658,6 +8662,69 @@ impl Executor {
         }
     }
 
+    /// Evaluate each select expression holding a correlated subquery per
+    /// row into a column appended to the rows, and name that column where
+    /// the expression stood, so a projection reads a plain column there
+    fn bind_correlated_select_columns(
+        &self,
+        select_exprs: &[Expression],
+        rows: RowVec,
+        all_columns: &[String],
+        table_alias: Option<&str>,
+        ctx: &ExecutionContext,
+    ) -> Result<(Vec<Expression>, RowVec, Vec<String>)> {
+        let correlated: Vec<usize> = select_exprs
+            .iter()
+            .enumerate()
+            .filter(|(_, expr)| Self::has_correlated_subqueries(expr))
+            .map(|(i, _)| i)
+            .collect();
+        let bare: Vec<Expression> = correlated
+            .iter()
+            .map(|&i| match &select_exprs[i] {
+                Expression::Aliased(aliased) => (*aliased.expression).clone(),
+                expr => expr.clone(),
+            })
+            .collect();
+        let values = self.project_rows_with_alias(
+            &bare,
+            RowVec::from_vec((*rows).clone()),
+            all_columns,
+            None,
+            ctx,
+            table_alias,
+        )?;
+        let mut columns = all_columns.to_vec();
+        let mut exprs = select_exprs.to_vec();
+        for (n, &i) in correlated.iter().enumerate() {
+            let name = format!("__correlated_{n}");
+            let column = Expression::Identifier(Identifier::new(
+                dummy_token(&name, TokenType::Identifier),
+                name.clone(),
+            ));
+            exprs[i] = match &select_exprs[i] {
+                Expression::Aliased(aliased) => Expression::Aliased(AliasedExpression {
+                    token: aliased.token.clone(),
+                    expression: Box::new(column),
+                    alias: aliased.alias.clone(),
+                }),
+                _ => column,
+            };
+            columns.push(name);
+        }
+        let rows = rows
+            .into_iter()
+            .zip(values)
+            .map(|((id, row), (_, extra))| {
+                let mut values = row.into_values();
+                values.extend(extra.into_values());
+                (id, Row::from_values(values))
+            })
+            .collect();
+        Ok((exprs, rows, columns))
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn project_rows_with_order_by(
         &self,
         select_exprs: &[Expression],
@@ -8665,8 +8732,28 @@ impl Executor {
         distinct_on: &[Expression],
         mut rows: RowVec,
         all_columns: &[String],
+        table_alias: Option<&str>,
         ctx: &ExecutionContext,
     ) -> Result<(RowVec, Vec<String>)> {
+        // A correlated select expression is evaluated per row first, and
+        // read below as the column it was bound to
+        let mut bound_exprs = None;
+        let mut bound_columns = None;
+        if Self::has_correlated_select_subqueries(select_exprs) {
+            let (exprs, bound_rows, columns) = self.bind_correlated_select_columns(
+                select_exprs,
+                rows,
+                all_columns,
+                table_alias,
+                ctx,
+            )?;
+            bound_exprs = Some(exprs);
+            rows = bound_rows;
+            bound_columns = Some(columns);
+        }
+        let select_exprs: &[Expression] = bound_exprs.as_deref().unwrap_or(select_exprs);
+        let all_columns: &[String] = bound_columns.as_deref().unwrap_or(all_columns);
+
         // Process scalar subqueries in SELECT columns before evaluation (single-pass)
         let processed = self.try_process_select_subqueries(select_exprs, ctx)?;
         let select_exprs = match &processed {

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -8676,7 +8676,9 @@ impl Executor {
                     || case.else_value.as_ref().is_some_and(|e| check(e))
             }
             Expression::Between(b) => check(&b.expr) || check(&b.lower) || check(&b.upper),
-            Expression::In(i) => check(&i.left),
+            Expression::In(i) => check(&i.left) || check(&i.right),
+            Expression::List(list) => list.elements.iter().any(check),
+            Expression::ExpressionList(list) => list.expressions.iter().any(check),
             Expression::Like(l) => check(&l.left) || check(&l.pattern),
             Expression::Distinct(d) => check(&d.expr),
             Expression::Window(w) => w.function.arguments.iter().any(check),

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -5572,8 +5572,31 @@ impl Executor {
             return Err(err);
         }
 
-        // Apply WHERE clause if present
+        // Apply WHERE clause if present. A parent row's column named through
+        // its own table is bound first, or the bare name it would fall
+        // back to could be this source's own
         let filtered_rows: RowVec = if let Some(ref where_clause) = stmt.where_clause {
+            let bound_where;
+            let where_clause: &Expression = match ctx.outer_row() {
+                Some(outer) => {
+                    let inner: Vec<&str> = subquery_source
+                        .alias
+                        .iter()
+                        .map(|a| a.value_lower.as_str())
+                        .collect();
+                    let scope = super::utils::InnerScope {
+                        tables: &inner,
+                        schema: None,
+                    };
+                    bound_where = super::utils::substitute_outer_references_in_scope(
+                        where_clause,
+                        outer,
+                        &scope,
+                    );
+                    &bound_where
+                }
+                None => where_clause,
+            };
             let where_filter = RowFilter::new(where_clause, &columns)?.with_context(ctx);
 
             let mut filtered = RowVec::with_capacity(rows.len());

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -1108,6 +1108,7 @@ impl QueryClassification {
             }
             Expression::AllAny(all_any) => {
                 Self::has_outer_column_reference(&all_any.left, inner_tables)
+                    || Self::nested_has_outer_reference(&all_any.subquery, inner_tables)
             }
             Expression::Cast(cast) => Self::has_outer_column_reference(&cast.expr, inner_tables),
             Expression::Like(like) => {
@@ -1150,8 +1151,35 @@ impl QueryClassification {
                 .chain(window.partition_by.iter())
                 .chain(window.order_by.iter().map(|o| &o.expression))
                 .any(|e| Self::has_outer_column_reference(e, inner_tables)),
+            // A subquery nested in this one may read a column from further
+            // out than either of them, which this one has to carry in
+            Expression::Exists(exists) => {
+                Self::nested_has_outer_reference(&exists.subquery, inner_tables)
+            }
+            Expression::ScalarSubquery(subquery) => {
+                Self::nested_has_outer_reference(&subquery.subquery, inner_tables)
+            }
             _ => false,
         }
+    }
+
+    /// Whether a subquery nested inside another reads a column that neither
+    /// of them defines
+    fn nested_has_outer_reference(nested: &SelectStatement, inner_tables: &[String]) -> bool {
+        let mut tables = inner_tables.to_vec();
+        tables.extend(Self::collect_subquery_tables(&nested.table_expr));
+        nested
+            .where_clause
+            .as_deref()
+            .is_some_and(|where_clause| Self::has_outer_column_reference(where_clause, &tables))
+            || nested
+                .columns
+                .iter()
+                .any(|column| Self::has_outer_column_reference(column, &tables))
+            || nested
+                .having
+                .as_deref()
+                .is_some_and(|having| Self::has_outer_column_reference(having, &tables))
     }
 }
 

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -699,11 +699,12 @@ impl QueryClassification {
     fn check_has_window_functions(stmt: &SelectStatement) -> bool {
         stmt.columns
             .iter()
+            .chain(stmt.order_by.iter().map(|ob| &ob.expression))
             .any(Self::expression_has_window_function)
     }
 
     /// Check if an expression contains window functions
-    fn expression_has_window_function(expr: &Expression) -> bool {
+    pub(crate) fn expression_has_window_function(expr: &Expression) -> bool {
         match expr {
             Expression::Window(_) => true,
             Expression::Aliased(aliased) => {

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -1014,6 +1014,15 @@ impl QueryClassification {
             }
         }
 
+        // An ORDER BY reads the parent row too, and decides what a LIMIT keeps
+        if subquery
+            .order_by
+            .iter()
+            .any(|o| Self::has_outer_column_reference(&o.expression, &subquery_tables))
+        {
+            return true;
+        }
+
         // A derived table in the FROM may read the parent row too
         subquery
             .table_expr
@@ -1207,6 +1216,10 @@ impl QueryClassification {
                 .having
                 .as_deref()
                 .is_some_and(|having| Self::has_outer_column_reference(having, &tables))
+            || nested
+                .order_by
+                .iter()
+                .any(|o| Self::has_outer_column_reference(&o.expression, &tables))
             || nested
                 .table_expr
                 .as_deref()

--- a/src/executor/query_classification.rs
+++ b/src/executor/query_classification.rs
@@ -1014,7 +1014,33 @@ impl QueryClassification {
             }
         }
 
-        false
+        // A derived table in the FROM may read the parent row too
+        subquery
+            .table_expr
+            .as_deref()
+            .is_some_and(|from| Self::from_has_outer_reference(from, &subquery_tables))
+    }
+
+    /// Whether a derived table in a FROM, or a join condition there, reads a
+    /// column that neither the query nor the derived table defines
+    fn from_has_outer_reference(from: &Expression, inner_tables: &[String]) -> bool {
+        match from {
+            Expression::SubquerySource(source) => {
+                Self::nested_has_outer_reference(&source.subquery, inner_tables)
+            }
+            Expression::JoinSource(join) => {
+                Self::from_has_outer_reference(&join.left, inner_tables)
+                    || Self::from_has_outer_reference(&join.right, inner_tables)
+                    || join
+                        .condition
+                        .as_deref()
+                        .is_some_and(|c| Self::has_outer_column_reference(c, inner_tables))
+            }
+            Expression::Aliased(aliased) => {
+                Self::from_has_outer_reference(&aliased.expression, inner_tables)
+            }
+            _ => false,
+        }
     }
 
     /// Collect table names and aliases from a subquery's FROM clause
@@ -1181,6 +1207,10 @@ impl QueryClassification {
                 .having
                 .as_deref()
                 .is_some_and(|having| Self::has_outer_column_reference(having, &tables))
+            || nested
+                .table_expr
+                .as_deref()
+                .is_some_and(|from| Self::from_has_outer_reference(from, &tables))
     }
 }
 

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -3784,6 +3784,27 @@ impl Executor {
     ) -> Option<SemiJoinInfo> {
         let subquery = &exists.subquery;
 
+        // 0. A semi-join answers whether the inner table holds a matching
+        // row. Anything that decides which rows the subquery returns beyond
+        // its WHERE has to run, so it is left to the general path: HAVING,
+        // a row count, a set operation, and a bare aggregate, which returns
+        // its one row whether or not anything matched
+        if subquery.having.is_some()
+            || subquery.limit.is_some()
+            || subquery.offset.is_some()
+            || !subquery.set_operations.is_empty()
+        {
+            return None;
+        }
+        if subquery.group_by.columns.is_empty()
+            && subquery
+                .columns
+                .iter()
+                .any(crate::executor::utils::expression_contains_aggregate)
+        {
+            return None;
+        }
+
         // 1. Check for simple table source (not a join)
         let (inner_table, inner_alias): (String, Option<String>) =
             match subquery.table_expr.as_ref().map(|b| b.as_ref()) {

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -691,11 +691,38 @@ impl Executor {
         Ok(Some(false))
     }
 
+    /// True when the rows an EXISTS subquery returns are not decided by its
+    /// WHERE clause alone. Neither a semi-join nor an index probe can stand
+    /// in for running such a subquery: a HAVING keeps only some of the
+    /// groups, a row count keeps only some of the rows, and a bare aggregate
+    /// returns its one row whether or not anything matched. Grouping on its
+    /// own is not among them, since a group is there exactly where a row is.
+    fn exists_subquery_is_more_than_its_where(subquery: &SelectStatement) -> bool {
+        if subquery.having.is_some()
+            || subquery.limit.is_some()
+            || subquery.offset.is_some()
+            || !subquery.set_operations.is_empty()
+        {
+            return true;
+        }
+        subquery.group_by.columns.is_empty()
+            && subquery
+                .columns
+                .iter()
+                .any(crate::executor::utils::expression_contains_aggregate)
+    }
+
     /// Extract index-nested-loop correlation info from a subquery.
     ///
     /// Looks for patterns like:
     /// SELECT 1 FROM orders WHERE orders.user_id = u.id [AND additional_predicates]
     fn extract_index_nested_loop_info(subquery: &SelectStatement) -> Option<IndexNestedLoopInfo> {
+        // Probing the index answers whether a matching row is there, which
+        // is the whole question only when the WHERE decides the rows
+        if Self::exists_subquery_is_more_than_its_where(subquery) {
+            return None;
+        }
+
         // Must have a simple table source
         let (inner_table, inner_alias) = match subquery.table_expr.as_ref().map(|b| b.as_ref()) {
             Some(Expression::TableSource(ts)) => {
@@ -3784,24 +3811,8 @@ impl Executor {
     ) -> Option<SemiJoinInfo> {
         let subquery = &exists.subquery;
 
-        // 0. A semi-join answers whether the inner table holds a matching
-        // row. Anything that decides which rows the subquery returns beyond
-        // its WHERE has to run, so it is left to the general path: HAVING,
-        // a row count, a set operation, and a bare aggregate, which returns
-        // its one row whether or not anything matched
-        if subquery.having.is_some()
-            || subquery.limit.is_some()
-            || subquery.offset.is_some()
-            || !subquery.set_operations.is_empty()
-        {
-            return None;
-        }
-        if subquery.group_by.columns.is_empty()
-            && subquery
-                .columns
-                .iter()
-                .any(crate::executor::utils::expression_contains_aggregate)
-        {
+        // 0. A semi-join answers whether the inner table holds a matching row
+        if Self::exists_subquery_is_more_than_its_where(subquery) {
             return None;
         }
 

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -3497,6 +3497,7 @@ impl Executor {
             }
             Expression::AllAny(all_any) => {
                 Self::references_outer_columns(&all_any.left, subquery_tables)
+                    || Self::nested_reads_outer_columns(&all_any.subquery, subquery_tables)
             }
             Expression::Cast(cast) => Self::references_outer_columns(&cast.expr, subquery_tables),
             Expression::Like(like) => {
@@ -3527,8 +3528,35 @@ impl Executor {
                 .chain(window.partition_by.iter())
                 .chain(window.order_by.iter().map(|o| &o.expression))
                 .any(|e| Self::references_outer_columns(e, subquery_tables)),
+            // A subquery nested in this one may read a column from further
+            // out than either of them, which this one has to carry in
+            Expression::Exists(exists) => {
+                Self::nested_reads_outer_columns(&exists.subquery, subquery_tables)
+            }
+            Expression::ScalarSubquery(subquery) => {
+                Self::nested_reads_outer_columns(&subquery.subquery, subquery_tables)
+            }
             _ => false,
         }
+    }
+
+    /// Whether a subquery nested inside another reads a column that neither
+    /// of them defines
+    fn nested_reads_outer_columns(nested: &SelectStatement, subquery_tables: &[String]) -> bool {
+        let mut tables = subquery_tables.to_vec();
+        tables.extend(Self::collect_subquery_table_columns(nested));
+        nested
+            .where_clause
+            .as_deref()
+            .is_some_and(|where_clause| Self::references_outer_columns(where_clause, &tables))
+            || nested
+                .columns
+                .iter()
+                .any(|column| Self::references_outer_columns(column, &tables))
+            || nested
+                .having
+                .as_deref()
+                .is_some_and(|having| Self::references_outer_columns(having, &tables))
     }
 
     /// Process WHERE clause with correlated subqueries for a specific outer row.
@@ -3940,9 +3968,11 @@ impl Executor {
             Expression::QualifiedIdentifier(qid) => {
                 // Use pre-computed value_lower to avoid allocation
                 let table = &qid.qualifier.value_lower;
-                // References outer if it's in outer_tables and NOT in inner_tables
-                outer_tables.iter().any(|t| t.eq_ignore_ascii_case(table))
-                    && !inner_tables.iter().any(|t| t.eq_ignore_ascii_case(table))
+                // One pass over the inner table answers every outer row, so
+                // any name the inner table does not own has to be read per
+                // row, whether it belongs to the query above or one further
+                let _ = outer_tables;
+                !inner_tables.iter().any(|t| t.eq_ignore_ascii_case(table))
             }
             Expression::Infix(infix) => {
                 Self::expression_references_outer_tables(&infix.left, outer_tables, inner_tables)

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -1780,6 +1780,17 @@ impl Executor {
         let is_non_correlated =
             ctx.outer_row().is_none() && !Self::is_subquery_correlated(subquery);
 
+        // A correlated subquery reads the parent row in what it selects and
+        // in its HAVING, not only in its WHERE
+        let bound;
+        let subquery = match Self::bind_outer_references(subquery, ctx) {
+            Some(rewritten) => {
+                bound = rewritten;
+                &bound
+            }
+            None => subquery,
+        };
+
         // For non-correlated subqueries, check cache first using SQL string
         // as key; bypassed inside explicit transactions (see
         // execute_in_subquery for the ROLLBACK rationale)
@@ -3267,7 +3278,57 @@ impl Executor {
             }
         }
 
+        // A HAVING reads the parent row the same way a WHERE does
+        if let Some(ref having) = subquery.having {
+            if Self::references_outer_columns(having, &subquery_tables) {
+                return true;
+            }
+        }
+
         false
+    }
+
+    /// The subquery with the parent row's values in place of the outer
+    /// references its own expressions carry. Its WHERE is bound where the
+    /// scan reads it; what it selects and its HAVING are bound here, since
+    /// a name the FROM does not define would otherwise fall back to an
+    /// inner column that happens to share it. None when it reads no
+    /// parent row or carries no outer reference
+    fn bind_outer_references(
+        subquery: &SelectStatement,
+        ctx: &ExecutionContext,
+    ) -> Option<SelectStatement> {
+        let outer_row = ctx.outer_row()?;
+        // With no table to own it, every qualified name reads as an outer
+        // one, so this asks whether there is anything at all to bind before
+        // the FROM's names are collected
+        if !subquery
+            .columns
+            .iter()
+            .chain(subquery.having.as_deref())
+            .any(|expr| Self::references_outer_columns(expr, &[]))
+        {
+            return None;
+        }
+        let tables = Self::collect_subquery_table_columns(subquery);
+        let tables: Vec<&str> = tables.iter().map(|table| table.as_str()).collect();
+        let scope = super::utils::InnerScope {
+            tables: &tables,
+            schema: None,
+        };
+        let bind = |expr: &Expression| {
+            super::utils::substitute_outer_references_in_scope(expr, outer_row, &scope)
+        };
+        let columns: Vec<Expression> = subquery.columns.iter().map(&bind).collect();
+        let having = subquery.having.as_deref().map(&bind);
+        if columns == subquery.columns && having.as_ref() == subquery.having.as_deref() {
+            return None;
+        }
+        Some(SelectStatement {
+            columns,
+            having: having.map(Box::new),
+            ..subquery.clone()
+        })
     }
 
     /// Collect table/alias names from a subquery's FROM clause

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -465,6 +465,15 @@ impl Executor {
         subquery: &SelectStatement,
         ctx: &ExecutionContext,
     ) -> Result<Option<bool>> {
+        // Probing the index answers whether a matching row is there, which
+        // is the whole question EXISTS asks only when the WHERE decides the
+        // rows. The extractor below is shared with the paths that read a
+        // correlated aggregate, where an aggregate without a GROUP BY is the
+        // very shape they are for, so the check belongs here
+        if Self::exists_subquery_is_more_than_its_where(subquery) {
+            return Ok(None);
+        }
+
         // Need outer row context for correlated subquery
         let outer_row = match ctx.outer_row() {
             Some(row) => row,
@@ -717,12 +726,6 @@ impl Executor {
     /// Looks for patterns like:
     /// SELECT 1 FROM orders WHERE orders.user_id = u.id [AND additional_predicates]
     fn extract_index_nested_loop_info(subquery: &SelectStatement) -> Option<IndexNestedLoopInfo> {
-        // Probing the index answers whether a matching row is there, which
-        // is the whole question only when the WHERE decides the rows
-        if Self::exists_subquery_is_more_than_its_where(subquery) {
-            return None;
-        }
-
         // Must have a simple table source
         let (inner_table, inner_alias) = match subquery.table_expr.as_ref().map(|b| b.as_ref()) {
             Some(Expression::TableSource(ts)) => {

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -4531,13 +4531,52 @@ impl Executor {
             ))
         };
 
+        // EXISTS asks whether an inner row equals the outer value, and a
+        // NULL on either side equals nothing. IN reads it differently: a
+        // NULL outer value, or a NULL among the members, leaves the answer
+        // unknown. For EXISTS the unknown is the same as false in a filter;
+        // for NOT EXISTS it is not, since the answer there is true. So the
+        // negated set is asked without its NULLs, and an outer NULL, which
+        // no inner row can match, is kept alongside
+        let (hash_set, not) = if info.is_negated && hash_set.iter().any(|v| v.is_null()) {
+            let without_nulls: ValueSet =
+                hash_set.iter().filter(|v| !v.is_null()).cloned().collect();
+            if without_nulls.is_empty() {
+                return Expression::BooleanLiteral(BooleanLiteral {
+                    token: dummy_token_clone(),
+                    value: true,
+                });
+            }
+            (CompactArc::new(without_nulls), true)
+        } else {
+            (hash_set, info.is_negated)
+        };
+
         // Use InHashSet with Arc for O(1) lookup and cheap cloning in parallel execution
-        Expression::InHashSet(InHashSetExpression {
+        let membership = Expression::InHashSet(InHashSetExpression {
             token: dummy_token_clone(),
-            column: Box::new(outer_col_expr),
+            column: Box::new(outer_col_expr.clone()),
             values: hash_set, // Already Arc, no wrapping needed
-            not: info.is_negated,
-        })
+            not,
+        });
+        if !not {
+            return membership;
+        }
+
+        let outer_is_null = Expression::Infix(InfixExpression::new(
+            dummy_token_clone(),
+            Box::new(outer_col_expr),
+            "IS".to_string(),
+            Box::new(Expression::NullLiteral(NullLiteral {
+                token: dummy_token_clone(),
+            })),
+        ));
+        Expression::Infix(InfixExpression::new(
+            dummy_token_clone(),
+            Box::new(membership),
+            "OR".to_string(),
+            Box::new(outer_is_null),
+        ))
     }
 
     /// Try to optimize correlated EXISTS subqueries to semi-join.

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -1030,6 +1030,21 @@ impl Executor {
         // Extract correlation info
         let correlation = Self::extract_index_nested_loop_info(subquery)?;
 
+        // One pass over the table answers every outer row at once, which
+        // holds only while the correlation predicate is the one place the
+        // parent row is read: anywhere else it would differ per row
+        let tables = Self::collect_subquery_table_columns(subquery);
+        let reads_parent_row = |expr: &Expression| Self::references_outer_columns(expr, &tables);
+        if subquery.columns.iter().any(&reads_parent_row)
+            || subquery.having.as_deref().is_some_and(&reads_parent_row)
+            || correlation
+                .additional_predicate
+                .as_ref()
+                .is_some_and(&reads_parent_row)
+        {
+            return None;
+        }
+
         // Pre-compute lowercase column names
         let outer_column_lower = correlation.outer_column.to_lowercase();
         let outer_qualified_lower = correlation
@@ -1065,11 +1080,14 @@ impl Executor {
         // Extract correlation column
         let correlation = Self::extract_index_nested_loop_info(subquery)?;
 
+        // The aggregate's own text, since two aggregates of one name over
+        // one table and one correlation column read different columns
         Some(format!(
-            "batch_agg:{}:{}:{}",
+            "batch_agg:{}:{}:{}:{}",
             table_name.to_lowercase(),
             correlation.inner_column.to_lowercase(),
-            agg_func
+            agg_func,
+            subquery.columns[0]
         ))
     }
 
@@ -1780,17 +1798,6 @@ impl Executor {
         let is_non_correlated =
             ctx.outer_row().is_none() && !Self::is_subquery_correlated(subquery);
 
-        // A correlated subquery reads the parent row in what it selects and
-        // in its HAVING, not only in its WHERE
-        let bound;
-        let subquery = match Self::bind_outer_references(subquery, ctx) {
-            Some(rewritten) => {
-                bound = rewritten;
-                &bound
-            }
-            None => subquery,
-        };
-
         // For non-correlated subqueries, check cache first using SQL string
         // as key; bypassed inside explicit transactions (see
         // execute_in_subquery for the ROLLBACK rationale)
@@ -1830,6 +1837,18 @@ impl Executor {
                 drop(batch_cache);
             }
         }
+
+        // A correlated subquery reads the parent row in what it selects and
+        // in its HAVING, not only in its WHERE. The paths above read the
+        // statement as written, and one of them keys a cache on its address
+        let bound;
+        let subquery = match Self::bind_outer_references(subquery, ctx) {
+            Some(rewritten) => {
+                bound = rewritten;
+                &bound
+            }
+            None => subquery,
+        };
 
         // Execute the subquery with incremented depth to avoid creating new TimeoutGuard
         let subquery_ctx = ctx.with_incremented_query_depth();

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -806,12 +806,7 @@ impl Executor {
             return Ok(None);
         }
 
-        let is_count = match &subquery.columns[0] {
-            Expression::Aliased(a) => Self::is_count_expression(&a.expression),
-            expr => Self::is_count_expression(expr),
-        };
-
-        if !is_count {
+        if !Self::is_count_star_probe(&subquery.columns[0]) {
             return Ok(None);
         }
 
@@ -937,6 +932,38 @@ impl Executor {
         Ok(None)
     }
 
+    /// Whether the parent row is read anywhere but the correlation
+    /// predicate. One pass over the table answers every parent row at once
+    /// only while it is not: read anywhere else, the pass would carry one
+    /// parent's value into all of them
+    fn aggregate_reads_parent_row(
+        subquery: &SelectStatement,
+        beside_correlation: Option<&Expression>,
+    ) -> bool {
+        let tables = Self::collect_subquery_table_columns(subquery);
+        let reads = |expr: &Expression| Self::references_outer_columns(expr, &tables);
+        subquery.columns.iter().any(&reads)
+            || subquery.having.as_deref().is_some_and(&reads)
+            || beside_correlation.is_some_and(&reads)
+    }
+
+    /// A COUNT one probe of an index answers: the probe counts rows, so it
+    /// must count rows, not the values of a column that may be NULL, and
+    /// neither a FILTER nor DISTINCT may narrow what it counts
+    fn is_count_star_probe(expr: &Expression) -> bool {
+        match expr {
+            Expression::Aliased(aliased) => Self::is_count_star_probe(&aliased.expression),
+            Expression::FunctionCall(func) => {
+                func.function.eq_ignore_ascii_case("COUNT")
+                    && func.filter.is_none()
+                    && !func.is_distinct
+                    && (func.arguments.is_empty()
+                        || matches!(func.arguments.first(), Some(Expression::Star(_))))
+            }
+            _ => false,
+        }
+    }
+
     /// Check if an expression is a COUNT aggregate function.
     fn is_count_expression(expr: &Expression) -> bool {
         match expr {
@@ -1030,18 +1057,7 @@ impl Executor {
         // Extract correlation info
         let correlation = Self::extract_index_nested_loop_info(subquery)?;
 
-        // One pass over the table answers every outer row at once, which
-        // holds only while the correlation predicate is the one place the
-        // parent row is read: anywhere else it would differ per row
-        let tables = Self::collect_subquery_table_columns(subquery);
-        let reads_parent_row = |expr: &Expression| Self::references_outer_columns(expr, &tables);
-        if subquery.columns.iter().any(&reads_parent_row)
-            || subquery.having.as_deref().is_some_and(&reads_parent_row)
-            || correlation
-                .additional_predicate
-                .as_ref()
-                .is_some_and(&reads_parent_row)
-        {
+        if Self::aggregate_reads_parent_row(subquery, correlation.additional_predicate.as_ref()) {
             return None;
         }
 
@@ -1124,6 +1140,10 @@ impl Executor {
             Some(c) => c,
             None => return Ok(None),
         };
+
+        if Self::aggregate_reads_parent_row(subquery, correlation.additional_predicate.as_ref()) {
+            return Ok(None);
+        }
 
         // Build cache key (includes additional predicate in key for uniqueness)
         let cache_key = match Self::build_batch_aggregate_key(subquery) {

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -3354,6 +3354,15 @@ impl Executor {
             }
         }
 
+        // So does an ORDER BY, which decides what a LIMIT keeps
+        if subquery
+            .order_by
+            .iter()
+            .any(|o| Self::references_outer_columns(&o.expression, &subquery_tables))
+        {
+            return true;
+        }
+
         // A derived table in the FROM may read the parent row too
         subquery
             .table_expr
@@ -3613,6 +3622,10 @@ impl Executor {
                 .having
                 .as_deref()
                 .is_some_and(|having| Self::references_outer_columns(having, &tables))
+            || nested
+                .order_by
+                .iter()
+                .any(|o| Self::references_outer_columns(&o.expression, &tables))
             || nested
                 .table_expr
                 .as_deref()

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -3354,7 +3354,33 @@ impl Executor {
             }
         }
 
-        false
+        // A derived table in the FROM may read the parent row too
+        subquery
+            .table_expr
+            .as_deref()
+            .is_some_and(|from| Self::from_reads_outer_columns(from, &subquery_tables))
+    }
+
+    /// Whether a derived table in a FROM, or a join condition there, reads a
+    /// column that neither the query nor the derived table defines
+    fn from_reads_outer_columns(from: &Expression, subquery_tables: &[String]) -> bool {
+        match from {
+            Expression::SubquerySource(source) => {
+                Self::nested_reads_outer_columns(&source.subquery, subquery_tables)
+            }
+            Expression::JoinSource(join) => {
+                Self::from_reads_outer_columns(&join.left, subquery_tables)
+                    || Self::from_reads_outer_columns(&join.right, subquery_tables)
+                    || join
+                        .condition
+                        .as_deref()
+                        .is_some_and(|c| Self::references_outer_columns(c, subquery_tables))
+            }
+            Expression::Aliased(aliased) => {
+                Self::from_reads_outer_columns(&aliased.expression, subquery_tables)
+            }
+            _ => false,
+        }
     }
 
     /// The subquery with the parent row's values in place of the outer
@@ -3587,6 +3613,10 @@ impl Executor {
                 .having
                 .as_deref()
                 .is_some_and(|having| Self::references_outer_columns(having, &tables))
+            || nested
+                .table_expr
+                .as_deref()
+                .is_some_and(|from| Self::from_reads_outer_columns(from, &tables))
     }
 
     /// Process WHERE clause with correlated subqueries for a specific outer row.

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -35,11 +35,11 @@ use crate::core::value::NULL_VALUE;
 use crate::core::{DataType, Operator, Row, Schema, Value};
 use crate::executor::operators::index_nested_loop::ColumnSource;
 use crate::parser::ast::{
-    BetweenExpression, BooleanLiteral, CaseExpression, CastExpression, DistinctExpression,
-    Expression, ExpressionList, FloatLiteral, FunctionCall, Identifier, InExpression,
-    InHashSetExpression, InfixExpression, InfixOperator, IntegerLiteral, LikeExpression,
-    ListExpression, NullLiteral, PrefixExpression, QualifiedIdentifier, StringLiteral, WhenClause,
-    WindowFrameBound,
+    AliasedExpression, BetweenExpression, BooleanLiteral, CaseExpression, CastExpression,
+    DistinctExpression, Expression, ExpressionList, FloatLiteral, FunctionCall, Identifier,
+    InExpression, InHashSetExpression, InfixExpression, InfixOperator, IntegerLiteral,
+    LikeExpression, ListExpression, NullLiteral, PrefixExpression, QualifiedIdentifier,
+    StringLiteral, WhenClause, WindowFrameBound,
 };
 use crate::parser::token::{Position, Token, TokenType};
 
@@ -391,6 +391,15 @@ fn substitute_outer_references_inner(
                     type_name: cast.type_name.clone(),
                 })
             }),
+        Expression::Aliased(aliased) => {
+            substitute_outer_references_inner(&aliased.expression, outer_row, scope).map(|expr| {
+                Expression::Aliased(AliasedExpression {
+                    token: aliased.token.clone(),
+                    expression: Box::new(expr),
+                    alias: aliased.alias.clone(),
+                })
+            })
+        }
         Expression::Distinct(distinct) => {
             substitute_outer_references_inner(&distinct.expr, outer_row, scope).map(|expr| {
                 Expression::Distinct(DistinctExpression {

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -134,20 +134,25 @@ pub fn substitute_outer_references(
 /// alone: an inner column may share its name with an outer one, and SQL
 /// binds the nearer scope first.
 pub struct InnerScope<'a> {
-    pub table: &'a str,
-    pub alias: Option<&'a str>,
-    pub schema: &'a Schema,
+    /// The names the subquery's own FROM defines. With an alias only the
+    /// alias names the table; the table's own name may then be an alias in
+    /// the outer query.
+    pub tables: &'a [&'a str],
+    /// The scanned table's schema, where there is one table to have it.
+    /// Without it a bare name is left alone: it can only mean the inner one
+    pub schema: Option<&'a Schema>,
 }
 
 impl InnerScope<'_> {
-    /// With an alias only the alias names the inner table; the table's own
-    /// name may then be an alias in the outer query.
     fn owns_qualifier(&self, qualifier: &str) -> bool {
-        qualifier == self.alias.unwrap_or(self.table)
+        self.tables.contains(&qualifier)
     }
 
     fn owns_column(&self, column: &str) -> bool {
-        self.schema.column_index_map().contains_key(column)
+        match self.schema {
+            Some(schema) => schema.column_index_map().contains_key(column),
+            None => true,
+        }
     }
 }
 
@@ -2185,9 +2190,8 @@ mod tests {
             .add("Name", DataType::Text)
             .build();
         let scope = InnerScope {
-            table: "parent",
-            alias: Some("p"),
-            schema: &schema,
+            tables: &["p"],
+            schema: Some(&schema),
         };
         let mut outer: FxHashMap<CompactArc<str>, Value> = FxHashMap::default();
         for (key, value) in [
@@ -2243,9 +2247,8 @@ mod tests {
 
         // without an alias, the table name is the inner qualifier
         let bare = InnerScope {
-            table: "parent",
-            alias: None,
-            schema: &schema,
+            tables: &["parent"],
+            schema: Some(&schema),
         };
         assert!(matches!(
             substitute_outer_references_in_scope(&qualified("parent", "id"), &outer, &bare),

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -35,11 +35,12 @@ use crate::core::value::NULL_VALUE;
 use crate::core::{DataType, Operator, Row, Schema, Value};
 use crate::executor::operators::index_nested_loop::ColumnSource;
 use crate::parser::ast::{
-    AliasedExpression, BetweenExpression, BooleanLiteral, CaseExpression, CastExpression,
-    DistinctExpression, Expression, ExpressionList, FloatLiteral, FunctionCall, Identifier,
-    InExpression, InHashSetExpression, InfixExpression, InfixOperator, IntegerLiteral,
-    LikeExpression, ListExpression, NullLiteral, PrefixExpression, QualifiedIdentifier,
-    StringLiteral, WhenClause, WindowFrameBound,
+    AliasedExpression, AllAnyExpression, BetweenExpression, BooleanLiteral, CaseExpression,
+    CastExpression, DistinctExpression, ExistsExpression, Expression, ExpressionList, FloatLiteral,
+    FunctionCall, Identifier, InExpression, InHashSetExpression, InfixExpression, InfixOperator,
+    IntegerLiteral, JoinTableSource, LikeExpression, ListExpression, NullLiteral, PrefixExpression,
+    QualifiedIdentifier, ScalarSubquery, SelectStatement, StringLiteral, SubqueryTableSource,
+    WhenClause, WindowFrameBound,
 };
 use crate::parser::token::{Position, Token, TokenType};
 
@@ -494,7 +495,148 @@ fn substitute_outer_references_inner(
             })))
         }
 
+        // A subquery keeps what its own FROM defines and takes the rest
+        // from the outer row, so one that reads only the outer row runs
+        // once instead of once per row of the query holding it
+        Expression::ScalarSubquery(subquery) => {
+            substitute_in_select(&subquery.subquery, outer_row, scope).map(|select| {
+                Expression::ScalarSubquery(ScalarSubquery {
+                    token: subquery.token.clone(),
+                    subquery: Box::new(select),
+                })
+            })
+        }
+        Expression::Exists(exists) => {
+            substitute_in_select(&exists.subquery, outer_row, scope).map(|select| {
+                Expression::Exists(ExistsExpression {
+                    token: exists.token.clone(),
+                    subquery: Box::new(select),
+                })
+            })
+        }
+        Expression::AllAny(all_any) => {
+            let new_left = substitute_outer_references_inner(&all_any.left, outer_row, scope);
+            let new_subquery = substitute_in_select(&all_any.subquery, outer_row, scope);
+            if new_left.is_none() && new_subquery.is_none() {
+                return None;
+            }
+            Some(Expression::AllAny(AllAnyExpression {
+                token: all_any.token.clone(),
+                left: Box::new(new_left.unwrap_or_else(|| (*all_any.left).clone())),
+                operator: all_any.operator.clone(),
+                all_any_type: all_any.all_any_type,
+                subquery: Box::new(new_subquery.unwrap_or_else(|| (*all_any.subquery).clone())),
+            }))
+        }
+
         // Literals and other expressions that don't need substitution
+        _ => None,
+    }
+}
+
+/// The statement with the outer row bound into its expressions; the names
+/// its own FROM defines are shielded along with the enclosing scope's
+fn substitute_in_select(
+    stmt: &SelectStatement,
+    outer_row: &FxHashMap<CompactArc<str>, Value>,
+    scope: Option<&InnerScope<'_>>,
+) -> Option<SelectStatement> {
+    let mut tables: Vec<String> = scope
+        .map(|s| s.tables.iter().map(|t| t.to_string()).collect())
+        .unwrap_or_default();
+    if let Some(table_expr) = stmt.table_expr.as_deref() {
+        collect_table_aliases(table_expr, &mut tables);
+    }
+    let tables: Vec<&str> = tables.iter().map(String::as_str).collect();
+    let inner = InnerScope {
+        tables: &tables,
+        schema: None,
+    };
+    let inner = Some(&inner);
+    let substitute = |expr: &Expression| substitute_outer_references_inner(expr, outer_row, inner);
+
+    let columns: Vec<Option<Expression>> = stmt.columns.iter().map(substitute).collect();
+    let table_expr = stmt
+        .table_expr
+        .as_deref()
+        .and_then(|expr| substitute_in_table_expr(expr, outer_row, inner));
+    let where_clause = stmt.where_clause.as_deref().and_then(substitute);
+    let having = stmt.having.as_deref().and_then(substitute);
+    let order_by: Vec<Option<Expression>> = stmt
+        .order_by
+        .iter()
+        .map(|o| substitute(&o.expression))
+        .collect();
+    let changed = columns.iter().any(Option::is_some)
+        || table_expr.is_some()
+        || where_clause.is_some()
+        || having.is_some()
+        || order_by.iter().any(Option::is_some);
+    if !changed {
+        return None;
+    }
+
+    let mut bound = stmt.clone();
+    for (target, new) in bound.columns.iter_mut().zip(columns) {
+        if let Some(new) = new {
+            *target = new;
+        }
+    }
+    if let Some(expr) = table_expr {
+        bound.table_expr = Some(Box::new(expr));
+    }
+    if let Some(expr) = where_clause {
+        bound.where_clause = Some(Box::new(expr));
+    }
+    if let Some(expr) = having {
+        bound.having = Some(Box::new(expr));
+    }
+    for (target, new) in bound.order_by.iter_mut().zip(order_by) {
+        if let Some(new) = new {
+            target.expression = new;
+        }
+    }
+    Some(bound)
+}
+
+/// A FROM with the outer row bound into its join conditions and derived tables
+fn substitute_in_table_expr(
+    expr: &Expression,
+    outer_row: &FxHashMap<CompactArc<str>, Value>,
+    scope: Option<&InnerScope<'_>>,
+) -> Option<Expression> {
+    match expr {
+        Expression::JoinSource(join) => {
+            let left = substitute_in_table_expr(&join.left, outer_row, scope);
+            let right = substitute_in_table_expr(&join.right, outer_row, scope);
+            let condition = join
+                .condition
+                .as_deref()
+                .and_then(|c| substitute_outer_references_inner(c, outer_row, scope));
+            if left.is_none() && right.is_none() && condition.is_none() {
+                return None;
+            }
+            Some(Expression::JoinSource(Box::new(JoinTableSource {
+                token: join.token.clone(),
+                left: Box::new(left.unwrap_or_else(|| (*join.left).clone())),
+                join_type: join.join_type.clone(),
+                right: Box::new(right.unwrap_or_else(|| (*join.right).clone())),
+                condition: match condition {
+                    Some(c) => Some(Box::new(c)),
+                    None => join.condition.clone(),
+                },
+                using_columns: join.using_columns.clone(),
+            })))
+        }
+        Expression::SubquerySource(source) => {
+            substitute_in_select(&source.subquery, outer_row, scope).map(|select| {
+                Expression::SubquerySource(Box::new(SubqueryTableSource {
+                    token: source.token.clone(),
+                    subquery: Box::new(select),
+                    alias: source.alias.clone(),
+                }))
+            })
+        }
         _ => None,
     }
 }

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -1642,7 +1642,9 @@ pub fn expression_to_string(expr: &Expression) -> String {
             format!("{}({})", func.function, args.join(", "))
         }
         // An operand bound less tightly than its operator keeps its
-        // parentheses, or (a + b) * 2 and a + b * 2 would read the same
+        // parentheses, or (a + b) * 2 and a + b * 2 would read the same; a
+        // right operand of the same precedence keeps them too unless it is
+        // the same associative operator, or a * (b % 3) and a * b % 3 would
         Expression::Infix(infix) => {
             let precedence = infix_precedence(&infix.op_type);
             let side = |operand: &Expression, on_the_right: bool| -> String {
@@ -1650,10 +1652,10 @@ pub fn expression_to_string(expr: &Expression) -> String {
                 match operand {
                     Expression::Infix(inner) => {
                         let inner_precedence = infix_precedence(&inner.op_type);
+                        let same_associative =
+                            inner.op_type == infix.op_type && infix_is_commutative(&infix.op_type);
                         if inner_precedence < precedence
-                            || (on_the_right
-                                && inner_precedence == precedence
-                                && !infix_is_commutative(&infix.op_type))
+                            || (on_the_right && inner_precedence == precedence && !same_associative)
                         {
                             format!("({text})")
                         } else {

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -1641,16 +1641,80 @@ pub fn expression_to_string(expr: &Expression) -> String {
             let args: Vec<String> = func.arguments.iter().map(expression_to_string).collect();
             format!("{}({})", func.function, args.join(", "))
         }
+        // An operand bound less tightly than its operator keeps its
+        // parentheses, or (a + b) * 2 and a + b * 2 would read the same
         Expression::Infix(infix) => {
+            let precedence = infix_precedence(&infix.op_type);
+            let side = |operand: &Expression, on_the_right: bool| -> String {
+                let text = expression_to_string(operand);
+                match operand {
+                    Expression::Infix(inner) => {
+                        let inner_precedence = infix_precedence(&inner.op_type);
+                        if inner_precedence < precedence
+                            || (on_the_right
+                                && inner_precedence == precedence
+                                && !infix_is_commutative(&infix.op_type))
+                        {
+                            format!("({text})")
+                        } else {
+                            text
+                        }
+                    }
+                    _ => text,
+                }
+            };
             format!(
                 "{} {} {}",
-                expression_to_string(&infix.left),
+                side(&infix.left, false),
                 infix.operator,
-                expression_to_string(&infix.right)
+                side(&infix.right, true)
+            )
+        }
+        Expression::Prefix(prefix) => {
+            let operand = expression_to_string(&prefix.right);
+            let operand = match prefix.right.as_ref() {
+                Expression::Infix(_) => format!("({operand})"),
+                _ => operand,
+            };
+            if prefix.operator == "-" || prefix.operator == "+" {
+                format!("{}{}", prefix.operator, operand)
+            } else {
+                format!("{} {}", prefix.operator, operand)
+            }
+        }
+        Expression::Cast(cast) => {
+            format!(
+                "CAST({} AS {})",
+                expression_to_string(&cast.expr),
+                cast.type_name
             )
         }
         _ => format!("{}", expr),
     }
+}
+
+/// How tightly an infix operator binds, higher first
+fn infix_precedence(op: &InfixOperator) -> u8 {
+    match op {
+        InfixOperator::Or => 1,
+        InfixOperator::And | InfixOperator::Xor => 2,
+        InfixOperator::Multiply | InfixOperator::Divide | InfixOperator::Modulo => 5,
+        InfixOperator::Add | InfixOperator::Subtract | InfixOperator::Concat => 4,
+        _ => 3,
+    }
+}
+
+/// Whether a op (b op c) reads as (a op b) op c
+fn infix_is_commutative(op: &InfixOperator) -> bool {
+    matches!(
+        op,
+        InfixOperator::Or
+            | InfixOperator::And
+            | InfixOperator::Xor
+            | InfixOperator::Add
+            | InfixOperator::Multiply
+            | InfixOperator::Concat
+    )
 }
 
 // ============================================================================

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -99,11 +99,31 @@ pub fn value_to_expression(v: &Value) -> Expression {
         Value::Null(_) => Expression::NullLiteral(NullLiteral {
             token: dummy_token("NULL", TokenType::Keyword),
         }),
-        _ => Expression::StringLiteral(StringLiteral {
-            token: dummy_token(&format!("'{}'", v), TokenType::String),
+        // A timestamp keeps its type through the literal's hint, the way
+        // TIMESTAMP '...' does when written
+        Value::Timestamp(_) => Expression::StringLiteral(StringLiteral {
+            token: dummy_token(&format!("TIMESTAMP '{}'", v), TokenType::String),
             value: v.to_string().into(),
-            type_hint: None,
+            type_hint: Some("TIMESTAMP".into()),
         }),
+        // JSON and a vector keep theirs through an explicit CAST; a hint
+        // alone would read as the loose one the parser puts on any text
+        // shaped like an object
+        Value::Extension(_) => {
+            let type_name = match v.data_type() {
+                crate::core::DataType::Vector => "VECTOR",
+                _ => "JSON",
+            };
+            Expression::Cast(CastExpression {
+                token: dummy_token("CAST", TokenType::Keyword),
+                expr: Box::new(Expression::StringLiteral(StringLiteral {
+                    token: dummy_token(&format!("'{}'", v), TokenType::String),
+                    value: v.to_string().into(),
+                    type_hint: None,
+                })),
+                type_name: type_name.into(),
+            })
+        }
     }
 }
 

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -1185,6 +1185,23 @@ pub fn get_table_alias_from_expr(expr: &Expression) -> Option<String> {
     }
 }
 
+/// The lowercased table names and aliases of every leaf of a FROM
+/// expression, so a nested join lists all of its tables
+pub fn collect_table_aliases(expr: &Expression, out: &mut Vec<String>) {
+    match expr {
+        Expression::JoinSource(join) => {
+            collect_table_aliases(&join.left, out);
+            collect_table_aliases(&join.right, out);
+        }
+        Expression::Aliased(aliased) => out.push(aliased.alias.value_lower.to_string()),
+        _ => {
+            if let Some(alias) = get_table_alias_from_expr(expr) {
+                out.push(alias.to_lowercase());
+            }
+        }
+    }
+}
+
 /// Strip table qualifier from an expression, replacing qualified identifiers
 /// with unqualified ones. Used when pushing filters to individual table scans.
 pub fn strip_table_qualifier(expr: &Expression, table_alias: &str) -> Expression {

--- a/src/executor/utils.rs
+++ b/src/executor/utils.rs
@@ -1669,8 +1669,16 @@ pub fn expression_to_string(expr: &Expression) -> String {
                 match operand {
                     Expression::Infix(inner) => {
                         let inner_precedence = infix_precedence(&inner.op_type);
-                        let same_associative =
-                            inner.op_type == infix.op_type && infix_is_commutative(&infix.op_type);
+                        // Arithmetic is not associative in floats or at the
+                        // limits of an integer, so only these fold
+                        let same_associative = inner.op_type == infix.op_type
+                            && matches!(
+                                infix.op_type,
+                                InfixOperator::Or
+                                    | InfixOperator::And
+                                    | InfixOperator::Xor
+                                    | InfixOperator::Concat
+                            );
                         if inner_precedence < precedence
                             || (on_the_right && inner_precedence == precedence && !same_associative)
                         {
@@ -1721,19 +1729,6 @@ fn infix_precedence(op: &InfixOperator) -> u8 {
         InfixOperator::Add | InfixOperator::Subtract | InfixOperator::Concat => 4,
         _ => 3,
     }
-}
-
-/// Whether a op (b op c) reads as (a op b) op c
-fn infix_is_commutative(op: &InfixOperator) -> bool {
-    matches!(
-        op,
-        InfixOperator::Or
-            | InfixOperator::And
-            | InfixOperator::Xor
-            | InfixOperator::Add
-            | InfixOperator::Multiply
-            | InfixOperator::Concat
-    )
 }
 
 // ============================================================================

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -361,6 +361,46 @@ pub struct WindowPreGroupedState {
 impl Executor {
     /// Execute SELECT with window functions
     /// Accepts &[(i64, Row)] to allow RowVec to be passed directly via deref
+    /// The window functions ORDER BY reads that no select column is named
+    /// for, each as a column aliased to its own text, so the sort finds it
+    /// by name and the projection drops it afterwards
+    pub(crate) fn hidden_order_by_windows(stmt: &SelectStatement) -> Vec<Expression> {
+        let mut names: Vec<String> = Vec::new();
+        stmt.order_by
+            .iter()
+            .map(|ob| &ob.expression)
+            .filter(|expr| {
+                super::query_classification::QueryClassification::expression_has_window_function(
+                    expr,
+                )
+            })
+            .filter_map(|expr| {
+                let name = expr.to_string();
+                let carried = names.contains(&name)
+                    || stmt.columns.iter().any(|c| match c {
+                        Expression::Aliased(a) => {
+                            a.alias.value.as_str() == name || a.expression.to_string() == name
+                        }
+                        _ => false,
+                    });
+                if carried {
+                    return None;
+                }
+                names.push(name.clone());
+                let token = crate::parser::token::Token::new(
+                    crate::parser::token::TokenType::Identifier,
+                    name.clone(),
+                    crate::parser::token::Position::default(),
+                );
+                Some(Expression::Aliased(crate::parser::ast::AliasedExpression {
+                    token: token.clone(),
+                    expression: Box::new(expr.clone()),
+                    alias: crate::parser::ast::Identifier::new(token, name),
+                }))
+            })
+            .collect()
+    }
+
     pub(crate) fn execute_select_with_window_functions(
         &self,
         stmt: &SelectStatement,
@@ -463,6 +503,23 @@ impl Executor {
                 )
             }
             None => (stmt, base_rows, base_columns),
+        };
+
+        // A window function in ORDER BY that the select list does not carry
+        // is computed into a column of its own, named after it, which the
+        // sort reads and the projection then drops. Beside a star nothing
+        // is dropped, so there the select list stays as written
+        let extended_stmt;
+        let stmt = {
+            let hidden = Self::hidden_order_by_windows(stmt);
+            if hidden.is_empty() {
+                stmt
+            } else {
+                let mut extended = stmt.clone();
+                extended.columns.extend(hidden);
+                extended_stmt = extended;
+                &extended_stmt
+            }
         };
 
         // Parse window functions from the SELECT list

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -1919,10 +1919,16 @@ impl Executor {
                 .iter()
                 .find(|wd| wd.name.eq_ignore_ascii_case(win_ref))
                 .ok_or_else(|| Error::NotSupported(format!("Unknown window name: {}", win_ref)))?;
+            // OVER (w ...) adds its own ORDER BY, where the named window
+            // has none, and its own frame on top of the named window
             (
                 win_def.partition_by.clone(),
-                win_def.order_by.clone(),
-                win_def.frame.clone(),
+                if window_expr.order_by.is_empty() {
+                    win_def.order_by.clone()
+                } else {
+                    window_expr.order_by.clone()
+                },
+                window_expr.frame.clone().or_else(|| win_def.frame.clone()),
             )
         } else {
             (

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -4273,7 +4273,9 @@ impl Executor {
                                                 }
                                                 start_idx
                                             } else {
-                                                0
+                                                // No offset measures against a NULL
+                                                // key: the row frames to its peers
+                                                peer_groups[i].0
                                             }
                                         } else {
                                             0
@@ -4309,7 +4311,7 @@ impl Executor {
                                                 }
                                                 start_idx
                                             } else {
-                                                i
+                                                peer_groups[i].0
                                             }
                                         } else {
                                             i
@@ -4361,7 +4363,7 @@ impl Executor {
                                                     }
                                                     end_idx
                                                 } else {
-                                                    partition_len
+                                                    peer_groups[i].1
                                                 }
                                             } else {
                                                 partition_len
@@ -4398,7 +4400,7 @@ impl Executor {
                                                     }
                                                     end_idx
                                                 } else {
-                                                    i + 1
+                                                    peer_groups[i].1
                                                 }
                                             } else {
                                                 i + 1

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -470,6 +470,23 @@ impl Executor {
         pre_sorted: Option<WindowPreSortedState>,
         pre_grouped: Option<WindowPreGroupedState>,
     ) -> Result<Box<dyn QueryResult>> {
+        // A window function in ORDER BY that the select list does not carry
+        // is computed into a column of its own, named after it, which the
+        // sort reads and the projection then drops. It goes in before the
+        // subqueries are lifted, so one inside it is lifted with the rest
+        let extended_stmt;
+        let stmt = {
+            let hidden = Self::hidden_order_by_windows(stmt);
+            if hidden.is_empty() {
+                stmt
+            } else {
+                let mut extended = stmt.clone();
+                extended.columns.extend(hidden);
+                extended_stmt = extended;
+                &extended_stmt
+            }
+        };
+
         // A subquery inside a window function or its OVER clause is resolved
         // per input row first; the columns it adds stay out of SELECT *
         let visible_columns = base_columns.len();
@@ -503,23 +520,6 @@ impl Executor {
                 )
             }
             None => (stmt, base_rows, base_columns),
-        };
-
-        // A window function in ORDER BY that the select list does not carry
-        // is computed into a column of its own, named after it, which the
-        // sort reads and the projection then drops. Beside a star nothing
-        // is dropped, so there the select list stays as written
-        let extended_stmt;
-        let stmt = {
-            let hidden = Self::hidden_order_by_windows(stmt);
-            if hidden.is_empty() {
-                stmt
-            } else {
-                let mut extended = stmt.clone();
-                extended.columns.extend(hidden);
-                extended_stmt = extended;
-                &extended_stmt
-            }
         };
 
         // Parse window functions from the SELECT list

--- a/src/functions/aggregate/avg.rs
+++ b/src/functions/aggregate/avg.rs
@@ -66,6 +66,9 @@ impl AggregateFunction for AvgFunction {
         let numeric_value = match value {
             Value::Integer(i) => *i as f64,
             Value::Float(f) => *f,
+            // A boolean counts as one or nought, so AVG(v > 100) is the
+            // share of rows the condition holds for
+            Value::Boolean(b) => *b as i64 as f64,
             _ => return, // Ignore non-numeric types
         };
 

--- a/src/functions/aggregate/compiled.rs
+++ b/src/functions/aggregate/compiled.rs
@@ -557,6 +557,8 @@ impl CompiledAggregate {
         match value {
             Value::Integer(i) => Some(*i as f64),
             Value::Float(f) => Some(*f),
+            // A boolean counts as one or nought, as the aggregate reads it
+            Value::Boolean(b) => Some(*b as i64 as f64),
             _ => None,
         }
     }

--- a/src/functions/aggregate/compiled.rs
+++ b/src/functions/aggregate/compiled.rs
@@ -534,6 +534,14 @@ impl CompiledAggregate {
     /// Helper: accumulate into SumState
     #[inline(always)]
     fn accumulate_sum(state: &mut SumState, value: &Value) {
+        // A boolean counts as one or nought, as SUM reads it
+        let promoted;
+        let value = if let Value::Boolean(b) = value {
+            promoted = Value::Integer(*b as i64);
+            &promoted
+        } else {
+            value
+        };
         match value {
             Value::Integer(i) => match state {
                 SumState::Empty => *state = SumState::Integer(*i),

--- a/src/functions/aggregate/sum.rs
+++ b/src/functions/aggregate/sum.rs
@@ -75,6 +75,17 @@ impl AggregateFunction for SumFunction {
             }
         }
 
+        // A boolean counts as one or nought, so SUM(v > 100) counts the
+        // rows the condition holds for, the way both reference engines
+        // read it, rather than adding nothing and answering NULL
+        let promoted;
+        let value = if let Value::Boolean(b) = value {
+            promoted = Value::Integer(*b as i64);
+            &promoted
+        } else {
+            value
+        };
+
         // Extract numeric value
         match value {
             Value::Integer(i) => match &mut self.state {

--- a/src/functions/scalar/string.rs
+++ b/src/functions/scalar/string.rs
@@ -443,20 +443,31 @@ impl ScalarFunction for TrimFunction {
         FunctionInfo::new(
             "TRIM",
             FunctionType::Scalar,
-            "Removes leading and trailing whitespace from a string",
-            FunctionSignature::new(FunctionDataType::String, vec![FunctionDataType::Any], 1, 1),
+            "Removes leading and trailing whitespace, or the given characters, from a string",
+            FunctionSignature::new(
+                FunctionDataType::String,
+                vec![FunctionDataType::Any, FunctionDataType::String],
+                1,
+                2,
+            ),
         )
     }
 
     fn evaluate(&self, args: &[Value]) -> Result<Value> {
-        validate_arg_count!(args, "TRIM", 1);
+        validate_arg_count!(args, "TRIM", 1, 2);
 
-        if args[0].is_null() {
+        if args[0].is_null() || args.get(1).is_some_and(Value::is_null) {
             return Ok(Value::null_unknown());
         }
 
         let s = value_to_string(&args[0]);
-        Ok(Value::Text(SmartString::from(s.trim())))
+        Ok(Value::Text(SmartString::from(match args.get(1) {
+            Some(chars) => {
+                let chars = value_to_string(chars);
+                s.trim_matches(|c| chars.contains(c))
+            }
+            None => s.trim(),
+        })))
     }
 
     fn clone_box(&self) -> Box<dyn ScalarFunction> {
@@ -481,20 +492,31 @@ impl ScalarFunction for LtrimFunction {
         FunctionInfo::new(
             "LTRIM",
             FunctionType::Scalar,
-            "Removes leading whitespace from a string",
-            FunctionSignature::new(FunctionDataType::String, vec![FunctionDataType::Any], 1, 1),
+            "Removes leading whitespace, or the given characters, from a string",
+            FunctionSignature::new(
+                FunctionDataType::String,
+                vec![FunctionDataType::Any, FunctionDataType::String],
+                1,
+                2,
+            ),
         )
     }
 
     fn evaluate(&self, args: &[Value]) -> Result<Value> {
-        validate_arg_count!(args, "LTRIM", 1);
+        validate_arg_count!(args, "LTRIM", 1, 2);
 
-        if args[0].is_null() {
+        if args[0].is_null() || args.get(1).is_some_and(Value::is_null) {
             return Ok(Value::null_unknown());
         }
 
         let s = value_to_string(&args[0]);
-        Ok(Value::Text(SmartString::from(s.trim_start())))
+        Ok(Value::Text(SmartString::from(match args.get(1) {
+            Some(chars) => {
+                let chars = value_to_string(chars);
+                s.trim_start_matches(|c| chars.contains(c))
+            }
+            None => s.trim_start(),
+        })))
     }
 
     fn clone_box(&self) -> Box<dyn ScalarFunction> {
@@ -519,20 +541,31 @@ impl ScalarFunction for RtrimFunction {
         FunctionInfo::new(
             "RTRIM",
             FunctionType::Scalar,
-            "Removes trailing whitespace from a string",
-            FunctionSignature::new(FunctionDataType::String, vec![FunctionDataType::Any], 1, 1),
+            "Removes trailing whitespace, or the given characters, from a string",
+            FunctionSignature::new(
+                FunctionDataType::String,
+                vec![FunctionDataType::Any, FunctionDataType::String],
+                1,
+                2,
+            ),
         )
     }
 
     fn evaluate(&self, args: &[Value]) -> Result<Value> {
-        validate_arg_count!(args, "RTRIM", 1);
+        validate_arg_count!(args, "RTRIM", 1, 2);
 
-        if args[0].is_null() {
+        if args[0].is_null() || args.get(1).is_some_and(Value::is_null) {
             return Ok(Value::null_unknown());
         }
 
         let s = value_to_string(&args[0]);
-        Ok(Value::Text(SmartString::from(s.trim_end())))
+        Ok(Value::Text(SmartString::from(match args.get(1) {
+            Some(chars) => {
+                let chars = value_to_string(chars);
+                s.trim_end_matches(|c| chars.contains(c))
+            }
+            None => s.trim_end(),
+        })))
     }
 
     fn clone_box(&self) -> Box<dyn ScalarFunction> {

--- a/src/functions/scalar/string.rs
+++ b/src/functions/scalar/string.rs
@@ -583,6 +583,12 @@ impl ScalarFunction for ReplaceFunction {
         let from = value_to_string(&args[1]);
         let to = value_to_string(&args[2]);
 
+        // There is nothing to find in a string that holds no characters,
+        // so the subject is returned as it stands
+        if from.is_empty() {
+            return Ok(Value::Text(SmartString::from_string(s)));
+        }
+
         Ok(Value::Text(SmartString::from_string(s.replace(&from, &to))))
     }
 

--- a/src/functions/scalar/string.rs
+++ b/src/functions/scalar/string.rs
@@ -339,31 +339,37 @@ impl ScalarFunction for SubstringFunction {
         let s = value_to_string(&args[0]);
         let chars: Vec<char> = s.chars().collect();
 
-        // SQL SUBSTRING uses 1-based indexing
+        // SQL SUBSTRING counts from one. A start below one names a
+        // position before the string, and a negative one counts back from
+        // the end, so the window it opens may reach in from either side
         let start = value_to_i64(&args[1]).ok_or_else(|| {
             Error::invalid_argument("SUBSTRING start position must be an integer")
         })?;
+        let len = chars.len() as i64;
+        let start = if start < 0 { len + start + 1 } else { start };
 
-        // Convert to 0-based index, handling negative values
-        let start_idx = if start < 1 { 0 } else { (start - 1) as usize };
-
-        if start_idx >= chars.len() {
+        // The window runs from the start for a length, or back from it for
+        // a negative one, and only the part inside the string is returned
+        let (from, to) = if args.len() == 3 {
+            let length = value_to_i64(&args[2])
+                .ok_or_else(|| Error::invalid_argument("SUBSTRING length must be an integer"))?;
+            if length < 0 {
+                (start + length, start)
+            } else {
+                (start, start + length)
+            }
+        } else {
+            (start, len + 1)
+        };
+        let from = from.max(1);
+        let to = to.min(len + 1);
+        if to <= from {
             return Ok(Value::Text(SmartString::from("")));
         }
 
-        let result: String = if args.len() == 3 {
-            let length = value_to_i64(&args[2])
-                .ok_or_else(|| Error::invalid_argument("SUBSTRING length must be an integer"))?;
-
-            if length < 0 {
-                return Ok(Value::Text(SmartString::from("")));
-            }
-
-            let end_idx = std::cmp::min(start_idx + length as usize, chars.len());
-            chars[start_idx..end_idx].iter().collect()
-        } else {
-            chars[start_idx..].iter().collect()
-        };
+        let result: String = chars[(from - 1) as usize..(to - 1) as usize]
+            .iter()
+            .collect();
 
         Ok(Value::Text(SmartString::from_string(result)))
     }

--- a/src/functions/scalar/string.rs
+++ b/src/functions/scalar/string.rs
@@ -346,17 +346,23 @@ impl ScalarFunction for SubstringFunction {
             Error::invalid_argument("SUBSTRING start position must be an integer")
         })?;
         let len = chars.len() as i64;
-        let start = if start < 0 { len + start + 1 } else { start };
+        let start = if start < 0 {
+            len.saturating_add(start).saturating_add(1)
+        } else {
+            start
+        };
 
         // The window runs from the start for a length, or back from it for
         // a negative one, and only the part inside the string is returned
         let (from, to) = if args.len() == 3 {
             let length = value_to_i64(&args[2])
                 .ok_or_else(|| Error::invalid_argument("SUBSTRING length must be an integer"))?;
+            // A length near the limits runs past either end of the string,
+            // which the clamp below turns into that end
             if length < 0 {
-                (start + length, start)
+                (start.saturating_add(length), start)
             } else {
-                (start, start + length)
+                (start, start.saturating_add(length))
             }
         } else {
             (start, len + 1)

--- a/src/optimizer/simplify.rs
+++ b/src/optimizer/simplify.rs
@@ -335,14 +335,6 @@ impl ExpressionSimplifier {
         if self.is_one(left) {
             return Some(right.clone());
         }
-        // x * 0 → 0
-        if self.is_zero(right) {
-            return Some(self.make_int(0));
-        }
-        // 0 * x → 0
-        if self.is_zero(left) {
-            return Some(self.make_int(0));
-        }
         // Constant folding
         self.try_eval_arithmetic(left, right, InfixOperator::Multiply)
     }
@@ -866,14 +858,10 @@ mod tests {
         let result = simplify_expression(&expr);
         assert!(matches!(result, Expression::Identifier(_)));
 
-        // x * 0 → 0
+        // x * 0 is NULL for a NULL x, so it is left alone
         let expr = make_infix(x.clone(), InfixOperator::Multiply, make_int_lit(0));
         let result = simplify_expression(&expr);
-        if let Expression::IntegerLiteral(lit) = result {
-            assert_eq!(lit.value, 0);
-        } else {
-            panic!("Expected IntegerLiteral(0)");
-        }
+        assert!(matches!(result, Expression::Infix(_)));
     }
 
     #[test]

--- a/src/optimizer/simplify.rs
+++ b/src/optimizer/simplify.rs
@@ -18,7 +18,7 @@
 //! It handles:
 //! - Constant folding (1 + 1 → 2)
 //! - Boolean simplification (TRUE AND x → x, FALSE OR x → x)
-//! - Tautology elimination (1 = 1 → TRUE, x = x → TRUE for NOT NULL cols)
+//! - Tautology elimination (1 = 1 → TRUE)
 //! - Contradiction detection (1 = 2 → FALSE)
 //! - Range predicate merging (a > 5 AND a > 3 → a > 5)
 //! - De Morgan's law application where beneficial
@@ -258,10 +258,6 @@ impl ExpressionSimplifier {
         if let Some(result) = self.try_eval_comparison(left, right, InfixOperator::Equal) {
             return Some(self.make_bool(result));
         }
-        // x = x → TRUE (for deterministic expressions)
-        if self.is_deterministic(left) && self.expr_equals(left, right) {
-            return Some(self.make_bool(true));
-        }
         None
     }
 
@@ -269,10 +265,6 @@ impl ExpressionSimplifier {
     fn simplify_not_equal(&self, left: &Expression, right: &Expression) -> Option<Expression> {
         if let Some(result) = self.try_eval_comparison(left, right, InfixOperator::NotEqual) {
             return Some(self.make_bool(result));
-        }
-        // x <> x → FALSE (for deterministic expressions)
-        if self.is_deterministic(left) && self.expr_equals(left, right) {
-            return Some(self.make_bool(false));
         }
         None
     }
@@ -282,10 +274,6 @@ impl ExpressionSimplifier {
         if let Some(result) = self.try_eval_comparison(left, right, InfixOperator::LessThan) {
             return Some(self.make_bool(result));
         }
-        // x < x → FALSE
-        if self.is_deterministic(left) && self.expr_equals(left, right) {
-            return Some(self.make_bool(false));
-        }
         None
     }
 
@@ -293,10 +281,6 @@ impl ExpressionSimplifier {
     fn simplify_less_equal(&self, left: &Expression, right: &Expression) -> Option<Expression> {
         if let Some(result) = self.try_eval_comparison(left, right, InfixOperator::LessEqual) {
             return Some(self.make_bool(result));
-        }
-        // x <= x → TRUE
-        if self.is_deterministic(left) && self.expr_equals(left, right) {
-            return Some(self.make_bool(true));
         }
         None
     }
@@ -306,10 +290,6 @@ impl ExpressionSimplifier {
         if let Some(result) = self.try_eval_comparison(left, right, InfixOperator::GreaterThan) {
             return Some(self.make_bool(result));
         }
-        // x > x → FALSE
-        if self.is_deterministic(left) && self.expr_equals(left, right) {
-            return Some(self.make_bool(false));
-        }
         None
     }
 
@@ -317,10 +297,6 @@ impl ExpressionSimplifier {
     fn simplify_greater_equal(&self, left: &Expression, right: &Expression) -> Option<Expression> {
         if let Some(result) = self.try_eval_comparison(left, right, InfixOperator::GreaterEqual) {
             return Some(self.make_bool(result));
-        }
-        // x >= x → TRUE
-        if self.is_deterministic(left) && self.expr_equals(left, right) {
-            return Some(self.make_bool(true));
         }
         None
     }
@@ -344,10 +320,6 @@ impl ExpressionSimplifier {
         // x - 0 → x
         if self.is_zero(right) {
             return Some(left.clone());
-        }
-        // x - x → 0
-        if self.is_deterministic(left) && self.expr_equals(left, right) {
-            return Some(self.make_int(0));
         }
         // Constant folding
         self.try_eval_arithmetic(left, right, InfixOperator::Subtract)
@@ -458,14 +430,12 @@ impl ExpressionSimplifier {
         match expr {
             Expression::BooleanLiteral(b) => b.value,
             Expression::Infix(infix) => {
-                // 1 = 1 is always true
-                if infix.op_type == InfixOperator::Equal
+                // 1 = 1 is always true. A column compared with itself is not:
+                // wherever the column is NULL the answer is unknown, and NULL
+                // = NULL is unknown too
+                infix.op_type == InfixOperator::Equal
+                    && Self::is_non_null_literal(&infix.left)
                     && self.expr_equals(&infix.left, &infix.right)
-                    && self.is_deterministic(&infix.left)
-                {
-                    return true;
-                }
-                false
             }
             _ => false,
         }
@@ -490,33 +460,15 @@ impl ExpressionSimplifier {
         }
     }
 
-    /// Check if expression is deterministic (same input → same output)
-    fn is_deterministic(&self, expr: &Expression) -> bool {
-        match expr {
-            Expression::Identifier(_)
-            | Expression::QualifiedIdentifier(_)
-            | Expression::IntegerLiteral(_)
-            | Expression::FloatLiteral(_)
-            | Expression::StringLiteral(_)
-            | Expression::BooleanLiteral(_)
-            | Expression::NullLiteral(_) => true,
-            Expression::Infix(infix) => {
-                self.is_deterministic(&infix.left) && self.is_deterministic(&infix.right)
-            }
-            Expression::Prefix(prefix) => self.is_deterministic(&prefix.right),
-            Expression::FunctionCall(func) => {
-                // Most functions are deterministic, but not RANDOM(), NOW(), etc.
-                let name = func.function.to_uppercase();
-                if matches!(
-                    name.as_str(),
-                    "RANDOM" | "NOW" | "CURRENT_TIMESTAMP" | "UUID"
-                ) {
-                    return false;
-                }
-                func.arguments.iter().all(|a| self.is_deterministic(a))
-            }
-            _ => false,
-        }
+    /// Check if expression is a literal that can never be NULL
+    fn is_non_null_literal(expr: &Expression) -> bool {
+        matches!(
+            expr,
+            Expression::IntegerLiteral(_)
+                | Expression::FloatLiteral(_)
+                | Expression::StringLiteral(_)
+                | Expression::BooleanLiteral(_)
+        )
     }
 
     /// Check if two expressions are structurally equal
@@ -970,37 +922,29 @@ mod tests {
     fn test_self_comparison() {
         let x = make_identifier("x");
 
-        // x = x → TRUE (for deterministic x)
+        // x = x is unknown wherever x is NULL, so it stands as written
         let expr = make_infix(x.clone(), InfixOperator::Equal, x.clone());
-        let result = simplify_expression(&expr);
-        if let Expression::BooleanLiteral(lit) = result {
-            assert!(lit.value);
-        } else {
-            panic!("Expected BooleanLiteral(true)");
-        }
+        assert!(matches!(simplify_expression(&expr), Expression::Infix(_)));
 
-        // x < x → FALSE
+        // x < x reads the same way
         let expr = make_infix(x.clone(), InfixOperator::LessThan, x.clone());
-        let result = simplify_expression(&expr);
-        if let Expression::BooleanLiteral(lit) = result {
-            assert!(!lit.value);
-        } else {
-            panic!("Expected BooleanLiteral(false)");
-        }
+        assert!(matches!(simplify_expression(&expr), Expression::Infix(_)));
     }
 
     #[test]
     fn test_subtraction_identity() {
         let x = make_identifier("x");
 
-        // x - x → 0
+        // x - x is NULL wherever x is, so it stands as written
         let expr = make_infix(x.clone(), InfixOperator::Subtract, x.clone());
-        let result = simplify_expression(&expr);
-        if let Expression::IntegerLiteral(lit) = result {
-            assert_eq!(lit.value, 0);
-        } else {
-            panic!("Expected IntegerLiteral(0)");
-        }
+        assert!(matches!(simplify_expression(&expr), Expression::Infix(_)));
+
+        // x - 0 → x still holds
+        let expr = make_infix(x.clone(), InfixOperator::Subtract, make_int_lit(0));
+        assert!(matches!(
+            simplify_expression(&expr),
+            Expression::Identifier(_)
+        ));
     }
 
     #[test]

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1570,6 +1570,8 @@ pub struct InsertStatement {
     pub on_duplicate: bool,
     pub update_columns: Vec<Identifier>,
     pub update_expressions: Vec<Expression>,
+    /// DO UPDATE ... WHERE: the row is updated only where this holds
+    pub update_where: Option<Box<Expression>>,
     /// ON CONFLICT DO NOTHING (skip duplicates silently)
     pub do_nothing: bool,
     /// Conflict target columns for ON CONFLICT (col1, col2, ...)
@@ -1627,6 +1629,9 @@ impl fmt::Display for InsertStatement {
                 .map(|(col, expr)| format!("{} = {}", col, expr))
                 .collect();
             result.push_str(&updates.join(", "));
+            if let Some(ref update_where) = self.update_where {
+                result.push_str(&format!(" WHERE {}", update_where));
+            }
         }
         if !self.returning.is_empty() {
             let returning: Vec<String> = self.returning.iter().map(|e| e.to_string()).collect();
@@ -2552,6 +2557,7 @@ mod tests {
             on_duplicate: false,
             update_columns: vec![],
             update_expressions: vec![],
+            update_where: None,
             do_nothing: false,
             conflict_target: vec![],
             returning: vec![],

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -943,11 +943,23 @@ pub struct WindowExpression {
 impl fmt::Display for WindowExpression {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut result = self.function.to_string();
-        if let Some(ref win_ref) = self.window_ref {
+        let extends_named = self.window_ref.is_some()
+            && (!self.partition_by.is_empty() || !self.order_by.is_empty() || self.frame.is_some());
+        if let (Some(win_ref), false) = (&self.window_ref, extends_named) {
             result.push_str(" OVER ");
             result.push_str(win_ref);
         } else {
             result.push_str(" OVER (");
+            // OVER (w ...) names the window it builds on first
+            if let Some(ref win_ref) = self.window_ref {
+                result.push_str(win_ref);
+                if !self.partition_by.is_empty()
+                    || !self.order_by.is_empty()
+                    || self.frame.is_some()
+                {
+                    result.push(' ');
+                }
+            }
             if !self.partition_by.is_empty() {
                 result.push_str("PARTITION BY ");
                 let parts: Vec<String> = self.partition_by.iter().map(|e| e.to_string()).collect();

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1662,11 +1662,16 @@ pub struct UpdateStatement {
     pub where_clause: Option<Box<Expression>>,
     /// RETURNING clause expressions
     pub returning: Vec<Expression>,
+    /// WITH clause the statement's subqueries may read
+    pub with: Option<WithClause>,
 }
 
 impl fmt::Display for UpdateStatement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut result = format!("UPDATE {} SET ", self.table_name);
+        let mut result = match self.with {
+            Some(ref with) => format!("{} UPDATE {} SET ", with, self.table_name),
+            None => format!("UPDATE {} SET ", self.table_name),
+        };
         let updates: Vec<String> = self
             .updates
             .iter()
@@ -1694,11 +1699,16 @@ pub struct DeleteStatement {
     pub where_clause: Option<Box<Expression>>,
     /// RETURNING clause expressions
     pub returning: Vec<Expression>,
+    /// WITH clause the statement's subqueries may read
+    pub with: Option<WithClause>,
 }
 
 impl fmt::Display for DeleteStatement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut result = format!("DELETE FROM {}", self.table_name);
+        let mut result = match self.with {
+            Some(ref with) => format!("{} DELETE FROM {}", with, self.table_name),
+            None => format!("DELETE FROM {}", self.table_name),
+        };
         if let Some(ref alias) = self.alias {
             result.push_str(&format!(" AS {}", alias));
         }

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1006,6 +1006,15 @@ impl Parser {
             return None;
         }
 
+        // OVER (w ...) builds on a named window: its own ORDER BY, where the
+        // named window has none, and its own frame go on top of it
+        let window_ref = if self.peek_token_is(TokenType::Identifier) {
+            self.next_token(); // consume window name
+            Some(self.cur_token.literal.clone())
+        } else {
+            None
+        };
+
         let mut partition_by = Vec::new();
         let mut order_by = Vec::new();
         let mut frame = None;
@@ -1068,7 +1077,7 @@ impl Parser {
         Some(Expression::Window(Box::new(WindowExpression {
             token,
             function: Box::new(function),
-            window_ref: None,
+            window_ref,
             partition_by,
             order_by,
             frame,

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -29,6 +29,7 @@ struct ConflictClause {
     on_duplicate: bool,
     update_columns: Vec<Identifier>,
     update_expressions: Vec<Expression>,
+    update_where: Option<Box<Expression>>,
     do_nothing: bool,
     conflict_target: Vec<Identifier>,
 }
@@ -929,6 +930,7 @@ impl Parser {
                 on_duplicate: conflict.on_duplicate,
                 update_columns: conflict.update_columns,
                 update_expressions: conflict.update_expressions,
+                update_where: conflict.update_where,
                 do_nothing: conflict.do_nothing,
                 conflict_target: conflict.conflict_target,
                 returning,
@@ -966,6 +968,7 @@ impl Parser {
                 on_duplicate: conflict.on_duplicate,
                 update_columns: conflict.update_columns,
                 update_expressions: conflict.update_expressions,
+                update_where: conflict.update_where,
                 do_nothing: conflict.do_nothing,
                 conflict_target: conflict.conflict_target,
                 returning,
@@ -995,6 +998,7 @@ impl Parser {
             on_duplicate: conflict.on_duplicate,
             update_columns: conflict.update_columns,
             update_expressions: conflict.update_expressions,
+            update_where: conflict.update_where,
             do_nothing: conflict.do_nothing,
             conflict_target: conflict.conflict_target,
             returning,
@@ -1065,10 +1069,23 @@ impl Parser {
                     return ConflictClause::default();
                 }
                 let (update_columns, update_expressions) = self.parse_update_assignments();
+                // DO UPDATE ... WHERE: the row is updated only where this holds
+                let update_where = if self.peek_token_is_keyword("WHERE") {
+                    self.next_token(); // consume WHERE
+                    self.current_clause = "WHERE".to_string();
+                    self.next_token();
+                    match self.parse_expression(Precedence::Lowest) {
+                        Some(expr) => Some(Box::new(expr)),
+                        None => return ConflictClause::default(),
+                    }
+                } else {
+                    None
+                };
                 ConflictClause {
                     on_duplicate: true,
                     update_columns,
                     update_expressions,
+                    update_where,
                     conflict_target,
                     do_nothing: false,
                 }

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -766,9 +766,17 @@ impl Parser {
                 return None;
             }
             Some(Statement::Insert(insert))
+        } else if self.cur_token_is_keyword("UPDATE") {
+            let mut update = self.parse_update_statement()?;
+            update.with = Some(with_clause);
+            Some(Statement::Update(update))
+        } else if self.cur_token_is_keyword("DELETE") {
+            let mut delete = self.parse_delete_statement()?;
+            delete.with = Some(with_clause);
+            Some(Statement::Delete(delete))
         } else {
             self.add_error(format!(
-                "expected SELECT or INSERT after WITH clause at {}",
+                "expected SELECT, INSERT, UPDATE or DELETE after WITH clause at {}",
                 self.cur_token.position
             ));
             None
@@ -1492,6 +1500,7 @@ impl Parser {
             updates,
             where_clause,
             returning,
+            with: None,
         })
     }
 
@@ -1561,6 +1570,7 @@ impl Parser {
             alias,
             where_clause,
             returning,
+            with: None,
         })
     }
 

--- a/src/storage/expression/compiled.rs
+++ b/src/storage/expression/compiled.rs
@@ -1848,6 +1848,40 @@ impl CompiledFilter {
     /// However, NOT(UNKNOWN) should remain UNKNOWN, not become true.
     ///
     /// This method detects when a false result is actually UNKNOWN due to NULL.
+    /// A conjunction is UNKNOWN where no part is false and some part is
+    fn conjunction_is_unknown<'a>(
+        filters: impl Iterator<Item = &'a CompiledFilter>,
+        unknown: impl Fn(&CompiledFilter) -> bool,
+        holds: impl Fn(&CompiledFilter) -> bool,
+    ) -> bool {
+        let mut any_unknown = false;
+        for filter in filters {
+            if unknown(filter) {
+                any_unknown = true;
+            } else if !holds(filter) {
+                return false;
+            }
+        }
+        any_unknown
+    }
+
+    /// A disjunction is UNKNOWN where no part is true and some part is
+    fn disjunction_is_unknown<'a>(
+        filters: impl Iterator<Item = &'a CompiledFilter>,
+        unknown: impl Fn(&CompiledFilter) -> bool,
+        holds: impl Fn(&CompiledFilter) -> bool,
+    ) -> bool {
+        let mut any_unknown = false;
+        for filter in filters {
+            if unknown(filter) {
+                any_unknown = true;
+            } else if holds(filter) {
+                return false;
+            }
+        }
+        any_unknown
+    }
+
     #[inline(always)]
     pub fn is_unknown_due_to_null(&self, row: &Row) -> bool {
         match self {
@@ -1901,13 +1935,28 @@ impl CompiledFilter {
             // IS NULL / IS NOT NULL - never produces UNKNOWN (they check for NULL explicitly)
             CompiledFilter::IsNull { .. } | CompiledFilter::IsNotNull { .. } => false,
 
-            // AND/OR: Match original Expression behavior which returns false by default
-            // for is_unknown_due_to_null. This means NOT(AND(...)) won't propagate
-            // UNKNOWN from children, matching the existing Expression semantics.
-            CompiledFilter::And(_, _) | CompiledFilter::AndN(_) => false,
-
-            // OR: Match original Expression behavior which returns false by default
-            CompiledFilter::Or(_, _) | CompiledFilter::OrN(_) => false,
+            // UNKNOWN AND FALSE is FALSE, UNKNOWN AND TRUE is UNKNOWN;
+            // UNKNOWN OR TRUE is TRUE, UNKNOWN OR FALSE is UNKNOWN
+            CompiledFilter::And(a, b) => Self::conjunction_is_unknown(
+                [a.as_ref(), b.as_ref()].into_iter(),
+                |f| f.is_unknown_due_to_null(row),
+                |f| f.matches(row),
+            ),
+            CompiledFilter::AndN(filters) => Self::conjunction_is_unknown(
+                filters.iter(),
+                |f| f.is_unknown_due_to_null(row),
+                |f| f.matches(row),
+            ),
+            CompiledFilter::Or(a, b) => Self::disjunction_is_unknown(
+                [a.as_ref(), b.as_ref()].into_iter(),
+                |f| f.is_unknown_due_to_null(row),
+                |f| f.matches(row),
+            ),
+            CompiledFilter::OrN(filters) => Self::disjunction_is_unknown(
+                filters.iter(),
+                |f| f.is_unknown_due_to_null(row),
+                |f| f.matches(row),
+            ),
 
             // NOT(UNKNOWN) = UNKNOWN
             CompiledFilter::Not(inner) => inner.is_unknown_due_to_null(row),
@@ -1974,9 +2023,26 @@ impl CompiledFilter {
             // IS NULL / IS NOT NULL - never produces UNKNOWN
             CompiledFilter::IsNull { .. } | CompiledFilter::IsNotNull { .. } => false,
 
-            // AND/OR: Match original Expression behavior
-            CompiledFilter::And(_, _) | CompiledFilter::AndN(_) => false,
-            CompiledFilter::Or(_, _) | CompiledFilter::OrN(_) => false,
+            CompiledFilter::And(a, b) => Self::conjunction_is_unknown(
+                [a.as_ref(), b.as_ref()].into_iter(),
+                |f| f.is_unknown_due_to_null_slice(values),
+                |f| f.matches_arc_slice(values),
+            ),
+            CompiledFilter::AndN(filters) => Self::conjunction_is_unknown(
+                filters.iter(),
+                |f| f.is_unknown_due_to_null_slice(values),
+                |f| f.matches_arc_slice(values),
+            ),
+            CompiledFilter::Or(a, b) => Self::disjunction_is_unknown(
+                [a.as_ref(), b.as_ref()].into_iter(),
+                |f| f.is_unknown_due_to_null_slice(values),
+                |f| f.matches_arc_slice(values),
+            ),
+            CompiledFilter::OrN(filters) => Self::disjunction_is_unknown(
+                filters.iter(),
+                |f| f.is_unknown_due_to_null_slice(values),
+                |f| f.matches_arc_slice(values),
+            ),
 
             // NOT(UNKNOWN) = UNKNOWN
             CompiledFilter::Not(inner) => inner.is_unknown_due_to_null_slice(values),
@@ -2046,9 +2112,26 @@ impl CompiledFilter {
             // IS NULL / IS NOT NULL - never produces UNKNOWN
             CompiledFilter::IsNull { .. } | CompiledFilter::IsNotNull { .. } => false,
 
-            // AND/OR: Match original Expression behavior
-            CompiledFilter::And(_, _) | CompiledFilter::AndN(_) => false,
-            CompiledFilter::Or(_, _) | CompiledFilter::OrN(_) => false,
+            CompiledFilter::And(a, b) => Self::conjunction_is_unknown(
+                [a.as_ref(), b.as_ref()].into_iter(),
+                |f| f.is_unknown_due_to_null_arc_slice(values),
+                |f| f.matches_arc_slice(values),
+            ),
+            CompiledFilter::AndN(filters) => Self::conjunction_is_unknown(
+                filters.iter(),
+                |f| f.is_unknown_due_to_null_arc_slice(values),
+                |f| f.matches_arc_slice(values),
+            ),
+            CompiledFilter::Or(a, b) => Self::disjunction_is_unknown(
+                [a.as_ref(), b.as_ref()].into_iter(),
+                |f| f.is_unknown_due_to_null_arc_slice(values),
+                |f| f.matches_arc_slice(values),
+            ),
+            CompiledFilter::OrN(filters) => Self::disjunction_is_unknown(
+                filters.iter(),
+                |f| f.is_unknown_due_to_null_arc_slice(values),
+                |f| f.matches_arc_slice(values),
+            ),
 
             // NOT(UNKNOWN) = UNKNOWN
             CompiledFilter::Not(inner) => inner.is_unknown_due_to_null_arc_slice(values),

--- a/src/storage/expression/logical.rs
+++ b/src/storage/expression/logical.rs
@@ -84,6 +84,19 @@ impl Expression for AndExpr {
         true // All expressions were true
     }
 
+    /// UNKNOWN AND FALSE is FALSE; UNKNOWN AND TRUE is UNKNOWN
+    fn is_unknown_due_to_null(&self, row: &Row) -> bool {
+        let mut any_unknown = false;
+        for expr in &self.expressions {
+            if expr.is_unknown_due_to_null(row) {
+                any_unknown = true;
+            } else if !expr.evaluate_fast(row) {
+                return false;
+            }
+        }
+        any_unknown
+    }
+
     fn with_aliases(&self, aliases: &FxHashMap<String, String>) -> Box<dyn Expression> {
         let aliased_exprs: Vec<Box<dyn Expression>> = self
             .expressions
@@ -187,6 +200,19 @@ impl Expression for OrExpr {
             }
         }
         false // No expression was true
+    }
+
+    /// UNKNOWN OR TRUE is TRUE; UNKNOWN OR FALSE is UNKNOWN
+    fn is_unknown_due_to_null(&self, row: &Row) -> bool {
+        let mut any_unknown = false;
+        for expr in &self.expressions {
+            if expr.is_unknown_due_to_null(row) {
+                any_unknown = true;
+            } else if expr.evaluate_fast(row) {
+                return false;
+            }
+        }
+        any_unknown
     }
 
     fn with_aliases(&self, aliases: &FxHashMap<String, String>) -> Box<dyn Expression> {

--- a/src/storage/mvcc/scanner.rs
+++ b/src/storage/mvcc/scanner.rs
@@ -218,6 +218,13 @@ impl Scanner for MVCCScanner {
         std::mem::take(&mut self.rows[idx].1)
     }
 
+    fn current_row_id(&self) -> i64 {
+        if self.current_index < 0 || (self.current_index as usize) >= self.rows.len() {
+            return 0;
+        }
+        self.rows[self.current_index as usize].0
+    }
+
     fn estimated_count(&self) -> Option<usize> {
         Some(self.rows.len())
     }

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -1302,7 +1302,19 @@ impl MVCCTable {
                     return Ok(());
                 }
                 let entries = index.find(&values)?;
-                if let Some(entry) = entries.first() {
+                // A row this transaction has deleted no longer holds the
+                // value against it
+                let taken = {
+                    let txn_versions = self.txn_versions.read().unwrap();
+                    entries.iter().find(|entry| {
+                        !txn_versions
+                            .local_versions_ref()
+                            .and_then(|versions| versions.get(entry.row_id))
+                            .and_then(|versions| versions.last())
+                            .is_some_and(|version| version.is_deleted())
+                    })
+                };
+                if let Some(entry) = taken {
                     let col_names: Vec<&str> = column_ids
                         .iter()
                         .map(|&col_id| {
@@ -1387,16 +1399,23 @@ impl MVCCTable {
             )));
         }
 
-        // Check if row already exists in local versions
-        {
+        // Check if row already exists in local versions. A row this
+        // transaction has deleted is gone for it, whatever the global
+        // store still holds, so the key may be taken again
+        let deleted_locally = {
             let txn_versions = self.txn_versions.read().unwrap();
             if txn_versions.has_locally_seen(row_id) && txn_versions.get(row_id).is_some() {
                 return Err(Error::primary_key_constraint(row_id));
             }
-        }
+            txn_versions
+                .local_versions_ref()
+                .and_then(|versions| versions.get(row_id))
+                .and_then(|versions| versions.last())
+                .is_some_and(|version| version.is_deleted())
+        };
 
         // Check if row exists in global store
-        if self.version_store.quick_check_row_existence(row_id) {
+        if !deleted_locally && self.version_store.quick_check_row_existence(row_id) {
             if let Some(version) = self.version_store.get_visible_version(row_id, self.txn_id) {
                 if !version.is_deleted() {
                     return Err(Error::primary_key_constraint(row_id));

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -1302,16 +1302,28 @@ impl MVCCTable {
                     return Ok(());
                 }
                 let entries = index.find(&values)?;
-                // A row this transaction has deleted no longer holds the
-                // value against it
+                // The index holds the committed rows. A row this transaction
+                // has deleted no longer holds the value against it, and one
+                // it has rewritten holds only what its latest version says
                 let taken = {
                     let txn_versions = self.txn_versions.read().unwrap();
                     entries.iter().find(|entry| {
-                        !txn_versions
+                        let local = txn_versions
                             .local_versions_ref()
                             .and_then(|versions| versions.get(entry.row_id))
-                            .and_then(|versions| versions.last())
-                            .is_some_and(|version| version.is_deleted())
+                            .and_then(|versions| versions.last());
+                        match local {
+                            None => true,
+                            Some(version) if version.is_deleted() => false,
+                            Some(version) => {
+                                column_ids
+                                    .iter()
+                                    .zip(values.iter())
+                                    .all(|(&col_id, value)| {
+                                        version.data.get(col_id as usize) == Some(value)
+                                    })
+                            }
+                        }
                     })
                 };
                 if let Some(entry) = taken {

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -4205,6 +4205,10 @@ impl VersionStore {
                         *float_sum += *f;
                         *cnt += 1;
                     }
+                    Value::Boolean(b) => {
+                        *int_sum += *b as i128;
+                        *cnt += 1;
+                    }
                     _ => {}
                 },
                 (AggregateAccumulator::Min(min), AggregateOp::Min) if !val.is_null() => match min {
@@ -4231,6 +4235,10 @@ impl VersionStore {
                     }
                     Value::Float(f) => {
                         *float_sum += *f;
+                        *cnt += 1;
+                    }
+                    Value::Boolean(b) => {
+                        *int_sum += *b as i128;
                         *cnt += 1;
                     }
                     _ => {}
@@ -5990,6 +5998,11 @@ impl VersionStore {
                                 }
                                 Value::Float(f) => {
                                     accum.float_sum += *f;
+                                    accum.count += 1;
+                                }
+                                // A boolean counts as one or nought
+                                Value::Boolean(b) => {
+                                    accum.int_sum += *b as i128;
                                     accum.count += 1;
                                 }
                                 _ => {}

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -3834,6 +3834,11 @@ impl VersionStore {
                     *float_sum += *f;
                     *count += 1;
                 }
+                // A boolean counts as one or nought, as SUM reads it
+                Value::Boolean(b) => {
+                    *int_sum += *b as i128;
+                    *count += 1;
+                }
                 _ => {} // NULL or non-numeric
             }
         }

--- a/src/storage/volume/stats.rs
+++ b/src/storage/volume/stats.rs
@@ -68,6 +68,11 @@ impl ColumnAggregateStats {
                 self.sum_float += *f;
                 self.numeric_count += 1;
             }
+            // A boolean counts as one or nought, as SUM and AVG read it
+            Value::Boolean(b) => {
+                self.sum_int += *b as i128;
+                self.numeric_count += 1;
+            }
             Value::Float(_) => {}
             _ => {}
         }

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -2352,7 +2352,15 @@ impl Table for SegmentedTable {
         // overlapping row_ids between volumes. After UPDATE + seal, tombstones
         // are cleared but overlap remains (two volumes share the same row_id).
         // Compare raw vs deduped count to detect this (cached, O(1)).
-        let can_use_stats = self.segment_mgr.is_tombstone_set_empty()
+        // A boolean column is read by scanning: volumes sealed before
+        // booleans counted as one or nought carry zeros for it in their
+        // stats, and there is no telling them from volumes sealed since
+        let is_boolean_column = schema
+            .columns
+            .get(col_idx)
+            .is_some_and(|c| c.data_type == crate::core::DataType::Boolean);
+        let can_use_stats = !is_boolean_column
+            && self.segment_mgr.is_tombstone_set_empty()
             && !self.segment_mgr.has_pending_tombstones(self.txn_id())
             && self.segment_mgr.total_row_count() == self.segment_mgr.deduped_row_count();
 
@@ -4384,6 +4392,10 @@ impl Table for SegmentedTable {
                                     acc.count += 1;
                                     acc.is_int_agg = false;
                                 }
+                                Value::Boolean(b) => {
+                                    acc.int_sum += *b as i128;
+                                    acc.count += 1;
+                                }
                                 _ => {}
                             }
                         }
@@ -4537,6 +4549,10 @@ impl Table for SegmentedTable {
                                             acc.is_int_agg = false;
                                         }
                                     }
+                                    DataType::Boolean => {
+                                        acc.int_sum += col.get_bool(i) as i128;
+                                        acc.count += 1;
+                                    }
                                     _ => {}
                                 }
                             }
@@ -4550,6 +4566,10 @@ impl Table for SegmentedTable {
                                     acc.float_sum += *f;
                                     acc.count += 1;
                                     acc.is_int_agg = false;
+                                }
+                                Value::Boolean(b) => {
+                                    acc.int_sum += *b as i128;
+                                    acc.count += 1;
                                 }
                                 _ => {}
                             }
@@ -5248,6 +5268,10 @@ impl Table for SegmentedTable {
                                     accum.count += 1;
                                     accum.is_int_agg = false;
                                 }
+                                Value::Boolean(b) => {
+                                    accum.int_sum += *b as i128;
+                                    accum.count += 1;
+                                }
                                 _ => {}
                             }
                         }
@@ -5406,6 +5430,10 @@ impl Table for SegmentedTable {
                                             acc.is_int_agg = false;
                                         }
                                     }
+                                    DataType::Boolean => {
+                                        acc.int_sum += col.get_bool(i) as i128;
+                                        acc.count += 1;
+                                    }
                                     _ => {}
                                 }
                             }
@@ -5419,6 +5447,10 @@ impl Table for SegmentedTable {
                                     acc.float_sum += *f;
                                     acc.count += 1;
                                     acc.is_int_agg = false;
+                                }
+                                Value::Boolean(b) => {
+                                    acc.int_sum += *b as i128;
+                                    acc.count += 1;
                                 }
                                 _ => {}
                             }

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -2339,6 +2339,8 @@ impl Table for SegmentedTable {
         let default_f64 = match &default_val {
             Value::Integer(v) => Some(*v as f64),
             Value::Float(v) => Some(*v),
+            // A boolean counts as one or nought, as SUM reads it
+            Value::Boolean(b) => Some(*b as i64 as f64),
             _ => None, // NULL or non-numeric default → no contribution
         };
 

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -2444,6 +2444,10 @@ impl Table for SegmentedTable {
                             total_sum += values[i];
                             total_count += 1;
                         }
+                        crate::storage::volume::column::ColumnData::Boolean { values, .. } => {
+                            total_sum += if values[i] { 1.0 } else { 0.0 };
+                            total_count += 1;
+                        }
                         _ => {}
                     }
                 } else if let Some(def) = default_f64 {

--- a/tests/aggregate_expression_names_test.rs
+++ b/tests/aggregate_expression_names_test.rs
@@ -1,0 +1,54 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Two aggregates over expressions that differ only in their parentheses
+//! are two aggregates, named apart, and computed apart.
+
+use stoolap::Database;
+
+fn row(db: &Database, sql: &str) -> (Vec<String>, Vec<i64>) {
+    let result = db.query(sql, ()).unwrap();
+    let columns = result.columns().to_vec();
+    let values = result
+        .map(|r| r.unwrap())
+        .next()
+        .map(|r| (0..r.len()).map(|i| r.get::<i64>(i).unwrap()).collect())
+        .unwrap();
+    (columns, values)
+}
+
+#[test]
+fn test_parentheses_keep_aggregates_apart() {
+    let db = Database::open("memory://aggregate_expression_names").unwrap();
+    db.execute(
+        "CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO x VALUES (1, 1, 10), (2, 2, 20), (3, 3, 30)",
+        (),
+    )
+    .unwrap();
+    let (columns, values) = row(&db, "SELECT SUM(a + b * 2), SUM((a + b) * 2) FROM x");
+    assert_eq!(columns, ["SUM(a + b * 2)", "SUM((a + b) * 2)"]);
+    assert_eq!(values, [126, 132]);
+    let (columns, values) = row(&db, "SELECT SUM(-(a + b)), SUM(-a + b) FROM x");
+    assert_eq!(columns, ["SUM(-(a + b))", "SUM(-a + b)"]);
+    assert_eq!(values, [-66, 54]);
+    let (_, values) = row(&db, "SELECT SUM(a + b % 7), SUM((a + b) % 7) FROM x");
+    assert_eq!(values, [17, 10]);
+    let (_, values) = row(&db, "SELECT SUM((a - b) - 1), SUM(a - (b - 1)) FROM x");
+    assert_eq!(values, [-57, -51]);
+}

--- a/tests/aggregate_expression_names_test.rs
+++ b/tests/aggregate_expression_names_test.rs
@@ -51,4 +51,9 @@ fn test_parentheses_keep_aggregates_apart() {
     assert_eq!(values, [17, 10]);
     let (_, values) = row(&db, "SELECT SUM((a - b) - 1), SUM(a - (b - 1)) FROM x");
     assert_eq!(values, [-57, -51]);
+    let (columns, values) = row(&db, "SELECT SUM(a * (b % 3)), SUM(a * b % 3) FROM x");
+    assert_eq!(columns, ["SUM(a * (b % 3))", "SUM(a * b % 3)"]);
+    assert_eq!(values, [5, 2]);
+    let (_, values) = row(&db, "SELECT SUM(a * (b / 4)), SUM(a * b / 4) FROM x");
+    assert_eq!(values, [33, 34]);
 }

--- a/tests/aggregate_expression_names_test.rs
+++ b/tests/aggregate_expression_names_test.rs
@@ -57,3 +57,25 @@ fn test_parentheses_keep_aggregates_apart() {
     let (_, values) = row(&db, "SELECT SUM(a * (b / 4)), SUM(a * b / 4) FROM x");
     assert_eq!(values, [33, 34]);
 }
+
+#[test]
+fn test_float_addition_keeps_its_grouping() {
+    let db = Database::open("memory://aggregate_expression_names_float").unwrap();
+    db.execute(
+        "CREATE TABLE f (id INTEGER PRIMARY KEY, a FLOAT, b FLOAT, c FLOAT)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO f VALUES (1, 1e16, -1e16, 1)", ())
+        .unwrap();
+    let result = db
+        .query("SELECT SUM(a + (b + c)), SUM((a + b) + c) FROM f", ())
+        .unwrap();
+    let columns = result.columns().to_vec();
+    let r = result.map(|r| r.unwrap()).next().unwrap();
+    assert_eq!(columns[0], "SUM(a + (b + c))");
+    assert_eq!(
+        (r.get::<f64>(0).unwrap(), r.get::<f64>(1).unwrap()),
+        (0.0, 1.0)
+    );
+}

--- a/tests/boolean_aggregate_test.rs
+++ b/tests/boolean_aggregate_test.rs
@@ -81,3 +81,104 @@ fn test_a_null_boolean_is_left_out() {
     assert_eq!(one(&db, "SELECT SUM(b) FROM t WHERE id = 3"), "NULL");
     assert_eq!(one(&db, "SELECT COUNT(b) FROM t"), "3");
 }
+
+fn int(db: &Database, sql: &str) -> i64 {
+    db.query(sql, ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap()
+}
+
+#[test]
+fn test_summing_distinct_booleans() {
+    let db = setup("boolean_sum_distinct");
+    assert_eq!(int(&db, "SELECT SUM(DISTINCT b) FROM t"), 1);
+    assert_eq!(int(&db, "SELECT SUM(DISTINCT b) FROM t WHERE NOT b"), 0);
+}
+
+#[test]
+fn test_boolean_sums_over_many_rows_and_groups() {
+    let db = Database::open("memory://boolean_sum_many").unwrap();
+    db.execute(
+        "CREATE TABLE m (id INTEGER PRIMARY KEY, k INTEGER, b BOOLEAN)",
+        (),
+    )
+    .unwrap();
+    // per k: (count of TRUE, count of non-NULL)
+    let mut expect = [(0i64, 0i64); 4];
+    let mut values = String::new();
+    for id in 1..=20_000i64 {
+        let k = (id % 4) as usize;
+        let b = if id % 7 == 0 {
+            "NULL"
+        } else if id % 3 == 0 {
+            expect[k].0 += 1;
+            "TRUE"
+        } else {
+            "FALSE"
+        };
+        if b != "NULL" {
+            expect[k].1 += 1;
+        }
+        if !values.is_empty() {
+            values.push(',');
+        }
+        values.push_str(&format!("({id}, {k}, {b})"));
+        if id % 500 == 0 {
+            db.execute(&format!("INSERT INTO m VALUES {values}"), ())
+                .unwrap();
+            values.clear();
+        }
+    }
+    let total: i64 = expect.iter().map(|e| e.0).sum();
+    assert_eq!(int(&db, "SELECT SUM(b) FROM m"), total);
+    assert_eq!(int(&db, "SELECT SUM(b) FROM m WHERE k = 1"), expect[1].0);
+
+    let grouped = |sql: &str| -> Vec<(i64, i64, f64)> {
+        db.query(sql, ())
+            .unwrap()
+            .map(|r| {
+                let r = r.unwrap();
+                (
+                    r.get::<i64>(0).unwrap(),
+                    r.get::<i64>(1).unwrap(),
+                    r.get::<f64>(2).unwrap(),
+                )
+            })
+            .collect()
+    };
+    let rows = grouped("SELECT k, SUM(b), AVG(b) FROM m GROUP BY k ORDER BY k");
+    assert_eq!(rows.len(), 4);
+    for (k, sum, avg) in rows {
+        let (ones, seen) = expect[k as usize];
+        assert_eq!(sum, ones, "k {k}");
+        assert!(
+            (avg - ones as f64 / seen as f64).abs() < 1e-9,
+            "k {k}: {avg}"
+        );
+    }
+
+    // tombstones send the sum down the scanning path
+    db.execute("DELETE FROM m WHERE id % 5 = 0", ()).unwrap();
+    let mut kept = [(0i64, 0i64); 4];
+    for id in (1..=20_000i64).filter(|id| id % 5 != 0 && id % 7 != 0) {
+        let k = (id % 4) as usize;
+        kept[k].1 += 1;
+        if id % 3 == 0 {
+            kept[k].0 += 1;
+        }
+    }
+    let total: i64 = kept.iter().map(|e| e.0).sum();
+    assert_eq!(int(&db, "SELECT SUM(b) FROM m"), total);
+    for (k, sum, avg) in grouped("SELECT k, SUM(b), AVG(b) FROM m GROUP BY k ORDER BY k") {
+        let (ones, seen) = kept[k as usize];
+        assert_eq!(sum, ones, "after delete, k {k}");
+        assert!(
+            (avg - ones as f64 / seen as f64).abs() < 1e-9,
+            "after delete, k {k}: {avg}"
+        );
+    }
+}

--- a/tests/boolean_aggregate_test.rs
+++ b/tests/boolean_aggregate_test.rs
@@ -1,0 +1,83 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A boolean handed to SUM or AVG counts as one or nought, so a condition
+//! can be summed to count the rows it holds for, and averaged for the
+//! share of them. A NULL is left out as it is for any other value.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER, b BOOLEAN)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO t VALUES (1, 50, TRUE), (2, 150, FALSE), (3, NULL, NULL), (4, 250, TRUE)",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn one(db: &Database, sql: &str) -> String {
+    db.query(sql, ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get::<Option<String>>(0)
+        .unwrap()
+        .unwrap_or_else(|| "NULL".into())
+}
+
+#[test]
+fn test_summing_a_condition_counts_the_rows_it_holds_for() {
+    let db = setup("boolean_agg_sum");
+    assert_eq!(one(&db, "SELECT SUM(v > 100) FROM t"), "2");
+    assert_eq!(one(&db, "SELECT SUM(b) FROM t"), "2");
+    assert_eq!(one(&db, "SELECT SUM(TRUE) FROM t"), "4");
+    assert_eq!(
+        one(&db, "SELECT SUM(v > 100) FROM t"),
+        one(
+            &db,
+            "SELECT SUM(CASE WHEN v > 100 THEN 1 ELSE 0 END) FROM t"
+        ),
+        "the same count the spelled-out form gives"
+    );
+}
+
+#[test]
+fn test_averaging_a_condition_gives_the_share_of_rows() {
+    let db = setup("boolean_agg_avg");
+    // Three rows carry a boolean; two of them are true
+    let share: f64 = db
+        .query("SELECT AVG(b) FROM t", ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap();
+    assert!((share - 2.0 / 3.0).abs() < 1e-9, "{share}");
+}
+
+#[test]
+fn test_a_null_boolean_is_left_out() {
+    let db = setup("boolean_agg_null");
+    assert_eq!(one(&db, "SELECT SUM(b) FROM t WHERE id = 3"), "NULL");
+    assert_eq!(one(&db, "SELECT COUNT(b) FROM t"), "3");
+}

--- a/tests/boolean_predicate_test.rs
+++ b/tests/boolean_predicate_test.rs
@@ -1,0 +1,84 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A boolean column standing on its own is a condition, and it holds
+//! wherever the column is true.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, b BOOLEAN, n INTEGER)",
+        (),
+    )
+    .unwrap();
+    for (id, b, n) in [(1i64, true, 1i64), (2, false, 2), (3, true, 3)] {
+        db.execute("INSERT INTO c VALUES ($1, $2, $3)", (id, b, n))
+            .unwrap();
+    }
+    db
+}
+
+fn count(db: &Database, sql: &str) -> i64 {
+    db.query(sql, ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap()
+}
+
+fn ids(db: &Database, sql: &str) -> Vec<i64> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| row.unwrap().get(0).unwrap())
+        .collect()
+}
+
+#[test]
+fn test_a_boolean_column_reads_as_a_condition() {
+    let db = setup("boolean_predicate_where");
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM c WHERE b"), 2);
+    assert_eq!(ids(&db, "SELECT id FROM c WHERE b ORDER BY id"), [1, 3]);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM c WHERE (b)"), 2);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM c WHERE c.b"), 2);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM c WHERE NOT b"), 1);
+}
+
+/// The same column beside another condition
+#[test]
+fn test_a_boolean_column_beside_another_condition() {
+    let db = setup("boolean_predicate_combined");
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM c WHERE b AND 1 = 1"), 2);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM c WHERE b OR FALSE"), 2);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM c WHERE b AND n > 1"), 1);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM c WHERE b = TRUE"), 2);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM c WHERE b IS TRUE"), 2);
+}
+
+/// A condition is a condition wherever the query puts one
+#[test]
+fn test_a_boolean_column_in_the_other_clauses() {
+    let db = setup("boolean_predicate_clauses");
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM c x JOIN c y ON x.id = y.id AND x.b"
+        ),
+        2
+    );
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM c GROUP BY b HAVING b"), 2);
+}

--- a/tests/case_operand_test.rs
+++ b/tests/case_operand_test.rs
@@ -1,0 +1,166 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A CASE that compares an operand against its WHEN values answers with
+//! its result and nothing else, wherever the expression around it reads it.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, g TEXT)", ())
+        .unwrap();
+    for id in 1..=6i64 {
+        db.execute(
+            "INSERT INTO t VALUES ($1, $2)",
+            (id, if id % 2 == 0 { "a" } else { "b" }),
+        )
+        .unwrap();
+    }
+    db
+}
+
+fn count(db: &Database, sql: &str) -> i64 {
+    db.query(sql, ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap()
+}
+
+fn values(db: &Database, sql: &str) -> Vec<String> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| row.unwrap().get::<String>(0).unwrap())
+        .collect()
+}
+
+/// The comparison around the CASE reads the CASE's result, not its operand
+#[test]
+fn test_case_on_the_right_of_a_comparison() {
+    let db = setup("case_operand_right");
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM t WHERE id > CASE 1 WHEN 1 THEN 2 ELSE 3 END"
+        ),
+        4,
+        "the first WHEN matches"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM t WHERE id > CASE 1 WHEN 9 THEN 2 ELSE 3 END"
+        ),
+        3,
+        "the ELSE is taken"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM t WHERE id > CASE 1 WHEN 1 THEN 2 END"
+        ),
+        4,
+        "no ELSE to take"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM t WHERE id = CASE 1 WHEN 1 THEN 2 ELSE 3 END"
+        ),
+        1,
+        "equality"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM t WHERE id > CASE 'x' WHEN 'x' THEN 2 ELSE 3 END"
+        ),
+        4,
+        "a text operand"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM t WHERE g <> 'z' AND id > CASE 1 WHEN 1 THEN 2 ELSE 3 END"
+        ),
+        4,
+        "beside another predicate"
+    );
+}
+
+/// A column operand is read per row
+#[test]
+fn test_case_on_a_column_operand() {
+    let db = setup("case_operand_column");
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM t WHERE id > CASE g WHEN 'a' THEN 3 ELSE 2 END"
+        ),
+        4
+    );
+    assert_eq!(
+        values(
+            &db,
+            "SELECT CASE g WHEN 'a' THEN 1 WHEN 'b' THEN 2 ELSE 3 END FROM t ORDER BY id"
+        ),
+        ["2", "1", "2", "1", "2", "1"]
+    );
+}
+
+/// The same CASE reads the same either side of the comparison
+#[test]
+fn test_case_reads_the_same_on_either_side() {
+    let db = setup("case_operand_sides");
+    let right = count(
+        &db,
+        "SELECT COUNT(*) FROM t WHERE id > CASE 1 WHEN 1 THEN 2 ELSE 3 END",
+    );
+    let left = count(
+        &db,
+        "SELECT COUNT(*) FROM t WHERE CASE 1 WHEN 1 THEN 2 ELSE 3 END < id",
+    );
+    assert_eq!((right, left), (4, 4));
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM t WHERE CASE 1 WHEN 1 THEN 2 ELSE 3 END < CASE 2 WHEN 2 THEN id ELSE 0 END"
+        ),
+        4,
+        "a CASE on both sides"
+    );
+}
+
+/// Nesting one CASE inside another leaves nothing of the outer operand
+#[test]
+fn test_nested_case_operands() {
+    let db = setup("case_operand_nested");
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM t WHERE id > CASE 1 WHEN 1 THEN CASE 2 WHEN 2 THEN 2 ELSE 5 END ELSE 3 END"
+        ),
+        4
+    );
+    assert_eq!(
+        values(
+            &db,
+            "SELECT CASE 1 WHEN 1 THEN CASE g WHEN 'a' THEN 'even' ELSE 'odd' END ELSE 'no' END FROM t ORDER BY id"
+        ),
+        ["odd", "even", "odd", "even", "odd", "even"]
+    );
+}

--- a/tests/cast_padded_text_test.rs
+++ b/tests/cast_padded_text_test.rs
@@ -1,0 +1,36 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! CAST of text to a number ignores the whitespace around it.
+
+use stoolap::Database;
+
+#[test]
+fn test_cast_of_padded_text_to_a_number() {
+    let db = Database::open("memory://cast_padded_text").unwrap();
+    let row = db
+        .query(
+            "SELECT CAST(' 7' AS INTEGER), CAST('7 ' AS INTEGER), CAST(' -3' AS INTEGER), CAST(' 7.5 ' AS FLOAT), CAST('x' AS INTEGER)",
+            (),
+        )
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.get::<Option<i64>>(0).unwrap(), Some(7));
+    assert_eq!(row.get::<Option<i64>>(1).unwrap(), Some(7));
+    assert_eq!(row.get::<Option<i64>>(2).unwrap(), Some(-3));
+    assert_eq!(row.get::<Option<f64>>(3).unwrap(), Some(7.5));
+    assert_eq!(row.get::<Option<i64>>(4).unwrap(), None);
+}

--- a/tests/correlated_over_derived_source_test.rs
+++ b/tests/correlated_over_derived_source_test.rs
@@ -199,3 +199,31 @@ fn test_a_bound_parent_value_keeps_its_type() {
         [1, 2]
     );
 }
+
+#[test]
+fn test_a_view_source_binds_two_parent_columns() {
+    let db = setup("correlated_view_two_columns");
+    db.execute("INSERT INTO y VALUES (5, 2, 20)", ()).unwrap();
+    // a y row of the parent's a with a larger b: x1 (10) and x4 (40) see 50, x2 (20) does not
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM x WHERE EXISTS (SELECT 1 FROM vy WHERE vy.a = x.a AND vy.b > x.b) ORDER BY id"
+        ),
+        [1, 4]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM x WHERE x.b > (SELECT AVG(b) FROM vy v WHERE v.a = x.a) ORDER BY id"
+        ),
+        [2, 4]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM x WHERE EXISTS (SELECT 1 FROM vy v JOIN y ON y.id = v.id WHERE v.a = x.a AND y.b = x.b) ORDER BY id"
+        ),
+        [2]
+    );
+}

--- a/tests/correlated_over_derived_source_test.rs
+++ b/tests/correlated_over_derived_source_test.rs
@@ -1,0 +1,124 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A correlated subquery whose FROM is a derived table, a view or a CTE
+//! binds the parent's column through the parent's table name; the bare
+//! name it would otherwise fall back to is the source's own column.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE y (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO x VALUES (1, 1, 10), (2, 2, 20), (3, 3, 30), (4, 1, 40)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO y VALUES (1, 1, 5), (2, 1, 50), (3, 1, 7), (4, 2, 9)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE VIEW vy AS SELECT a, b FROM y", ())
+        .unwrap();
+    db
+}
+
+fn ids(db: &Database, sql: &str) -> Vec<i64> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect()
+}
+
+fn values(db: &Database, sql: &str) -> Vec<Option<i64>> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<Option<i64>>(1).unwrap())
+        .collect()
+}
+
+#[test]
+fn test_a_derived_table_source_binds_the_parent_column() {
+    let db = setup("correlated_derived");
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM x WHERE EXISTS (SELECT 1 FROM (SELECT a, ROW_NUMBER() OVER (PARTITION BY a ORDER BY id) AS rn FROM y) w WHERE w.a = x.a AND w.rn = 3) ORDER BY id"
+        ),
+        [1, 4]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM x WHERE EXISTS (SELECT 1 FROM (SELECT a, b FROM y) w WHERE w.a = x.b) ORDER BY id"
+        ),
+        Vec::<i64>::new()
+    );
+    assert_eq!(
+        values(
+            &db,
+            "SELECT id, (SELECT COUNT(*) FROM (SELECT a FROM y) w WHERE w.a = x.a) FROM x ORDER BY id"
+        ),
+        [Some(3), Some(1), Some(0), Some(3)]
+    );
+}
+
+#[test]
+fn test_a_cte_source_binds_the_parent_column() {
+    let db = setup("correlated_cte");
+    assert_eq!(
+        ids(
+            &db,
+            "WITH t AS (SELECT a, MAX(b) AS mb FROM y GROUP BY a) SELECT id FROM x WHERE b > (SELECT mb FROM t WHERE t.a = x.a) ORDER BY id"
+        ),
+        [2]
+    );
+    assert_eq!(
+        values(
+            &db,
+            "WITH t AS (SELECT a, MAX(b) AS mb FROM y GROUP BY a) SELECT id, (SELECT mb FROM t WHERE t.a = x.a) FROM x ORDER BY id"
+        ),
+        [Some(50), Some(9), None, Some(50)]
+    );
+}
+
+#[test]
+fn test_a_view_source_binds_the_parent_column() {
+    let db = setup("correlated_view");
+    assert_eq!(
+        values(
+            &db,
+            "SELECT id, (SELECT COUNT(*) FROM vy WHERE vy.a = x.a) FROM x ORDER BY id"
+        ),
+        [Some(3), Some(1), Some(0), Some(3)]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM x WHERE EXISTS (SELECT 1 FROM vy v WHERE v.a = x.a AND v.b > 40) ORDER BY id"
+        ),
+        [1, 4]
+    );
+}

--- a/tests/correlated_over_derived_source_test.rs
+++ b/tests/correlated_over_derived_source_test.rs
@@ -122,3 +122,43 @@ fn test_a_view_source_binds_the_parent_column() {
         [1, 4]
     );
 }
+
+#[test]
+fn test_a_derived_table_in_the_subquery_from_reads_the_parent() {
+    let db = setup("correlated_derived_in_from");
+    // per x row, the largest group count of y rows sharing a, grouped by b
+    assert_eq!(
+        values(
+            &db,
+            "SELECT id, (SELECT MAX(c) FROM (SELECT COUNT(*) AS c FROM y WHERE y.a = x.a GROUP BY b) t) FROM x ORDER BY id"
+        ),
+        [Some(1), Some(1), None, Some(1)]
+    );
+    assert_eq!(
+        values(
+            &db,
+            "SELECT id, (SELECT SUM(b) FROM (SELECT b FROM y WHERE y.a = x.a ORDER BY b DESC LIMIT 2) top) FROM x ORDER BY id"
+        ),
+        [Some(57), Some(9), None, Some(57)]
+    );
+}
+
+#[test]
+fn test_a_join_of_derived_tables_binds_the_parent_column() {
+    let db = setup("correlated_join_of_derived");
+    // pairs of y rows sharing the parent's a with p.b < q.b: a = 1 has 5, 50, 7
+    assert_eq!(
+        values(
+            &db,
+            "SELECT id, (SELECT COUNT(*) FROM (SELECT a, b FROM y) p JOIN (SELECT a, b FROM y) q ON p.a = q.a AND p.b < q.b WHERE p.a = x.a) FROM x ORDER BY id"
+        ),
+        [Some(3), Some(0), Some(0), Some(3)]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM x WHERE EXISTS (SELECT 1 FROM (SELECT a, b FROM y) p JOIN (SELECT a, b FROM y) q ON p.a = q.a AND p.b < q.b WHERE p.a = x.a) ORDER BY id"
+        ),
+        [1, 4]
+    );
+}

--- a/tests/correlated_over_derived_source_test.rs
+++ b/tests/correlated_over_derived_source_test.rs
@@ -162,3 +162,40 @@ fn test_a_join_of_derived_tables_binds_the_parent_column() {
         [1, 4]
     );
 }
+
+#[test]
+fn test_a_bound_parent_value_keeps_its_type() {
+    let db = Database::open("memory://correlated_bound_types").unwrap();
+    db.execute(
+        "CREATE TABLE tx (id INTEGER PRIMARY KEY, ts TIMESTAMP, j JSON, v VECTOR(2))",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO tx VALUES (1, '2024-01-01 10:00:00', '{\"k\": 1}', '[1, 2]'), (2, '2024-02-01 10:00:00', '{\"k\": 2}', '[3, 4]'), (3, NULL, NULL, NULL)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE TABLE ty (id INTEGER PRIMARY KEY, ts TIMESTAMP)", ())
+        .unwrap();
+    db.execute("INSERT INTO ty VALUES (1, '2024-01-15 00:00:00')", ())
+        .unwrap();
+    let ids = |sql: &str| -> Vec<i64> {
+        db.query(sql, ())
+            .unwrap()
+            .map(|r| r.unwrap().get::<i64>(0).unwrap())
+            .collect()
+    };
+    assert_eq!(
+        ids("SELECT id FROM tx WHERE EXISTS (SELECT 1 FROM (SELECT ts FROM ty) d WHERE TYPEOF(tx.ts) = 'TIMESTAMP') ORDER BY id"),
+        [1, 2]
+    );
+    assert_eq!(
+        ids("SELECT id FROM tx WHERE EXISTS (SELECT 1 FROM (SELECT ts FROM ty) d WHERE d.ts > tx.ts) ORDER BY id"),
+        [1]
+    );
+    assert_eq!(
+        ids("SELECT id FROM tx WHERE EXISTS (SELECT 1 FROM (SELECT ts FROM ty) d WHERE TYPEOF(tx.j) = 'JSON' AND TYPEOF(tx.v) = 'VECTOR') ORDER BY id"),
+        [1, 2]
+    );
+}

--- a/tests/correlated_over_view_test.rs
+++ b/tests/correlated_over_view_test.rs
@@ -91,6 +91,44 @@ fn test_correlated_subquery_over_view() {
 }
 
 #[test]
+fn test_bound_column_does_not_shadow_a_source_column() {
+    let db = Database::open("memory://correlated_over_view_shadow").unwrap();
+    db.execute(
+        "CREATE TABLE q (id INTEGER PRIMARY KEY, __correlated_0 INTEGER, a INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO q VALUES (1, 100, 1), (2, 200, 2), (3, 300, NULL)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE VIEW vq AS SELECT id, __correlated_0, a FROM q", ())
+        .unwrap();
+    let expected = [
+        [Some(300), Some(0)],
+        [Some(200), Some(0)],
+        [Some(100), Some(1)],
+    ];
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT __correlated_0, (SELECT COUNT(*) FROM q q2 WHERE q2.a > v.a) AS n \
+             FROM vq v ORDER BY v.id DESC"
+        ),
+        expected
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT __correlated_0, (SELECT COUNT(*) FROM q q2 WHERE q2.a > d.a) AS n \
+             FROM (SELECT id, __correlated_0, a FROM q) d ORDER BY d.id DESC"
+        ),
+        expected
+    );
+}
+
+#[test]
 fn test_correlated_where_over_derived_table() {
     let db = setup("correlated_over_derived");
     assert_eq!(

--- a/tests/correlated_over_view_test.rs
+++ b/tests/correlated_over_view_test.rs
@@ -35,7 +35,8 @@ fn setup(name: &str) -> Database {
         .unwrap();
     db.execute("INSERT INTO x VALUES (1, 1), (2, 2), (3, NULL)", ())
         .unwrap();
-    db.execute("CREATE VIEW vx AS SELECT a FROM x", ()).unwrap();
+    db.execute("CREATE VIEW vx AS SELECT id, a FROM x", ())
+        .unwrap();
     db
 }
 
@@ -70,6 +71,22 @@ fn test_correlated_subquery_over_view() {
             "SELECT a FROM vx v WHERE (SELECT COUNT(*) FROM x x2 WHERE x2.a > v.a) = 1"
         ),
         [[Some(1)]]
+    );
+    // A sort column the select list leaves out rides along
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT (SELECT COUNT(*) FROM x x2 WHERE x2.a > v.a) FROM vx v ORDER BY v.id DESC"
+        ),
+        [[Some(0)], [Some(0)], [Some(1)]]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT (SELECT COUNT(*) FROM x x2 WHERE x2.a > d.a) AS n \
+             FROM (SELECT id, a FROM x) d ORDER BY d.id DESC, n"
+        ),
+        [[Some(0)], [Some(0)], [Some(1)]]
     );
 }
 

--- a/tests/correlated_over_view_test.rs
+++ b/tests/correlated_over_view_test.rs
@@ -1,0 +1,110 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A correlated subquery in the select list or the WHERE of a query over a
+//! view or a derived table reads each row of that source as its outer row.
+
+use stoolap::Database;
+
+fn rows(db: &Database, sql: &str) -> Vec<Vec<Option<i64>>> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap())
+        .map(|r| {
+            (0..r.len())
+                .map(|i| r.get::<Option<i64>>(i).unwrap())
+                .collect()
+        })
+        .collect()
+}
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO x VALUES (1, 1), (2, 2), (3, NULL)", ())
+        .unwrap();
+    db.execute("CREATE VIEW vx AS SELECT a FROM x", ()).unwrap();
+    db
+}
+
+#[test]
+fn test_correlated_subquery_over_view() {
+    let db = setup("correlated_over_view");
+    let counts = [[Some(1), Some(1)], [Some(2), Some(0)], [None, Some(0)]];
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT a, (SELECT COUNT(*) FROM vx v2 WHERE v2.a > vx.a) FROM vx ORDER BY 1"
+        ),
+        counts
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT v.a, (SELECT COUNT(*) FROM x x2 WHERE x2.a > v.a) FROM vx v ORDER BY 1"
+        ),
+        counts
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT a FROM vx WHERE EXISTS (SELECT 1 FROM vx v2 WHERE v2.a > vx.a)"
+        ),
+        [[Some(1)]]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT a FROM vx v WHERE (SELECT COUNT(*) FROM x x2 WHERE x2.a > v.a) = 1"
+        ),
+        [[Some(1)]]
+    );
+}
+
+#[test]
+fn test_correlated_where_over_derived_table() {
+    let db = setup("correlated_over_derived");
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT a FROM (SELECT a FROM x) d WHERE EXISTS (SELECT 1 FROM x x2 WHERE x2.a > d.a)"
+        ),
+        [[Some(1)]]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT a FROM (SELECT a FROM x) d \
+             WHERE a IN (SELECT x2.a - 1 FROM x x2 WHERE x2.a > d.a)"
+        ),
+        [[Some(1)]]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT a FROM (SELECT a FROM x) d \
+             WHERE a > 0 AND (SELECT COUNT(*) FROM x x2 WHERE x2.a > d.a) = 1"
+        ),
+        [[Some(1)]]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT COUNT(*) FROM x WHERE a IN (SELECT a FROM (SELECT a FROM x) d \
+             WHERE EXISTS (SELECT 1 FROM x x2 WHERE x2.a > d.a AND x2.a > x.a))"
+        ),
+        [[Some(1)]]
+    );
+}

--- a/tests/correlated_subquery_scope_test.rs
+++ b/tests/correlated_subquery_scope_test.rs
@@ -294,9 +294,12 @@ fn test_count_that_narrows_or_reads_the_parent() {
             "DISTINCT, indexed: {indexed}"
         );
         assert_eq!(
-            answers(&db, &format!("SELECT u.id, (SELECT COUNT(u.id) {where_it}")),
+            answers(
+                &db,
+                &format!("SELECT u.id, (SELECT COUNT(u.id + x.id) {where_it}")
+            ),
             ["3", "3", "3", "3"],
-            "counting the parent's column, indexed: {indexed}"
+            "counting what reads the parent, indexed: {indexed}"
         );
         assert_eq!(
             answers(&db, &format!("SELECT u.id, (SELECT COUNT(*) {where_it}")),
@@ -351,4 +354,43 @@ fn test_grouped_aggregate_honours_filter_and_distinct() {
     );
     distinct.sort();
     assert_eq!(distinct, ["1", "1", "1", "1"]);
+}
+
+/// A subquery two levels in reads the row its grandparent sits on
+#[test]
+fn test_grandparent_row_reaches_a_nested_subquery() {
+    let db = setup("correlated_scope_two_levels");
+    // Users whose largest order clears ten times the grandparent's id
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT COUNT(*) FROM users v WHERE EXISTS (SELECT 1 FROM orders x WHERE x.user_id = v.id AND x.amount > u.id * 10)) FROM users u ORDER BY u.id"
+        ),
+        ["4", "3", "2", "1"],
+        "through EXISTS"
+    );
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT COUNT(*) FROM users v WHERE v.id IN (SELECT x.user_id FROM orders x WHERE x.amount > u.id * 10)) FROM users u ORDER BY u.id"
+        ),
+        ["4", "3", "2", "1"],
+        "through IN"
+    );
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT (SELECT u.id) FROM users v LIMIT 1) FROM users u ORDER BY u.id"
+        ),
+        ["1", "2", "3", "4"],
+        "a scalar subquery inside a scalar subquery"
+    );
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT COUNT(*) FROM users v WHERE EXISTS (SELECT 1 FROM orders x WHERE x.user_id = v.id)) FROM users u ORDER BY u.id"
+        ),
+        ["4", "4", "4", "4"],
+        "a nested subquery that reads no grandparent is unchanged"
+    );
 }

--- a/tests/correlated_subquery_scope_test.rs
+++ b/tests/correlated_subquery_scope_test.rs
@@ -1,0 +1,164 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A correlated subquery reads the parent row wherever it names it, not
+//! only in its WHERE. A name its own FROM does not define belongs to the
+//! parent, even when an inner column happens to share it.
+
+use stoolap::Database;
+
+/// 4 users, 3 orders each, order amount user * 10 + k
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, city TEXT)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount INTEGER)",
+        (),
+    )
+    .unwrap();
+    let mut order_id = 0i64;
+    for user in 1..=4i64 {
+        db.execute(
+            "INSERT INTO users VALUES ($1, $2)",
+            (user, if user % 2 == 0 { "a" } else { "b" }),
+        )
+        .unwrap();
+        for k in 0..3i64 {
+            order_id += 1;
+            db.execute(
+                "INSERT INTO orders VALUES ($1, $2, $3)",
+                (order_id, user, user * 10 + k),
+            )
+            .unwrap();
+        }
+    }
+    db
+}
+
+/// The second column of every row, the subquery's answer
+fn answers(db: &Database, sql: &str) -> Vec<String> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            row.get::<Option<String>>(1)
+                .unwrap()
+                .unwrap_or_else(|| "NULL".into())
+        })
+        .collect()
+}
+
+#[test]
+fn test_outer_reference_in_an_aggregate_filter() {
+    let db = setup("correlated_scope_filter");
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT COUNT(*) FILTER (WHERE x.user_id = u.id) FROM orders x) FROM users u ORDER BY u.id"
+        ),
+        ["3", "3", "3", "3"]
+    );
+}
+
+#[test]
+fn test_outer_reference_in_an_aggregate_argument() {
+    let db = setup("correlated_scope_argument");
+    // Orders of users 1 and 2 sum their user_id to 9, times the parent id
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT SUM(x.user_id * u.id) FROM orders x WHERE x.user_id <= 2) FROM users u ORDER BY u.id"
+        ),
+        ["9", "18", "27", "36"]
+    );
+}
+
+#[test]
+fn test_outer_reference_in_a_plain_expression() {
+    let db = setup("correlated_scope_expression");
+    // User 1's orders all carry user_id 1, so the max is 10 + the parent id
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT MAX(x.user_id * 10 + u.id) FROM orders x WHERE x.user_id = 1) FROM users u ORDER BY u.id"
+        ),
+        ["11", "12", "13", "14"]
+    );
+}
+
+/// The parent's column wins over an inner column of the same bare name
+#[test]
+fn test_outer_reference_beats_a_same_named_inner_column() {
+    let db = setup("correlated_scope_shadowing");
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT u.id FROM orders x LIMIT 1) FROM users u ORDER BY u.id"
+        ),
+        ["1", "2", "3", "4"],
+        "the subquery selects the parent's id, not the order's"
+    );
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT MAX(CASE WHEN x.user_id = 1 THEN u.id ELSE 0 END) FROM orders x) FROM users u ORDER BY u.id"
+        ),
+        ["1", "2", "3", "4"],
+        "inside a CASE"
+    );
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT MAX(x.id) FROM orders x WHERE x.user_id = u.id) FROM users u ORDER BY u.id"
+        ),
+        ["3", "6", "9", "12"],
+        "the inner id still means the order's"
+    );
+}
+
+/// A HAVING reads the parent row, and a subquery that names it only there
+/// is still correlated
+#[test]
+fn test_outer_reference_in_having() {
+    let db = setup("correlated_scope_having");
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT COUNT(*) FROM orders x GROUP BY x.user_id HAVING x.user_id = u.id) FROM users u ORDER BY u.id"
+        ),
+        ["3", "3", "3", "3"]
+    );
+}
+
+/// What already worked keeps working
+#[test]
+fn test_outer_reference_in_where_still_works() {
+    let db = setup("correlated_scope_where");
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT COUNT(*) FROM orders x WHERE x.user_id = u.id) FROM users u ORDER BY u.id"
+        ),
+        ["3", "3", "3", "3"]
+    );
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT COUNT(*) FROM orders x WHERE x.amount > u.id * 10) FROM users u ORDER BY u.id"
+        ),
+        ["11", "8", "5", "2"],
+        "orders above ten times the parent id"
+    );
+}

--- a/tests/correlated_subquery_scope_test.rs
+++ b/tests/correlated_subquery_scope_test.rs
@@ -252,3 +252,103 @@ fn test_two_subqueries_keep_their_own_answers() {
         ]
     );
 }
+
+/// A COUNT that reads the parent row, or narrows what it counts, is not
+/// answered by one pass over the table or one probe of an index
+#[test]
+fn test_count_that_narrows_or_reads_the_parent() {
+    let db = setup("correlated_scope_count_paths");
+    for indexed in [false, true] {
+        if indexed {
+            db.execute("CREATE INDEX idx_orders_user ON orders(user_id)", ())
+                .unwrap();
+        }
+        let where_it = "FROM orders x WHERE x.user_id = u.id) FROM users u ORDER BY u.id";
+        // Amounts of user n are 10n, 10n+1, 10n+2, so two clear ten times n
+        assert_eq!(
+            answers(
+                &db,
+                &format!(
+                    "SELECT u.id, (SELECT COUNT(*) FILTER (WHERE x.amount > u.id * 10) {where_it}"
+                )
+            ),
+            ["2", "2", "2", "2"],
+            "a FILTER reading the parent, indexed: {indexed}"
+        );
+        assert_eq!(
+            answers(
+                &db,
+                &format!(
+                    "SELECT u.id, (SELECT COUNT(*) FILTER (WHERE x.amount % 10 > 0) {where_it}"
+                )
+            ),
+            ["2", "2", "2", "2"],
+            "a FILTER of its own, indexed: {indexed}"
+        );
+        assert_eq!(
+            answers(
+                &db,
+                &format!("SELECT u.id, (SELECT COUNT(DISTINCT x.user_id) {where_it}")
+            ),
+            ["1", "1", "1", "1"],
+            "DISTINCT, indexed: {indexed}"
+        );
+        assert_eq!(
+            answers(&db, &format!("SELECT u.id, (SELECT COUNT(u.id) {where_it}")),
+            ["3", "3", "3", "3"],
+            "counting the parent's column, indexed: {indexed}"
+        );
+        assert_eq!(
+            answers(&db, &format!("SELECT u.id, (SELECT COUNT(*) {where_it}")),
+            ["3", "3", "3", "3"],
+            "the plain count still takes the short way, indexed: {indexed}"
+        );
+    }
+}
+
+/// A COUNT of a column counts the values it has, not the rows it sits in
+#[test]
+fn test_count_of_a_column_skips_nulls() {
+    let db = Database::open("memory://correlated_scope_count_nulls").unwrap();
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX idx_orders_user ON orders(user_id)", ())
+        .unwrap();
+    db.execute("INSERT INTO users VALUES (1), (2)", ()).unwrap();
+    db.execute(
+        "INSERT INTO orders VALUES (1, 1, 10), (2, 1, NULL), (3, 2, 20)",
+        (),
+    )
+    .unwrap();
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT COUNT(x.amount) FROM orders x WHERE x.user_id = u.id) FROM users u ORDER BY u.id"
+        ),
+        ["1", "1"]
+    );
+}
+
+/// A grouped aggregate reads what its FILTER and DISTINCT leave it, however
+/// its columns are written
+#[test]
+fn test_grouped_aggregate_honours_filter_and_distinct() {
+    let db = setup("correlated_scope_grouped_filter");
+    let mut filtered = answers(
+        &db,
+        "SELECT user_id, COUNT(*) FILTER (WHERE amount % 10 > 0) FROM orders GROUP BY user_id",
+    );
+    filtered.sort();
+    assert_eq!(filtered, ["2", "2", "2", "2"]);
+    let mut distinct = answers(
+        &db,
+        "SELECT user_id, COUNT(DISTINCT user_id) FROM orders GROUP BY user_id",
+    );
+    distinct.sort();
+    assert_eq!(distinct, ["1", "1", "1", "1"]);
+}

--- a/tests/correlated_subquery_scope_test.rs
+++ b/tests/correlated_subquery_scope_test.rs
@@ -162,3 +162,93 @@ fn test_outer_reference_in_where_still_works() {
         "orders above ten times the parent id"
     );
 }
+
+/// An aggregate that reads the parent row is answered per parent row, not
+/// once for the whole table with the first row's value inside it
+#[test]
+fn test_outer_reference_inside_an_aggregate_with_a_correlation() {
+    let db = setup("correlated_scope_batch");
+    // User n has three orders, each carrying user_id n
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT SUM(x.user_id * u.id) FROM orders x WHERE x.user_id = u.id) FROM users u ORDER BY u.id"
+        ),
+        ["3", "12", "27", "48"]
+    );
+    // Amounts of user n sum to 30n + 3, plus the parent id once per order
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT SUM(x.amount + u.id) FROM orders x WHERE x.user_id = u.id) FROM users u ORDER BY u.id"
+        ),
+        ["36", "69", "102", "135"]
+    );
+}
+
+/// An alias over the parent's column keeps the alias and the parent's value
+#[test]
+fn test_outer_reference_under_an_alias() {
+    let db = setup("correlated_scope_alias");
+    assert_eq!(
+        answers(
+            &db,
+            "SELECT u.id, (SELECT u.id AS parent_id FROM orders x LIMIT 1) FROM users u ORDER BY u.id"
+        ),
+        ["1", "2", "3", "4"]
+    );
+}
+
+/// Two aggregates of one name over one table and one correlation column
+/// read the columns they name, not one another's
+#[test]
+fn test_two_aggregates_over_one_correlation_column() {
+    let db = setup("correlated_scope_two_aggregates");
+    let rows: Vec<Vec<String>> = db
+        .query(
+            "SELECT u.id, (SELECT SUM(x.amount) FROM orders x WHERE x.user_id = u.id), (SELECT SUM(x.id) FROM orders x WHERE x.user_id = u.id) FROM users u ORDER BY u.id",
+            (),
+        )
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (0..3).map(|i| row.get::<String>(i).unwrap()).collect()
+        })
+        .collect();
+    // Amounts of user n are 10n, 10n+1, 10n+2; its order ids are 3n-2, 3n-1, 3n
+    assert_eq!(
+        rows,
+        vec![
+            vec!["1", "33", "6"],
+            vec!["2", "63", "15"],
+            vec!["3", "93", "24"],
+            vec!["4", "123", "33"],
+        ]
+    );
+}
+
+/// A subquery that reads the parent row does not answer for the one beside it
+#[test]
+fn test_two_subqueries_keep_their_own_answers() {
+    let db = setup("correlated_scope_neighbours");
+    let rows: Vec<Vec<String>> = db
+        .query(
+            "SELECT u.id, (SELECT SUM(x.user_id * u.id) FROM orders x WHERE x.user_id = u.id), (SELECT u.id FROM orders x LIMIT 1) FROM users u ORDER BY u.id",
+            (),
+        )
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (0..3).map(|i| row.get::<String>(i).unwrap()).collect()
+        })
+        .collect();
+    assert_eq!(
+        rows,
+        vec![
+            vec!["1", "3", "1"],
+            vec!["2", "12", "2"],
+            vec!["3", "27", "3"],
+            vec!["4", "48", "4"],
+        ]
+    );
+}

--- a/tests/cte_multi_reference_test.rs
+++ b/tests/cte_multi_reference_test.rs
@@ -87,6 +87,23 @@ fn test_cte_read_by_select_list_having_and_order_by() {
         ),
         [[Some(2)], [Some(1)], [None]]
     );
+    assert_eq!(
+        rows(
+            &db,
+            "WITH c AS (SELECT a FROM x) \
+             SELECT ROW_NUMBER() OVER (ORDER BY (SELECT MAX(a) FROM c)) FROM c"
+        )
+        .len(),
+        3
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "WITH c AS (SELECT a FROM x) \
+             SELECT COUNT(*) OVER w FROM c WINDOW w AS (ORDER BY (SELECT MIN(a) FROM c))"
+        ),
+        [[Some(3)], [Some(3)], [Some(3)]]
+    );
 }
 
 #[test]

--- a/tests/cte_multi_reference_test.rs
+++ b/tests/cte_multi_reference_test.rs
@@ -1,0 +1,146 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A CTE stays readable from every place that names it: both branches of a
+//! set operation, the select list, HAVING, ORDER BY, a correlated subquery
+//! and a later CTE.
+
+use stoolap::Database;
+
+fn rows(db: &Database, sql: &str) -> Vec<Vec<Option<i64>>> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap())
+        .map(|r| {
+            (0..r.len())
+                .map(|i| r.get::<Option<i64>>(i).unwrap())
+                .collect()
+        })
+        .collect()
+}
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO x VALUES (1, 1), (2, 2), (3, NULL)", ())
+        .unwrap();
+    db
+}
+
+#[test]
+fn test_cte_read_by_both_set_operation_branches() {
+    let db = setup("cte_multi_reference_set_ops");
+    let union = rows(
+        &db,
+        "WITH c AS (SELECT a FROM x) SELECT a FROM c UNION ALL SELECT a + 1 FROM c",
+    );
+    assert_eq!(union.len(), 6);
+    let counted = rows(
+        &db,
+        "WITH c AS (SELECT a FROM x) SELECT COUNT(*) \
+         FROM (SELECT a FROM c UNION ALL SELECT a + 1 FROM c) u WHERE a IS NOT NULL",
+    );
+    assert_eq!(counted, [[Some(4)]]);
+    let except = rows(
+        &db,
+        "WITH c AS (SELECT a FROM x) SELECT COUNT(*) \
+         FROM (SELECT a FROM c EXCEPT SELECT a + 1 FROM c) u",
+    );
+    assert_eq!(except, [[Some(1)]]);
+}
+
+#[test]
+fn test_cte_read_by_select_list_having_and_order_by() {
+    let db = setup("cte_multi_reference_clauses");
+    assert_eq!(
+        rows(
+            &db,
+            "WITH c AS (SELECT a FROM x) SELECT (SELECT MAX(a) FROM c) FROM c"
+        ),
+        [[Some(2)], [Some(2)], [Some(2)]]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "WITH c AS (SELECT a FROM x) SELECT a, COUNT(*) FROM c GROUP BY a \
+             HAVING COUNT(*) >= (SELECT MIN(a) FROM c) ORDER BY a"
+        )
+        .len(),
+        3
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "WITH c AS (SELECT a FROM x) SELECT a FROM c ORDER BY (SELECT MAX(a) FROM c) - a"
+        ),
+        [[Some(2)], [Some(1)], [None]]
+    );
+}
+
+#[test]
+fn test_correlated_subquery_over_cte() {
+    let db = setup("cte_multi_reference_correlated");
+    let counts = [[Some(1), Some(1)], [Some(2), Some(0)], [None, Some(0)]];
+    assert_eq!(
+        rows(
+            &db,
+            "WITH c AS (SELECT a FROM x) \
+             SELECT a, (SELECT COUNT(*) FROM c c2 WHERE c2.a > c.a) FROM c ORDER BY a"
+        ),
+        counts
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "WITH c AS (SELECT a FROM x) \
+             SELECT c1.a, (SELECT COUNT(*) FROM c c2 WHERE c2.a > c1.a) FROM c c1 ORDER BY a"
+        ),
+        counts
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "WITH c AS (SELECT a FROM x) \
+             SELECT a FROM c WHERE EXISTS (SELECT 1 FROM c c2 WHERE c2.a > c.a)"
+        ),
+        [[Some(1)]]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "WITH c AS (SELECT a FROM x) \
+             SELECT a FROM c WHERE a IN (SELECT c2.a - 1 FROM c c2 WHERE c2.a > c.a)"
+        ),
+        [[Some(1)]]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "WITH c AS (SELECT a FROM x), \
+             d AS (SELECT a FROM c WHERE EXISTS (SELECT 1 FROM c c2 WHERE c2.a > c.a)) \
+             SELECT a FROM d"
+        ),
+        [[Some(1)]]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "WITH c AS (SELECT a FROM x), \
+             d AS (SELECT a FROM c ORDER BY (SELECT MAX(a) FROM c) - a LIMIT 1) \
+             SELECT a FROM d"
+        ),
+        [[Some(2)]]
+    );
+}

--- a/tests/delete_without_primary_key_test.rs
+++ b/tests/delete_without_primary_key_test.rs
@@ -254,3 +254,56 @@ fn test_a_refusal_below_a_cascade_leaves_nothing_behind() {
         );
     }
 }
+
+/// A key beneath a cascade names the column it points at, which need not
+/// be the child's primary key; the walk reads the child rows through that
+/// column, before anything goes and while the cascade runs
+#[test]
+fn test_keys_beneath_a_cascade_read_the_column_they_name() {
+    for (parent, child) in [
+        (
+            "CREATE TABLE par (code INTEGER UNIQUE)",
+            "CREATE TABLE child (ccode INTEGER UNIQUE, pcode INTEGER REFERENCES par(code) ON DELETE CASCADE)",
+        ),
+        (
+            "CREATE TABLE par (code INTEGER PRIMARY KEY)",
+            "CREATE TABLE child (id INTEGER PRIMARY KEY, ccode INTEGER UNIQUE, pcode INTEGER REFERENCES par(code) ON DELETE CASCADE)",
+        ),
+    ] {
+        let keyed = child.contains("PRIMARY KEY");
+        let db = Database::open(&format!(
+            "memory://delete_fk_unique_chain_{}",
+            if keyed { "keyed" } else { "unique" }
+        ))
+        .unwrap();
+        db.execute(parent, ()).unwrap();
+        db.execute(child, ()).unwrap();
+        db.execute(
+            "CREATE TABLE grand (id INTEGER PRIMARY KEY, ccode INTEGER REFERENCES child(ccode) ON DELETE RESTRICT)",
+            (),
+        )
+        .unwrap();
+        db.execute("INSERT INTO par VALUES (1), (2)", ()).unwrap();
+        if keyed {
+            db.execute("INSERT INTO child VALUES (1, 10, 1), (2, 20, 2)", ())
+                .unwrap();
+        } else {
+            db.execute("INSERT INTO child VALUES (10, 1), (20, 2)", ())
+                .unwrap();
+        }
+        db.execute("INSERT INTO grand VALUES (1, 20)", ()).unwrap();
+
+        // The grandchild holds child 20, which belongs to parent 2
+        assert!(
+            db.execute("DELETE FROM par WHERE code = 2", ()).is_err(),
+            "the grandchild refuses ({child})"
+        );
+        assert_eq!(ids(&db, "SELECT ccode FROM child ORDER BY ccode"), [10, 20], "{child}");
+        assert_eq!(ids(&db, "SELECT id FROM grand"), [1], "{child}");
+
+        // Parent 1's child has nothing beneath it and goes with the parent
+        db.execute("DELETE FROM par WHERE code = 1", ()).unwrap();
+        assert_eq!(ids(&db, "SELECT ccode FROM child"), [20], "{child}");
+        assert_eq!(ids(&db, "SELECT code FROM par"), [2], "{child}");
+    }
+}

--- a/tests/delete_without_primary_key_test.rs
+++ b/tests/delete_without_primary_key_test.rs
@@ -107,3 +107,54 @@ fn test_rows_that_hold_the_same_values() {
     assert_eq!(removed, 2, "both rows holding a 1");
     assert_eq!(ids(&db, "SELECT n FROM t"), [2]);
 }
+
+/// A key that names a column of a table without a primary key is enforced
+/// the same way, since the rows are still read before they go
+#[test]
+fn test_foreign_keys_on_a_parent_without_a_primary_key() {
+    let db = Database::open("memory://delete_no_pk_restrict").unwrap();
+    db.execute("CREATE TABLE par (code INTEGER UNIQUE, name TEXT)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE ch (id INTEGER PRIMARY KEY, code INTEGER REFERENCES par(code) ON DELETE RESTRICT)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO par VALUES (1, 'a'), (2, 'b')", ())
+        .unwrap();
+    db.execute("INSERT INTO ch VALUES (1, 1)", ()).unwrap();
+
+    assert!(
+        db.execute("DELETE FROM par WHERE code IN (SELECT 1)", ())
+            .is_err(),
+        "the child still references it"
+    );
+    assert_eq!(ids(&db, "SELECT code FROM par ORDER BY code"), [1, 2]);
+    assert_eq!(ids(&db, "SELECT id FROM ch"), [1]);
+
+    let removed = db
+        .execute("DELETE FROM par WHERE code IN (SELECT 2)", ())
+        .unwrap();
+    assert_eq!(removed, 1, "the row nothing references goes");
+    assert_eq!(ids(&db, "SELECT code FROM par"), [1]);
+}
+
+#[test]
+fn test_cascade_on_a_parent_without_a_primary_key() {
+    let db = Database::open("memory://delete_no_pk_cascade").unwrap();
+    db.execute("CREATE TABLE par (code INTEGER UNIQUE)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE ch (id INTEGER PRIMARY KEY, code INTEGER REFERENCES par(code) ON DELETE CASCADE)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO par VALUES (1), (2)", ()).unwrap();
+    db.execute("INSERT INTO ch VALUES (1, 1), (2, 2)", ())
+        .unwrap();
+
+    db.execute("DELETE FROM par WHERE code IN (SELECT 1)", ())
+        .unwrap();
+    assert_eq!(ids(&db, "SELECT code FROM par"), [2]);
+    assert_eq!(ids(&db, "SELECT id FROM ch"), [2], "the child went with it");
+}

--- a/tests/delete_without_primary_key_test.rs
+++ b/tests/delete_without_primary_key_test.rs
@@ -1,0 +1,109 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A DELETE names the rows it removes by primary key. A table without one
+//! names them by the ids the scan read them under, so a condition the
+//! storage layer cannot answer on its own still removes what it matched.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE a (id INTEGER, n INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE b (id INTEGER)", ()).unwrap();
+    db.execute("INSERT INTO a VALUES (1, 10), (2, 20), (3, 30)", ())
+        .unwrap();
+    db.execute("INSERT INTO b VALUES (2)", ()).unwrap();
+    db
+}
+
+fn ids(db: &Database, sql: &str) -> Vec<i64> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| row.unwrap().get(0).unwrap())
+        .collect()
+}
+
+#[test]
+fn test_delete_with_an_in_subquery() {
+    let db = setup("delete_no_pk_in");
+    let removed = db
+        .execute("DELETE FROM a WHERE id IN (SELECT id FROM b)", ())
+        .unwrap();
+    assert_eq!(removed, 1);
+    assert_eq!(ids(&db, "SELECT id FROM a ORDER BY id"), [1, 3]);
+}
+
+#[test]
+fn test_delete_with_exists_and_not_exists() {
+    let db = setup("delete_no_pk_exists");
+    let removed = db
+        .execute(
+            "DELETE FROM a WHERE EXISTS (SELECT 1 FROM b WHERE b.id = a.id)",
+            (),
+        )
+        .unwrap();
+    assert_eq!(removed, 1);
+    assert_eq!(ids(&db, "SELECT id FROM a ORDER BY id"), [1, 3]);
+
+    let removed = db
+        .execute(
+            "DELETE FROM a WHERE NOT EXISTS (SELECT 1 FROM b WHERE b.id = a.id)",
+            (),
+        )
+        .unwrap();
+    assert_eq!(removed, 2);
+    assert_eq!(ids(&db, "SELECT id FROM a ORDER BY id"), Vec::<i64>::new());
+}
+
+/// A condition the storage layer cannot answer on its own reaches the same
+/// rows a SELECT would
+#[test]
+fn test_delete_with_a_condition_over_two_columns() {
+    let db = setup("delete_no_pk_expression");
+    let removed = db.execute("DELETE FROM a WHERE id + n > 21", ()).unwrap();
+    assert_eq!(removed, 2);
+    assert_eq!(ids(&db, "SELECT id FROM a ORDER BY id"), [1]);
+}
+
+/// The rows a DELETE returns are the rows it removed
+#[test]
+fn test_delete_returning() {
+    let db = setup("delete_no_pk_returning");
+    let returned: Vec<i64> = db
+        .query(
+            "DELETE FROM a WHERE id IN (SELECT id FROM b) RETURNING id",
+            (),
+        )
+        .unwrap()
+        .map(|row| row.unwrap().get(0).unwrap())
+        .collect();
+    assert_eq!(returned, [2]);
+    assert_eq!(ids(&db, "SELECT id FROM a ORDER BY id"), [1, 3]);
+}
+
+/// Two rows holding the same values are two rows
+#[test]
+fn test_rows_that_hold_the_same_values() {
+    let db = Database::open("memory://delete_no_pk_twins").unwrap();
+    db.execute("CREATE TABLE t (n INTEGER)", ()).unwrap();
+    db.execute("INSERT INTO t VALUES (1), (1), (2)", ())
+        .unwrap();
+    let removed = db
+        .execute("DELETE FROM t WHERE n IN (SELECT 1)", ())
+        .unwrap();
+    assert_eq!(removed, 2, "both rows holding a 1");
+    assert_eq!(ids(&db, "SELECT n FROM t"), [2]);
+}

--- a/tests/delete_without_primary_key_test.rs
+++ b/tests/delete_without_primary_key_test.rs
@@ -200,3 +200,57 @@ fn test_a_refusal_leaves_no_cascade_behind() {
         );
     }
 }
+
+/// A key that refuses two levels down refuses the whole statement, before
+/// a key one level down has taken anything away
+#[test]
+fn test_a_refusal_below_a_cascade_leaves_nothing_behind() {
+    for parent in [
+        "CREATE TABLE par (code INTEGER UNIQUE)",
+        "CREATE TABLE par (code INTEGER PRIMARY KEY)",
+    ] {
+        let keyed = parent.contains("PRIMARY KEY");
+        let db = Database::open(&format!(
+            "memory://delete_fk_chain_{}",
+            if keyed { "pk" } else { "nopk" }
+        ))
+        .unwrap();
+        db.execute(parent, ()).unwrap();
+        db.execute(
+            "CREATE TABLE child (id INTEGER PRIMARY KEY, pcode INTEGER REFERENCES par(code) ON DELETE CASCADE)",
+            (),
+        )
+        .unwrap();
+        db.execute(
+            "CREATE TABLE grand (id INTEGER PRIMARY KEY, cid INTEGER REFERENCES child(id) ON DELETE RESTRICT)",
+            (),
+        )
+        .unwrap();
+        db.execute("INSERT INTO par VALUES (1), (2)", ()).unwrap();
+        db.execute("INSERT INTO child VALUES (1, 1), (2, 2)", ())
+            .unwrap();
+        db.execute("INSERT INTO grand VALUES (1, 2)", ()).unwrap();
+
+        db.execute("BEGIN", ()).unwrap();
+        assert!(
+            db.execute("DELETE FROM par WHERE code <= 2", ()).is_err(),
+            "the grandchild refuses ({parent})"
+        );
+        assert_eq!(
+            ids(&db, "SELECT id FROM child ORDER BY id"),
+            [1, 2],
+            "the first parent's child did not go before the refusal ({parent})"
+        );
+        assert_eq!(
+            ids(&db, "SELECT code FROM par ORDER BY code"),
+            [1, 2],
+            "{parent}"
+        );
+        db.execute("COMMIT", ()).unwrap();
+        assert_eq!(
+            ids(&db, "SELECT id FROM child ORDER BY id"),
+            [1, 2],
+            "nothing was left to commit ({parent})"
+        );
+    }
+}

--- a/tests/delete_without_primary_key_test.rs
+++ b/tests/delete_without_primary_key_test.rs
@@ -158,3 +158,45 @@ fn test_cascade_on_a_parent_without_a_primary_key() {
     assert_eq!(ids(&db, "SELECT code FROM par"), [2]);
     assert_eq!(ids(&db, "SELECT id FROM ch"), [2], "the child went with it");
 }
+
+/// A key that cascades and a key that refuses, in that order, must leave
+/// nothing behind when the refusal comes
+#[test]
+fn test_a_refusal_leaves_no_cascade_behind() {
+    for parent in [
+        "CREATE TABLE par (code INTEGER UNIQUE)",
+        "CREATE TABLE par (code INTEGER PRIMARY KEY)",
+    ] {
+        let keyed = parent.contains("PRIMARY KEY");
+        let db = Database::open(&format!(
+            "memory://delete_fk_atomic_{}",
+            if keyed { "pk" } else { "nopk" }
+        ))
+        .unwrap();
+        db.execute(parent, ()).unwrap();
+        db.execute(
+            "CREATE TABLE kid (id INTEGER PRIMARY KEY, a INTEGER REFERENCES par(code) ON DELETE CASCADE, b INTEGER REFERENCES par(code) ON DELETE RESTRICT)",
+            (),
+        )
+        .unwrap();
+        db.execute("INSERT INTO par VALUES (1), (2)", ()).unwrap();
+        db.execute("INSERT INTO kid VALUES (1, 1, NULL), (2, NULL, 1)", ())
+            .unwrap();
+
+        assert!(
+            db.execute("DELETE FROM par WHERE code IN (SELECT 1)", ())
+                .is_err(),
+            "the second key refuses ({parent})"
+        );
+        assert_eq!(
+            ids(&db, "SELECT code FROM par ORDER BY code"),
+            [1, 2],
+            "{parent}"
+        );
+        assert_eq!(
+            ids(&db, "SELECT id FROM kid ORDER BY id"),
+            [1, 2],
+            "the first key cascaded nothing away ({parent})"
+        );
+    }
+}

--- a/tests/distinct_limit_test.rs
+++ b/tests/distinct_limit_test.rs
@@ -1,0 +1,99 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! DISTINCT reads the columns the SELECT asked for, and a LIMIT counts the
+//! rows it left behind.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE p (id INTEGER PRIMARY KEY, g TEXT, n INTEGER)",
+        (),
+    )
+    .unwrap();
+    for (id, g, n) in [
+        (1i64, "a", 10i64),
+        (2, "a", 20),
+        (3, "b", 30),
+        (4, "b", 40),
+        (5, "c", 50),
+    ] {
+        db.execute("INSERT INTO p VALUES ($1, $2, $3)", (id, g, n))
+            .unwrap();
+    }
+    db
+}
+
+fn values(db: &Database, sql: &str) -> Vec<String> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| {
+            row.unwrap()
+                .get::<Option<String>>(0)
+                .unwrap()
+                .unwrap_or_else(|| "NULL".into())
+        })
+        .collect()
+}
+
+#[test]
+fn test_distinct_with_a_limit() {
+    let db = setup("distinct_limit");
+    assert_eq!(
+        values(&db, "SELECT DISTINCT g FROM p ORDER BY g LIMIT 2"),
+        ["a", "b"]
+    );
+    assert_eq!(
+        values(&db, "SELECT DISTINCT g FROM p ORDER BY g LIMIT 10"),
+        ["a", "b", "c"]
+    );
+    assert_eq!(
+        values(&db, "SELECT DISTINCT g FROM p ORDER BY g LIMIT 1"),
+        ["a"]
+    );
+    assert_eq!(
+        values(&db, "SELECT DISTINCT g FROM p ORDER BY g DESC LIMIT 2"),
+        ["c", "b"]
+    );
+}
+
+#[test]
+fn test_distinct_with_a_limit_and_an_offset() {
+    let db = setup("distinct_limit_offset");
+    assert_eq!(
+        values(&db, "SELECT DISTINCT g FROM p ORDER BY g LIMIT 2 OFFSET 1"),
+        ["b", "c"]
+    );
+    assert_eq!(
+        values(&db, "SELECT DISTINCT g FROM p ORDER BY g OFFSET 1"),
+        ["b", "c"]
+    );
+}
+
+/// Sorting by a column the SELECT leaves out does not widen what DISTINCT
+/// reads
+#[test]
+fn test_distinct_sorted_by_a_column_it_does_not_read() {
+    let db = setup("distinct_limit_hidden");
+    assert_eq!(
+        values(&db, "SELECT DISTINCT g FROM p ORDER BY id LIMIT 2"),
+        ["a", "b"]
+    );
+    assert_eq!(
+        values(&db, "SELECT DISTINCT UPPER(g) FROM p ORDER BY 1 LIMIT 2"),
+        ["A", "B"]
+    );
+}

--- a/tests/exists_subquery_test.rs
+++ b/tests/exists_subquery_test.rs
@@ -457,3 +457,52 @@ fn test_exists_reads_the_same_with_an_index_on_the_correlation() {
         );
     }
 }
+
+/// No inner row equals a NULL, so EXISTS over one is false and NOT EXISTS
+/// is true; the set the rewrite reads must not turn that into unknown
+#[test]
+fn test_not_exists_over_a_null_outer_value() {
+    for keyed in [true, false] {
+        let db = Database::open(&format!(
+            "memory://not_exists_null_outer_{}",
+            if keyed { "pk" } else { "nopk" }
+        ))
+        .unwrap();
+        let pk = if keyed { "PRIMARY KEY" } else { "" };
+        db.execute(&format!("CREATE TABLE t (id INTEGER {pk}, k INTEGER)"), ())
+            .unwrap();
+        db.execute("CREATE TABLE r (k INTEGER)", ()).unwrap();
+        db.execute("INSERT INTO t VALUES (1, 1), (2, 2), (3, NULL), (4, 9)", ())
+            .unwrap();
+        db.execute("INSERT INTO r VALUES (1), (2), (NULL)", ())
+            .unwrap();
+
+        let count = |sql: &str| -> i64 {
+            db.query(sql, ())
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap()
+                .get(0)
+                .unwrap()
+        };
+        assert_eq!(
+            count("SELECT COUNT(*) FROM t WHERE NOT EXISTS (SELECT 1 FROM r WHERE r.k = t.k)"),
+            2,
+            "the NULL row and the 9 row, keyed: {keyed}"
+        );
+        assert_eq!(
+            count("SELECT COUNT(*) FROM t WHERE EXISTS (SELECT 1 FROM r WHERE r.k = t.k)"),
+            2,
+            "keyed: {keyed}"
+        );
+        let removed = db
+            .execute(
+                "DELETE FROM t WHERE NOT EXISTS (SELECT 1 FROM r WHERE r.k = t.k)",
+                (),
+            )
+            .unwrap();
+        assert_eq!(removed, 2, "keyed: {keyed}");
+        assert_eq!(count("SELECT COUNT(*) FROM t"), 2, "keyed: {keyed}");
+    }
+}

--- a/tests/exists_subquery_test.rs
+++ b/tests/exists_subquery_test.rs
@@ -543,3 +543,66 @@ fn test_having_binds_the_group_to_a_correlated_exists() {
         vec![3]
     );
 }
+
+#[test]
+fn test_update_binds_each_row_to_a_where_the_semi_join_rewrite_refused() {
+    for keyed in [true, false] {
+        let db =
+            Database::open(&format!("memory://update_two_conjunct_not_exists_{keyed}")).unwrap();
+        let pk = if keyed { "PRIMARY KEY" } else { "" };
+        db.execute(
+            &format!("CREATE TABLE uy (id INTEGER {pk}, a INTEGER, s TEXT, b INTEGER)"),
+            (),
+        )
+        .unwrap();
+        db.execute("CREATE TABLE ux (a INTEGER, s TEXT)", ())
+            .unwrap();
+        db.execute("INSERT INTO ux VALUES (1, 'p'), (2, 'q')", ())
+            .unwrap();
+        db.execute(
+            "INSERT INTO uy VALUES (1, 1, 'p', 1), (2, 1, 'q', 1), (3, 2, 'q', 1), (4, 3, 'p', 1), (5, NULL, 'p', 1)",
+            (),
+        )
+        .unwrap();
+        let count = |sql: &str| -> i64 {
+            db.query(sql, ())
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap()
+                .get(0)
+                .unwrap()
+        };
+
+        let changed = db
+            .execute(
+                "UPDATE uy SET b = 0 WHERE NOT EXISTS (SELECT 1 FROM ux WHERE ux.a = uy.a AND ux.s = uy.s)",
+                (),
+            )
+            .unwrap();
+        assert_eq!(changed, 3, "keyed: {keyed}");
+        assert_eq!(
+            count("SELECT COUNT(*) FROM uy WHERE b = 0"),
+            3,
+            "keyed: {keyed}"
+        );
+
+        let changed = db
+            .execute(
+                "UPDATE uy SET b = 5 WHERE EXISTS (SELECT 1 FROM ux WHERE ux.a = uy.a AND ux.s = uy.s)",
+                (),
+            )
+            .unwrap();
+        assert_eq!(changed, 2, "keyed: {keyed}");
+
+        // a correlated SET alongside the correlated WHERE
+        let changed = db
+            .execute(
+                "UPDATE uy SET b = (SELECT COUNT(*) FROM ux WHERE ux.a = uy.a) WHERE NOT EXISTS (SELECT 1 FROM ux WHERE ux.a = uy.a AND ux.s = uy.s)",
+                (),
+            )
+            .unwrap();
+        assert_eq!(changed, 3, "keyed: {keyed}");
+        assert_eq!(count("SELECT SUM(b) FROM uy"), 11, "keyed: {keyed}");
+    }
+}

--- a/tests/exists_subquery_test.rs
+++ b/tests/exists_subquery_test.rs
@@ -506,3 +506,40 @@ fn test_not_exists_over_a_null_outer_value() {
         assert_eq!(count("SELECT COUNT(*) FROM t"), 2, "keyed: {keyed}");
     }
 }
+
+#[test]
+fn test_having_binds_the_group_to_a_correlated_exists() {
+    let db = Database::open("memory://having_correlated_exists").unwrap();
+    db.execute("CREATE TABLE hx (a INTEGER, b INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE hy (a INTEGER)", ()).unwrap();
+    db.execute(
+        "INSERT INTO hx VALUES (1, 10), (1, 11), (2, 20), (3, 30), (NULL, 40)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO hy VALUES (1), (3), (NULL)", ())
+        .unwrap();
+
+    let groups = |having: &str| -> Vec<i64> {
+        db.query(
+            &format!("SELECT COALESCE(a, -1) FROM hx GROUP BY a HAVING {having} ORDER BY a"),
+            (),
+        )
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect()
+    };
+    assert_eq!(
+        groups("EXISTS (SELECT 1 FROM hy WHERE hy.a = hx.a)"),
+        vec![1, 3]
+    );
+    assert_eq!(
+        groups("NOT EXISTS (SELECT 1 FROM hy WHERE hy.a = hx.a)"),
+        vec![2, -1]
+    );
+    assert_eq!(
+        groups("COUNT(*) = 1 AND EXISTS (SELECT 1 FROM hy WHERE hy.a = hx.a)"),
+        vec![3]
+    );
+}

--- a/tests/exists_subquery_test.rs
+++ b/tests/exists_subquery_test.rs
@@ -398,3 +398,62 @@ fn test_exists_over_a_bare_aggregate() {
         0
     );
 }
+
+/// An index on the correlation column offers a shorter road to the same
+/// question, and it is only the same question under the same conditions
+#[test]
+fn test_exists_reads_the_same_with_an_index_on_the_correlation() {
+    for indexed in [false, true] {
+        let name = if indexed {
+            "exists_guard_indexed"
+        } else {
+            "exists_guard_plain"
+        };
+        let db = Database::open(&format!("memory://{name}")).unwrap();
+        db.execute("CREATE TABLE d (id INTEGER PRIMARY KEY)", ())
+            .unwrap();
+        db.execute("CREATE TABLE e (id INTEGER PRIMARY KEY, d_id INTEGER)", ())
+            .unwrap();
+        db.execute("INSERT INTO d VALUES (1),(2),(3)", ()).unwrap();
+        db.execute("INSERT INTO e VALUES (1,1),(2,1),(3,2)", ())
+            .unwrap();
+        if indexed {
+            db.execute("CREATE INDEX ed ON e (d_id)", ()).unwrap();
+        }
+
+        let count = |sql: &str| -> i64 {
+            db.query(sql, ())
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap()
+                .get(0)
+                .unwrap()
+        };
+
+        assert_eq!(
+            count(
+                "SELECT COUNT(*) FROM d WHERE EXISTS (SELECT 1 FROM e WHERE e.d_id = d.id LIMIT 0)"
+            ),
+            0,
+            "indexed: {indexed}"
+        );
+        assert_eq!(
+            count("SELECT COUNT(*) FROM d WHERE EXISTS (SELECT 1 FROM e WHERE e.d_id = d.id GROUP BY e.d_id HAVING COUNT(*) > 1)"),
+            1,
+            "indexed: {indexed}"
+        );
+        assert_eq!(
+            count(
+                "SELECT COUNT(*) FROM d WHERE EXISTS (SELECT COUNT(*) FROM e WHERE e.d_id = d.id)"
+            ),
+            3,
+            "indexed: {indexed}"
+        );
+        assert_eq!(
+            count("SELECT COUNT(*) FROM d WHERE EXISTS (SELECT 1 FROM e WHERE e.d_id = d.id)"),
+            2,
+            "indexed: {indexed}"
+        );
+    }
+}

--- a/tests/exists_subquery_test.rs
+++ b/tests/exists_subquery_test.rs
@@ -311,3 +311,90 @@ fn test_update_with_exists() {
         .expect("Failed to count");
     assert_eq!(count, 4, "Expected all 4 products to be out of stock");
 }
+
+/// A subquery that groups its rows and then keeps only some of the groups
+/// is asked whether a group survived, not whether a row matched
+#[test]
+fn test_exists_over_a_subquery_that_groups_and_filters() {
+    let db = Database::open("memory://exists_group_having").unwrap();
+    db.execute("CREATE TABLE d (id INTEGER PRIMARY KEY, g TEXT)", ())
+        .unwrap();
+    db.execute("CREATE TABLE e (id INTEGER PRIMARY KEY, d_id INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO d VALUES (1,'a'),(2,'a'),(3,'b')", ())
+        .unwrap();
+    db.execute("INSERT INTO e VALUES (1,1),(2,1),(3,2)", ())
+        .unwrap();
+
+    let count = |sql: &str| -> i64 {
+        db.query(sql, ())
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .get(0)
+            .unwrap()
+    };
+
+    assert_eq!(
+        count(
+            "SELECT COUNT(*) FROM d WHERE EXISTS (SELECT 1 FROM e WHERE e.d_id = d.id GROUP BY e.d_id HAVING COUNT(*) > 1)"
+        ),
+        1,
+        "only the row with two children"
+    );
+    assert_eq!(
+        count(
+            "SELECT COUNT(*) FROM d WHERE EXISTS (SELECT 1 FROM e WHERE e.d_id = d.id GROUP BY e.d_id HAVING COUNT(*) > 99)"
+        ),
+        0
+    );
+    assert_eq!(
+        count(
+            "SELECT COUNT(*) FROM d WHERE NOT EXISTS (SELECT 1 FROM e WHERE e.d_id = d.id GROUP BY e.d_id HAVING COUNT(*) > 1)"
+        ),
+        2
+    );
+    assert_eq!(
+        count("SELECT COUNT(*) FROM d WHERE EXISTS (SELECT 1 FROM e WHERE e.d_id = d.id GROUP BY e.d_id)"),
+        2,
+        "grouping alone does not change whether a row is there"
+    );
+}
+
+/// A bare aggregate returns its one row whether or not anything matched
+#[test]
+fn test_exists_over_a_bare_aggregate() {
+    let db = Database::open("memory://exists_bare_aggregate").unwrap();
+    db.execute("CREATE TABLE d (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    db.execute("CREATE TABLE e (id INTEGER PRIMARY KEY, d_id INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO d VALUES (1),(2),(3)", ()).unwrap();
+    db.execute("INSERT INTO e VALUES (1,1),(2,1)", ()).unwrap();
+
+    let count = |sql: &str| -> i64 {
+        db.query(sql, ())
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .get(0)
+            .unwrap()
+    };
+
+    assert_eq!(
+        count("SELECT COUNT(*) FROM d WHERE EXISTS (SELECT COUNT(*) FROM e WHERE e.d_id = d.id)"),
+        3
+    );
+    assert_eq!(
+        count(
+            "SELECT COUNT(*) FROM d WHERE NOT EXISTS (SELECT COUNT(*) FROM e WHERE e.d_id = d.id)"
+        ),
+        0
+    );
+    assert_eq!(
+        count("SELECT COUNT(*) FROM d WHERE EXISTS (SELECT 1 FROM e WHERE e.d_id = d.id LIMIT 0)"),
+        0
+    );
+}

--- a/tests/expression_pushdown_test.rs
+++ b/tests/expression_pushdown_test.rs
@@ -99,10 +99,11 @@ fn test_not_with_and_condition() {
         &db,
         "SELECT * FROM test_products WHERE NOT (category = 'Electronics' AND price > 500)",
     );
-    // Not (Electronics AND expensive): should exclude Laptop(1200) and Smartphone(800)
+    // Not (Electronics AND expensive) excludes Laptop(1200) and Smartphone(800),
+    // and the all-NULL row, for which the conjunction is UNKNOWN and so is its NOT
     assert_eq!(
-        count, 8,
-        "Expected 8 products not (Electronics AND expensive)"
+        count, 7,
+        "Expected 7 products not (Electronics AND expensive)"
     );
 }
 
@@ -147,10 +148,11 @@ fn test_not_with_composite_condition() {
         &db,
         "SELECT * FROM test_products WHERE NOT (category = 'Electronics' AND price > 500 AND in_stock = true)",
     );
-    // Not (expensive Electronics in stock)
+    // Not (expensive Electronics in stock), less the all-NULL row whose
+    // conjunction is UNKNOWN
     assert_eq!(
-        count, 8,
-        "Expected 8 products not (expensive Electronics in stock)"
+        count, 7,
+        "Expected 7 products not (expensive Electronics in stock)"
     );
 }
 

--- a/tests/group_key_projection_test.rs
+++ b/tests/group_key_projection_test.rs
@@ -1,0 +1,101 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A select column that is an expression over a GROUP BY key is evaluated
+//! for every group, the NULL group included, while a column that repeats a
+//! GROUP BY expression is read from the group as it is.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE hx (a INTEGER, b INTEGER, s TEXT)", ())
+        .unwrap();
+    db.execute(
+        "INSERT INTO hx VALUES (1, 10, 'p'), (1, 11, 'p'), (2, 20, 'q'), (3, 30, NULL), (NULL, 40, 'q')",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn rows(db: &Database, sql: &str) -> Vec<String> {
+    let mut out: Vec<String> = db
+        .query(sql, ())
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            (0..r.len())
+                .map(|i| {
+                    r.get::<Option<String>>(i)
+                        .unwrap()
+                        .unwrap_or_else(|| "NULL".into())
+                })
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn test_a_function_of_the_group_key_is_evaluated() {
+    let db = setup("group_key_function");
+    assert_eq!(
+        rows(&db, "SELECT COALESCE(a, 5) FROM hx GROUP BY a"),
+        ["1", "2", "3", "5"]
+    );
+    assert_eq!(
+        rows(&db, "SELECT IFNULL(a, 5), SUM(b) FROM hx GROUP BY a"),
+        ["1,21", "2,20", "3,30", "5,40"]
+    );
+    assert_eq!(
+        rows(&db, "SELECT NULLIF(a, 1) FROM hx GROUP BY a"),
+        ["2", "3", "NULL", "NULL"]
+    );
+    assert_eq!(
+        rows(&db, "SELECT COALESCE(s, '-'), COUNT(*) FROM hx GROUP BY s"),
+        ["-,1", "p,2", "q,2"]
+    );
+}
+
+#[test]
+fn test_a_literal_or_cast_beside_the_group_key_is_evaluated() {
+    let db = setup("group_key_literal");
+    assert_eq!(
+        rows(&db, "SELECT 1, COUNT(*) FROM hx GROUP BY a"),
+        ["1,1", "1,1", "1,1", "1,2"]
+    );
+    assert_eq!(
+        rows(&db, "SELECT CAST(a AS TEXT), COUNT(*) FROM hx GROUP BY a"),
+        ["1,2", "2,1", "3,1", "NULL,1"]
+    );
+}
+
+#[test]
+fn test_a_group_by_expression_column_is_read_as_it_is() {
+    let db = setup("group_key_expression");
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT UPPER(s), COUNT(*), SUM(b) FROM hx GROUP BY UPPER(s)"
+        ),
+        ["NULL,1,30", "P,2,21", "Q,2,60"]
+    );
+    assert_eq!(
+        rows(&db, "SELECT LENGTH(s), COUNT(*) FROM hx GROUP BY LENGTH(s)"),
+        ["1,4", "NULL,1"]
+    );
+}

--- a/tests/group_key_projection_test.rs
+++ b/tests/group_key_projection_test.rs
@@ -99,3 +99,26 @@ fn test_a_group_by_expression_column_is_read_as_it_is() {
         ["1,4", "NULL,1"]
     );
 }
+
+#[test]
+fn test_counting_alone_over_a_text_key_of_a_derived_table() {
+    let db = setup("group_key_derived_text");
+    assert_eq!(
+        rows(&db, "SELECT COUNT(*) FROM (SELECT s FROM hx) t GROUP BY s"),
+        ["1", "2", "2"]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT COUNT(*) FROM (SELECT '' AS t UNION ALL SELECT '' UNION ALL SELECT NULL) GROUP BY t"
+        ),
+        ["1", "2"]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT COUNT(*), s FROM (SELECT s FROM hx) t GROUP BY s"
+        ),
+        ["1,NULL", "2,p", "2,q"]
+    );
+}

--- a/tests/having_without_group_by_test.rs
+++ b/tests/having_without_group_by_test.rs
@@ -1,0 +1,65 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! HAVING without GROUP BY judges the single aggregate row, and drops it
+//! when it does not hold, on the counting and min/max shortcuts too.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE hx (id INTEGER PRIMARY KEY, b INTEGER)", ())
+        .unwrap();
+    db.execute(
+        "INSERT INTO hx VALUES (1, 10), (2, 11), (3, 50), (4, 30)",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn rows(db: &Database, sql: &str) -> usize {
+    db.query(sql, ()).unwrap().count()
+}
+
+#[test]
+fn test_having_drops_the_single_row_when_it_does_not_hold() {
+    let db = setup("having_no_group_by");
+    assert_eq!(
+        rows(&db, "SELECT COUNT(*) FROM hx HAVING COUNT(*) > 100"),
+        0
+    );
+    assert_eq!(rows(&db, "SELECT COUNT(*) FROM hx HAVING COUNT(*) > 1"), 1);
+    assert_eq!(rows(&db, "SELECT MAX(b) FROM hx HAVING MAX(b) > 100"), 0);
+    assert_eq!(rows(&db, "SELECT MIN(b) FROM hx HAVING MIN(b) < 100"), 1);
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT COUNT(*) FROM (SELECT COUNT(*) AS c FROM hx HAVING COUNT(*) > 100) t WHERE c IS NOT NULL"
+        ),
+        1
+    );
+    let inner: i64 = db
+        .query(
+            "SELECT COUNT(*) FROM (SELECT COUNT(*) AS c FROM hx HAVING COUNT(*) > 100)",
+            (),
+        )
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap();
+    assert_eq!(inner, 0);
+}

--- a/tests/in_list_of_expressions_test.rs
+++ b/tests/in_list_of_expressions_test.rs
@@ -77,3 +77,19 @@ fn test_the_value_is_evaluated_once() {
         .collect();
     assert_eq!(nulls, [Some(true), None, None, Some(true), None, None]);
 }
+
+#[test]
+fn test_a_list_longer_than_a_short_count_holds() {
+    let db = Database::open("memory://in_list_long").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 1)", ()).unwrap();
+    // 65,536 items: the first is the column itself, the rest are zeros
+    let zeros = vec!["0"; 65_535].join(", ");
+    let hit: Vec<bool> = db
+        .query(&format!("SELECT a IN (a + 0, {zeros}) FROM t"), ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<bool>(0).unwrap())
+        .collect();
+    assert_eq!(hit, [true]);
+}

--- a/tests/in_list_of_expressions_test.rs
+++ b/tests/in_list_of_expressions_test.rs
@@ -1,0 +1,48 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! IN over a list of expressions that are not constants compares the
+//! items in turn, with IN's NULL rule.
+
+use stoolap::Database;
+
+#[test]
+fn test_in_over_expressions() {
+    let db = Database::open("memory://in_list_of_expressions").unwrap();
+    db.execute(
+        "CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO x VALUES (1, 1, 10), (2, 2, 3), (3, 3, 3), (4, NULL, 5), (5, 6, NULL)",
+        (),
+    )
+    .unwrap();
+    let count = |where_clause: &str| -> i64 {
+        db.query(&format!("SELECT COUNT(*) FROM x WHERE {where_clause}"), ())
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .get(0)
+            .unwrap()
+    };
+    // 2 in (3, 4, 2) and 3 in (3, 4, 2)
+    assert_eq!(count("a IN (b, b + 1, b - 1)"), 2);
+    assert_eq!(count("a NOT IN (b, b + 1, b - 1)"), 1);
+    assert_eq!(count("a IN (b, NULL)"), 1);
+    assert_eq!(count("a NOT IN (b, NULL)"), 0);
+    assert_eq!(count("a IN (b * 2, 1)"), 1);
+}

--- a/tests/in_list_of_expressions_test.rs
+++ b/tests/in_list_of_expressions_test.rs
@@ -46,3 +46,34 @@ fn test_in_over_expressions() {
     assert_eq!(count("a NOT IN (b, NULL)"), 0);
     assert_eq!(count("a IN (b * 2, 1)"), 1);
 }
+
+#[test]
+fn test_the_value_is_evaluated_once() {
+    let db = Database::open("memory://in_list_value_once").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, b BOOLEAN)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, true), (2, false)", ())
+        .unwrap();
+    // A value judged against b and NOT b is in the list whatever it is,
+    // unless it is rolled again for each item
+    for _ in 0..200 {
+        let hits: Vec<bool> = db
+            .query("SELECT (RANDOM() < 0.5) IN (b, NOT b) FROM t", ())
+            .unwrap()
+            .map(|r| r.unwrap().get::<bool>(0).unwrap())
+            .collect();
+        assert_eq!(hits, [true, true]);
+    }
+    let nulls: Vec<Option<bool>> = db
+        .query(
+            "SELECT id IN (NULL, id + 0), id IN (NULL, 5), NULL IN (id) FROM t",
+            (),
+        )
+        .unwrap()
+        .flat_map(|r| {
+            let r = r.unwrap();
+            [0, 1, 2].map(|i| r.get::<Option<bool>>(i).unwrap())
+        })
+        .collect();
+    assert_eq!(nulls, [Some(true), None, None, Some(true), None, None]);
+}

--- a/tests/join_on_condition_test.rs
+++ b/tests/join_on_condition_test.rs
@@ -1,0 +1,165 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An outer join keeps a row of the side it preserves only where the whole
+//! ON condition matched nothing for it, and one such row however many
+//! candidates the condition turned away.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, g TEXT)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE u (id INTEGER PRIMARY KEY, t_id INTEGER, w INTEGER)",
+        (),
+    )
+    .unwrap();
+    for (id, g) in [
+        (1i64, "a"),
+        (2, "a"),
+        (3, "b"),
+        (4, "b"),
+        (5, "c"),
+        (6, "c"),
+    ] {
+        db.execute("INSERT INTO t VALUES ($1, $2)", (id, g))
+            .unwrap();
+    }
+    // t 1 has two, t 2 and t 5 have one, the last belongs to nobody
+    for (id, t_id, w) in [
+        (1i64, Some(1i64), 100i64),
+        (2, Some(1), 200),
+        (3, Some(2), 300),
+        (4, Some(5), 400),
+        (5, None, 500),
+    ] {
+        db.execute("INSERT INTO u VALUES ($1, $2, $3)", (id, t_id, w))
+            .unwrap();
+    }
+    db
+}
+
+fn rows(db: &Database, sql: &str) -> Vec<String> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (0..row.len())
+                .map(|i| {
+                    row.get::<Option<String>>(i)
+                        .unwrap()
+                        .unwrap_or_else(|| "NULL".into())
+                })
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect()
+}
+
+fn count(db: &Database, sql: &str) -> i64 {
+    db.query(sql, ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap()
+}
+
+/// A left row that the condition matched keeps its matches and gains no
+/// row of its own, however many candidates it turned away
+#[test]
+fn test_left_join_with_a_predicate_beside_the_key() {
+    let db = setup("join_on_condition_left");
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT t.id, u.id FROM t LEFT JOIN u ON u.t_id = t.id AND u.w > 150 ORDER BY t.id, u.id"
+        ),
+        [
+            "1,2", "2,3", "3,NULL", "4,NULL", "5,4", "6,NULL"
+        ],
+        "t 1 turned one candidate away and keeps only the match"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM t LEFT JOIN u ON u.t_id = t.id AND u.w > 150"
+        ),
+        6
+    );
+}
+
+/// A condition nothing satisfies leaves one row per left row, not one per
+/// candidate it turned away
+#[test]
+fn test_left_join_with_a_condition_nothing_meets() {
+    let db = setup("join_on_condition_false");
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT t.id, u.id FROM t LEFT JOIN u ON u.t_id = t.id AND 1 = 0 ORDER BY t.id"
+        ),
+        ["1,NULL", "2,NULL", "3,NULL", "4,NULL", "5,NULL", "6,NULL"]
+    );
+}
+
+/// A predicate on the preserved side reads the same way
+#[test]
+fn test_left_join_with_a_predicate_on_the_left() {
+    let db = setup("join_on_condition_left_side");
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM t LEFT JOIN u ON u.t_id = t.id AND t.id > 3"
+        ),
+        6
+    );
+}
+
+/// What the condition keeps is what an inner join would have kept
+#[test]
+fn test_inner_join_keeps_only_the_matches() {
+    let db = setup("join_on_condition_inner");
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM t JOIN u ON u.t_id = t.id AND u.w > 150"
+        ),
+        3
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM t LEFT JOIN u ON u.t_id = t.id AND u.w > 50"
+        ),
+        7,
+        "a condition every candidate meets changes nothing"
+    );
+}
+
+/// The right side of a right join is preserved the same way
+#[test]
+fn test_right_join_with_a_predicate_beside_the_key() {
+    let db = setup("join_on_condition_right");
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT t.id, u.id FROM u RIGHT JOIN t ON u.t_id = t.id AND u.w > 150 ORDER BY t.id, u.id"
+        ),
+        ["1,2", "2,3", "3,NULL", "4,NULL", "5,4", "6,NULL"]
+    );
+}

--- a/tests/join_on_condition_test.rs
+++ b/tests/join_on_condition_test.rs
@@ -271,3 +271,95 @@ fn test_sorted_inputs_honour_the_condition() {
         "the rows the condition turned away are kept without a right side"
     );
 }
+
+/// A subquery in the ON clause is read once and the join compares each pair
+/// against what it returned
+#[test]
+fn test_a_subquery_in_the_join_condition() {
+    let db = Database::open("memory://join_on_subquery").unwrap();
+    db.execute("CREATE TABLE p (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE r (id INTEGER PRIMARY KEY, p_id INTEGER, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO p VALUES (1), (2), (3)", ())
+        .unwrap();
+    db.execute(
+        "INSERT INTO r VALUES (1,1,100), (2,1,200), (3,2,300), (4,3,400), (5,3,500)",
+        (),
+    )
+    .unwrap();
+
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM p JOIN r ON r.p_id = p.id AND r.v > (SELECT AVG(v) FROM r)"
+        ),
+        2
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM p LEFT JOIN r ON r.p_id = p.id AND r.v > (SELECT AVG(v) FROM r)"
+        ),
+        4,
+        "two matches and two rows the condition turned away"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM p JOIN r ON r.p_id = p.id WHERE r.v > (SELECT AVG(v) FROM r)"
+        ),
+        2,
+        "the same condition in the WHERE clause"
+    );
+}
+
+/// A LEFT JOIN keeps its left rows whatever the right side is read from
+#[test]
+fn test_left_join_against_a_derived_table() {
+    let db = Database::open("memory://join_left_derived").unwrap();
+    db.execute("CREATE TABLE p (id INTEGER PRIMARY KEY, n INTEGER)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE r (id INTEGER PRIMARY KEY, p_id INTEGER, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO p VALUES (1,10),(2,20),(3,30)", ())
+        .unwrap();
+    db.execute("INSERT INTO r VALUES (1,1,100),(2,2,200)", ())
+        .unwrap();
+
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT p.id, s.t FROM p LEFT JOIN (SELECT p_id, SUM(v) AS t FROM r GROUP BY p_id) s ON s.p_id = p.id ORDER BY p.id"
+        ),
+        ["1,100", "2,200", "3,NULL"]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT p.id, s.v FROM p LEFT JOIN (SELECT p_id, v FROM r) s ON s.p_id = p.id ORDER BY p.id"
+        ),
+        ["1,100", "2,200", "3,NULL"]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "WITH s AS (SELECT p_id, SUM(v) AS t FROM r GROUP BY p_id) SELECT p.id, s.t FROM p LEFT JOIN s ON s.p_id = p.id ORDER BY p.id"
+        ),
+        ["1,100", "2,200", "3,NULL"]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT * FROM p LEFT JOIN (SELECT p_id, v FROM r) s ON s.p_id = p.id ORDER BY p.id"
+        ),
+        ["1,10,1,100", "2,20,2,200", "3,30,NULL,NULL"],
+        "the left side comes first"
+    );
+}

--- a/tests/join_on_condition_test.rs
+++ b/tests/join_on_condition_test.rs
@@ -426,3 +426,37 @@ fn test_the_condition_holds_when_an_index_answers_the_key() {
         );
     }
 }
+
+/// The ON clause reads the transaction it runs in, whether or not an index
+/// answers the key
+#[test]
+fn test_the_condition_sees_the_transaction() {
+    for indexed in [false, true] {
+        let db = Database::open(&format!(
+            "memory://join_on_txn_{}",
+            if indexed { "yes" } else { "no" }
+        ))
+        .unwrap();
+        db.execute("CREATE TABLE p (id INTEGER PRIMARY KEY)", ())
+            .unwrap();
+        db.execute("CREATE TABLE r (id INTEGER PRIMARY KEY, p_id INTEGER)", ())
+            .unwrap();
+        db.execute("INSERT INTO p VALUES (1), (2)", ()).unwrap();
+        db.execute("INSERT INTO r VALUES (1, 1), (2, 2)", ())
+            .unwrap();
+        if indexed {
+            db.execute("CREATE INDEX rp ON r (p_id)", ()).unwrap();
+        }
+
+        db.execute("BEGIN", ()).unwrap();
+        assert_eq!(
+            rows(
+                &db,
+                "SELECT p.id FROM p JOIN r ON r.p_id = p.id AND CURRENT_TRANSACTION_ID() IS NOT NULL ORDER BY p.id"
+            ),
+            ["1", "2"],
+            "indexed: {indexed}"
+        );
+        db.execute("ROLLBACK", ()).unwrap();
+    }
+}

--- a/tests/join_on_condition_test.rs
+++ b/tests/join_on_condition_test.rs
@@ -163,3 +163,111 @@ fn test_right_join_with_a_predicate_beside_the_key() {
         ["1,2", "2,3", "3,NULL", "4,NULL", "5,4", "6,NULL"]
     );
 }
+
+/// Two left rows holding the same values are two rows, and each keeps a
+/// row of its own when the condition turns its candidates away
+#[test]
+fn test_left_rows_that_hold_the_same_values_stay_apart() {
+    let db = Database::open("memory://join_on_condition_twins").unwrap();
+    db.execute("CREATE TABLE l (k INTEGER)", ()).unwrap();
+    db.execute("CREATE TABLE r (k INTEGER, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO l VALUES (1), (1), (2)", ())
+        .unwrap();
+    db.execute("INSERT INTO r VALUES (1, 0), (1, 9), (3, 7)", ())
+        .unwrap();
+
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM l LEFT JOIN r ON l.k = r.k AND r.v > 900"
+        ),
+        3,
+        "both rows holding a 1 are turned away and both are kept"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT l.k, r.v FROM l LEFT JOIN r ON l.k = r.k AND r.v > 100 ORDER BY l.k"
+        ),
+        ["1,NULL", "1,NULL", "2,NULL"]
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM l LEFT JOIN r ON l.k = r.k AND r.v > 1"
+        ),
+        3,
+        "each 1 keeps its one match and the 2 keeps a row of its own"
+    );
+}
+
+/// A full join returns the rows of both sides and nothing besides
+#[test]
+fn test_full_join_adds_no_row_of_its_own() {
+    let db = Database::open("memory://join_on_condition_full").unwrap();
+    db.execute("CREATE TABLE l (k INTEGER)", ()).unwrap();
+    db.execute("CREATE TABLE r (k INTEGER, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO l VALUES (1), (2)", ()).unwrap();
+    db.execute("INSERT INTO r VALUES (1, 0), (3, 7)", ())
+        .unwrap();
+
+    let out = rows(
+        &db,
+        "SELECT l.k, r.k, r.v FROM l FULL OUTER JOIN r ON l.k = r.k AND r.v > 0",
+    );
+    assert_eq!(out.len(), 4, "two left rows and two right rows: {out:?}");
+    assert!(
+        !out.contains(&"NULL,NULL,NULL".to_string()),
+        "a row of nothing but NULLs belongs to neither side: {out:?}"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM l FULL OUTER JOIN r ON l.k = r.k AND 1 = 0"
+        ),
+        4
+    );
+}
+
+/// Sorted inputs take a different path through the join and honour the
+/// condition on it just the same
+#[test]
+fn test_sorted_inputs_honour_the_condition() {
+    let db = Database::open("memory://join_on_condition_sorted").unwrap();
+    db.execute("CREATE TABLE a (k INTEGER, x INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE b (k INTEGER, v INTEGER)", ())
+        .unwrap();
+    for i in 1i64..=400 {
+        db.execute("INSERT INTO a VALUES ($1, $2)", (i, i * 10))
+            .unwrap();
+        db.execute("INSERT INTO b VALUES ($1, $2)", (i, i % 4))
+            .unwrap();
+    }
+
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM a JOIN b ON a.k = b.k AND b.v = 2"
+        ),
+        100,
+        "every fourth row meets the condition"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM a LEFT JOIN b ON a.k = b.k AND b.v = 2"
+        ),
+        400
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(b.v) FROM a LEFT JOIN b ON a.k = b.k AND b.v = 2"
+        ),
+        100,
+        "the rows the condition turned away are kept without a right side"
+    );
+}

--- a/tests/join_on_condition_test.rs
+++ b/tests/join_on_condition_test.rs
@@ -363,3 +363,66 @@ fn test_left_join_against_a_derived_table() {
         "the left side comes first"
     );
 }
+
+/// An index on the key offers a shorter road to the pairs, and the rest of
+/// the ON clause is still asked of each one it returns
+#[test]
+fn test_the_condition_holds_when_an_index_answers_the_key() {
+    for indexed in [false, true] {
+        let db = Database::open(&format!(
+            "memory://join_on_indexed_{}",
+            if indexed { "yes" } else { "no" }
+        ))
+        .unwrap();
+        db.execute("CREATE TABLE p (id INTEGER PRIMARY KEY)", ())
+            .unwrap();
+        db.execute(
+            "CREATE TABLE r (id INTEGER PRIMARY KEY, p_id INTEGER, v INTEGER)",
+            (),
+        )
+        .unwrap();
+        db.execute("INSERT INTO p VALUES (1), (2), (3)", ())
+            .unwrap();
+        db.execute(
+            "INSERT INTO r VALUES (1,1,100), (2,1,200), (3,2,300), (4,3,400), (5,3,500)",
+            (),
+        )
+        .unwrap();
+        if indexed {
+            db.execute("CREATE INDEX rp ON r (p_id)", ()).unwrap();
+        }
+
+        assert_eq!(
+            rows(
+                &db,
+                "SELECT p.id FROM p JOIN r ON r.p_id = p.id AND r.v > 300 ORDER BY p.id"
+            ),
+            ["3", "3"],
+            "indexed: {indexed}"
+        );
+        assert_eq!(
+            rows(
+                &db,
+                "SELECT p.id FROM p JOIN r ON r.p_id = p.id AND r.v > (SELECT AVG(v) FROM r) ORDER BY p.id"
+            ),
+            ["3", "3"],
+            "indexed: {indexed}"
+        );
+        assert_eq!(
+            rows(
+                &db,
+                "SELECT p.id, r.v FROM p LEFT JOIN r ON r.p_id = p.id AND r.v > 300 ORDER BY p.id, r.v"
+            ),
+            ["1,NULL", "2,NULL", "3,400", "3,500"],
+            "indexed: {indexed}"
+        );
+        assert_eq!(
+            rows(
+                &db,
+                "SELECT p.id, (SELECT COUNT(*) FROM r WHERE r.p_id = p.id) FROM p ORDER BY p.id"
+            ),
+            ["1,2", "2,1", "3,2"],
+            "a correlated count still reads the same, indexed: {indexed}"
+        );
+    }
+}

--- a/tests/join_using_column_test.rs
+++ b/tests/join_using_column_test.rs
@@ -1,0 +1,97 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A column named in JOIN ... USING is one column of the joined row, found
+//! by its bare name or through either table, in a select list, an
+//! aggregate and a GROUP BY alike.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE ux (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE uy (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    db.execute(
+        "INSERT INTO ux VALUES (1, 1), (2, 2), (3, 3), (4, NULL), (5, 2)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO uy VALUES (1, 2), (2, 5), (3, 3), (4, 2), (5, NULL)",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn rows(db: &Database, sql: &str) -> Vec<String> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            (0..r.len())
+                .map(|i| {
+                    r.get::<Option<String>>(i)
+                        .unwrap()
+                        .unwrap_or_else(|| "NULL".into())
+                })
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect()
+}
+
+#[test]
+fn test_the_using_column_is_found_by_every_name() {
+    let db = setup("using_every_name");
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT a, ux.a, uy.a FROM ux JOIN uy USING (a) ORDER BY ux.id, uy.id"
+        ),
+        ["2,2,2", "2,2,2", "3,3,3", "2,2,2", "2,2,2"]
+    );
+}
+
+#[test]
+fn test_the_using_column_is_aggregated_and_grouped() {
+    let db = setup("using_aggregated");
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT SUM(a), SUM(ux.a), MAX(a), COUNT(*) FROM ux JOIN uy USING (a)"
+        ),
+        ["11,11,3,5"]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT a, COUNT(*) FROM ux JOIN uy USING (a) GROUP BY a ORDER BY a"
+        ),
+        ["2,4", "3,1"]
+    );
+    assert_eq!(
+        rows(&db, "SELECT SUM(a) FROM ux LEFT JOIN uy USING (a)"),
+        ["12"]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT ux.id, uy.id FROM ux JOIN uy USING (a) WHERE a = 3"
+        ),
+        ["3,3"]
+    );
+}

--- a/tests/join_using_column_test.rs
+++ b/tests/join_using_column_test.rs
@@ -95,3 +95,27 @@ fn test_the_using_column_is_aggregated_and_grouped() {
         ["3,3"]
     );
 }
+
+#[test]
+fn test_a_qualified_star_keeps_the_using_column() {
+    let db = setup("using_qualified_star");
+    let result = db
+        .query("SELECT ux.* FROM ux JOIN uy USING (a) ORDER BY ux.id", ())
+        .unwrap();
+    assert_eq!(result.columns(), ["id", "a"]);
+    let rows: Vec<String> = result
+        .map(|r| {
+            let r = r.unwrap();
+            format!("{},{}", r.get::<i64>(0).unwrap(), r.get::<i64>(1).unwrap())
+        })
+        .collect();
+    assert_eq!(rows, ["2,2", "2,2", "3,3", "5,2", "5,2"]);
+    assert_eq!(
+        rows_of(&db, "SELECT uy.*, a FROM ux JOIN uy USING (a) WHERE a = 3"),
+        ["3,3,3"]
+    );
+}
+
+fn rows_of(db: &Database, sql: &str) -> Vec<String> {
+    rows(db, sql)
+}

--- a/tests/named_window_extension_test.rs
+++ b/tests/named_window_extension_test.rs
@@ -1,0 +1,81 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! OVER (w ...) builds on a named window: it keeps the window's partition
+//! and takes its own ORDER BY, where the window has none, and its own frame.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE hx (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO hx VALUES (1, 1, 10), (2, 1, 11), (3, 2, 50), (4, 3, 30), (5, 3, 40), (6, 3, 5)",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn pairs(db: &Database, sql: &str) -> Vec<(i64, i64)> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            (r.get::<i64>(0).unwrap(), r.get::<i64>(1).unwrap())
+        })
+        .collect()
+}
+
+#[test]
+fn test_a_frame_on_top_of_a_named_window() {
+    let db = setup("named_window_frame");
+    assert_eq!(
+        pairs(
+            &db,
+            "SELECT id, SUM(b) OVER (w ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM hx WINDOW w AS (PARTITION BY a ORDER BY id) ORDER BY id"
+        ),
+        [(1, 10), (2, 21), (3, 50), (4, 30), (5, 70), (6, 45)]
+    );
+    assert_eq!(
+        pairs(
+            &db,
+            "SELECT id, SUM(b) OVER (w ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM hx WINDOW w AS (PARTITION BY a ORDER BY id) ORDER BY id"
+        ),
+        [(1, 21), (2, 21), (3, 50), (4, 75), (5, 75), (6, 75)]
+    );
+}
+
+#[test]
+fn test_an_order_by_on_top_of_a_partition_only_window() {
+    let db = setup("named_window_order");
+    assert_eq!(
+        pairs(
+            &db,
+            "SELECT id, RANK() OVER (w ORDER BY b DESC) FROM hx WINDOW w AS (PARTITION BY a) ORDER BY id"
+        ),
+        [(1, 2), (2, 1), (3, 1), (4, 2), (5, 1), (6, 3)]
+    );
+    assert_eq!(
+        pairs(
+            &db,
+            "SELECT id, COUNT(*) OVER (w) FROM hx WINDOW w AS (PARTITION BY a) ORDER BY id"
+        ),
+        [(1, 2), (2, 2), (3, 1), (4, 3), (5, 3), (6, 3)]
+    );
+}

--- a/tests/named_window_extension_test.rs
+++ b/tests/named_window_extension_test.rs
@@ -79,3 +79,19 @@ fn test_an_order_by_on_top_of_a_partition_only_window() {
         [(1, 2), (2, 2), (3, 1), (4, 3), (5, 3), (6, 3)]
     );
 }
+
+#[test]
+fn test_two_extensions_of_one_window_stay_apart() {
+    let db = setup("named_window_apart");
+    // rn by id within a: 1,2 | 1 | 1,2,3 ; sorting by the reverse numbering
+    // puts the last row of each partition first
+    let ids: Vec<i64> = db
+        .query(
+            "SELECT id, ROW_NUMBER() OVER (w ORDER BY id) AS rn FROM hx WINDOW w AS (PARTITION BY a) ORDER BY ROW_NUMBER() OVER (w ORDER BY id DESC), id",
+            (),
+        )
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect();
+    assert_eq!(ids, [2, 3, 6, 1, 5, 4]);
+}

--- a/tests/nested_join_outer_scope_test.rs
+++ b/tests/nested_join_outer_scope_test.rs
@@ -1,0 +1,70 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A correlated subquery joining three tables keeps every joined table in
+//! its own scope, so only the parent's column is bound from the outer row.
+
+use stoolap::Database;
+
+fn rows(db: &Database, sql: &str) -> Vec<Vec<Option<i64>>> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap())
+        .map(|r| {
+            (0..r.len())
+                .map(|i| r.get::<Option<i64>>(i).unwrap())
+                .collect()
+        })
+        .collect()
+}
+
+#[test]
+fn test_three_table_join_inside_correlated_subquery() {
+    let db = Database::open("memory://nested_join_outer_scope").unwrap();
+    db.execute("CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO x VALUES (1, 1), (2, 2), (3, 3)", ())
+        .unwrap();
+    for t in ["p", "q", "r"] {
+        db.execute(
+            &format!("CREATE TABLE {t} (id INTEGER PRIMARY KEY, a INTEGER)"),
+            (),
+        )
+        .unwrap();
+        db.execute(&format!("INSERT INTO {t} VALUES (1, 1), (2, 2)"), ())
+            .unwrap();
+    }
+    let join = "FROM p JOIN q ON p.id = q.id JOIN r ON q.id = r.id";
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT a, (SELECT COUNT(*) {join} WHERE p.a = x.a) FROM x ORDER BY a")
+        ),
+        [[Some(1), Some(1)], [Some(2), Some(1)], [Some(3), Some(0)]]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT a, (SELECT COUNT(*) {join} WHERE r.a = x.a) FROM x ORDER BY a")
+        ),
+        [[Some(1), Some(1)], [Some(2), Some(1)], [Some(3), Some(0)]]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT COUNT(*) FROM x WHERE EXISTS (SELECT 1 {join} WHERE p.a = x.a)")
+        ),
+        [[Some(2)]]
+    );
+}

--- a/tests/nested_outer_reference_test.rs
+++ b/tests/nested_outer_reference_test.rs
@@ -1,0 +1,91 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A subquery whose only tie to the parent row sits in a subquery of its
+//! own is still correlated: it is run once per parent row, in WHERE as it
+//! already was in the select list.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE nx (id INTEGER PRIMARY KEY, b INTEGER, s TEXT)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE ny (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER, s TEXT)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO nx VALUES (1, 5, 'p'), (2, 9, 'q'), (3, 1, 'p'), (4, 4, 'q'), (5, 7, 'r')",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO ny VALUES (1, 2, 10, 'p'), (2, 5, 2, 'q'), (3, 3, 6, 'p'), (4, 2, 8, 'r'), (5, NULL, 1, 'q')",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn ids(db: &Database, sql: &str) -> Vec<i64> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect()
+}
+
+#[test]
+fn test_a_scalar_subquery_tied_to_the_parent_through_its_own_subquery() {
+    let db = setup("nested_outer_scalar");
+    // the least a among ny rows sharing the parent's s: p and r give 2, q gives 5;
+    // the mean b at a = 2 is 9, at a = 5 it is 2
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM nx WHERE b > (SELECT AVG(b) FROM ny WHERE ny.a = (SELECT MIN(a) FROM ny WHERE ny.s = nx.s)) ORDER BY id"
+        ),
+        [2, 4]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM nx WHERE b > (SELECT AVG(b) FROM ny WHERE ny.a IN (SELECT MIN(z.a) FROM ny z WHERE z.s = nx.s)) ORDER BY id"
+        ),
+        [2, 4]
+    );
+}
+
+#[test]
+fn test_an_exists_tied_to_the_parent_through_its_own_subquery() {
+    let db = setup("nested_outer_exists");
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM nx WHERE EXISTS (SELECT 1 FROM ny WHERE ny.a = (SELECT MIN(a) FROM ny WHERE ny.s = nx.s) AND ny.b > 5) ORDER BY id"
+        ),
+        [1, 3, 5]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM nx WHERE NOT EXISTS (SELECT 1 FROM ny WHERE ny.a = (SELECT MIN(a) FROM ny WHERE ny.s = nx.s) AND ny.b > 5) ORDER BY id"
+        ),
+        [2, 4]
+    );
+}

--- a/tests/nested_outer_reference_test.rs
+++ b/tests/nested_outer_reference_test.rs
@@ -89,3 +89,35 @@ fn test_an_exists_tied_to_the_parent_through_its_own_subquery() {
         [2, 4]
     );
 }
+
+#[test]
+fn test_a_subquery_tied_to_the_parent_only_through_its_order_by() {
+    let db = Database::open("memory://nested_outer_order_by").unwrap();
+    db.execute("CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO x VALUES (1, 0)", ()).unwrap();
+    db.execute("CREATE TABLE y (id INTEGER PRIMARY KEY, b INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO y VALUES (1, 1), (2, 2)", ())
+        .unwrap();
+    db.execute("CREATE TABLE z (id INTEGER PRIMARY KEY, c INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO z VALUES (1, 1), (2, 2)", ())
+        .unwrap();
+    // The nearest z.c to each y.b is y.b itself, so every y row matches
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT (SELECT COUNT(*) FROM y WHERE y.b = \
+             (SELECT z.c + x.a FROM z ORDER BY ABS(z.c - y.b) LIMIT 1)) FROM x"
+        ),
+        [2]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT COUNT(*) FROM y WHERE y.b = (SELECT z.c FROM z ORDER BY ABS(z.c - y.b) LIMIT 1)"
+        ),
+        [2]
+    );
+}

--- a/tests/nested_subquery_binding_test.rs
+++ b/tests/nested_subquery_binding_test.rs
@@ -1,0 +1,74 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A subquery two levels down that reads only the outermost row is bound
+//! to that row and folded once, not run again for every row of the query
+//! that holds it; and the plain conjuncts beside a correlated subquery
+//! still narrow the outer scan.
+
+use std::time::{Duration, Instant};
+use stoolap::Database;
+
+fn count(db: &Database, sql: &str) -> i64 {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .next()
+        .unwrap()
+}
+
+#[test]
+fn test_grandparent_only_subquery_folds_once() {
+    let db = Database::open("memory://nested_subquery_binding").unwrap();
+    for t in ["x", "y"] {
+        db.execute(
+            &format!("CREATE TABLE {t} (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER, s TEXT)"),
+            (),
+        )
+        .unwrap();
+        let rows: Vec<String> = (1..=2500)
+            .map(|i| format!("({i}, {}, {}, 's{}')", i % 40, (i * 3) % 25, i % 30))
+            .collect();
+        for chunk in rows.chunks(500) {
+            db.execute(&format!("INSERT INTO {t} VALUES {}", chunk.join(", ")), ())
+                .unwrap();
+        }
+    }
+
+    let started = Instant::now();
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM x WHERE id <= 20 AND b > \
+             (SELECT AVG(b) FROM y WHERE y.a = (SELECT MIN(a) FROM y WHERE y.s = x.s))"
+        ),
+        10
+    );
+    // Twenty outer rows, one inner fold each: well under a second; the
+    // per-row shape ran the inner subquery fifty thousand times
+    assert!(
+        started.elapsed() < Duration::from_secs(20),
+        "took {:?}",
+        started.elapsed()
+    );
+
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM x WHERE id <= 20 AND EXISTS (SELECT 1 FROM y WHERE y.a = x.a \
+             AND EXISTS (SELECT 1 FROM (SELECT b FROM y z WHERE z.a = x.a) w WHERE w.b > y.b))"
+        ),
+        20
+    );
+}

--- a/tests/not_over_compound_test.rs
+++ b/tests/not_over_compound_test.rs
@@ -1,0 +1,63 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! NOT over AND or OR follows three-valued logic on the storage filter too:
+//! NOT (UNKNOWN AND TRUE) is UNKNOWN, and a row it holds for is not kept.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    // every pairing of a in (NULL, 1, 2) with b in (NULL, 5, 20)
+    db.execute(
+        "INSERT INTO x VALUES (1, NULL, NULL), (2, NULL, 5), (3, NULL, 20), (4, 1, NULL), (5, 1, 5), (6, 1, 20), (7, 2, NULL), (8, 2, 5), (9, 2, 20)",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn count(db: &Database, where_clause: &str) -> i64 {
+    db.query(&format!("SELECT COUNT(*) FROM x WHERE {where_clause}"), ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap()
+}
+
+#[test]
+fn test_not_over_a_conjunction_with_nulls() {
+    let db = setup("not_over_and");
+    // held only where a = 1 AND b > 10 is false outright: a = 2 (three rows),
+    // a = 1 with b = 5, and a NULL with b = 5
+    assert_eq!(count(&db, "NOT (a = 1 AND b > 10)"), 5);
+    assert_eq!(count(&db, "NOT (a = 1 AND b > 10) AND id > 0"), 5);
+    assert_eq!(count(&db, "NOT (a = 1 AND b > 10) OR b = 20"), 7);
+    assert_eq!(count(&db, "NOT (a IS NULL AND b > 10)"), 7);
+}
+
+#[test]
+fn test_not_over_a_disjunction_with_nulls() {
+    let db = setup("not_over_or");
+    // held only where both sides are false outright: a = 2 with b = 5
+    assert_eq!(count(&db, "NOT (a = 1 OR b > 10)"), 1);
+    assert_eq!(count(&db, "NOT (a = 1 OR b > 10) AND id > 0"), 1);
+}

--- a/tests/null_comparison_test.rs
+++ b/tests/null_comparison_test.rs
@@ -149,3 +149,44 @@ fn test_in_and_not_in_over_an_empty_set() {
         2
     );
 }
+
+/// The members of a set are put in order to name it; a NULL among them is
+/// ordered too, rather than tripping the sort
+#[test]
+fn test_a_set_holding_a_null_among_many_members() {
+    let db = Database::open("memory://null_cmp_set_sort").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, k INTEGER, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    // The shape is the one the sort was seen to trip on: enough members
+    // that the sort splits the set, with a NULL landing among them
+    let mut rows = Vec::new();
+    for i in 1..=3000i64 {
+        let k = if i % 47 == 0 {
+            "NULL".to_string()
+        } else {
+            (i % 200).to_string()
+        };
+        let v = if i % 31 == 0 {
+            "NULL".to_string()
+        } else {
+            (i % 90).to_string()
+        };
+        rows.push(format!("({i}, {k}, {v})"));
+    }
+    for chunk in rows.chunks(500) {
+        db.execute(&format!("INSERT INTO t VALUES {}", chunk.join(", ")), ())
+            .unwrap();
+    }
+    let matching = count(
+        &db,
+        "SELECT COUNT(*) FROM t WHERE k IN (SELECT k FROM t WHERE v = 5)",
+    );
+    assert_eq!(matching, 294);
+    let removed = db
+        .execute("DELETE FROM t WHERE k IN (SELECT k FROM t WHERE v = 5)", ())
+        .unwrap();
+    assert_eq!(removed, matching);
+}

--- a/tests/null_comparison_test.rs
+++ b/tests/null_comparison_test.rs
@@ -1,0 +1,99 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Comparing a NULL leaves the answer unknown, so the row is not kept. This
+//! holds when both sides are the same column, when both are NULL, and for
+//! the operators that carry an equality half.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE s (id INTEGER PRIMARY KEY, n INTEGER, m INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO s VALUES (1, 10, 10), (2, 20, NULL), (3, NULL, NULL), (4, NULL, 5)",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn count(db: &Database, sql: &str) -> i64 {
+    db.query(sql, ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap()
+}
+
+fn ids(db: &Database, sql: &str) -> Vec<i64> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| row.unwrap().get(0).unwrap())
+        .collect()
+}
+
+/// A column compared with itself keeps the rows where it holds a value
+#[test]
+fn test_a_column_equals_itself_only_where_it_has_a_value() {
+    let db = setup("null_cmp_self");
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM s WHERE n = n"), 2);
+    assert_eq!(ids(&db, "SELECT id FROM s WHERE n = n ORDER BY id"), [1, 2]);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM s WHERE n <> n"), 0);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM s WHERE n <= n"), 2);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM s WHERE n >= n"), 2);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM s WHERE n < n"), 0);
+}
+
+/// The same reading holds when the comparison is written out in full
+#[test]
+fn test_two_nulls_are_not_equal() {
+    let db = setup("null_cmp_literal");
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM s WHERE NULL = NULL"), 0);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM s WHERE n = NULL"), 0);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM s WHERE NULL <> NULL"), 0);
+}
+
+/// The operators that carry an equality half read a NULL the same way as `=`
+#[test]
+fn test_less_equal_and_greater_equal_do_not_match_two_nulls() {
+    let db = setup("null_cmp_ordered");
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM s WHERE n = m"), 1);
+    assert_eq!(
+        count(&db, "SELECT COUNT(*) FROM s WHERE n <= m"),
+        1,
+        "only the row holding two tens"
+    );
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM s WHERE n >= m"), 1);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM s WHERE n > m"), 0);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM s WHERE n < m"), 0);
+}
+
+/// Subtracting a column from itself is NULL wherever the column is
+#[test]
+fn test_a_column_minus_itself_is_null_where_the_column_is() {
+    let db = setup("null_cmp_subtract");
+    assert_eq!(count(&db, "SELECT COUNT(n - n) FROM s"), 2);
+    assert_eq!(
+        count(&db, "SELECT SUM(n - n) FROM s"),
+        0,
+        "the two rows holding a value each contribute a zero"
+    );
+}

--- a/tests/null_comparison_test.rs
+++ b/tests/null_comparison_test.rs
@@ -97,3 +97,55 @@ fn test_a_column_minus_itself_is_null_where_the_column_is() {
         "the two rows holding a value each contribute a zero"
     );
 }
+
+/// A set holding nothing matches nothing, so NOT IN over it holds for
+/// every row, including the rows the column is NULL in
+#[test]
+fn test_in_and_not_in_over_an_empty_set() {
+    let db = Database::open("memory://null_cmp_empty_set").unwrap();
+    db.execute("CREATE TABLE a (id INTEGER PRIMARY KEY, k INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE b (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO a VALUES (1, 10), (2, 20), (3, NULL)", ())
+        .unwrap();
+    db.execute("INSERT INTO b VALUES (1, 100), (2, NULL)", ())
+        .unwrap();
+
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM a WHERE k NOT IN (SELECT v FROM b WHERE v > 9999)"
+        ),
+        3
+    );
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM a WHERE k NOT IN (SELECT v FROM b WHERE v > 9999) ORDER BY id"
+        ),
+        [1, 2, 3]
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM a WHERE k IN (SELECT v FROM b WHERE v > 9999)"
+        ),
+        0
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM a WHERE k NOT IN (SELECT v FROM b)"
+        ),
+        0,
+        "a set holding a NULL still leaves it unknown"
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM a WHERE k NOT IN (SELECT v FROM b WHERE v IS NOT NULL)"
+        ),
+        2
+    );
+}

--- a/tests/null_times_zero_test.rs
+++ b/tests/null_times_zero_test.rs
@@ -1,0 +1,45 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Multiplying a column by zero is NULL for a NULL column value, so the
+//! simplifier leaves `x * 0` alone instead of folding it to 0.
+
+use stoolap::Database;
+
+#[test]
+fn test_a_null_times_zero_stays_null() {
+    let db = Database::open("memory://null_times_zero").unwrap();
+    db.execute("CREATE TABLE hx (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO hx VALUES (1, 1), (2, 2), (3, NULL)", ())
+        .unwrap();
+    let count = |sql: &str| -> i64 {
+        db.query(sql, ())
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .get(0)
+            .unwrap()
+    };
+    assert_eq!(count("SELECT COUNT(*) FROM hx WHERE a * 0 IS NOT NULL"), 2);
+    assert_eq!(count("SELECT COUNT(*) FROM hx WHERE 0 * a IS NULL"), 1);
+    assert_eq!(count("SELECT COUNT(a * 0) FROM hx"), 2);
+    let values: Vec<Option<i64>> = db
+        .query("SELECT a * 0 FROM hx ORDER BY id", ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<Option<i64>>(0).unwrap())
+        .collect();
+    assert_eq!(values, [Some(0), Some(0), None]);
+}

--- a/tests/order_by_hidden_column_test.rs
+++ b/tests/order_by_hidden_column_test.rs
@@ -237,3 +237,54 @@ fn test_sorting_by_a_function_of_an_expression() {
     assert_eq!(columns, 1);
     assert!(widths.iter().all(|w| *w == 1), "{widths:?}");
 }
+
+/// A key the sort has to work out for itself does not cost the keys that
+/// already have a column
+#[test]
+fn test_a_deferred_key_beside_a_computed_one() {
+    let db = setup("order_by_mixed_keys");
+    assert_eq!(
+        values(&db, "SELECT n AS x FROM t ORDER BY ABS(n - 20), x + 0"),
+        ["20", "10", "30", "40"],
+        "the first key still reads its column"
+    );
+    assert_eq!(
+        values(&db, "SELECT n AS x FROM t ORDER BY ABS(n - 20)"),
+        ["20", "30", "10", "40"]
+    );
+    assert_eq!(
+        values(&db, "SELECT n AS x FROM t ORDER BY id DESC, x + 0"),
+        ["40", "20", "10", "30"]
+    );
+}
+
+/// Two expressions that differ only in the case of a string literal are two
+/// expressions, and each reads its own column
+#[test]
+fn test_keys_differing_only_in_the_case_of_a_literal() {
+    let db = Database::open("memory://order_by_literal_case").unwrap();
+    db.execute("CREATE TABLE u (id INTEGER PRIMARY KEY, g TEXT)", ())
+        .unwrap();
+    for (id, g) in [(1i64, "A"), (2, "a"), (3, "B")] {
+        db.execute("INSERT INTO u VALUES ($1, $2)", (id, g))
+            .unwrap();
+    }
+    let ids = |sql: &str| -> Vec<String> {
+        db.query(sql, ())
+            .unwrap()
+            .map(|row| row.unwrap().get::<i64>(0).unwrap().to_string())
+            .collect()
+    };
+    assert_eq!(
+        ids("SELECT id FROM u ORDER BY INSTR(g, 'a'), INSTR(g, 'A'), id"),
+        ["3", "1", "2"]
+    );
+    assert_eq!(
+        ids("SELECT id FROM u ORDER BY INSTR(g, 'a'), id"),
+        ["1", "3", "2"]
+    );
+    assert_eq!(
+        ids("SELECT id FROM u ORDER BY INSTR(g, 'A'), id"),
+        ["2", "3", "1"]
+    );
+}

--- a/tests/order_by_hidden_column_test.rs
+++ b/tests/order_by_hidden_column_test.rs
@@ -179,3 +179,61 @@ fn test_sorting_by_a_correlated_subquery() {
         5
     );
 }
+
+/// An expression naming an alias reads it, since the projection brings the
+/// name into scope before the sort runs
+#[test]
+fn test_sorting_by_an_expression_over_a_select_alias() {
+    let db = setup("order_by_alias_expression");
+    assert_eq!(
+        values(&db, "SELECT n AS x FROM t ORDER BY x + 0"),
+        ["10", "20", "30", "40"]
+    );
+    assert_eq!(
+        values(&db, "SELECT n AS x FROM t ORDER BY x * 1 DESC"),
+        ["40", "30", "20", "10"]
+    );
+    assert_eq!(
+        values(&db, "SELECT n AS x FROM t ORDER BY ABS(x)"),
+        ["10", "20", "30", "40"]
+    );
+}
+
+/// Inside an expression a source column wins over an alias of the same
+/// name; a bare name in ORDER BY reads the alias
+#[test]
+fn test_a_source_column_wins_over_an_alias_of_the_same_name() {
+    let db = setup("order_by_alias_shadow");
+    assert_eq!(
+        values(&db, "SELECT n AS id FROM t ORDER BY id + 0"),
+        ["30", "10", "20", "40"],
+        "id + 0 reads the table's id"
+    );
+    assert_eq!(
+        values(&db, "SELECT n AS id FROM t ORDER BY id"),
+        ["10", "20", "30", "40"],
+        "a bare id reads the alias"
+    );
+}
+
+/// A function of anything but a bare column is read from the column the
+/// projection names after the whole call
+#[test]
+fn test_sorting_by_a_function_of_an_expression() {
+    let db = setup("order_by_function_expression");
+    assert_eq!(
+        values(&db, "SELECT id FROM t ORDER BY ABS(n - 20)"),
+        ["3", "1", "2", "4"]
+    );
+    assert_eq!(
+        values(&db, "SELECT g FROM t ORDER BY ABS(n - 20)"),
+        ["b", "b", "a", "a"]
+    );
+    assert_eq!(
+        values(&db, "SELECT id FROM t ORDER BY ABS(n)"),
+        ["2", "3", "1", "4"]
+    );
+    let (columns, widths) = widths(&db, "SELECT id FROM t ORDER BY ABS(n - 20)");
+    assert_eq!(columns, 1);
+    assert!(widths.iter().all(|w| *w == 1), "{widths:?}");
+}

--- a/tests/order_by_hidden_column_test.rs
+++ b/tests/order_by_hidden_column_test.rs
@@ -96,3 +96,86 @@ fn test_sorting_by_a_column_the_select_leaves_out() {
         ["b", "a", "b", "a"]
     );
 }
+
+/// Sorting by an expression the SELECT leaves out sorts by it
+#[test]
+fn test_sorting_by_an_expression() {
+    let db = Database::open("memory://order_by_expression").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER, f FLOAT, s TEXT)",
+        (),
+    )
+    .unwrap();
+    for (id, n, f, s) in [
+        (1i64, 10i64, 1.25f64, "b"),
+        (2, 20, -2.5, "a"),
+        (3, 30, 0.0, "c"),
+        (4, 40, 10.0, "d"),
+        (5, 50, -0.5, "e"),
+    ] {
+        db.execute("INSERT INTO t VALUES ($1, $2, $3, $4)", (id, n, f, s))
+            .unwrap();
+    }
+    assert_eq!(
+        values(&db, "SELECT id FROM t ORDER BY ABS(f)"),
+        ["3", "5", "1", "2", "4"],
+        "a function of a column the SELECT leaves out"
+    );
+    assert_eq!(
+        values(&db, "SELECT id FROM t ORDER BY n * -1"),
+        ["5", "4", "3", "2", "1"],
+        "arithmetic"
+    );
+    assert_eq!(
+        values(&db, "SELECT id FROM t ORDER BY -n"),
+        ["5", "4", "3", "2", "1"],
+        "a negation"
+    );
+    assert_eq!(
+        values(&db, "SELECT id FROM t ORDER BY s || ''"),
+        ["2", "1", "3", "4", "5"],
+        "a text expression"
+    );
+    assert_eq!(
+        values(&db, "SELECT id FROM t ORDER BY ABS(f) LIMIT 3"),
+        ["3", "5", "1"],
+        "with a limit"
+    );
+    let (columns, row_widths) = widths(&db, "SELECT id FROM t ORDER BY ABS(f)");
+    assert!(
+        row_widths.iter().all(|width| *width == columns),
+        "the expression stays out of the rows: {columns} columns, rows {row_widths:?}"
+    );
+}
+
+/// A subquery in the ORDER BY reads the row it sorts, not one value for all
+#[test]
+fn test_sorting_by_a_correlated_subquery() {
+    let db = Database::open("memory://order_by_subquery").unwrap();
+    db.execute("CREATE TABLE a (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    db.execute("CREATE TABLE b (id INTEGER PRIMARY KEY, a_id INTEGER)", ())
+        .unwrap();
+    for id in 1..=5i64 {
+        db.execute("INSERT INTO a VALUES ($1)", (id,)).unwrap();
+    }
+    for (id, a_id) in [(1i64, 1i64), (2, 1), (3, 2), (4, 4)] {
+        db.execute("INSERT INTO b VALUES ($1, $2)", (id, a_id))
+            .unwrap();
+    }
+    assert_eq!(
+        values(
+            &db,
+            "SELECT id FROM a ORDER BY (SELECT COUNT(*) FROM b WHERE b.a_id = a.id) DESC, id"
+        ),
+        ["1", "2", "4", "3", "5"]
+    );
+    assert_eq!(
+        values(
+            &db,
+            "SELECT id, (SELECT COUNT(*) FROM b WHERE b.a_id = a.id) AS c FROM a ORDER BY c DESC, id"
+        )
+        .len(),
+        5
+    );
+}

--- a/tests/order_by_hidden_column_test.rs
+++ b/tests/order_by_hidden_column_test.rs
@@ -1,0 +1,98 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Sorting by a column the SELECT leaves out reads that column, and the
+//! rows go out with the columns the SELECT asked for and no others.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, g TEXT, n INTEGER)",
+        (),
+    )
+    .unwrap();
+    for (id, g, n) in [(1i64, "b", 30i64), (2, "a", 10), (3, "b", 20), (4, "a", 40)] {
+        db.execute("INSERT INTO t VALUES ($1, $2, $3)", (id, g, n))
+            .unwrap();
+    }
+    db
+}
+
+/// The column count the result declares and the width of its rows agree
+fn widths(db: &Database, sql: &str) -> (usize, Vec<usize>) {
+    let rows = db.query(sql, ()).unwrap();
+    let columns = rows.columns().len();
+    (columns, rows.map(|row| row.unwrap().len()).collect())
+}
+
+fn values(db: &Database, sql: &str) -> Vec<String> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (0..row.len())
+                .map(|i| {
+                    row.get::<Option<String>>(i)
+                        .unwrap()
+                        .unwrap_or_else(|| "NULL".into())
+                })
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect()
+}
+
+#[test]
+fn test_sort_key_stays_out_of_the_rows() {
+    let db = setup("order_by_hidden_column");
+    for sql in [
+        "SELECT x.g FROM t x ORDER BY x.id",
+        "SELECT x.g FROM t x ORDER BY x.n",
+        "SELECT x.g FROM t x ORDER BY x.id DESC",
+        "SELECT x.g FROM t x ORDER BY x.n, x.id",
+        "SELECT x.g, x.n FROM t x ORDER BY x.id",
+        "SELECT g FROM t ORDER BY id",
+        "SELECT g FROM t ORDER BY n",
+        "SELECT x.g FROM t x ORDER BY x.n LIMIT 2",
+        "SELECT x.g FROM t x ORDER BY x.g",
+        "SELECT DISTINCT x.g FROM t x ORDER BY x.g",
+    ] {
+        let (columns, row_widths) = widths(&db, sql);
+        assert!(
+            row_widths.iter().all(|width| *width == columns),
+            "{sql}: {columns} columns, rows {row_widths:?}"
+        );
+    }
+}
+
+#[test]
+fn test_sorting_by_a_column_the_select_leaves_out() {
+    let db = setup("order_by_hidden_column_values");
+    assert_eq!(
+        values(&db, "SELECT x.g FROM t x ORDER BY x.n"),
+        ["a", "b", "b", "a"],
+        "by the column's own order"
+    );
+    assert_eq!(
+        values(&db, "SELECT x.g FROM t x ORDER BY x.n DESC"),
+        ["a", "b", "b", "a"],
+        "and its reverse"
+    );
+    assert_eq!(
+        values(&db, "SELECT x.g FROM t x ORDER BY x.id"),
+        ["b", "a", "b", "a"]
+    );
+}

--- a/tests/order_by_hidden_derived_column_test.rs
+++ b/tests/order_by_hidden_derived_column_test.rs
@@ -1,0 +1,110 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! ORDER BY may name a column of a view, a derived table or a CTE that the
+//! select list leaves out; the sort still reads it.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE hx (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO hx VALUES (1, 1, 10), (2, 1, 11), (3, 2, 50), (4, 3, 30), (5, NULL, 40), (6, 3, 5)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE VIEW va AS SELECT a, COUNT(*) AS c, SUM(b) AS sb FROM hx GROUP BY a",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE VIEW vp AS SELECT id, a, b * 2 AS d FROM hx", ())
+        .unwrap();
+    db
+}
+
+fn ints(db: &Database, sql: &str) -> Vec<i64> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect()
+}
+
+#[test]
+fn test_a_view_column_outside_the_select_list_sorts() {
+    let db = setup("hidden_view_column");
+    // sums: a = 2 gives 50, a = 3 gives 35, a = 1 gives 21
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT a FROM va WHERE a IS NOT NULL ORDER BY sb DESC, a LIMIT 3"
+        ),
+        [2, 3, 1]
+    );
+    assert_eq!(
+        ints(&db, "SELECT id FROM vp ORDER BY d DESC, id"),
+        [3, 5, 4, 2, 1, 6]
+    );
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT id FROM vp WHERE a IS NOT NULL ORDER BY d, id LIMIT 2"
+        ),
+        [6, 1]
+    );
+    let columns: Vec<String> = db
+        .query("SELECT a FROM va ORDER BY sb DESC", ())
+        .unwrap()
+        .columns()
+        .to_vec();
+    assert_eq!(columns, ["a"]);
+}
+
+#[test]
+fn test_a_derived_table_or_cte_column_outside_the_select_list_sorts() {
+    let db = setup("hidden_derived_column");
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT a FROM (SELECT a, SUM(b) AS sb FROM hx GROUP BY a) t WHERE a IS NOT NULL ORDER BY sb DESC, a"
+        ),
+        [2, 3, 1]
+    );
+    assert_eq!(
+        ints(
+            &db,
+            "WITH t AS (SELECT a, SUM(b) AS sb FROM hx GROUP BY a) SELECT a FROM t WHERE a IS NOT NULL ORDER BY sb DESC, a"
+        ),
+        [2, 3, 1]
+    );
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT id FROM (SELECT id, a, b FROM hx) t ORDER BY t.b DESC, id LIMIT 2"
+        ),
+        [3, 5]
+    );
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT DISTINCT a FROM (SELECT id, a, b FROM hx) t WHERE a IS NOT NULL ORDER BY a DESC"
+        ),
+        [3, 2, 1]
+    );
+}

--- a/tests/order_by_hidden_derived_column_test.rs
+++ b/tests/order_by_hidden_derived_column_test.rs
@@ -108,3 +108,17 @@ fn test_a_derived_table_or_cte_column_outside_the_select_list_sorts() {
         [3, 2, 1]
     );
 }
+
+#[test]
+fn test_an_alias_inside_an_in_list_sorts_the_projected_row() {
+    let db = Database::open("memory://order_by_alias_in_list").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, -1), (2, 1)", ())
+        .unwrap();
+    // z is 1 for a = -1, so that row sorts first
+    assert_eq!(
+        ints(&db, "SELECT -a AS z FROM t ORDER BY 1 IN (z, 99), a"),
+        [-1, 1]
+    );
+}

--- a/tests/order_by_subquery_test.rs
+++ b/tests/order_by_subquery_test.rs
@@ -1,0 +1,95 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A subquery in ORDER BY is a sort key like any other: a correlated one
+//! reads the row it sorts, whether or not the select list carries the
+//! columns it reads, and one that reads nothing of the row is run once.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE ox (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE oy (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    db.execute(
+        "INSERT INTO ox VALUES (1, 1), (2, 2), (3, 3), (4, NULL), (5, 2)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO oy VALUES (1, 2), (2, 5), (3, 3), (4, 2), (5, NULL)",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn ids(db: &Database, sql: &str) -> Vec<i64> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect()
+}
+
+#[test]
+fn test_a_correlated_subquery_sorts_rows_the_select_list_hides_the_key_of() {
+    let db = setup("order_by_correlated_subquery");
+    let by_matches = "(SELECT COUNT(*) FROM oy WHERE oy.a = ox.a)";
+    assert_eq!(
+        ids(
+            &db,
+            &format!("SELECT id FROM ox ORDER BY {by_matches} DESC, id")
+        ),
+        [2, 5, 3, 1, 4]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            &format!("SELECT id FROM ox ORDER BY {by_matches} DESC, id LIMIT 3")
+        ),
+        [2, 5, 3]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            &format!("SELECT id FROM ox WHERE a IS NOT NULL ORDER BY {by_matches} * 10 + id DESC")
+        ),
+        [5, 2, 3, 1]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            &format!("SELECT id, a FROM ox ORDER BY {by_matches} DESC, id")
+        ),
+        [2, 5, 3, 1, 4]
+    );
+}
+
+#[test]
+fn test_a_subquery_that_reads_nothing_of_the_row_is_a_constant_key() {
+    let db = setup("order_by_plain_subquery");
+    assert_eq!(
+        ids(&db, "SELECT id FROM ox ORDER BY (SELECT 7) - id"),
+        [5, 4, 3, 2, 1]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM ox ORDER BY (SELECT MAX(a) FROM oy) - id, id"
+        ),
+        [5, 4, 3, 2, 1]
+    );
+}

--- a/tests/order_by_window_test.rs
+++ b/tests/order_by_window_test.rs
@@ -1,0 +1,102 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A window function in ORDER BY is a sort key like any other, whether or
+//! not the select list carries it, beside a star included.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE hx (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO hx VALUES (1, 1, 10), (2, 1, 11), (3, 2, 50), (4, 3, 30), (5, NULL, 40), (6, 3, 5)",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn ids(db: &Database, sql: &str) -> Vec<i64> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect()
+}
+
+#[test]
+fn test_a_window_in_order_by_sorts_the_rows() {
+    let db = setup("order_by_window");
+    // by b descending: 3, 5, 4, 2, 1, 6
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM hx ORDER BY ROW_NUMBER() OVER (ORDER BY b DESC)"
+        ),
+        [3, 5, 4, 2, 1, 6]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM hx WHERE b > 8 ORDER BY RANK() OVER (ORDER BY b DESC), id LIMIT 3"
+        ),
+        [3, 5, 4]
+    );
+    // sums by a: 2 gives 50, NULL 40, 3 gives 35, 1 gives 21
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM hx ORDER BY SUM(b) OVER (PARTITION BY a) DESC, id"
+        ),
+        [3, 5, 4, 6, 1, 2]
+    );
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id, ROW_NUMBER() OVER (ORDER BY b DESC) FROM hx ORDER BY ROW_NUMBER() OVER (ORDER BY b DESC) DESC"
+        ),
+        [6, 1, 2, 4, 5, 3]
+    );
+}
+
+#[test]
+fn test_the_hidden_window_column_is_dropped_beside_a_star() {
+    let db = setup("order_by_window_star");
+    let result = db
+        .query(
+            "SELECT * FROM hx ORDER BY ROW_NUMBER() OVER (ORDER BY b DESC) LIMIT 2",
+            (),
+        )
+        .unwrap();
+    assert_eq!(result.columns(), ["id", "a", "b"]);
+    let rows: Vec<Vec<Option<i64>>> = result
+        .map(|r| {
+            let r = r.unwrap();
+            (0..r.len())
+                .map(|i| r.get::<Option<i64>>(i).unwrap())
+                .collect()
+        })
+        .collect();
+    assert_eq!(
+        rows,
+        [
+            vec![Some(3), Some(2), Some(50)],
+            vec![Some(5), None, Some(40)]
+        ]
+    );
+}

--- a/tests/order_by_window_test.rs
+++ b/tests/order_by_window_test.rs
@@ -100,3 +100,15 @@ fn test_the_hidden_window_column_is_dropped_beside_a_star() {
         ]
     );
 }
+
+#[test]
+fn test_a_subquery_inside_an_order_by_window_is_read() {
+    let db = setup("order_by_window_subquery");
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM hx ORDER BY RANK() OVER (ORDER BY (SELECT -hx.id)), id"
+        ),
+        [6, 5, 4, 3, 2, 1]
+    );
+}

--- a/tests/reinsert_deleted_key_in_transaction_test.rs
+++ b/tests/reinsert_deleted_key_in_transaction_test.rs
@@ -115,3 +115,15 @@ fn test_a_key_still_held_is_refused() {
     db.execute("COMMIT", ()).unwrap();
     assert_eq!(rows(&db), [(2, 8, 20), (3, 7, 30), (9, 1, 10)]);
 }
+
+#[test]
+fn test_unique_values_are_swapped_through_delete_and_reinsert() {
+    let db = setup("reinsert_swap_unique", false);
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("DELETE FROM x WHERE id IN (1, 2)", ()).unwrap();
+    db.execute("INSERT INTO x VALUES (1, 8, 20), (2, 7, 10)", ())
+        .unwrap();
+    db.execute("COMMIT", ()).unwrap();
+    assert_eq!(rows(&db), [(1, 8, 20), (2, 7, 10), (3, 7, 30)]);
+    assert!(db.execute("INSERT INTO x VALUES (4, 1, 10)", ()).is_err());
+}

--- a/tests/reinsert_deleted_key_in_transaction_test.rs
+++ b/tests/reinsert_deleted_key_in_transaction_test.rs
@@ -1,0 +1,117 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A key a transaction has deleted may be taken again by the same
+//! transaction: the primary key check and the unique index check look past
+//! rows the transaction itself has deleted.
+
+use stoolap::Database;
+
+fn setup(name: &str, index: bool) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER, u INTEGER UNIQUE)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO x VALUES (1, 7, 10), (2, 8, 20), (3, 7, 30)",
+        (),
+    )
+    .unwrap();
+    if index {
+        db.execute("CREATE INDEX ix_a ON x (a)", ()).unwrap();
+    }
+    db
+}
+
+fn rows(db: &Database) -> Vec<(i64, i64, i64)> {
+    db.query("SELECT id, a, u FROM x ORDER BY id", ())
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            (
+                r.get::<i64>(0).unwrap(),
+                r.get::<i64>(1).unwrap(),
+                r.get::<i64>(2).unwrap(),
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn test_a_deleted_key_is_taken_again_and_committed() {
+    for index in [false, true] {
+        let db = setup(&format!("reinsert_commit_{index}"), index);
+        db.execute("BEGIN", ()).unwrap();
+        assert_eq!(db.execute("DELETE FROM x WHERE a = 7", ()).unwrap(), 2);
+        assert_eq!(
+            db.execute("INSERT INTO x VALUES (1, 7, 100), (3, 9, 30)", ())
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            rows(&db),
+            [(1, 7, 100), (2, 8, 20), (3, 9, 30)],
+            "index {index}"
+        );
+        let by_index: i64 = db
+            .query("SELECT COUNT(*) FROM x WHERE a = 7", ())
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert_eq!(by_index, 1, "index {index}");
+        db.execute("COMMIT", ()).unwrap();
+        assert_eq!(
+            rows(&db),
+            [(1, 7, 100), (2, 8, 20), (3, 9, 30)],
+            "index {index}"
+        );
+        let by_index: i64 = db
+            .query("SELECT COUNT(*) FROM x WHERE a = 9", ())
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert_eq!(by_index, 1, "index {index}");
+    }
+}
+
+#[test]
+fn test_a_rolled_back_reinsert_leaves_the_old_row() {
+    let db = setup("reinsert_rollback", true);
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("DELETE FROM x WHERE id = 1", ()).unwrap();
+    db.execute("INSERT INTO x VALUES (1, 7, 100)", ()).unwrap();
+    db.execute("ROLLBACK", ()).unwrap();
+    assert_eq!(rows(&db), [(1, 7, 10), (2, 8, 20), (3, 7, 30)]);
+}
+
+#[test]
+fn test_a_key_still_held_is_refused() {
+    let db = setup("reinsert_refused", false);
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("DELETE FROM x WHERE id = 1", ()).unwrap();
+    assert!(db.execute("INSERT INTO x VALUES (2, 1, 1)", ()).is_err());
+    // the unique value of the deleted row is free, another row's is not
+    db.execute("INSERT INTO x VALUES (9, 1, 10)", ()).unwrap();
+    assert!(db.execute("INSERT INTO x VALUES (8, 1, 20)", ()).is_err());
+    db.execute("COMMIT", ()).unwrap();
+    assert_eq!(rows(&db), [(2, 8, 20), (3, 7, 30), (9, 1, 10)]);
+}

--- a/tests/set_operation_order_limit_test.rs
+++ b/tests/set_operation_order_limit_test.rs
@@ -1,0 +1,102 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! ORDER BY, LIMIT and OFFSET at the end of a set operation apply to the
+//! whole of it, not to its first branch.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE y (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO x VALUES (1, 1, 10), (2, 2, 20), (3, 1, 30)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO y VALUES (1, 1, 5), (2, 1, 50), (3, 2, 7), (4, 3, 9)",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn ints(db: &Database, sql: &str) -> Vec<i64> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect()
+}
+
+#[test]
+fn test_order_by_and_limit_apply_to_the_whole_union() {
+    let db = setup("set_op_order_limit");
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT a FROM x WHERE a > 0 UNION SELECT a FROM y WHERE a > 0 ORDER BY a DESC LIMIT 2"
+        ),
+        [3, 2]
+    );
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT a FROM x WHERE a > 0 INTERSECT SELECT a FROM y WHERE a > 0 ORDER BY a DESC LIMIT 3"
+        ),
+        [2, 1]
+    );
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT id FROM x WHERE a = 1 UNION ALL SELECT id FROM y WHERE a = 1 ORDER BY id LIMIT 3"
+        ),
+        [1, 1, 2]
+    );
+}
+
+#[test]
+fn test_offset_skips_rows_of_the_whole_union() {
+    let db = setup("set_op_offset");
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT id FROM x UNION ALL SELECT id FROM y ORDER BY id LIMIT 10 OFFSET 5"
+        ),
+        [3, 4]
+    );
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT COUNT(*) FROM (SELECT id FROM x UNION ALL SELECT id FROM y LIMIT 10 OFFSET 5)"
+        ),
+        [2]
+    );
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT COUNT(*) FROM (SELECT id FROM x UNION ALL SELECT id FROM y ORDER BY id LIMIT 2)"
+        ),
+        [2]
+    );
+}

--- a/tests/slt/basic/types.slt
+++ b/tests/slt/basic/types.slt
@@ -185,11 +185,11 @@ SELECT COUNT(*) FROM types_test WHERE i_val = NULL
 ----
 0
 
-# NULL = NULL in stoolap evaluates to true (non-standard behavior)
+# NULL = NULL is unknown, so it keeps no rows
 query I
 SELECT COUNT(*) FROM types_test WHERE NULL = NULL
 ----
-2
+0
 
 statement ok
 DROP TABLE types_test

--- a/tests/string_boundary_test.rs
+++ b/tests/string_boundary_test.rs
@@ -1,0 +1,87 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SUBSTRING opens a window on a string, which may start before it or
+//! reach back from its end, and LIKE reads the character after its escape
+//! as itself whatever that character is. Every answer here is the one
+//! SQLite 3.51 and DuckDB 1.2 both give.
+
+use stoolap::Database;
+
+fn text(db: &Database, sql: &str) -> String {
+    db.query(sql, ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get::<String>(0)
+        .unwrap()
+}
+
+fn count(db: &Database, sql: &str) -> i64 {
+    db.query(sql, ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap()
+}
+
+#[test]
+fn test_substring_window() {
+    let db = Database::open("memory://string_boundary_substr").unwrap();
+    for (sql, expected) in [
+        ("SELECT SUBSTR('abcdef', 2, 3)", "bcd"),
+        ("SELECT SUBSTR('abcdef', -3, 2)", "de"),
+        ("SELECT SUBSTR('abcdef', -3)", "def"),
+        ("SELECT SUBSTR('abcdef', -1, 5)", "f"),
+        ("SELECT SUBSTR('abcdef', -10, 3)", ""),
+        ("SELECT SUBSTR('abcdef', 0, 2)", "a"),
+        ("SELECT SUBSTR('abcdef', 0)", "abcdef"),
+        ("SELECT SUBSTR('abcdef', 2, 0)", ""),
+        ("SELECT SUBSTR('abcdef', 3, 100)", "cdef"),
+        ("SELECT SUBSTR('abcdef', 3, -2)", "ab"),
+        ("SELECT SUBSTR('abcdef', 7, 2)", ""),
+    ] {
+        assert_eq!(text(&db, sql), expected, "{sql}");
+    }
+}
+
+#[test]
+fn test_like_escape_reads_the_next_character_as_itself() {
+    let db = Database::open("memory://string_boundary_like").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, s TEXT)", ())
+        .unwrap();
+    for (id, s) in [
+        (1i64, "x,y"),
+        (2, "a%b"),
+        (3, "c_d"),
+        (4, "e!f"),
+        (5, "plain"),
+    ] {
+        db.execute("INSERT INTO t VALUES ($1, $2)", (id, s))
+            .unwrap();
+    }
+    for (sql, expected) in [
+        ("SELECT COUNT(*) FROM t WHERE s LIKE '%!,%' ESCAPE '!'", 1),
+        ("SELECT COUNT(*) FROM t WHERE s LIKE '%!%%' ESCAPE '!'", 1),
+        ("SELECT COUNT(*) FROM t WHERE s LIKE '%!_%' ESCAPE '!'", 1),
+        ("SELECT COUNT(*) FROM t WHERE s LIKE '%!!%' ESCAPE '!'", 1),
+        ("SELECT COUNT(*) FROM t WHERE s LIKE '%_%'", 5),
+        ("SELECT COUNT(*) FROM t WHERE s LIKE 'a%b'", 1),
+    ] {
+        assert_eq!(count(&db, sql), expected, "{sql}");
+    }
+}

--- a/tests/string_boundary_test.rs
+++ b/tests/string_boundary_test.rs
@@ -114,3 +114,13 @@ fn test_a_window_at_the_limits_of_the_type() {
         assert_eq!(text(&db, sql), expected, "{sql}");
     }
 }
+
+/// There is nothing to find in a string that holds no characters
+#[test]
+fn test_replacing_a_string_that_holds_nothing() {
+    let db = Database::open("memory://string_boundary_replace").unwrap();
+    assert_eq!(text(&db, "SELECT REPLACE('abc', '', 'x')"), "abc");
+    assert_eq!(text(&db, "SELECT REPLACE('', '', 'x')"), "");
+    assert_eq!(text(&db, "SELECT REPLACE('aaa', 'a', '')"), "");
+    assert_eq!(text(&db, "SELECT REPLACE('abc', 'b', 'xy')"), "axyc");
+}

--- a/tests/string_boundary_test.rs
+++ b/tests/string_boundary_test.rs
@@ -85,3 +85,32 @@ fn test_like_escape_reads_the_next_character_as_itself() {
         assert_eq!(count(&db, sql), expected, "{sql}");
     }
 }
+
+/// A start or a length at the limits of the type runs past an end of the
+/// string, which is the same as reaching that end
+#[test]
+fn test_a_window_at_the_limits_of_the_type() {
+    let db = Database::open("memory://string_boundary_limits").unwrap();
+    for (sql, expected) in [
+        ("SELECT SUBSTR('abc', 1, 9223372036854775807)", "abc"),
+        (
+            "SELECT '[' || SUBSTR('abc', 9223372036854775807, 2) || ']'",
+            "[]",
+        ),
+        (
+            "SELECT '[' || SUBSTR('abc', 3, -9223372036854775808) || ']'",
+            "[ab]",
+        ),
+        ("SELECT SUBSTR('abc', -2, 9223372036854775807)", "bc"),
+        (
+            "SELECT '[' || SUBSTR('abc', -9223372036854775808, 3) || ']'",
+            "[]",
+        ),
+        (
+            "SELECT '[' || SUBSTR('abc', -9223372036854775807, 9223372036854775807) || ']'",
+            "[abc]",
+        ),
+    ] {
+        assert_eq!(text(&db, sql), expected, "{sql}");
+    }
+}

--- a/tests/table_level_primary_key_test.rs
+++ b/tests/table_level_primary_key_test.rs
@@ -1,0 +1,80 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A PRIMARY KEY given at table level is a key: over one column it is the
+//! column's own primary key, over several it is kept unique the way a
+//! composite UNIQUE is, and ON CONFLICT finds it either way.
+
+use stoolap::Database;
+
+fn rows(db: &Database, sql: &str) -> Vec<String> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            (0..r.len())
+                .map(|i| r.get::<i64>(i).unwrap().to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect()
+}
+
+#[test]
+fn test_a_composite_primary_key_is_unique() {
+    let db = Database::open("memory://composite_primary_key").unwrap();
+    db.execute(
+        "CREATE TABLE cu (k1 INTEGER, k2 INTEGER, v INTEGER, PRIMARY KEY (k1, k2))",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO cu VALUES (1, 1, 10), (1, 2, 20)", ())
+        .unwrap();
+    assert!(db.execute("INSERT INTO cu VALUES (1, 1, 99)", ()).is_err());
+    db.execute(
+        "INSERT INTO cu VALUES (1, 1, 100), (3, 3, 33) ON CONFLICT (k1, k2) DO UPDATE SET v = cu.v + excluded.v",
+        (),
+    )
+    .unwrap();
+    let skipped = db
+        .execute(
+            "INSERT INTO cu VALUES (1, 2, 999) ON CONFLICT (k1, k2) DO NOTHING",
+            (),
+        )
+        .unwrap();
+    assert_eq!(skipped, 0);
+    assert_eq!(
+        rows(&db, "SELECT k1, k2, v FROM cu ORDER BY k1, k2"),
+        ["1,1,110", "1,2,20", "3,3,33"]
+    );
+}
+
+#[test]
+fn test_a_table_level_primary_key_over_one_column_is_the_column_key() {
+    let db = Database::open("memory://table_level_primary_key").unwrap();
+    db.execute(
+        "CREATE TABLE t1 (id INTEGER, v INTEGER, PRIMARY KEY (id))",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO t1 VALUES (1, 10)", ()).unwrap();
+    assert!(db.execute("INSERT INTO t1 VALUES (1, 11)", ()).is_err());
+    db.execute(
+        "INSERT INTO t1 VALUES (1, 12) ON CONFLICT (id) DO UPDATE SET v = excluded.v",
+        (),
+    )
+    .unwrap();
+    assert_eq!(rows(&db, "SELECT id, v FROM t1 ORDER BY id"), ["1,12"]);
+    assert_eq!(rows(&db, "SELECT v FROM t1 WHERE id = 1"), ["12"]);
+}

--- a/tests/table_level_primary_key_test.rs
+++ b/tests/table_level_primary_key_test.rs
@@ -78,3 +78,21 @@ fn test_a_table_level_primary_key_over_one_column_is_the_column_key() {
     assert_eq!(rows(&db, "SELECT id, v FROM t1 ORDER BY id"), ["1,12"]);
     assert_eq!(rows(&db, "SELECT v FROM t1 WHERE id = 1"), ["12"]);
 }
+
+#[test]
+fn test_a_composite_primary_key_takes_no_null() {
+    let db = Database::open("memory://composite_primary_key_null").unwrap();
+    db.execute(
+        "CREATE TABLE cu (k1 INTEGER, k2 INTEGER, v INTEGER, PRIMARY KEY (k1, k2))",
+        (),
+    )
+    .unwrap();
+    assert!(db
+        .execute("INSERT INTO cu VALUES (NULL, 1, 10)", ())
+        .is_err());
+    assert!(db
+        .execute("INSERT INTO cu VALUES (1, NULL, 10)", ())
+        .is_err());
+    db.execute("INSERT INTO cu VALUES (1, 1, 10)", ()).unwrap();
+    assert_eq!(rows(&db, "SELECT COUNT(*) FROM cu"), ["1"]);
+}

--- a/tests/trim_characters_test.rs
+++ b/tests/trim_characters_test.rs
@@ -1,0 +1,44 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TRIM, LTRIM and RTRIM take a second argument naming the characters to
+//! strip; without it they strip whitespace.
+
+use stoolap::Database;
+
+fn one(db: &Database, sql: &str) -> Option<String> {
+    db.query(sql, ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get::<Option<String>>(0)
+        .unwrap()
+}
+
+#[test]
+fn test_trim_strips_the_named_characters() {
+    let db = Database::open("memory://trim_characters").unwrap();
+    assert_eq!(one(&db, "SELECT TRIM('xxaxx', 'x')").as_deref(), Some("a"));
+    assert_eq!(one(&db, "SELECT TRIM('xyaxy', 'xy')").as_deref(), Some("a"));
+    assert_eq!(one(&db, "SELECT LTRIM('xxa', 'x')").as_deref(), Some("a"));
+    assert_eq!(one(&db, "SELECT RTRIM('axx', 'x')").as_deref(), Some("a"));
+    assert_eq!(one(&db, "SELECT LTRIM('axx', 'x')").as_deref(), Some("axx"));
+    assert_eq!(one(&db, "SELECT TRIM('  a  ')").as_deref(), Some("a"));
+    assert_eq!(
+        one(&db, "SELECT TRIM('  a  ', 'x')").as_deref(),
+        Some("  a  ")
+    );
+    assert_eq!(one(&db, "SELECT TRIM('a', NULL)"), None);
+}

--- a/tests/update_correlated_restrict_test.rs
+++ b/tests/update_correlated_restrict_test.rs
@@ -1,0 +1,60 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! ON UPDATE RESTRICT holds for an UPDATE whose WHERE is a correlated
+//! subquery the semi-join rewrite refused: the check binds each row the way
+//! the update does, so it looks at the rows the update would touch.
+
+use stoolap::Database;
+
+#[test]
+fn test_restrict_holds_for_a_correlated_where() {
+    let db = Database::open("memory://update_correlated_restrict").unwrap();
+    db.execute(
+        "CREATE TABLE p (id INTEGER PRIMARY KEY, code INTEGER UNIQUE)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, code INTEGER REFERENCES p(code) ON UPDATE RESTRICT)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE TABLE q (k INTEGER)", ()).unwrap();
+    db.execute("INSERT INTO p VALUES (1, 1), (2, 5)", ())
+        .unwrap();
+    db.execute("INSERT INTO c VALUES (1, 1)", ()).unwrap();
+    db.execute("INSERT INTO q VALUES (1)", ()).unwrap();
+
+    let refused = db.execute(
+        "UPDATE p SET code = 2 WHERE EXISTS (SELECT 1 FROM q WHERE q.k = p.code LIMIT 1)",
+        (),
+    );
+    assert!(refused.is_err(), "the referenced code must not change");
+    let codes: Vec<i64> = db
+        .query("SELECT code FROM p ORDER BY id", ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect();
+    assert_eq!(codes, [1, 5]);
+
+    // a row nothing references still changes
+    let changed = db
+        .execute(
+            "UPDATE p SET code = 6 WHERE EXISTS (SELECT 1 FROM q WHERE q.k + 4 = p.code LIMIT 1)",
+            (),
+        )
+        .unwrap();
+    assert_eq!(changed, 1);
+}

--- a/tests/update_set_default_test.rs
+++ b/tests/update_set_default_test.rs
@@ -43,3 +43,24 @@ fn test_set_default_writes_the_column_default() {
     assert_eq!(row.get::<String>(1).unwrap(), "x");
     assert_eq!(row.get::<Option<String>>(2).unwrap(), None);
 }
+
+#[test]
+fn test_set_default_draws_a_volatile_default_again() {
+    let db = Database::open("memory://update_set_default_volatile").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 1), (2, 2), (3, 3), (4, 4)", ())
+        .unwrap();
+    db.execute("ALTER TABLE t ADD COLUMN r FLOAT DEFAULT (RANDOM())", ())
+        .unwrap();
+    db.execute("UPDATE t SET r = DEFAULT", ()).unwrap();
+    let distinct: i64 = db
+        .query("SELECT COUNT(DISTINCT r) FROM t", ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap();
+    assert_eq!(distinct, 4);
+}

--- a/tests/update_set_default_test.rs
+++ b/tests/update_set_default_test.rs
@@ -1,0 +1,45 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SET col = DEFAULT in an UPDATE writes the column's default.
+
+use stoolap::Database;
+
+#[test]
+fn test_set_default_writes_the_column_default() {
+    let db = Database::open("memory://update_set_default").unwrap();
+    db.execute(
+        "CREATE TABLE dv (id INTEGER PRIMARY KEY, n INTEGER DEFAULT 7, t TEXT DEFAULT 'x', u TEXT)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO dv VALUES (1, 1, 'y', 'z')", ())
+        .unwrap();
+    let changed = db
+        .execute(
+            "UPDATE dv SET t = DEFAULT, n = DEFAULT, u = DEFAULT WHERE id = 1",
+            (),
+        )
+        .unwrap();
+    assert_eq!(changed, 1);
+    let row = db
+        .query("SELECT n, t, u FROM dv WHERE id = 1", ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 7);
+    assert_eq!(row.get::<String>(1).unwrap(), "x");
+    assert_eq!(row.get::<Option<String>>(2).unwrap(), None);
+}

--- a/tests/upsert_where_test.rs
+++ b/tests/upsert_where_test.rs
@@ -1,0 +1,58 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! ON CONFLICT ... DO UPDATE SET ... WHERE updates the row met only where
+//! the condition holds, read against that row and the EXCLUDED row.
+
+use stoolap::Database;
+
+fn rows(db: &Database) -> Vec<(i64, Option<i64>)> {
+    db.query("SELECT k, v FROM u ORDER BY k", ())
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            (r.get::<i64>(0).unwrap(), r.get::<Option<i64>>(1).unwrap())
+        })
+        .collect()
+}
+
+#[test]
+fn test_do_update_where_holds_back_the_rows_it_does_not_cover() {
+    let db = Database::open("memory://upsert_where").unwrap();
+    db.execute("CREATE TABLE u (k INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO u VALUES (3, 30), (4, 40)", ())
+        .unwrap();
+
+    db.execute(
+        "INSERT INTO u (k, v) VALUES (3, 1), (4, 1), (5, 1) ON CONFLICT (k) DO UPDATE SET v = excluded.v WHERE u.v > 35",
+        (),
+    )
+    .unwrap();
+    assert_eq!(rows(&db), [(3, Some(30)), (4, Some(1)), (5, Some(1))]);
+
+    db.execute(
+        "INSERT INTO u (k, v) VALUES (3, 7), (4, 7) ON CONFLICT (k) DO UPDATE SET v = excluded.v WHERE excluded.v > v",
+        (),
+    )
+    .unwrap();
+    assert_eq!(rows(&db), [(3, Some(30)), (4, Some(7)), (5, Some(1))]);
+
+    db.execute(
+        "INSERT INTO u (k, v) VALUES (3, 9) ON CONFLICT (k) DO UPDATE SET v = u.v + excluded.v WHERE u.v < 100",
+        (),
+    )
+    .unwrap();
+    assert_eq!(rows(&db), [(3, Some(39)), (4, Some(7)), (5, Some(1))]);
+}

--- a/tests/upsert_where_test.rs
+++ b/tests/upsert_where_test.rs
@@ -97,3 +97,20 @@ fn test_the_condition_sees_the_transaction() {
     db.execute("COMMIT", ()).unwrap();
     assert_eq!(rows(&db), [(1, Some(99))]);
 }
+
+#[test]
+fn test_a_condition_that_fails_to_evaluate_is_an_error() {
+    let db = Database::open("memory://upsert_where_error").unwrap();
+    db.execute("CREATE TABLE u (k INTEGER PRIMARY KEY, p TEXT)", ())
+        .unwrap();
+    db.execute("INSERT INTO u VALUES (1, 'a')", ()).unwrap();
+    let result = db.execute(
+        "INSERT INTO u VALUES (1, '[') ON CONFLICT (k) DO UPDATE SET p = excluded.p \
+         WHERE 'abc' REGEXP excluded.p",
+        (),
+    );
+    assert!(
+        result.is_err(),
+        "an invalid pattern must not read as a false condition"
+    );
+}

--- a/tests/upsert_where_test.rs
+++ b/tests/upsert_where_test.rs
@@ -56,3 +56,44 @@ fn test_do_update_where_holds_back_the_rows_it_does_not_cover() {
     .unwrap();
     assert_eq!(rows(&db), [(3, Some(39)), (4, Some(7)), (5, Some(1))]);
 }
+
+#[test]
+fn test_a_row_the_condition_leaves_alone_is_not_an_affected_row() {
+    let db = Database::open("memory://upsert_where_count").unwrap();
+    db.execute("CREATE TABLE u (k INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO u VALUES (1, 10)", ()).unwrap();
+    let skipped = db
+        .execute(
+            "INSERT INTO u VALUES (1, 99) ON CONFLICT (k) DO UPDATE SET v = excluded.v WHERE FALSE",
+            (),
+        )
+        .unwrap();
+    assert_eq!(skipped, 0);
+    let taken = db
+        .execute(
+            "INSERT INTO u VALUES (1, 99), (2, 20) ON CONFLICT (k) DO UPDATE SET v = excluded.v WHERE u.v < 50",
+            (),
+        )
+        .unwrap();
+    assert_eq!(taken, 2);
+    assert_eq!(rows(&db), [(1, Some(99)), (2, Some(20))]);
+}
+
+#[test]
+fn test_the_condition_sees_the_transaction() {
+    let db = Database::open("memory://upsert_where_transaction").unwrap();
+    db.execute("CREATE TABLE u (k INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO u VALUES (1, 10)", ()).unwrap();
+    db.execute("BEGIN", ()).unwrap();
+    let taken = db
+        .execute(
+            "INSERT INTO u VALUES (1, 99) ON CONFLICT (k) DO UPDATE SET v = excluded.v WHERE CURRENT_TRANSACTION_ID() IS NOT NULL",
+            (),
+        )
+        .unwrap();
+    assert_eq!(taken, 1);
+    db.execute("COMMIT", ()).unwrap();
+    assert_eq!(rows(&db), [(1, Some(99))]);
+}

--- a/tests/view_join_filter_test.rs
+++ b/tests/view_join_filter_test.rs
@@ -1,0 +1,84 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A predicate the join pushes to a view on one of its sides filters the
+//! view's rows, as it does a table's or a CTE's.
+
+use stoolap::Database;
+
+fn count(db: &Database, sql: &str) -> i64 {
+    db.query(sql, ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .get(0)
+        .unwrap()
+}
+
+#[test]
+fn test_a_filter_pushed_to_a_view_side_of_a_join_applies() {
+    let db = Database::open("memory://view_join_filter").unwrap();
+    db.execute(
+        "CREATE TABLE y (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO y VALUES (1, 1, 5), (2, 1, 50), (3, 1, 7), (4, 2, 9), (5, 2, 20)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE VIEW vy AS SELECT a, b, id FROM y", ())
+        .unwrap();
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM vy v JOIN y ON y.id = v.id WHERE v.a = 2"
+        ),
+        2
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM y JOIN vy v ON y.id = v.id WHERE v.a = 2"
+        ),
+        2
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM vy v JOIN y ON y.id = v.id WHERE v.a = 2 AND y.b = 20"
+        ),
+        1
+    );
+    // and through a correlated EXISTS, where the parent's columns are bound first
+    db.execute(
+        "CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO x VALUES (1, 1, 10), (2, 2, 20), (3, 1, 50)",
+        (),
+    )
+    .unwrap();
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM x WHERE EXISTS (SELECT 1 FROM vy v JOIN y ON y.id = v.id WHERE v.a = x.a AND y.b = x.b)"
+        ),
+        2
+    );
+}

--- a/tests/volatile_filter_test.rs
+++ b/tests/volatile_filter_test.rs
@@ -40,6 +40,9 @@ fn test_random_beside_a_subquery_rolls_once() {
         "SELECT COUNT(*) FROM x WHERE RANDOM() < 0.5 AND EXISTS (SELECT 1)",
         "SELECT COUNT(*) FROM x WHERE RANDOM() < 0.5 AND a = 0 AND (SELECT 1) = 1",
         "SELECT COUNT(*) FROM x WHERE RANDOM() < 0.5 AND a = 0",
+        "SELECT COUNT(*) FROM x WHERE id % 2 = (CASE WHEN RANDOM() < 0.5 THEN 0 ELSE 1 END) \
+         AND EXISTS (SELECT 1)",
+        "SELECT COUNT(*) FROM x WHERE RANDOM() BETWEEN 0 AND 0.5 AND EXISTS (SELECT 1)",
     ] {
         let kept = count(&db, sql);
         assert!((8500..=11500).contains(&kept), "{sql} kept {kept}");

--- a/tests/volatile_filter_test.rs
+++ b/tests/volatile_filter_test.rs
@@ -43,6 +43,8 @@ fn test_random_beside_a_subquery_rolls_once() {
         "SELECT COUNT(*) FROM x WHERE a = 1 + (CASE WHEN RANDOM() < 0.5 THEN -1 ELSE 0 END) \
          AND EXISTS (SELECT 1)",
         "SELECT COUNT(*) FROM x WHERE RANDOM() BETWEEN 0 AND 0.5 AND EXISTS (SELECT 1)",
+        "SELECT COUNT(*) FROM x WHERE a = 1 + (CASE WHEN TRUE IN (RANDOM() < 0.5) THEN -1 ELSE 0 END) \
+         AND EXISTS (SELECT 1)",
     ] {
         let kept = count(&db, sql);
         assert!((8500..=11500).contains(&kept), "{sql} kept {kept}");

--- a/tests/volatile_filter_test.rs
+++ b/tests/volatile_filter_test.rs
@@ -1,0 +1,47 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A volatile function in the WHERE is judged once per row, however the
+//! rest of the WHERE is split between storage and memory.
+
+use stoolap::Database;
+
+fn count(db: &Database, sql: &str) -> i64 {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .next()
+        .unwrap()
+}
+
+#[test]
+fn test_random_beside_a_subquery_rolls_once() {
+    let db = Database::open("memory://volatile_filter").unwrap();
+    db.execute("CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER)", ())
+        .unwrap();
+    let rows: Vec<String> = (1..=20000).map(|i| format!("({i}, 0)")).collect();
+    for chunk in rows.chunks(1000) {
+        db.execute(&format!("INSERT INTO x VALUES {}", chunk.join(", ")), ())
+            .unwrap();
+    }
+    // Half the rows pass, give or take a few hundred; rolled twice, a quarter would
+    for sql in [
+        "SELECT COUNT(*) FROM x WHERE RANDOM() < 0.5 AND EXISTS (SELECT 1)",
+        "SELECT COUNT(*) FROM x WHERE RANDOM() < 0.5 AND a = 0 AND (SELECT 1) = 1",
+        "SELECT COUNT(*) FROM x WHERE RANDOM() < 0.5 AND a = 0",
+    ] {
+        let kept = count(&db, sql);
+        assert!((8500..=11500).contains(&kept), "{sql} kept {kept}");
+    }
+}

--- a/tests/volatile_filter_test.rs
+++ b/tests/volatile_filter_test.rs
@@ -30,7 +30,7 @@ fn test_random_beside_a_subquery_rolls_once() {
     let db = Database::open("memory://volatile_filter").unwrap();
     db.execute("CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER)", ())
         .unwrap();
-    let rows: Vec<String> = (1..=20000).map(|i| format!("({i}, 0)")).collect();
+    let rows: Vec<String> = (1..=20000).map(|i| format!("({i}, {})", i % 2)).collect();
     for chunk in rows.chunks(1000) {
         db.execute(&format!("INSERT INTO x VALUES {}", chunk.join(", ")), ())
             .unwrap();
@@ -38,9 +38,9 @@ fn test_random_beside_a_subquery_rolls_once() {
     // Half the rows pass, give or take a few hundred; rolled twice, a quarter would
     for sql in [
         "SELECT COUNT(*) FROM x WHERE RANDOM() < 0.5 AND EXISTS (SELECT 1)",
-        "SELECT COUNT(*) FROM x WHERE RANDOM() < 0.5 AND a = 0 AND (SELECT 1) = 1",
-        "SELECT COUNT(*) FROM x WHERE RANDOM() < 0.5 AND a = 0",
-        "SELECT COUNT(*) FROM x WHERE id % 2 = (CASE WHEN RANDOM() < 0.5 THEN 0 ELSE 1 END) \
+        "SELECT COUNT(*) FROM x WHERE RANDOM() < 0.5 AND a >= 0 AND (SELECT 1) = 1",
+        "SELECT COUNT(*) FROM x WHERE RANDOM() < 0.5 AND a >= 0",
+        "SELECT COUNT(*) FROM x WHERE a = 1 + (CASE WHEN RANDOM() < 0.5 THEN -1 ELSE 0 END) \
          AND EXISTS (SELECT 1)",
         "SELECT COUNT(*) FROM x WHERE RANDOM() BETWEEN 0 AND 0.5 AND EXISTS (SELECT 1)",
     ] {

--- a/tests/where_subquery_shaping_test.rs
+++ b/tests/where_subquery_shaping_test.rs
@@ -1,0 +1,139 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A subquery in the WHERE clause narrows the rows. Everything the query
+//! says about the rows it keeps still applies: what to count, what order to
+//! return them in, how to group them, and what to number them by.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE s (id INTEGER PRIMARY KEY, g TEXT, n INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO s VALUES (1,'a',10), (2,'a',20), (3,'b',30), (4,'b',40), (5,'c',50)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE TABLE p (id INTEGER PRIMARY KEY, s_id INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO p VALUES (1, 1), (2, 2)", ())
+        .unwrap();
+    db
+}
+
+fn rows(db: &Database, sql: &str) -> Vec<String> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (0..row.len())
+                .map(|i| {
+                    row.get::<Option<String>>(i)
+                        .unwrap()
+                        .unwrap_or_else(|| "NULL".into())
+                })
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect()
+}
+
+const NOT_EXISTS: &str = "NOT EXISTS (SELECT 1 FROM p WHERE p.s_id = s.id)";
+const EXISTS: &str = "EXISTS (SELECT 1 FROM p WHERE p.s_id = s.id)";
+const NOT_IN: &str = "id NOT IN (SELECT s_id FROM p WHERE s_id IS NOT NULL)";
+
+/// An aggregate over the rows a NOT EXISTS keeps
+#[test]
+fn test_aggregate_over_a_not_exists() {
+    let db = setup("where_sub_shape_aggregate");
+    assert_eq!(
+        rows(&db, &format!("SELECT COUNT(*) FROM s WHERE {NOT_EXISTS}")),
+        ["3"]
+    );
+    assert_eq!(
+        rows(&db, &format!("SELECT SUM(n) FROM s WHERE {NOT_EXISTS}")),
+        ["120"]
+    );
+}
+
+/// Grouping the rows a NOT EXISTS keeps
+#[test]
+fn test_group_by_over_a_not_exists() {
+    let db = setup("where_sub_shape_group");
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT g, COUNT(*) FROM s WHERE {NOT_EXISTS} GROUP BY g ORDER BY g")
+        ),
+        ["b,2", "c,1"]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT g FROM s WHERE {NOT_EXISTS} GROUP BY g HAVING COUNT(*) > 1")
+        ),
+        ["b"]
+    );
+}
+
+/// Sorting by a column the SELECT list leaves out
+#[test]
+fn test_order_by_a_column_the_select_leaves_out() {
+    let db = setup("where_sub_shape_order");
+    for predicate in [NOT_EXISTS, NOT_IN] {
+        assert_eq!(
+            rows(
+                &db,
+                &format!("SELECT id FROM s WHERE {predicate} ORDER BY n DESC")
+            ),
+            ["5", "4", "3"],
+            "{predicate}"
+        );
+    }
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT id FROM s WHERE {EXISTS} ORDER BY n DESC")
+        ),
+        ["2", "1"]
+    );
+}
+
+/// Numbering the rows a subquery keeps
+#[test]
+fn test_window_function_over_a_subquery_predicate() {
+    let db = setup("where_sub_shape_window");
+    for predicate in [NOT_EXISTS, NOT_IN] {
+        assert_eq!(
+            rows(
+                &db,
+                &format!("SELECT ROW_NUMBER() OVER (ORDER BY id) FROM s WHERE {predicate}")
+            ),
+            ["1", "2", "3"],
+            "{predicate}"
+        );
+    }
+    assert_eq!(
+        rows(
+            &db,
+            &format!("SELECT ROW_NUMBER() OVER (ORDER BY id) FROM s WHERE {EXISTS}")
+        ),
+        ["1", "2"]
+    );
+}

--- a/tests/window_over_group_by_aggregate_test.rs
+++ b/tests/window_over_group_by_aggregate_test.rs
@@ -64,3 +64,32 @@ fn test_a_window_orders_by_an_aggregate_outside_the_select_list() {
         [(1, 50), (2, 50), (3, 50)]
     );
 }
+
+#[test]
+fn test_a_named_window_orders_by_an_aggregate() {
+    let db = Database::open("memory://named_window_over_aggregate").unwrap();
+    db.execute(
+        "CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO x VALUES (1, 1, 10), (2, 2, 20), (3, 3, 30), (4, 1, 40)",
+        (),
+    )
+    .unwrap();
+    assert_eq!(
+        pairs(
+            &db,
+            "SELECT a, RANK() OVER w FROM x GROUP BY a WINDOW w AS (ORDER BY SUM(b) DESC) ORDER BY a"
+        ),
+        [(1, 1), (2, 3), (3, 2)]
+    );
+    assert_eq!(
+        pairs(
+            &db,
+            "SELECT a, ROW_NUMBER() OVER w FROM x GROUP BY a WINDOW w AS (PARTITION BY COUNT(*) ORDER BY a) ORDER BY a"
+        ),
+        [(1, 1), (2, 1), (3, 2)]
+    );
+}

--- a/tests/window_over_group_by_aggregate_test.rs
+++ b/tests/window_over_group_by_aggregate_test.rs
@@ -1,0 +1,66 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A window function over a GROUP BY result may order or partition by an
+//! aggregate the select list does not carry; the aggregate is computed
+//! for it.
+
+use stoolap::Database;
+
+fn pairs(db: &Database, sql: &str) -> Vec<(i64, i64)> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            (r.get::<i64>(0).unwrap(), r.get::<i64>(1).unwrap())
+        })
+        .collect()
+}
+
+#[test]
+fn test_a_window_orders_by_an_aggregate_outside_the_select_list() {
+    let db = Database::open("memory://window_over_group_by_aggregate").unwrap();
+    db.execute(
+        "CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO x VALUES (1, 1, 10), (2, 2, 20), (3, 3, 30), (4, 1, 40)",
+        (),
+    )
+    .unwrap();
+    // sums: a = 1 gives 50, a = 3 gives 30, a = 2 gives 20
+    assert_eq!(
+        pairs(
+            &db,
+            "SELECT a, ROW_NUMBER() OVER (ORDER BY SUM(b) DESC, a) AS r FROM x GROUP BY a ORDER BY r"
+        ),
+        [(1, 1), (3, 2), (2, 3)]
+    );
+    assert_eq!(
+        pairs(
+            &db,
+            "SELECT a, RANK() OVER (ORDER BY COUNT(*) DESC, a) AS r FROM x GROUP BY a ORDER BY r"
+        ),
+        [(1, 1), (2, 2), (3, 3)]
+    );
+    assert_eq!(
+        pairs(
+            &db,
+            "SELECT a, SUM(SUM(b)) OVER (PARTITION BY COUNT(*)) AS s FROM x GROUP BY a ORDER BY a"
+        ),
+        [(1, 50), (2, 50), (3, 50)]
+    );
+}

--- a/tests/window_range_null_test.rs
+++ b/tests/window_range_null_test.rs
@@ -1,0 +1,95 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A RANGE offset is measured against the sort key, and nothing can be
+//! measured against a NULL. A row holding one sees the rows that hold one
+//! too, and no others.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE w (id INTEGER, k INTEGER, v INTEGER)", ())
+        .unwrap();
+    db.execute(
+        "INSERT INTO w VALUES (1,10,1), (2,20,2), (3,NULL,3), (4,NULL,4), (5,30,5)",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn rows(db: &Database, sql: &str) -> Vec<String> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            row.get::<Option<String>>(0)
+                .unwrap()
+                .unwrap_or_else(|| "NULL".into())
+        })
+        .collect()
+}
+
+#[test]
+fn test_a_null_key_sees_only_the_rows_that_hold_one() {
+    let db = setup("window_range_null_both");
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT SUM(v) OVER (ORDER BY k RANGE BETWEEN 10 PRECEDING AND 10 FOLLOWING) FROM w ORDER BY id"
+        ),
+        ["3", "8", "7", "7", "7"],
+        "the two rows holding a NULL see each other and nothing else"
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT COUNT(*) OVER (ORDER BY k RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING) FROM w ORDER BY id"
+        ),
+        ["1", "1", "2", "2", "1"]
+    );
+}
+
+#[test]
+fn test_an_offset_paired_with_the_current_row() {
+    let db = setup("window_range_null_current");
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT SUM(v) OVER (ORDER BY k RANGE BETWEEN 10 PRECEDING AND CURRENT ROW) FROM w ORDER BY id"
+        ),
+        ["1", "3", "7", "7", "7"]
+    );
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT SUM(v) OVER (ORDER BY k RANGE BETWEEN CURRENT ROW AND 10 FOLLOWING) FROM w ORDER BY id"
+        ),
+        ["3", "7", "7", "7", "5"]
+    );
+}
+
+#[test]
+fn test_a_row_offset_still_counts_rows() {
+    let db = setup("window_range_null_rows");
+    assert_eq!(
+        rows(
+            &db,
+            "SELECT SUM(v) OVER (ORDER BY k ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM w ORDER BY id"
+        ),
+        ["3", "8", "12", "7", "10"],
+        "ROWS counts neighbours, so a NULL key changes nothing"
+    );
+}

--- a/tests/with_before_dml_test.rs
+++ b/tests/with_before_dml_test.rs
@@ -1,0 +1,95 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A WITH clause may stand before UPDATE and DELETE; the statement's
+//! subqueries read the CTEs it defines.
+
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE x (id INTEGER PRIMARY KEY, a INTEGER, s TEXT)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE y (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO x VALUES (1, 1, ''), (2, 2, ''), (3, 1, ''), (4, 3, '')",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO y VALUES (1, 1, 5), (2, 1, NULL), (3, 2, 7), (4, 1, 9)",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn texts(db: &Database, sql: &str) -> Vec<String> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<String>(0).unwrap())
+        .collect()
+}
+
+#[test]
+fn test_with_before_update() {
+    let db = setup("with_before_update");
+    let changed = db
+        .execute(
+            "WITH hot AS (SELECT a FROM y GROUP BY a HAVING COUNT(*) > 1) UPDATE x SET s = 'hot' WHERE a IN (SELECT a FROM hot)",
+            (),
+        )
+        .unwrap();
+    assert_eq!(changed, 2);
+    assert_eq!(
+        texts(&db, "SELECT s FROM x ORDER BY id"),
+        ["hot", "", "hot", ""]
+    );
+    let changed = db
+        .execute(
+            "WITH RECURSIVE n(v) AS (SELECT 1 UNION ALL SELECT v + 1 FROM n WHERE v < 2) UPDATE x SET s = 'n' WHERE id IN (SELECT v FROM n)",
+            (),
+        )
+        .unwrap();
+    assert_eq!(changed, 2);
+    assert_eq!(
+        texts(&db, "SELECT s FROM x ORDER BY id"),
+        ["n", "n", "hot", ""]
+    );
+}
+
+#[test]
+fn test_with_before_delete() {
+    let db = setup("with_before_delete");
+    let removed = db
+        .execute(
+            "WITH gone AS (SELECT id FROM y WHERE b IS NULL) DELETE FROM y WHERE id IN (SELECT id FROM gone)",
+            (),
+        )
+        .unwrap();
+    assert_eq!(removed, 1);
+    let ids: Vec<i64> = db
+        .query("SELECT id FROM y ORDER BY id", ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect();
+    assert_eq!(ids, [1, 3, 4]);
+}


### PR DESCRIPTION
A correctness campaign driven by static review and by differential runs against SQLite 3.51 and DuckDB 1.2. Only a case where both engines agree and stoolap differs counted as a bug; 34 waves of about 1630 queries were run over correlated subqueries, joins, window functions, set operations, DML, expression evaluation, three-valued logic and layered views and CTEs. Every wrong answer found is fixed here, each with a test that fails on the head before its fix.

**Correlated subqueries**
- A subquery reads the parent row wherever it names it: the select list, an aggregate argument or FILTER, HAVING, CASE, and a HAVING that names the parent is classified as correlated. Names the subquery's own FROM defines win, and bare names still mean the inner table.
- The parent's columns are bound in scope before a derived table, view, CTE or join splits its WHERE, and the scope lists every leaf of a nested join.
- A correlated subquery over a view, a derived table or a materialized CTE is evaluated per row in the WHERE and in the select list, also when a sort column the select list leaves out rides along, and the column it is bound to never shadows a source column.
- Correlation is detected through a nested subquery, a derived table in the FROM, and an ORDER BY that reads the parent row; a subquery in ORDER BY is sorted by whether or not the select list carries its key.
- EXISTS answers what its subquery returns, and NOT EXISTS keeps its rows when the outer value is NULL; the counting shortcuts and the batch aggregate paths stay honest about what they count.
- The parent row is bound into the subqueries a WHERE holds, so a subquery two levels down that reads only the outermost row folds once instead of running for every row of the query holding it, and the plain conjuncts beside a correlated subquery are pushed down to storage. A three-level probe went from 102 seconds to 37 milliseconds.

**CTEs and views**
- Every reference is counted before a CTE is inlined, including set-operation branches, the select list, HAVING and ORDER BY, so a CTE named twice is materialized once and read from both places.
- The query-on-CTE-result path hands ORDER BY expressions, DISTINCT and set operations to execute_select, and a later CTE's subqueries read the earlier ones.
- A predicate pushed to a view on a join side is applied; a column of a view, derived table or CTE that the select list leaves out can still sort the result.

**Joins, set operations, windows**
- A join decides a match where it has the row in hand and asks the whole ON clause where an index answers its key; a join filter runs in its transaction.
- USING names its column by the bare name for every select list and keeps the qualified copy beside it.
- ORDER BY, LIMIT and OFFSET apply to the whole set operation.
- Windows: OVER (w ...) builds on a named window and prints what it adds; a window the select list does not carry can sort; the aggregates a window orders or partitions by are computed; NULL sort keys frame together; a window argument reads its column through its table.

**DML and DDL**
- DELETE removes what it matched on a table without a key; every key that can refuse a delete or an update is asked before anything changes, through cascades and with a correlated WHERE.
- INSERT ... ON CONFLICT DO UPDATE takes a WHERE, counts a skipped row as not affected, reports an error the condition raises, and runs in its transaction; WITH before UPDATE and DELETE; SET col = DEFAULT writes the column's default expression.
- A table-level PRIMARY KEY is a key, composite key columns are NOT NULL, a transaction can take again a key it deleted, and a committed unique entry is read against the row's latest local version.

**Expressions and functions**
- NOT over AND and OR follows three-valued logic in storage filters; a comparison against NULL stays unknown; x * 0 is not folded (NULL for a NULL x); an empty set matches nothing.
- IN over items that are not constants compiles to one InList op that judges the value once; an expression's name keeps the parentheses precedence and float grouping need, so SUM(a * (b % 3)) and SUM(a * b % 3) stay two aggregates; a timestamp, JSON or vector bound into an expression keeps its type.
- A volatile function such as RANDOM() is judged once, in memory, wherever it sits in the WHERE (CASE, BETWEEN, IN lists included), instead of once in storage and again in memory.
- Booleans count as one or nought in SUM and AVG on every path; SUBSTRING holds its window at the type's limits; searching an empty string finds nothing; TRIM, LTRIM and RTRIM take the characters to strip; a number cast from text ignores surrounding whitespace.

**Left open, as dialect or design**
NULLs first on DESC and last on ASC (PostgreSQL rule), backslash as an escape in literals, CAST('3.9' AS INTEGER) and float equality following SQLite, and the parser gaps UPDATE ... FROM, GROUPS BETWEEN, EXCLUDE, WITH inside a subquery, WITH RECURSIVE with UNION, several named windows in one WINDOW clause, and a correlated subquery inside JOIN ON. XOR is stoolap-only. A primary key UPDATE stays an explicit error by design.

**Test runs**
`.config/nextest.toml` adds two profiles: the default run leaves out the tests that judge wall-clock time and the two concurrency stress binaries, which turn red under load; `cargo nextest run -P full` runs everything.

**Verification**
Every new test fails on the commit before its fix. Both suites pass with the full profile (5248, and 5250 with test-filedb), clippy is clean, and all 34 waves rerun clean after the last commit in about two minutes; the remaining differences are the dialect items above. Subquery benchmarks against main sit within a point of parity.
