### PR TITLE
fix(parser): accept a non-reserved keyword as a name in every statement

### DIFF
--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -289,11 +289,18 @@ impl Parser {
                 token: self.cur_token.clone(),
             })),
             "CASE" => self.parse_case_expression(),
-            "CAST" => self.parse_cast_expression(),
-            "EXTRACT" => self.parse_extract_expression(),
+            // Without the shape that follows them, CAST, EXTRACT and INTERVAL
+            // are columns of that name
+            "CAST" if self.peek_token_is_punctuator("(") => self.parse_cast_expression(),
+            "EXTRACT" if self.peek_token_is_punctuator("(") => self.parse_extract_expression(),
             "EXISTS" => self.parse_exists_expression(),
             "NOT" => self.parse_not_expression(),
-            "INTERVAL" => self.parse_interval_literal(),
+            "INTERVAL"
+                if self.peek_token_is(TokenType::String)
+                    || self.peek_token_is(TokenType::Integer) =>
+            {
+                self.parse_interval_literal()
+            }
             "DEFAULT" => Some(Expression::Default(DefaultExpression {
                 token: self.cur_token.clone(),
             })),

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -99,6 +99,7 @@ static RESERVED_KEYWORDS: LazyLock<FxHashSet<&'static str>> = LazyLock::new(|| {
         "IF",
         "WITH",
         "RECURSIVE",
