### PR TITLE
docs: TRIM's character argument, read-only pragmas, and what ROLLBACK undoes for DDL

### DIFF
--- a/docs/_docs/functions/scalar-functions.md
+++ b/docs/_docs/functions/scalar-functions.md
@@ -67,13 +67,18 @@ SELECT CONCAT_WS('-', city, state, zip) AS address FROM customers;
 Note: NULL values are skipped.
 
 ### TRIM / LTRIM / RTRIM
-Removes whitespace from strings.
+Removes whitespace, or the characters given as the optional second argument, from strings.
 
 ```sql
 SELECT TRIM('  hello  ');                  -- Returns 'hello'
 SELECT LTRIM('  hello');                   -- Returns 'hello'
 SELECT RTRIM('hello  ');                   -- Returns 'hello'
+SELECT TRIM('xxhelloxx', 'x');             -- Returns 'hello'
+SELECT LTRIM('--hello', '-');              -- Returns 'hello'
+SELECT RTRIM('hello!!', '!');              -- Returns 'hello'
 ```
+
+The SQL-standard `TRIM(LEADING | TRAILING | BOTH chars FROM str)` form is not supported.
 
 ### LPAD / RPAD
 Pads a string to a specified length.

--- a/docs/_docs/functions/sql-functions-reference.md
+++ b/docs/_docs/functions/sql-functions-reference.md
@@ -48,9 +48,9 @@ Aggregate functions operate on a set of rows and return a single value. Used wit
 | `CONCAT_WS` | `CONCAT_WS(sep, str1, str2, ...)` | Concatenate with separator |
 | `SUBSTRING` | `SUBSTRING(str, pos, len)` | Extract substring |
 | `SUBSTR` | `SUBSTR(str, pos, len)` | Alias for SUBSTRING |
-| `TRIM` | `TRIM(str)` | Remove leading/trailing whitespace |
-| `LTRIM` | `LTRIM(str)` | Remove leading whitespace |
-| `RTRIM` | `RTRIM(str)` | Remove trailing whitespace |
+| `TRIM` | `TRIM(str [, chars])` | Remove leading/trailing whitespace or the given characters |
+| `LTRIM` | `LTRIM(str [, chars])` | Remove leading whitespace or the given characters |
+| `RTRIM` | `RTRIM(str [, chars])` | Remove trailing whitespace or the given characters |
 | `REPLACE` | `REPLACE(str, from, to)` | Replace occurrences |
 | `REVERSE` | `REVERSE(str)` | Reverse a string |
 | `LEFT` | `LEFT(str, n)` | First n characters |

--- a/docs/_docs/getting-started/connection-strings.md
+++ b/docs/_docs/getting-started/connection-strings.md
@@ -194,14 +194,15 @@ You can also configure settings after connection using PRAGMA commands:
 
 ```sql
 -- Set configuration values
-PRAGMA sync_mode = 2;
 PRAGMA checkpoint_interval = 60;
 PRAGMA compact_threshold = 4;
+PRAGMA target_volume_rows = 1048576;
 PRAGMA keep_snapshots = 5;
-PRAGMA wal_flush_trigger = 500;
 
--- Read current values
+-- Read current values (sync_mode and wal_flush_trigger are read-only here;
+-- set them in the connection string)
 PRAGMA sync_mode;
+PRAGMA wal_flush_trigger;
 PRAGMA checkpoint_interval;
 PRAGMA keep_snapshots;
 

--- a/docs/_docs/sql-features/transactions.md
+++ b/docs/_docs/sql-features/transactions.md
@@ -111,7 +111,7 @@ BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 
 ## Transaction Behavior with DDL
 
-DDL statements (CREATE TABLE, DROP TABLE, ALTER TABLE) can participate in explicit transactions:
+DDL statements are accepted inside an explicit transaction, but only CREATE TABLE is undone by ROLLBACK:
 
 ```sql
 BEGIN;
@@ -120,6 +120,16 @@ INSERT INTO temp_results VALUES (1, 'result');
 -- Both the table creation and insert are committed together
 COMMIT;
 ```
+
+| Statement inside a transaction | On ROLLBACK |
+|--------------------------------|-------------|
+| `CREATE TABLE` | Table is removed |
+| `ALTER TABLE`, `CREATE INDEX`, `CREATE VIEW`, `DROP INDEX`, `DROP VIEW` | Change persists |
+| `DROP TABLE` | Table definition returns, but its rows are lost (a warning is printed) |
+| `TRUNCATE TABLE` | Rows are lost |
+| `COPY ... FROM` | Rejected: cannot run inside an explicit transaction |
+
+Run schema changes, TRUNCATE and COPY outside explicit transactions when you need them to be reversible.
 
 ### Setting Default Isolation Level
 


### PR DESCRIPTION
## Summary

Three documentation corrections, checked against the current code:

- TRIM, LTRIM and RTRIM document the optional second argument naming the characters to strip, and note that the `TRIM(LEADING | TRAILING | BOTH chars FROM str)` form is not supported.
- The connection-strings page no longer shows `PRAGMA sync_mode = 2` and `PRAGMA wal_flush_trigger = 500`, which fail with "cannot be changed at runtime"; both are read-only pragmas set in the connection string. `PRAGMA target_volume_rows` is shown instead.
- The transactions page states what ROLLBACK undoes for DDL inside an explicit transaction: only CREATE TABLE is reverted; ALTER TABLE, CREATE INDEX, CREATE VIEW, DROP INDEX and DROP VIEW persist; DROP TABLE brings the definition back without its rows and prints a warning; TRUNCATE loses its rows; COPY ... FROM is rejected inside a transaction.

Docs only, no code changes.
