### PR TITLE
perf: read the key tree under its lock and run a bounded UNION ALL branch without a copy

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -470,9 +470,15 @@ impl Executor {
         };
 
         // ORDER BY, LIMIT and OFFSET belong to the whole set operation, so
-        // the first branch runs without them, apart from that bound
+        // the first branch runs without them, apart from that bound. With
+        // no ORDER BY or OFFSET the statement's own LIMIT is that bound,
+        // so the statement runs as it is, without a copy
         let branch_stmt;
-        let branch = if stmt.set_operations.is_empty() {
+        let branch = if stmt.set_operations.is_empty()
+            || (stmt.order_by.is_empty()
+                && stmt.offset.is_none()
+                && (stmt.limit.is_none() || set_limit.is_some()))
+        {
             stmt
         } else {
             branch_stmt = SelectStatement {

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -2687,7 +2687,9 @@ impl VersionStore {
             Some(c) => c,
             None => return Vec::new(),
         };
-        let versions = self.versions.read().clone();
+        // Read under the lock rather than cloning the tree: the walk stops
+        // at the limit, and a full one only reads keys and heads
+        let versions = self.versions.read();
         let mut result = Vec::with_capacity(limit.min(4096));
         for (&row_id, chain) in versions.iter() {
             if exclude.contains(row_id) {

--- a/tests/group_key_projection_test.rs
+++ b/tests/group_key_projection_test.rs
@@ -122,3 +122,33 @@ fn test_counting_alone_over_a_text_key_of_a_derived_table() {
         ["1,NULL", "2,p", "2,q"]
     );
 }
+
+#[test]
+fn test_a_derived_group_by_keeps_every_select_expression() {
+    let db = Database::open("memory://group_key_projection_derived_exprs").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, k TEXT)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 'a'), (2, 'a'), (3, 'b')", ())
+        .unwrap();
+    // An expression over the group column beside the aggregates is a
+    // column of its own, whatever path answers the query
+    let rows: Vec<(String, String, i64)> = db
+        .query(
+            "SELECT k, UPPER(k), COUNT(*) FROM (SELECT k FROM t) s GROUP BY k ORDER BY k",
+            (),
+        )
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            (
+                r.get::<String>(0).unwrap(),
+                r.get::<String>(1).unwrap(),
+                r.get::<i64>(2).unwrap(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        rows,
+        [("a".into(), "A".into(), 2), ("b".into(), "B".into(), 1)]
+    );
+}


### PR DESCRIPTION
Two trims left over from #95, measured in release in one session with the base run between two branch runs so drift cancels:

| Query | Base | Branch |
|---|---|---|
| UNION ALL | 20.4 us | 19.5 / 19.9 |
| NOT EXISTS subquery | 13.5 | 19.6 / 19.3 |

- The ordered key walk behind a NOT EXISTS on a primary key cloned the version tree on every call; it now reads under the read lock, the way the skip-set builder does.
- A pure UNION ALL whose only bound is its own LIMIT ran on a copy of the statement; it runs on the statement.

The six microseconds NOT EXISTS keeps over the base are the price of reading the keys the table actually holds with the transaction's visibility, where the base walked 1 to the row count and answered wrongly for sparse keys and committed deletes.

A test pins the shape a streaming shortcut for a derived-table GROUP BY must not take: an expression over the group column beside the aggregates stays a column of its own. It passes on main; a guard change tried on the way here would have broken it, and was dropped.

The memory suite passes with the full profile.
