### PR TITLE
perf(aggregate): judge the streaming derived GROUP BY by the shape of its select list

### DIFF
--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -6173,20 +6173,44 @@ impl Executor {
             }
             _ => false,
         };
-        let bare_aggregate_call = |expr: &crate::parser::ast::Expression| {
+        // The parser folds a repeated aggregate into one and appends the
+        // ones a hidden ORDER BY needs, so each select column is matched to
+        // the aggregate in its own position, by name, argument and DISTINCT
+        let same_aggregate = |expr: &crate::parser::ast::Expression, agg: &SqlAggregateFunction| {
             let inner = match expr {
                 crate::parser::ast::Expression::Aliased(aliased) => aliased.expression.as_ref(),
                 other => other,
             };
-            matches!(
-                inner,
-                crate::parser::ast::Expression::FunctionCall(func)
-                    if crate::executor::utils::is_aggregate_function(&func.function)
-            )
+            let crate::parser::ast::Expression::FunctionCall(func) = inner else {
+                return false;
+            };
+            if !crate::executor::utils::is_aggregate_function(&func.function)
+                || !agg.name.eq_ignore_ascii_case(&func.function)
+                || agg.distinct != func.is_distinct
+            {
+                return false;
+            }
+            match func.arguments.first() {
+                None | Some(crate::parser::ast::Expression::Star(_)) => agg.column == "*",
+                Some(arg) => {
+                    let arg_text = crate::executor::utils::expression_to_string(arg);
+                    match &agg.expression {
+                        Some(expr) => {
+                            crate::executor::utils::expression_to_string(expr) == arg_text
+                        }
+                        None => agg.column.eq_ignore_ascii_case(&arg_text),
+                    }
+                }
+            }
         };
         let shape_matches = stmt.columns.first().is_some_and(names_group_column)
-            && stmt.columns.iter().skip(1).all(bare_aggregate_call)
             && aggregations.len() + 1 == stmt.columns.len()
+            && stmt
+                .columns
+                .iter()
+                .skip(1)
+                .zip(&aggregations)
+                .all(|(column, agg)| same_aggregate(column, agg))
             && non_agg_columns
                 .iter()
                 .all(|column| column.eq_ignore_ascii_case(&group_col_name));

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -6161,20 +6161,36 @@ impl Executor {
         let (aggregations, non_agg_columns) = self.parse_aggregations(stmt)?;
 
         // The rows come out as the GROUP BY column and then the aggregates,
-        // so the select list has to read exactly that, in that order
-        if non_agg_columns.len() != 1 || !non_agg_columns[0].eq_ignore_ascii_case(&group_col_name) {
-            return Ok(None);
-        }
-        let leads_with_group_column = match stmt.columns.first() {
-            Some(crate::parser::ast::Expression::Identifier(id)) => {
+        // so the select list has to read exactly that, in that order: the
+        // group column first, bare or qualified, then nothing but aggregate
+        // calls, one per aggregate parsed
+        let names_group_column = |expr: &crate::parser::ast::Expression| match expr {
+            crate::parser::ast::Expression::Identifier(id) => {
                 id.value_lower.eq_ignore_ascii_case(&group_col_name)
             }
-            Some(crate::parser::ast::Expression::QualifiedIdentifier(qid)) => {
+            crate::parser::ast::Expression::QualifiedIdentifier(qid) => {
                 qid.name.value_lower.eq_ignore_ascii_case(&group_col_name)
             }
             _ => false,
         };
-        if !leads_with_group_column {
+        let bare_aggregate_call = |expr: &crate::parser::ast::Expression| {
+            let inner = match expr {
+                crate::parser::ast::Expression::Aliased(aliased) => aliased.expression.as_ref(),
+                other => other,
+            };
+            matches!(
+                inner,
+                crate::parser::ast::Expression::FunctionCall(func)
+                    if crate::executor::utils::is_aggregate_function(&func.function)
+            )
+        };
+        let shape_matches = stmt.columns.first().is_some_and(names_group_column)
+            && stmt.columns.iter().skip(1).all(bare_aggregate_call)
+            && aggregations.len() + 1 == stmt.columns.len()
+            && non_agg_columns
+                .iter()
+                .all(|column| column.eq_ignore_ascii_case(&group_col_name));
+        if !shape_matches {
             return Ok(None);
         }
 

--- a/tests/group_key_projection_test.rs
+++ b/tests/group_key_projection_test.rs
@@ -152,3 +152,28 @@ fn test_a_derived_group_by_keeps_every_select_expression() {
         [("a".into(), "A".into(), 2), ("b".into(), "B".into(), 1)]
     );
 }
+
+#[test]
+fn test_a_repeated_aggregate_beside_a_hidden_order_by_aggregate_keeps_its_place() {
+    let db = Database::open("memory://group_key_projection_hidden_aggregate").unwrap();
+    // COUNT(*) appears twice and SUM(v) only in ORDER BY: the parser folds
+    // the repeat and appends the hidden one, so the select list and the
+    // parsed aggregates disagree on positions
+    let rows: Vec<(String, i64, i64)> = db
+        .query(
+            "SELECT t.k, COUNT(*) AS a, COUNT(*) AS b FROM (SELECT 'x' AS k, 10 AS v) t \
+             GROUP BY t.k ORDER BY SUM(v)",
+            (),
+        )
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            (
+                r.get::<String>(0).unwrap(),
+                r.get::<i64>(1).unwrap(),
+                r.get::<i64>(2).unwrap(),
+            )
+        })
+        .collect();
+    assert_eq!(rows, [("x".into(), 1, 1)]);
+}


### PR DESCRIPTION
The derived-table GROUP BY on the benchmark (`SELECT t.age_group, COUNT(*) FROM (SELECT CASE ... END as age_group FROM users) t GROUP BY t.age_group`) took forty percent longer after #94. Bisecting with the benchmark itself lands on the guard that keeps the streaming text-key path to a select list of the group column followed by its aggregates: it read the group column through the aggregate parser, which never records a qualified column, so `t.age_group` could not pass and the query fell to the general path.

The guard now reads the shape off the select list: the group column first, bare or qualified, then nothing but aggregate calls, one per aggregate parsed. That still keeps out the two shapes the guard was written for, a count in the key's place (`SELECT COUNT(*) ... GROUP BY s`) and an expression beside the aggregates (`SELECT k, UPPER(k), COUNT(*)`), both covered by `group_key_projection_test`.

Benchmark, release, same session: base 383 to 441 us, before this change 539 to 570, with it 380 to 401.

Two other lines the benchmark reported are measurement, not code. UNION ALL reads 10 us right after the three window benchmarks, while the same statement re-prepared immediately afterwards reads 5.9 us flat from its first runs, and a probe replaying the benchmark's own DML workload puts base and branch at 4.8 and 5.1; a transient after heavy allocating queries that decays within a few milliseconds. NOT EXISTS keeps six microseconds over the base, which with that same workload answered 99 rows where 100 are right; the self join keeps four for asking the ON predicate the base never asked.

**Review finding.** An equal count of parsed aggregates and select columns did not prove the streaming output followed the select list: the parser folds a repeated aggregate into one and appends the ones a hidden ORDER BY needs, so `SELECT t.k, COUNT(*) AS a, COUNT(*) AS b ... ORDER BY SUM(v)` put the hidden sum where `b` belongs. Each select column is now matched to the aggregate in its own position, by name, argument and DISTINCT; `group_key_projection_test` pins it, and the benchmark line still reads 380 to 400 us.

The memory suite passes with the full profile.