+        "DEFAULT",
     ]
     .into_iter()
     .collect()

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -599,7 +599,7 @@ impl Parser {
         let mut alias = None;
         if self.peek_token_is_keyword("AS") {
             self.next_token(); // consume AS
-            if !self.expect_peek(TokenType::Identifier) {
+            if !self.expect_peek_identifier_like() {
                 return None;
             }
             alias = Some(Identifier::new(
@@ -906,7 +906,7 @@ impl Parser {
         }
 
         // Parse table name
-        if !self.expect_peek(TokenType::Identifier) {
+        if !self.expect_peek_identifier_like() {
             return None;
         }
         let table_name = Identifier::new(self.cur_token.clone(), self.cur_token.literal.clone());
@@ -1274,7 +1274,7 @@ impl Parser {
 
         if self.peek_token_is_keyword("AS") {
             self.next_token(); // consume AS
-            if !self.expect_peek(TokenType::Identifier) {
+            if !self.expect_peek_identifier_like() {
                 self.add_error(format!(
                     "expected alias after AS at {}",
                     self.cur_token.position
@@ -1378,7 +1378,7 @@ impl Parser {
 
         if self.peek_token_is_keyword("AS") {
             self.next_token(); // consume AS
-            if !self.expect_peek(TokenType::Identifier) {
+            if !self.expect_peek_identifier_like() {
                 self.add_error(format!(
                     "expected alias after AS at {}",
                     self.cur_token.position
@@ -1443,7 +1443,7 @@ impl Parser {
         let token = self.cur_token.clone();
 
         // Parse table name
-        if !self.expect_peek(TokenType::Identifier) {
+        if !self.expect_peek_identifier_like() {
             return None;
         }
         let table_name = Identifier::new(self.cur_token.clone(), self.cur_token.literal.clone());
@@ -1520,7 +1520,7 @@ impl Parser {
         }
 
         // Parse table name
-        if !self.peek_token_is(TokenType::Identifier) {
+        if !self.peek_token_is_identifier_like() {
             self.add_error(format!(
                 "expected table name after DELETE FROM, got {}",
                 Self::format_token_for_error(&self.peek_token)
@@ -1533,7 +1533,7 @@ impl Parser {
         // Parse optional alias (AS alias or just alias)
         let alias = if self.peek_token_is_keyword("AS") {
             self.next_token(); // consume AS
-            if !self.expect_peek(TokenType::Identifier) {
+            if !self.expect_peek_identifier_like() {
                 return None;
             }
             Some(Identifier::new(
@@ -1590,7 +1590,7 @@ impl Parser {
         }
 
         // Parse table name
-        if !self.expect_peek(TokenType::Identifier) {
+        if !self.expect_peek_identifier_like() {
             return None;
         }
         let table_name = Identifier::new(self.cur_token.clone(), self.cur_token.literal.clone());
@@ -1604,7 +1604,7 @@ impl Parser {
         let token = self.cur_token.clone();
 
         // Optional table name
-        let table_name = if self.peek_token_is(TokenType::Identifier) {
+        let table_name = if self.peek_token_is_identifier_like() {
             self.next_token();
             Some(Identifier::new(
                 self.cur_token.clone(),
@@ -1802,7 +1802,7 @@ impl Parser {
                 return None;
             }
             // Parse single FK column
-            if !self.expect_peek(TokenType::Identifier) {
+            if !self.expect_peek_identifier_like() {
                 return None;
             }
             let fk_column = Identifier::new(self.cur_token.clone(), self.cur_token.literal.clone());
@@ -1813,13 +1813,13 @@ impl Parser {
             if !self.expect_keyword("REFERENCES") {
                 return None;
             }
-            if !self.expect_peek(TokenType::Identifier) {
+            if !self.expect_peek_identifier_like() {
                 return None;
             }
             let ref_table = Identifier::new(self.cur_token.clone(), self.cur_token.literal.clone());
             let ref_column = if self.peek_token_is_punctuator("(") {
                 self.next_token();
-                if !self.expect_peek(TokenType::Identifier) {
+                if !self.expect_peek_identifier_like() {
                     return None;
                 }
                 let col = Identifier::new(self.cur_token.clone(), self.cur_token.literal.clone());
@@ -2066,14 +2066,14 @@ impl Parser {
                 }
                 "REFERENCES" => {
                     self.next_token(); // consume REFERENCES
-                    if !self.expect_peek(TokenType::Identifier) {
+                    if !self.expect_peek_identifier_like() {
                         return None;
                     }
                     let ref_table =
                         Identifier::new(self.cur_token.clone(), self.cur_token.literal.clone());
                     let ref_column = if self.peek_token_is_punctuator("(") {
                         self.next_token();
-                        if !self.expect_peek(TokenType::Identifier) {
+                        if !self.expect_peek_identifier_like() {
                             return None;
                         }
                         let col =
@@ -2128,7 +2128,7 @@ impl Parser {
         };
 
         // Parse index name
-        if !self.peek_token_is(TokenType::Identifier) {
+        if !self.peek_token_is_identifier_like() {
             self.add_error(format!(
                 "expected index name after CREATE INDEX, got {}",
                 Self::format_token_for_error(&self.peek_token)
@@ -2144,7 +2144,7 @@ impl Parser {
         }
 
         // Parse table name
-        if !self.expect_peek(TokenType::Identifier) {
+        if !self.expect_peek_identifier_like() {
             return None;
         }
         let table_name = Identifier::new(self.cur_token.clone(), self.cur_token.literal.clone());
@@ -2200,7 +2200,7 @@ impl Parser {
             let mut opts = Vec::new();
             loop {
                 // Parse key
-                if !self.expect_peek(TokenType::Identifier) {
+                if !self.expect_peek_identifier_like() {
                     return None;
                 }
                 let key = self.cur_token.literal.to_lowercase().to_string();
@@ -2290,7 +2290,7 @@ impl Parser {
         };
 
         // Parse view name
-        if !self.expect_peek(TokenType::Identifier) {
+        if !self.expect_peek_identifier_like() {
             return None;
         }
         let view_name = Identifier::new(self.cur_token.clone(), self.cur_token.literal.clone());
@@ -2370,7 +2370,7 @@ impl Parser {
         };
 
         // Parse table name
-        if !self.expect_peek(TokenType::Identifier) {
+        if !self.expect_peek_identifier_like() {
             return None;
         }
         let table_name = Identifier::new(self.cur_token.clone(), self.cur_token.literal.clone());
@@ -2398,7 +2398,7 @@ impl Parser {
         };
 
         // Parse index name
-        if !self.expect_peek(TokenType::Identifier) {
+        if !self.expect_peek_identifier_like() {
             return None;
         }
         let index_name = Identifier::new(self.cur_token.clone(), self.cur_token.literal.clone());
@@ -2406,7 +2406,7 @@ impl Parser {
         // Check for optional ON clause
         let table_name = if self.peek_token_is_keyword("ON") {
             self.next_token();
-            if !self.expect_peek(TokenType::Identifier) {
+            if !self.expect_peek_identifier_like() {
                 return None;
             }
             Some(Identifier::new(
@@ -2441,7 +2441,7 @@ impl Parser {
         };
 
         // Parse view name
-        if !self.expect_peek(TokenType::Identifier) {
+        if !self.expect_peek_identifier_like() {
             return None;
         }
         let view_name = Identifier::new(self.cur_token.clone(), self.cur_token.literal.clone());
@@ -2463,7 +2463,7 @@ impl Parser {
         }
 
         // Parse table name
-        if !self.expect_peek(TokenType::Identifier) {
+        if !self.expect_peek_identifier_like() {
             return None;
         }
         let table_name = Identifier::new(self.cur_token.clone(), self.cur_token.literal.clone());
@@ -2500,7 +2500,7 @@ impl Parser {
                     if self.peek_token_is_keyword("COLUMN") {
                         self.next_token();
                     }
-                    if !self.expect_peek(TokenType::Identifier) {
+                    if !self.expect_peek_identifier_like() {
                         return None;
                     }
                     let col_name =
@@ -2519,7 +2519,7 @@ impl Parser {
                     }
                     let rename_keyword = self.cur_token.literal.to_uppercase();
                     if rename_keyword == "COLUMN" {
-                        if !self.expect_peek(TokenType::Identifier) {
+                        if !self.expect_peek_identifier_like() {
                             return None;
                         }
                         let col_name =
@@ -2527,7 +2527,7 @@ impl Parser {
                         if !self.expect_keyword("TO") {
                             return None;
                         }
-                        if !self.expect_peek(TokenType::Identifier) {
+                        if !self.expect_peek_identifier_like() {
                             return None;
                         }
                         let new_col_name =
@@ -2540,7 +2540,7 @@ impl Parser {
                             None,
                         )
                     } else if rename_keyword == "TO" {
-                        if !self.expect_peek(TokenType::Identifier) {
+                        if !self.expect_peek_identifier_like() {
                             return None;
                         }
                         let new_tbl_name =
@@ -2682,7 +2682,7 @@ impl Parser {
             if self.peek_token_is_keyword("SAVEPOINT") {
                 self.next_token();
             }
-            if !self.expect_peek(TokenType::Identifier) {
+            if !self.expect_peek_identifier_like() {
                 return None;
             }
             Some(Identifier::new(
@@ -2703,7 +2703,7 @@ impl Parser {
     fn parse_savepoint_statement(&mut self) -> Option<SavepointStatement> {
         let token = self.cur_token.clone();
 
-        if !self.expect_peek(TokenType::Identifier) {
+        if !self.expect_peek_identifier_like() {
             return None;
         }
 
@@ -2725,7 +2725,7 @@ impl Parser {
             self.next_token();
         }
 
-        if !self.expect_peek(TokenType::Identifier) {
+        if !self.expect_peek_identifier_like() {
             return None;
         }
 
@@ -2814,7 +2814,7 @@ impl Parser {
             // Check for TABLE or VIEW
             if self.peek_token_is_keyword("TABLE") {
                 self.next_token();
-                if !self.expect_peek(TokenType::Identifier) {
+                if !self.expect_peek_identifier_like() {
                     return None;
                 }
                 let table_name =
@@ -2825,7 +2825,7 @@ impl Parser {
                 }))
             } else if self.peek_token_is_keyword("VIEW") {
                 self.next_token();
-                if !self.expect_peek(TokenType::Identifier) {
+                if !self.expect_peek_identifier_like() {
                     return None;
                 }
                 let view_name =
@@ -2846,7 +2846,7 @@ impl Parser {
             if !self.expect_keyword("FROM") {
                 return None;
             }
-            if !self.expect_peek(TokenType::Identifier) {
+            if !self.expect_peek_identifier_like() {
                 return None;
             }
             let table_name =

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -116,8 +116,7 @@ impl Parser {
             }
         } else if self.cur_token_is(TokenType::Identifier)
             && self.cur_token.literal.eq_ignore_ascii_case("RELEASE")
-            && (self.peek_token_is_keyword("SAVEPOINT")
-                || self.peek_token_is(TokenType::Identifier))
+            && (self.peek_token_is_keyword("SAVEPOINT") || self.peek_token_is_identifier_like())
         {
             // RELEASE stays a plain identifier elsewhere, so `release` remains a column name
             self.parse_release_savepoint_statement()
@@ -602,6 +601,14 @@ impl Parser {
             if !self.expect_peek_identifier_like() {
                 return None;
             }
+            alias = Some(Identifier::new(
+                self.cur_token.clone(),
+                self.cur_token.literal.clone(),
+            ));
+        } else if self.cur_token_is_keyword("AS") && self.peek_token_is_identifier_like() {
+            // The AS OF check above consumed a lone AS; after an explicit AS
+            // any non-reserved keyword is the alias
+            self.next_token();
             alias = Some(Identifier::new(
                 self.cur_token.clone(),
                 self.cur_token.literal.clone(),

--- a/tests/keyword_identifiers_test.rs
+++ b/tests/keyword_identifiers_test.rs
@@ -99,6 +99,8 @@ fn test_non_reserved_keywords_name_tables_views_and_savepoints() {
             format!("CREATE TABLE {kw} (id INTEGER PRIMARY KEY, v INTEGER)"),
             format!("INSERT INTO {kw} VALUES (1, 1)"),
             format!("UPDATE {kw} SET v = 2 WHERE id = 1"),
+            format!("SELECT {kw}.id FROM {kw} AS {kw} WHERE {kw}.id = 1"),
+            format!("SELECT a.id FROM {kw} AS a JOIN {kw} AS {kw} ON a.id = {kw}.id"),
             format!("CREATE VIEW {kw}_view AS SELECT id FROM {kw}"),
             format!("DROP VIEW {kw}_view"),
             format!("DELETE FROM {kw} WHERE id = 1"),
@@ -110,6 +112,8 @@ fn test_non_reserved_keywords_name_tables_views_and_savepoints() {
             format!("SAVEPOINT {kw}"),
             format!("ROLLBACK TO SAVEPOINT {kw}"),
             format!("RELEASE SAVEPOINT {kw}"),
+            format!("SAVEPOINT {kw}"),
+            format!("RELEASE {kw}"),
             "COMMIT".to_string(),
             format!("DROP TABLE {kw}"),
         ] {

--- a/tests/keyword_identifiers_test.rs
+++ b/tests/keyword_identifiers_test.rs
@@ -1,0 +1,201 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Every keyword is usable as a name in every position that takes a name:
+//! bare when it is not reserved, quoted when it is. A keyword that CREATE
+//! TABLE accepts as a column must be accepted everywhere else too.
+
+use std::collections::BTreeSet;
+use stoolap::parser::token::KEYWORDS;
+use stoolap::Database;
+
+fn err(db: &Database, sql: &str) -> Option<String> {
+    db.execute(sql, ()).err().map(|e| format!("{sql}: {e}"))
+}
+
+/// Statements naming a column `col` in the table `t`, in order
+fn column_positions(t: &str, col: &str) -> Vec<String> {
+    vec![
+        format!("INSERT INTO {t} (id, {col}) VALUES (1, 1)"),
+        format!("SELECT {col} FROM {t}"),
+        format!("SELECT id FROM {t} WHERE {col} = 1"),
+        format!("SELECT id FROM {t} ORDER BY {col}"),
+        format!("SELECT {col}, COUNT(*) FROM {t} GROUP BY {col}"),
+        format!("UPDATE {t} SET {col} = 2 WHERE id = 1"),
+        format!("SELECT id AS {col} FROM {t}"),
+        format!("CREATE INDEX idx_{t} ON {t} ({col})"),
+        format!("DROP INDEX idx_{t} ON {t}"),
+        format!("ALTER TABLE {t} RENAME COLUMN {col} TO renamed"),
+        format!("ALTER TABLE {t} RENAME COLUMN renamed TO {col}"),
+        format!("ALTER TABLE {t} DROP COLUMN {col}"),
+        format!("ALTER TABLE {t} ADD COLUMN {col} INTEGER"),
+        format!("DELETE FROM {t} WHERE {col} IS NULL"),
+    ]
+}
+
+#[test]
+fn test_every_keyword_works_as_a_name_bare_or_quoted() {
+    let db = Database::open("memory://keyword_identifiers_all").unwrap();
+    let keywords: BTreeSet<&str> = KEYWORDS.iter().copied().collect();
+    let mut failures = Vec::new();
+    let mut reserved = Vec::new();
+    for (i, kw) in keywords.iter().enumerate() {
+        let bare = kw.to_lowercase();
+        let t = format!("t{i}");
+        let col = if err(
+            &db,
+            &format!("CREATE TABLE {t} (id INTEGER PRIMARY KEY, {bare} INTEGER)"),
+        )
+        .is_some()
+        {
+            reserved.push(*kw);
+            let quoted = format!("\"{bare}\"");
+            if let Some(e) = err(
+                &db,
+                &format!("CREATE TABLE {t} (id INTEGER PRIMARY KEY, {quoted} INTEGER)"),
+            ) {
+                failures.push(e);
+                continue;
+            }
+            quoted
+        } else {
+            bare
+        };
+        failures.extend(
+            column_positions(&t, &col)
+                .iter()
+                .filter_map(|sql| err(&db, sql)),
+        );
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+    // The reserved words are the SQL skeleton; a name-like word must not be among them
+    for word in [
+        "LEVEL", "FORMAT", "DATE", "TEXT", "ROW", "FIRST", "LAST", "RELEASE",
+    ] {
+        assert!(!reserved.contains(&word), "{word} is reserved");
+    }
+    assert!(reserved.contains(&"SELECT") && reserved.contains(&"DEFAULT"));
+}
+
+#[test]
+fn test_non_reserved_keywords_name_tables_views_and_savepoints() {
+    let db = Database::open("memory://keyword_identifiers_objects").unwrap();
+    let mut failures = Vec::new();
+    for kw in [
+        "level", "format", "window", "row", "date", "release", "copy",
+    ] {
+        for sql in [
+            format!("CREATE TABLE {kw} (id INTEGER PRIMARY KEY, v INTEGER)"),
+            format!("INSERT INTO {kw} VALUES (1, 1)"),
+            format!("UPDATE {kw} SET v = 2 WHERE id = 1"),
+            format!("CREATE VIEW {kw}_view AS SELECT id FROM {kw}"),
+            format!("DROP VIEW {kw}_view"),
+            format!("DELETE FROM {kw} WHERE id = 1"),
+            format!("TRUNCATE TABLE {kw}"),
+            format!("VACUUM {kw}"),
+            format!("CREATE INDEX {kw} ON {kw} (v)"),
+            format!("DROP INDEX {kw} ON {kw}"),
+            "BEGIN".to_string(),
+            format!("SAVEPOINT {kw}"),
+            format!("ROLLBACK TO SAVEPOINT {kw}"),
+            format!("RELEASE SAVEPOINT {kw}"),
+            "COMMIT".to_string(),
+            format!("DROP TABLE {kw}"),
+        ] {
+            failures.extend(err(&db, &sql));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn test_cast_extract_and_interval_are_columns_without_their_shape() {
+    let db = Database::open("memory://keyword_identifiers_shape").unwrap();
+    db.execute(
+        "CREATE TABLE d (id INTEGER PRIMARY KEY, cast INTEGER, extract INTEGER, interval INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO d VALUES (1, 2, 3, 4)", ()).unwrap();
+    let row: Vec<i64> = db
+        .query(
+            "SELECT cast, extract, interval, CAST(cast AS TEXT) || '', \
+             EXTRACT(YEAR FROM TIMESTAMP '2024-05-06 00:00:00') FROM d \
+             WHERE interval = 4 AND cast + extract = 5",
+            (),
+        )
+        .unwrap()
+        .flat_map(|r| {
+            let r = r.unwrap();
+            [
+                r.get::<i64>(0).unwrap(),
+                r.get::<i64>(1).unwrap(),
+                r.get::<i64>(2).unwrap(),
+                r.get::<String>(3).unwrap().parse::<i64>().unwrap(),
+                r.get::<i64>(4).unwrap(),
+            ]
+        })
+        .collect();
+    assert_eq!(row, [2, 3, 4, 2, 2024]);
+    let intervals: Vec<String> = db
+        .query(
+            "SELECT TIMESTAMP '2024-01-31 00:00:00' + INTERVAL '1 day', \
+             TIMESTAMP '2024-01-31 00:00:00' + INTERVAL 1 DAY",
+            (),
+        )
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            format!(
+                "{} {}",
+                r.get::<String>(0).unwrap(),
+                r.get::<String>(1).unwrap()
+            )
+        })
+        .collect();
+    assert_eq!(intervals.len(), 1);
+    assert!(intervals[0].starts_with("2024-02-01"), "{}", intervals[0]);
+}
+
+#[test]
+fn test_default_is_reserved_and_keeps_its_meaning() {
+    let db = Database::open("memory://keyword_identifiers_default").unwrap();
+    let e = db
+        .execute(
+            "CREATE TABLE d (id INTEGER PRIMARY KEY, default INTEGER)",
+            (),
+        )
+        .unwrap_err()
+        .to_string();
+    assert!(e.contains("reserved"), "{e}");
+    db.execute(
+        "CREATE TABLE d (id INTEGER PRIMARY KEY, \"default\" INTEGER DEFAULT 7, v INTEGER DEFAULT 9)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO d (id) VALUES (1)", ()).unwrap();
+    db.execute("UPDATE d SET v = 1, \"default\" = 3 WHERE id = 1", ())
+        .unwrap();
+    db.execute("UPDATE d SET v = DEFAULT WHERE id = 1", ())
+        .unwrap();
+    let row: Vec<i64> = db
+        .query("SELECT \"default\", v FROM d", ())
+        .unwrap()
+        .flat_map(|r| {
+            let r = r.unwrap();
+            [r.get::<i64>(0).unwrap(), r.get::<i64>(1).unwrap()]
+        })
+        .collect();
+    assert_eq!(row, [3, 9]);
+}


### PR DESCRIPTION
## Summary

A column or table named `level`, `format`, `date`, `row`, `release` or any other non-reserved keyword could be created and queried, but not renamed, dropped, indexed, deleted from, vacuumed or used as a savepoint name. Thirty-three places in the statement parser demanded a plain identifier token instead of the identifier-like check CREATE TABLE and SELECT already use. Measured over the 164 keywords, RENAME COLUMN and DROP COLUMN rejected all 91 non-reserved ones.

- Every name position in the statement parser now accepts a non-reserved keyword: table, column, view, index, constraint, foreign key, savepoint (in `RELEASE name` too), table alias after AS, and COPY option keys. The AS OF check used to consume a lone AS, so `FROM t AS level` never reached the alias branch.
- CAST, EXTRACT and INTERVAL are columns of that name when the shape that makes them an expression does not follow (an opening parenthesis, or a string or integer literal for INTERVAL). `CAST(x AS TEXT)`, `EXTRACT(YEAR FROM ts)`, `INTERVAL '1 day'` and `INTERVAL 1 DAY` are unchanged.
- DEFAULT joins the reserved words, as in SQLite and PostgreSQL. A bare DEFAULT in SET or VALUES cannot be told from a column of that name; `"default"` still works as a column.
- New test `tests/keyword_identifiers_test.rs` walks the whole keyword table and checks every keyword in fourteen name positions, bare when it is not reserved and quoted when it is, and names tables, views, indexes, aliases and savepoints with seven keywords including `window`. A keyword added later cannot break a statement quietly.

Left as is: a bare table alias that is a keyword (`FROM level level` without AS) still needs AS or quotes; the join and clause keywords make that position ambiguous. The reserved list itself (67 words, now 68) is unchanged apart from DEFAULT.

## Test plan

- [x] `tests/keyword_identifiers_test.rs`: four tests, all fail on main and pass here
- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run`
