### PR TITLE
fix(aggregate): STDDEV and VARIANCE are the sample forms, as documented

### DIFF
--- a/src/functions/aggregate/statistics.rs
+++ b/src/functions/aggregate/statistics.rs
@@ -32,7 +32,7 @@ fn value_to_f64(value: &Value) -> Option<f64> {
 }
 
 // ============================================================================
-// STDDEV_POP / STDDEV - Population Standard Deviation
+// STDDEV_POP - Population Standard Deviation
 // ============================================================================
 
 /// STDDEV_POP aggregate function (Population Standard Deviation)
@@ -99,10 +99,10 @@ impl AggregateFunction for StddevPopFunction {
     }
 }
 
-/// STDDEV aggregate function (alias for STDDEV_POP)
+/// STDDEV aggregate function (alias for STDDEV_SAMP, as in PostgreSQL and DuckDB)
 #[derive(Default)]
 pub struct StddevFunction {
-    inner: StddevPopFunction,
+    inner: StddevSampFunction,
 }
 
 impl AggregateFunction for StddevFunction {
@@ -114,7 +114,7 @@ impl AggregateFunction for StddevFunction {
         FunctionInfo::new(
             "STDDEV",
             FunctionType::Aggregate,
-            "Returns the population standard deviation (alias for STDDEV_POP)",
+            "Returns the sample standard deviation (alias for STDDEV_SAMP)",
             FunctionSignature::new(FunctionDataType::Float, vec![FunctionDataType::Any], 1, 1),
         )
     }
@@ -207,7 +207,7 @@ impl AggregateFunction for StddevSampFunction {
 }
 
 // ============================================================================
-// VAR_POP / VARIANCE - Population Variance
+// VAR_POP - Population Variance
 // ============================================================================
 
 /// VAR_POP aggregate function (Population Variance)
@@ -274,10 +274,10 @@ impl AggregateFunction for VarPopFunction {
     }
 }
 
-/// VARIANCE aggregate function (alias for VAR_POP)
+/// VARIANCE aggregate function (alias for VAR_SAMP, as in PostgreSQL and DuckDB)
 #[derive(Default)]
 pub struct VarianceFunction {
-    inner: VarPopFunction,
+    inner: VarSampFunction,
 }
 
 impl AggregateFunction for VarianceFunction {
@@ -289,7 +289,7 @@ impl AggregateFunction for VarianceFunction {
         FunctionInfo::new(
             "VARIANCE",
             FunctionType::Aggregate,
-            "Returns the population variance (alias for VAR_POP)",
+            "Returns the sample variance (alias for VAR_SAMP)",
             FunctionSignature::new(FunctionDataType::Float, vec![FunctionDataType::Any], 1, 1),
         )
     }
@@ -495,13 +495,14 @@ mod tests {
 
     #[test]
     fn test_stddev_alias() {
+        // STDDEV is the sample standard deviation (alias for STDDEV_SAMP)
         let mut stddev = StddevFunction::default();
         for v in [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0] {
             stddev.accumulate(&Value::Float(v), false);
         }
         let result = stddev.result();
         if let Value::Float(f) = result {
-            assert!((f - 2.0).abs() < 0.0001);
+            assert!((f - 2.138).abs() < 0.01);
         } else {
             panic!("Expected float result");
         }
@@ -551,13 +552,14 @@ mod tests {
 
     #[test]
     fn test_variance_alias() {
+        // VARIANCE is the sample variance (alias for VAR_SAMP)
         let mut var = VarianceFunction::default();
         for v in [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0] {
             var.accumulate(&Value::Float(v), false);
         }
         let result = var.result();
         if let Value::Float(f) = result {
-            assert!((f - 4.0).abs() < 0.0001);
+            assert!((f - 4.571).abs() < 0.01);
         } else {
             panic!("Expected float result");
         }

--- a/tests/aggregate_functions_test.rs
+++ b/tests/aggregate_functions_test.rs
@@ -192,12 +192,12 @@ fn test_stddev_pop() {
 fn test_stddev_alias() {
     let db = setup_numbers_db("stddev_alias");
 
-    // STDDEV should be alias for STDDEV_POP
+    // STDDEV is an alias for STDDEV_SAMP (PostgreSQL semantics)
     let stddev: f64 = db
         .query_one("SELECT STDDEV(value) FROM numbers WHERE category = 'A'", ())
         .unwrap();
 
-    assert!((stddev - 2.0).abs() < 0.0001);
+    assert!((stddev - 2.138).abs() < 0.01);
 }
 
 #[test]
@@ -270,7 +270,7 @@ fn test_var_pop() {
 fn test_variance_alias() {
     let db = setup_numbers_db("variance_alias");
 
-    // VARIANCE should be alias for VAR_POP
+    // VARIANCE is an alias for VAR_SAMP (PostgreSQL semantics)
     let var: f64 = db
         .query_one(
             "SELECT VARIANCE(value) FROM numbers WHERE category = 'A'",
@@ -278,7 +278,7 @@ fn test_variance_alias() {
         )
         .unwrap();
 
-    assert!((var - 4.0).abs() < 0.0001);
+    assert!((var - 4.571).abs() < 0.01);
 }
 
 #[test]
@@ -365,7 +365,7 @@ fn test_multiple_aggregates_in_query() {
 
     let result = db
         .query(
-            "SELECT AVG(value), STDDEV_POP(value), VARIANCE(value), MEDIAN(value)
+            "SELECT AVG(value), STDDEV_POP(value), VAR_POP(value), MEDIAN(value)
          FROM numbers WHERE category = 'A'",
             (),
         )


### PR DESCRIPTION
## Summary

`STDDEV` and `VARIANCE` were aliases for the population forms, while the SQL functions reference has documented them as the sample forms (`STDDEV_SAMP`, `VAR_SAMP`). This makes the code match the docs and PostgreSQL and DuckDB: `STDDEV` is `STDDEV_SAMP` and `VARIANCE` is `VAR_SAMP`. `STDDEV_POP` and `VAR_POP` are unchanged.

MySQL treats `STDDEV` as the population form; anyone relying on that should call `STDDEV_POP` explicitly.

## Test plan

- [x] Unit and integration alias tests updated to the sample values (2.138 and 4.571 for the 2, 4, 4, 4, 5, 5, 7, 9 series)
- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --test aggregate_functions_test` and the `statistics` unit tests
