### PR TITLE
perf: bring UNION ALL, NOT EXISTS and the index join back to their pace before #94

### DIFF
--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -1733,16 +1733,11 @@ impl Executor {
                     .collect();
 
                 let target = early_termination_target.unwrap_or(usize::MAX);
-                let row_count = table.row_count();
 
-                for row_id in 1..=(row_count as i64) {
-                    if !exclusion_set.contains(row_id) {
-                        all_row_ids.push(row_id);
-                        if all_row_ids.len() >= target {
-                            break;
-                        }
-                    }
-                }
+                // The keys the table holds, in key order and no further
+                // than the LIMIT: a key it never held, or no longer holds,
+                // is not a row to keep
+                all_row_ids.extend(table.visible_row_ids_excluding(&exclusion_set, target)?);
             } else {
                 // IN: PRIMARY KEY - the value IS the row_id (for INTEGER PK)
                 for value in values.iter() {
@@ -1934,10 +1929,20 @@ impl Executor {
             // negated set is only probed on a primary key, which holds no
             // NULL, so the second side never fires there
             Expression::Infix(infix) if infix.op_type == InfixOperator::Or => {
-                let (column_name, values, negated, _) = Self::extract_in_hashset_info(&infix.left)?;
-                if !negated {
+                // Only the bare negated set qualifies: a set holding a NULL
+                // keeps no row, and a conjunct beside the set would be lost
+                let Expression::InHashSet(in_hash) = infix.left.as_ref() else {
+                    return None;
+                };
+                if !in_hash.not || in_hash.values.iter().any(|v| v.is_null()) {
                     return None;
                 }
+                let column_name = match in_hash.column.as_ref() {
+                    Expression::Identifier(id) => id.value_lower.to_string(),
+                    Expression::QualifiedIdentifier(qid) => qid.name.value_lower.to_string(),
+                    _ => return None,
+                };
+                let values = in_hash.values.clone();
                 match infix.right.as_ref() {
                     Expression::Infix(is_null)
                         if is_null.operator.eq_ignore_ascii_case("IS")

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -1723,11 +1723,13 @@ impl Executor {
             if is_negated {
                 // NOT IN optimization for INTEGER PRIMARY KEY (from NOT EXISTS semi-join):
                 // Iterate through row_ids and exclude those in the hash set
+                // Only a losslessly integral float can name a key; one past
+                // i64 would saturate onto a key it does not equal
                 let exclusion_set: I64Set = values
                     .iter()
                     .filter_map(|v| match v {
                         Value::Integer(id) => Some(*id),
-                        Value::Float(f) if f.fract() == 0.0 => Some(*f as i64),
+                        Value::Float(f) => Self::lossless_float_key(*f),
                         _ => None,
                     })
                     .collect();
@@ -1963,13 +1965,20 @@ impl Executor {
 
             // InHashSet with AND: column IN {hash_set} AND other_condition
             Expression::Infix(infix) if infix.op_type == InfixOperator::And => {
+                // A side that is itself an AND around the set brings its own
+                // remaining predicate, which the sibling joins rather than replaces
+                let keep_both = |rest: Option<Expression>, sibling: &Expression| {
+                    crate::executor::utils::combine_predicates_with_and(
+                        rest.into_iter().chain([sibling.clone()]).collect(),
+                    )
+                };
                 // Try left side as InHashSet
-                if let Some((col, vals, neg, _)) = Self::extract_in_hashset_info(&infix.left) {
-                    return Some((col, vals, neg, Some((*infix.right).clone())));
+                if let Some((col, vals, neg, rest)) = Self::extract_in_hashset_info(&infix.left) {
+                    return Some((col, vals, neg, keep_both(rest, &infix.right)));
                 }
                 // Try right side as InHashSet
-                if let Some((col, vals, neg, _)) = Self::extract_in_hashset_info(&infix.right) {
-                    return Some((col, vals, neg, Some((*infix.left).clone())));
+                if let Some((col, vals, neg, rest)) = Self::extract_in_hashset_info(&infix.right) {
+                    return Some((col, vals, neg, keep_both(rest, &infix.left)));
                 }
                 None
             }

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -1929,6 +1929,33 @@ impl Executor {
                 Some((column_name, in_hash.values.clone(), in_hash.not, None))
             }
 
+            // A NOT EXISTS rewrite keeps a NULL outer value beside the
+            // negated set: column NOT IN {hash_set} OR column IS NULL. The
+            // negated set is only probed on a primary key, which holds no
+            // NULL, so the second side never fires there
+            Expression::Infix(infix) if infix.op_type == InfixOperator::Or => {
+                let (column_name, values, negated, _) = Self::extract_in_hashset_info(&infix.left)?;
+                if !negated {
+                    return None;
+                }
+                match infix.right.as_ref() {
+                    Expression::Infix(is_null)
+                        if is_null.operator.eq_ignore_ascii_case("IS")
+                            && matches!(is_null.right.as_ref(), Expression::NullLiteral(_)) =>
+                    {
+                        let same_column = match is_null.left.as_ref() {
+                            Expression::Identifier(id) => id.value_lower == column_name,
+                            Expression::QualifiedIdentifier(qid) => {
+                                qid.name.value_lower == column_name
+                            }
+                            _ => false,
+                        };
+                        same_column.then_some((column_name, values, true, None))
+                    }
+                    _ => None,
+                }
+            }
+
             // InHashSet with AND: column IN {hash_set} AND other_condition
             Expression::Infix(infix) if infix.op_type == InfixOperator::And => {
                 // Try left side as InHashSet

--- a/src/executor/operators/index_nested_loop.rs
+++ b/src/executor/operators/index_nested_loop.rs
@@ -94,6 +94,9 @@ pub struct IndexNestedLoopJoinOperator {
     outer_key_idx: usize,
     lookup_strategy: IndexLookupStrategy,
     residual_filter: Option<JoinFilter>,
+    // The inner key column, checked on each fetched row: inside a
+    // transaction an index entry may be older than the row it points at
+    inner_key_idx: Option<usize>,
 
     // Output schema
     schema: Vec<ColumnInfo>,
@@ -165,6 +168,7 @@ impl IndexNestedLoopJoinOperator {
             outer_key_idx,
             lookup_strategy,
             residual_filter,
+            inner_key_idx: None,
             schema,
             inner_col_count,
             projection: None,
@@ -214,6 +218,13 @@ impl IndexNestedLoopJoinOperator {
     /// predicate on inner columns only
     pub fn with_inner_filter(mut self, filter: Box<dyn Expression>) -> Self {
         self.inner_filter = Some(filter);
+        self
+    }
+
+    /// The inner key column, so a row an index entry points at is kept
+    /// only when its own key equals the outer one
+    pub fn with_inner_key(mut self, inner_key_idx: Option<usize>) -> Self {
+        self.inner_key_idx = inner_key_idx;
         self
     }
 
@@ -358,7 +369,17 @@ impl IndexNestedLoopJoinOperator {
             &self.row_id_buffer,
             filter,
             &mut self.current_inner_rows,
-        )
+        )?;
+
+        // An index entry may point at a row whose key has since changed
+        // inside the transaction, so the row's own key decides
+        if let (IndexLookupStrategy::SecondaryIndex(_), Some(idx)) =
+            (&self.lookup_strategy, self.inner_key_idx)
+        {
+            self.current_inner_rows
+                .retain(|(_, row)| row.get(idx) == Some(key_value));
+        }
+        Ok(())
     }
 
     /// Advance to the next outer row and lookup matching inner rows.
@@ -537,6 +558,9 @@ pub struct BatchIndexNestedLoopJoinOperator {
     outer_key_idx: usize,
     lookup_strategy: IndexLookupStrategy,
     residual_filter: Option<JoinFilter>,
+    // The inner key column, checked on each fetched row: inside a
+    // transaction an index entry may be older than the row it points at
+    inner_key_idx: Option<usize>,
 
     // Output schema
     schema: Vec<ColumnInfo>,
@@ -580,6 +604,7 @@ impl BatchIndexNestedLoopJoinOperator {
             outer_key_idx,
             lookup_strategy,
             residual_filter,
+            inner_key_idx: None,
             schema,
             inner_col_count,
             projection: None,
@@ -589,6 +614,13 @@ impl BatchIndexNestedLoopJoinOperator {
             row_id_buffer: Vec::with_capacity(16),
             opened: false,
         }
+    }
+
+    /// The inner key column, so a row an index entry points at is kept
+    /// only when its own key equals the outer one
+    pub fn with_inner_key(mut self, inner_key_idx: Option<usize>) -> Self {
+        self.inner_key_idx = inner_key_idx;
+        self
     }
 
     /// Set projection pushdown configuration.
@@ -745,6 +777,16 @@ impl Operator for BatchIndexNestedLoopJoinOperator {
             if let Some(outer_indices) = key_to_outer_indices.get(*row_id) {
                 for &outer_idx in outer_indices {
                     let outer_row = &outer_rows[outer_idx];
+
+                    // An index entry may point at a row whose key has since
+                    // changed inside the transaction, so the row's own key decides
+                    if let (IndexLookupStrategy::SecondaryIndex(_), Some(idx)) =
+                        (&self.lookup_strategy, self.inner_key_idx)
+                    {
+                        if inner_row.get(idx) != outer_row.get(self.outer_key_idx) {
+                            continue;
+                        }
+                    }
 
                     // Apply residual filter if present
                     let passes_filter = if let Some(ref filter) = self.residual_filter {

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -440,15 +440,33 @@ impl Executor {
         // Execute the main query
         // The third return value indicates if LIMIT/OFFSET was already applied (by storage-level pushdown)
         // The fourth return value contains deferred projection info if applicable
+        // A pure UNION ALL without ORDER BY or DISTINCT needs LIMIT + OFFSET
+        // rows at most from each branch, so that many bound the first
+        // branch and the set operation; the whole is cut below
+        let all_union_all = stmt
+            .set_operations
+            .iter()
+            .all(|op| matches!(op.operation, SetOperationType::UnionAll));
+        let set_limit = if all_union_all && stmt.order_by.is_empty() && !stmt.distinct {
+            limit.map(|l| l + offset)
+        } else {
+            None
+        };
+
         // ORDER BY, LIMIT and OFFSET belong to the whole set operation, so
-        // the first branch runs without them
+        // the first branch runs without them, apart from that bound
         let branch_stmt;
         let branch = if stmt.set_operations.is_empty() {
             stmt
         } else {
             branch_stmt = SelectStatement {
                 order_by: Vec::new(),
-                limit: None,
+                limit: set_limit.map(|l| {
+                    Box::new(Expression::IntegerLiteral(IntegerLiteral {
+                        token: dummy_token(&l.to_string(), TokenType::Integer),
+                        value: l as i64,
+                    }))
+                }),
                 offset: None,
                 ..stmt.clone()
             };
@@ -461,17 +479,6 @@ impl Executor {
         // Pass limit+offset to enable early termination for UNION ALL
         let mut limit_offset_applied = limit_offset_applied;
         if !stmt.set_operations.is_empty() {
-            // Only enable limit pushdown for pure UNION ALL (no dedup needed)
-            let all_union_all = stmt
-                .set_operations
-                .iter()
-                .all(|op| matches!(op.operation, SetOperationType::UnionAll));
-            let set_limit = if all_union_all && stmt.order_by.is_empty() && !stmt.distinct {
-                // Only push limit when there's no ORDER BY or DISTINCT that needs full result
-                limit.map(|l| l + offset)
-            } else {
-                None
-            };
             result = self.execute_set_operations(result, &stmt.set_operations, ctx, set_limit)?;
 
             // The set operation gathers LIMIT + OFFSET rows at most; the

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -461,7 +461,10 @@ impl Executor {
             .iter()
             .all(|op| matches!(op.operation, SetOperationType::UnionAll));
         let set_limit = if all_union_all && stmt.order_by.is_empty() && !stmt.distinct {
-            limit.map(|l| l + offset)
+            // A sum past i64 is no bound the branch can take
+            limit
+                .and_then(|l| l.checked_add(offset))
+                .filter(|bound| i64::try_from(*bound).is_ok())
         } else {
             None
         };

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -141,6 +141,19 @@ impl ColumnKeyMapping {
     }
 }
 
+/// Whether a predicate is the equality of the two join keys, in either order
+fn is_key_equality(pred: &Expression, outer_key: &str, inner_key: &str) -> bool {
+    let Expression::Infix(infix) = pred else {
+        return false;
+    };
+    if infix.op_type != InfixOperator::Equal {
+        return false;
+    }
+    let left = super::utils::expression_to_string(&infix.left).to_lowercase();
+    let right = super::utils::expression_to_string(&infix.right).to_lowercase();
+    (left == outer_key && right == inner_key) || (left == inner_key && right == outer_key)
+}
+
 /// Partition WHERE clause predicates for JOIN filter pushdown.
 /// Returns (left_filter, right_filter, cross_table_filter).
 /// - left_filter: predicates referencing only left table
@@ -4565,14 +4578,26 @@ impl Executor {
                         let inner_filter = nl_right_filter
                             .as_ref()
                             .map(|rf| add_table_qualifier(rf, inner_alias));
-                        let combined = match (on_condition, inner_filter) {
+                        // The equality the probe answers is left out, so
+                        // only the rest of the clause is asked of each pair
+                        let inner_key = format!("{inner_alias}.{inner_col}").to_lowercase();
+                        let outer_key = outer_col.to_lowercase();
+                        let rest = on_condition.and_then(|on| {
+                            combine_predicates_with_and(
+                                flatten_and_predicates(on)
+                                    .into_iter()
+                                    .filter(|pred| !is_key_equality(pred, &outer_key, &inner_key))
+                                    .collect(),
+                            )
+                        });
+                        let combined = match (rest, inner_filter) {
                             (Some(on), Some(f)) => Some(Expression::Infix(InfixExpression::new(
                                 Token::new(TokenType::Operator, "AND", Position::default()),
-                                Box::new(on.clone()),
+                                Box::new(on),
                                 "AND".to_string(),
                                 Box::new(f),
                             ))),
-                            (Some(on), None) => Some(on.clone()),
+                            (Some(on), None) => Some(on),
                             (None, Some(f)) => Some(f),
                             (None, None) => None,
                         };

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -4577,6 +4577,13 @@ impl Executor {
                     // operator asks it where the pair is formed, so a pair it
                     // turns away leaves an outer row still unmatched. The
                     // filter is built per pass since the operator owns it
+                    // The inner key column, checked on each fetched row in
+                    // place of the equality the residual filter leaves out
+                    let inner_key_idx = inner_cols.iter().position(|c| {
+                        c.rsplit('.')
+                            .next()
+                            .is_some_and(|name| name.eq_ignore_ascii_case(&inner_col))
+                    });
                     let build_residual_filter = || {
                         let inner_filter = nl_right_filter
                             .as_ref()
@@ -4671,7 +4678,8 @@ impl Executor {
                                 outer_idx,
                                 lookup_strategy.clone(),
                                 build_residual_filter(),
-                            );
+                            )
+                            .with_inner_key(inner_key_idx);
                             if let Some(ref proj) = projection_pushdown {
                                 let projected_schema: Vec<ColumnInfo> =
                                     proj.output_columns.iter().map(ColumnInfo::new).collect();
@@ -4767,7 +4775,8 @@ impl Executor {
                             outer_idx,
                             lookup_strategy.clone(),
                             build_residual_filter(),
-                        );
+                        )
+                        .with_inner_key(inner_key_idx);
                         let mut join_op: Box<dyn Operator> =
                             if let Some(ref proj) = projection_pushdown {
                                 let projected_schema: Vec<ColumnInfo> =

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -2521,7 +2521,25 @@ impl Table for MVCCTable {
     }
 
     fn get_active_row_ids(&self) -> Result<Vec<i64>> {
-        Ok(self.version_store.get_all_row_ids())
+        let mut ids = self.version_store.get_all_row_ids();
+        // The transaction's own inserts and deletes are part of what it sees
+        let txn_versions = self.txn_versions.read().unwrap();
+        if txn_versions.has_local_changes() {
+            let mut deleted = crate::common::I64Set::new();
+            let mut inserted = Vec::new();
+            for (row_id, version) in txn_versions.iter_local() {
+                if version.is_deleted() {
+                    deleted.insert(row_id);
+                } else {
+                    inserted.push(row_id);
+                }
+            }
+            ids.retain(|id| !deleted.contains(*id));
+            ids.extend(inserted);
+            ids.sort_unstable();
+            ids.dedup();
+        }
+        Ok(ids)
     }
 
     fn visible_row_ids_excluding(

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -2521,7 +2521,13 @@ impl Table for MVCCTable {
     }
 
     fn get_active_row_ids(&self) -> Result<Vec<i64>> {
-        let mut ids = self.version_store.get_all_row_ids();
+        // Only the keys this transaction sees: a committed delete stays in
+        // the version tree until it is collected, but it is not a row
+        let mut ids = self.version_store.visible_row_ids_excluding(
+            self.txn_id,
+            &crate::common::I64Set::new(),
+            usize::MAX,
+        );
         // The transaction's own inserts and deletes are part of what it sees
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -2524,6 +2524,26 @@ impl Table for MVCCTable {
         Ok(self.version_store.get_all_row_ids())
     }
 
+    fn visible_row_ids_excluding(
+        &self,
+        exclude: &crate::common::I64Set,
+        limit: usize,
+    ) -> Result<Vec<i64>> {
+        // A transaction with writes of its own reads the whole key list
+        if self.txn_versions.read().unwrap().has_local_changes() {
+            let mut ids = self.get_active_row_ids()?;
+            ids.sort_unstable();
+            return Ok(ids
+                .into_iter()
+                .filter(|id| !exclude.contains(*id))
+                .take(limit)
+                .collect());
+        }
+        Ok(self
+            .version_store
+            .visible_row_ids_excluding(self.txn_id, exclude, limit))
+    }
+
     fn collect_hot_row_ids_into(&self, dest: &mut rustc_hash::FxHashSet<i64>) {
         self.version_store.collect_row_ids_into(dest);
     }

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -2672,6 +2672,49 @@ impl VersionStore {
         result
     }
 
+    /// The row ids visible to `txn_id`, in key order, leaving out the ones
+    /// in `exclude` and stopping after `limit` of them
+    pub fn visible_row_ids_excluding(
+        &self,
+        txn_id: i64,
+        exclude: &crate::common::I64Set,
+        limit: usize,
+    ) -> Vec<i64> {
+        if self.closed.load(Ordering::Acquire) || limit == 0 {
+            return Vec::new();
+        }
+        let checker = match self.visibility_checker.as_ref() {
+            Some(c) => c,
+            None => return Vec::new(),
+        };
+        let versions = self.versions.read().clone();
+        let mut result = Vec::with_capacity(limit.min(4096));
+        for (&row_id, chain) in versions.iter() {
+            if exclude.contains(row_id) {
+                continue;
+            }
+            // The newest version this transaction sees decides whether
+            // the row exists for it
+            let mut current: Option<&VersionChainEntry> = Some(chain);
+            let mut exists = false;
+            while let Some(e) = current {
+                if checker.is_visible(e.version.txn_id, txn_id) {
+                    let deleted_at = e.version.deleted_at_txn_id;
+                    exists = deleted_at == 0 || !checker.is_visible(deleted_at, txn_id);
+                    break;
+                }
+                current = e.prev.as_ref().map(|b| b.as_ref());
+            }
+            if exists {
+                result.push(row_id);
+                if result.len() >= limit {
+                    break;
+                }
+            }
+        }
+        result
+    }
+
     /// Get visible rows with LIMIT (with early termination).
     ///
     /// Note: Functionally identical to get_visible_rows_with_limit. Kept for API compatibility.

--- a/src/storage/traits/table.rs
+++ b/src/storage/traits/table.rs
@@ -376,6 +376,22 @@ pub trait Table: Send + Sync {
     /// Used for NOT IN (anti-join) optimization.
     fn get_active_row_ids(&self) -> Result<Vec<i64>>;
 
+    /// The row ids the current transaction sees, in key order, leaving
+    /// out the ones in `exclude` and stopping after `limit` of them
+    fn visible_row_ids_excluding(
+        &self,
+        exclude: &crate::common::I64Set,
+        limit: usize,
+    ) -> Result<Vec<i64>> {
+        let mut ids = self.get_active_row_ids()?;
+        ids.sort_unstable();
+        Ok(ids
+            .into_iter()
+            .filter(|id| !exclude.contains(*id))
+            .take(limit)
+            .collect())
+    }
+
     /// Populate a FxHashSet with all hot row_ids. Avoids the intermediate Vec
     /// allocation of get_active_row_ids() when building skip sets. Required
     /// (no default): implementations must stay infallible for hot data.

--- a/tests/exists_subquery_test.rs
+++ b/tests/exists_subquery_test.rs
@@ -732,3 +732,29 @@ fn test_not_exists_on_a_primary_key_sees_the_transaction_and_every_conjunct() {
         [9223372036854775807]
     );
 }
+
+#[test]
+fn test_not_exists_on_a_primary_key_skips_a_committed_delete() {
+    let db = Database::open("memory://exists_not_exists_committed_delete").unwrap();
+    db.execute("CREATE TABLE u (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    db.execute("INSERT INTO u VALUES (10), (20)", ()).unwrap();
+    db.execute("CREATE TABLE o (id INTEGER PRIMARY KEY, uid INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO o VALUES (1, 999)", ()).unwrap();
+    db.execute("DELETE FROM u WHERE id = 10", ()).unwrap();
+    let ids = |sql: &str| -> Vec<i64> {
+        db.query(sql, ())
+            .unwrap()
+            .map(|r| r.unwrap().get::<i64>(0).unwrap())
+            .collect()
+    };
+    // The deleted key stays in the version tree until it is collected,
+    // but it is not a row, so it must not use up the LIMIT
+    let query = "SELECT id FROM u WHERE NOT EXISTS (SELECT 1 FROM o WHERE o.uid = u.id) LIMIT 1";
+    assert_eq!(ids(query), [20]);
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("INSERT INTO u VALUES (30)", ()).unwrap();
+    assert_eq!(ids(query), [20]);
+    db.execute("ROLLBACK", ()).unwrap();
+}

--- a/tests/exists_subquery_test.rs
+++ b/tests/exists_subquery_test.rs
@@ -646,3 +646,35 @@ fn test_not_exists_on_a_primary_key_with_limit() {
         .unwrap();
     assert_eq!(count, 200);
 }
+
+#[test]
+fn test_not_exists_keeps_the_keys_the_table_holds() {
+    let db = Database::open("memory://exists_not_exists_sparse_pk").unwrap();
+    db.execute(
+        "CREATE TABLE u (id INTEGER PRIMARY KEY, enabled INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO u VALUES (10, 1), (20, 0), (30, 1)", ())
+        .unwrap();
+    db.execute("CREATE TABLE o (id INTEGER PRIMARY KEY, uid INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO o VALUES (1, 10), (2, NULL)", ())
+        .unwrap();
+    let ids = |sql: &str| -> Vec<i64> {
+        db.query(sql, ())
+            .unwrap()
+            .map(|r| r.unwrap().get::<i64>(0).unwrap())
+            .collect()
+    };
+    // The keys are 10, 20 and 30, not 1, 2 and 3
+    assert_eq!(
+        ids("SELECT id FROM u WHERE NOT EXISTS (SELECT 1 FROM o WHERE o.uid = u.id) LIMIT 5"),
+        [20, 30]
+    );
+    // A conjunct beside the negated set still applies
+    assert_eq!(
+        ids("SELECT id FROM u WHERE (NOT EXISTS (SELECT 1 FROM o WHERE o.uid = u.id) AND enabled = 1) OR id IS NULL"),
+        [30]
+    );
+}

--- a/tests/exists_subquery_test.rs
+++ b/tests/exists_subquery_test.rs
@@ -678,3 +678,57 @@ fn test_not_exists_keeps_the_keys_the_table_holds() {
         [30]
     );
 }
+
+#[test]
+fn test_not_exists_on_a_primary_key_sees_the_transaction_and_every_conjunct() {
+    let db = Database::open("memory://exists_not_exists_pk_transaction").unwrap();
+    db.execute(
+        "CREATE TABLE u (id INTEGER PRIMARY KEY, enabled INTEGER, region INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO u VALUES (10, 1, 1), (20, 0, 1), (40, 1, 1)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE TABLE o (id INTEGER PRIMARY KEY, uid INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO o VALUES (1, 10)", ()).unwrap();
+    let ids = |sql: &str| -> Vec<i64> {
+        let mut ids: Vec<i64> = db
+            .query(sql, ())
+            .unwrap()
+            .map(|r| r.unwrap().get::<i64>(0).unwrap())
+            .collect();
+        ids.sort_unstable();
+        ids
+    };
+    // A row inserted in the transaction is a key, a row deleted in it is not
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("INSERT INTO u VALUES (30, 1, 1)", ()).unwrap();
+    db.execute("DELETE FROM u WHERE id = 40", ()).unwrap();
+    assert_eq!(
+        ids("SELECT id FROM u WHERE NOT EXISTS (SELECT 1 FROM o WHERE o.uid = u.id) LIMIT 5"),
+        [20, 30]
+    );
+    db.execute("ROLLBACK", ()).unwrap();
+    // Every conjunct beside the negated set applies, however the AND nests
+    assert_eq!(
+        ids("SELECT id FROM u WHERE NOT EXISTS (SELECT 1 FROM o WHERE o.uid = u.id) AND enabled = 1 AND region = 1"),
+        [40]
+    );
+    // A float past i64 names no key, so it excludes none
+    db.execute("CREATE TABLE big (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    db.execute("INSERT INTO big VALUES (9223372036854775807)", ())
+        .unwrap();
+    db.execute("CREATE TABLE bo (id INTEGER PRIMARY KEY, uid FLOAT)", ())
+        .unwrap();
+    db.execute("INSERT INTO bo VALUES (1, 9223372036854775808.0)", ())
+        .unwrap();
+    assert_eq!(
+        ids("SELECT id FROM big WHERE NOT EXISTS (SELECT 1 FROM bo WHERE bo.uid = big.id) LIMIT 1"),
+        [9223372036854775807]
+    );
+}

--- a/tests/exists_subquery_test.rs
+++ b/tests/exists_subquery_test.rs
@@ -606,3 +606,43 @@ fn test_update_binds_each_row_to_a_where_the_semi_join_rewrite_refused() {
         assert_eq!(count("SELECT SUM(b) FROM uy"), 11, "keyed: {keyed}");
     }
 }
+
+#[test]
+fn test_not_exists_on_a_primary_key_with_limit() {
+    let db = Database::open("memory://exists_not_exists_pk_limit").unwrap();
+    db.execute("CREATE TABLE u (id INTEGER PRIMARY KEY, k INTEGER)", ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE o (id INTEGER PRIMARY KEY, uid INTEGER, s TEXT)",
+        (),
+    )
+    .unwrap();
+    let rows: Vec<String> = (1..=300).map(|i| format!("({i}, {})", i % 7)).collect();
+    db.execute(&format!("INSERT INTO u VALUES {}", rows.join(", ")), ())
+        .unwrap();
+    let orders: Vec<String> = (1..=300)
+        .map(|i| format!("({i}, {i}, '{}')", if i % 3 == 0 { "x" } else { "y" }))
+        .collect();
+    db.execute(&format!("INSERT INTO o VALUES {}", orders.join(", ")), ())
+        .unwrap();
+    // Every third user has an x order; the rest are kept, in id order
+    let kept: Vec<i64> = db
+        .query(
+            "SELECT id FROM u WHERE NOT EXISTS (SELECT 1 FROM o WHERE o.uid = u.id AND o.s = 'x') LIMIT 5",
+            (),
+        )
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect();
+    assert_eq!(kept, [1, 2, 4, 5, 7]);
+    let count: i64 = db
+        .query(
+            "SELECT COUNT(*) FROM u WHERE NOT EXISTS (SELECT 1 FROM o WHERE o.uid = u.id AND o.s = 'x')",
+            (),
+        )
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .next()
+        .unwrap();
+    assert_eq!(count, 200);
+}

--- a/tests/join_on_condition_test.rs
+++ b/tests/join_on_condition_test.rs
@@ -460,3 +460,34 @@ fn test_the_condition_sees_the_transaction() {
         db.execute("ROLLBACK", ()).unwrap();
     }
 }
+
+#[test]
+fn test_an_index_probe_checks_the_key_of_the_row_it_fetches() {
+    let db = Database::open("memory://join_on_stale_index_entry").unwrap();
+    db.execute("CREATE TABLE p (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE r (id INTEGER PRIMARY KEY, p_id INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE INDEX idx_r_p ON r(p_id)", ()).unwrap();
+    db.execute("INSERT INTO p VALUES (1, 100), (2, 200)", ())
+        .unwrap();
+    db.execute("INSERT INTO r VALUES (1, 1)", ()).unwrap();
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("UPDATE r SET p_id = 2 WHERE id = 1", ())
+        .unwrap();
+    // The index still points key 1 at the row, whose key is now 2: the
+    // row must not come back as a match for p.id = 1
+    let pairs: Vec<(i64, i64)> = db
+        .query("SELECT p.id, r.p_id FROM p JOIN r ON p.id = r.p_id", ())
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            (r.get::<i64>(0).unwrap(), r.get::<i64>(1).unwrap())
+        })
+        .collect();
+    assert!(
+        pairs.iter().all(|(p, r)| p == r),
+        "a pair whose keys differ came back: {pairs:?}"
+    );
+    db.execute("ROLLBACK", ()).unwrap();
+}

--- a/tests/set_operation_order_limit_test.rs
+++ b/tests/set_operation_order_limit_test.rs
@@ -137,3 +137,21 @@ fn test_union_all_limit_and_offset_without_order_by() {
         [1003]
     );
 }
+
+#[test]
+fn test_a_limit_and_offset_past_i64_do_not_fail_the_first_branch() {
+    let db = Database::open("memory://set_operation_limit_overflow").unwrap();
+    db.execute("CREATE TABLE a (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    db.execute("CREATE TABLE b (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    db.execute("INSERT INTO a VALUES (1)", ()).unwrap();
+    db.execute("INSERT INTO b VALUES (2)", ()).unwrap();
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT id FROM a UNION ALL SELECT id FROM b LIMIT 9223372036854775807 OFFSET 1"
+        ),
+        [2]
+    );
+}

--- a/tests/set_operation_order_limit_test.rs
+++ b/tests/set_operation_order_limit_test.rs
@@ -100,3 +100,40 @@ fn test_offset_skips_rows_of_the_whole_union() {
         [2]
     );
 }
+
+#[test]
+fn test_union_all_limit_and_offset_without_order_by() {
+    let db = Database::open("memory://set_operation_union_all_bound").unwrap();
+    db.execute("CREATE TABLE a (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE TABLE b (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    let rows: Vec<String> = (1..=1000).map(|i| format!("({i}, {i})")).collect();
+    db.execute(&format!("INSERT INTO a VALUES {}", rows.join(", ")), ())
+        .unwrap();
+    db.execute("INSERT INTO b VALUES (1, -1), (2, -2), (3, -3)", ())
+        .unwrap();
+    // The first branch alone covers LIMIT + OFFSET, so its rows are the answer
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT v FROM a UNION ALL SELECT v FROM b LIMIT 3 OFFSET 2"
+        ),
+        [3, 4, 5]
+    );
+    // The first branch runs out and the second one fills the rest
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT v FROM a WHERE id <= 2 UNION ALL SELECT v FROM b LIMIT 3 OFFSET 1"
+        ),
+        [2, -1, -2]
+    );
+    assert_eq!(
+        ints(
+            &db,
+            "SELECT COUNT(*) FROM (SELECT v FROM a UNION ALL SELECT v FROM b LIMIT 1500)"
+        ),
+        [1003]
+    );
+}


### PR DESCRIPTION
Three of the five regressions the benchmark reported after #94 were real and are fixed here; the other two are explained below. Each was bisected with a probe that builds the benchmark's tables (10,000 users, 30,000 orders, the same indexes) and times the exact statements, run at the branch base, at the merge and with the fixes, all in release.

| Query | Base | After #94 | Fixed |
|---|---|---|---|
| UNION ALL | 26.5 us | 164 | 24.1 |
| NOT EXISTS subquery | 17.9 | 107 | 18.7 |
| INNER JOIN | 16.0 | 16.4 | 15.0 |
| Self JOIN (same age) | 9.2 | 12.8 | 13.5 |
| Derived table (FROM sub) | 421 | 502 to 550 | 550 |

**UNION ALL** (bisected to fa60aeb2). Giving ORDER BY, LIMIT and OFFSET to the whole set operation left the first branch unbounded, so it scanned its table in full. A pure UNION ALL without ORDER BY or DISTINCT needs LIMIT + OFFSET rows at most from each branch, so that many bound the first branch again; the whole is still cut afterwards. `set_operation_order_limit_test` covers LIMIT with OFFSET when the first branch alone covers them, when it runs out, and the row count.

**NOT EXISTS** (bisected to 5a1c5021). Keeping the rows a NOT EXISTS keeps when the outer value is NULL wrapped the negated set in `OR column IS NULL`, a shape the primary key probe did not recognise, so the query scanned every row instead of stopping at its LIMIT. The probe now reads that shape; it only runs on a primary key, which holds no NULL, so the second side never fires there. `exists_subquery_test` covers a NOT EXISTS on a primary key with a LIMIT and its count.

**INNER JOIN and self join** (bisected to 4af7b80e). Asking the whole ON clause of each pair the index probe returns repeated the key equality the probe had already answered. The equality is now left out of the residual filter, so a join with nothing else in its ON clause has no filter at all, as before. The inner join is back at parity. The self join keeps about a third of its cost: its ON clause carries `u1.id < u2.id`, which the base never evaluated and answered wrongly (every pair the key matched came back, #94 fixed that); that predicate has to be asked of each pair.

**Derived table.** Not a regression as far as the probe can tell: in debug builds the base and the merge are within four percent of each other, and two release runs of the same merged code gave 502 and 550 microseconds, so the release figures move by more than the reported difference from run to run.

**Review findings on the first three commits**, all confirmed on a probe first:
- The negated set probe for a primary key walked 1 to the row count as if those were the keys, so a table whose keys are 10, 20 and 30 answered NOT EXISTS with nothing. This bug is older than #94, which had hidden it by routing around the probe. The keys are now read off the table in key order, stopping at the LIMIT, through a `visible_row_ids_excluding` method on the table (an ordered walk of the version tree for the memory table; the sorted active ids elsewhere). The OR shape is taken only for a bare negated set without NULLs, so a conjunct beside the set is not lost and a set holding a NULL keeps its answer.
- Inside a transaction a secondary index entry may be older than the row it points at, since the index is updated at commit, so a probe for key 1 could fetch a row whose key is now 2 and pair it wrongly; asking the whole ON clause had hidden that. The operator now compares the fetched row's own key with the outer key, one value comparison instead of the compiled equality. The row's new key is still not found through the index inside the transaction; that visibility is a separate, older matter.
- LIMIT 9223372036854775807 OFFSET 1 summed past i64 and the first branch refused a negative LIMIT; a sum that does not fit is no bound.

With those, the release probe reads UNION ALL 32, NOT EXISTS 29, INNER JOIN 21, self join 19 and derived table 786 microseconds on a run where every figure, base shapes included, sits a quarter above the table: the machine was warm after several release builds. The three restored queries keep their pace relative to each other.

**Second review round**, confirmed on a probe first:
- The key list a transaction with writes read left out the rows it had inserted and kept the ones it had deleted, so a NOT EXISTS inside the transaction missed its own insert; `get_active_row_ids` now merges the local versions, which is what its contract says, and the DELETE ... NOT IN path that reads it gains the same.
- An AND that nested another AND around the negated set dropped the inner remaining predicate, so `enabled = 1` beside `region = 1` was lost; the sibling now joins it.
- A float past i64 saturated onto i64::MAX and excluded that key; only a losslessly integral float names one.
- `get_active_row_ids` read every key in the version tree, where a committed delete stays until it is collected, so such a key could use up the LIMIT before the fetch dropped it: the memory table inside a transaction with writes, and the file table always, answered with nothing. The list is now read with the transaction's visibility, then merged with its own inserts and deletes; the test runs under both backends.

**Final measurement**, release, one session on a cool machine, base then branch then base again so drift cancels:

| Query | Base | Branch |
|---|---|---|
| UNION ALL | 20.4 us | 19.5 / 19.9 |
| INNER JOIN | 12.5 | 12.5 / 12.3 |
| Derived table (FROM sub) | 342 | 357 / 349 |
| NOT EXISTS subquery | 13.5 | 19.6 / 19.3 |
| Self JOIN (same age) | 7.5 | 12.2 / 11.7 |

UNION ALL and the inner join are at parity, and the derived table is within four percent, so the forty percent it showed against the stored baseline came from the conditions that baseline was recorded under, not from the code. Two differences remain and both buy a right answer: NOT EXISTS pays about six microseconds for reading the keys the table actually holds with the transaction's visibility, where the base walked 1 to the row count and answered wrongly for sparse keys and committed deletes; the self join pays about four for asking `u1.id < u2.id` of each pair, which the base never asked. The last commit trims what it can: the key walk reads under the lock instead of cloning the tree, and a bounded UNION ALL runs on the statement instead of a copy.

The memory suite passes with the full profile (5255); the file suite passed on the previous commit (5256), which the last one, executor and lock scope only, does not touch.
