### PR TITLE
perf(index): build and subtract the multi-column prefix and sorted structures in linear time

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,6 +7,7 @@
 default-filter = """
 not (
   test(=storage::mvcc::version_store::tests::test_unique_constraint_performance_bulk_update)
+  | test(=storage::index::multi_column::tests::test_prefix_build_and_batch_removal_scale)
   | test(=test_fk_cascade_delete_performance_with_auto_index)
   | binary(=concurrency_history_test)
   | binary(=volume_concurrency_test)

--- a/examples/candle_bench.rs
+++ b/examples/candle_bench.rs
@@ -1,0 +1,385 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Time-series workload bench: many (key, key, time) series in one table,
+//! bulk loaded, sealed, reopened, and queried the way a market data
+//! application does. Reports wall latency (median, p99, max), process CPU
+//! time and resident memory per phase, so a storage or index change can be
+//! judged on all three at once.
+//!
+//! Run: `cargo run --release --example candle_bench`
+//! Knobs (env): PAIRS (174), MINUTES (12500), THREADS (4), CKPT (30 s).
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use stoolap::Database;
+
+fn env_or(name: &str, default: i64) -> i64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn cpu_secs() -> f64 {
+    let mut ru: libc::rusage = unsafe { std::mem::zeroed() };
+    unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut ru) };
+    let t = |tv: libc::timeval| tv.tv_sec as f64 + tv.tv_usec as f64 / 1e6;
+    t(ru.ru_utime) + t(ru.ru_stime)
+}
+
+fn rss_mb() -> f64 {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &std::process::id().to_string()])
+        .output()
+        .ok();
+    out.and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| s.trim().parse::<f64>().ok())
+        .map(|kb| kb / 1024.0)
+        .unwrap_or(0.0)
+}
+
+fn fmt_ts(secs: i64) -> String {
+    chrono::DateTime::from_timestamp(secs, 0)
+        .map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string())
+        .unwrap_or_default()
+}
+
+struct Lat(Vec<f64>);
+
+impl Lat {
+    fn from_ms(mut v: Vec<f64>) -> Self {
+        v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        Lat(v)
+    }
+    fn pct(&self, p: f64) -> f64 {
+        if self.0.is_empty() {
+            return 0.0;
+        }
+        let i = ((self.0.len() as f64 - 1.0) * p).round() as usize;
+        self.0[i]
+    }
+    fn max(&self) -> f64 {
+        self.0.last().copied().unwrap_or(0.0)
+    }
+}
+
+fn row(phase: &str, metric: &str, value: String) {
+    println!("{phase:<10} {metric:<44} {value}");
+}
+
+/// Run `sql` `n` times, return latencies (ms) and rows of the last run.
+fn timed(db: &Database, sql: &str, n: usize) -> (Lat, usize, f64) {
+    let mut ms = Vec::with_capacity(n);
+    let mut rows = 0;
+    let cpu0 = cpu_secs();
+    for _ in 0..n {
+        let t = Instant::now();
+        rows = db.query(sql, ()).unwrap().count();
+        ms.push(t.elapsed().as_secs_f64() * 1000.0);
+    }
+    let cpu_ms = (cpu_secs() - cpu0) * 1000.0 / n as f64;
+    (Lat::from_ms(ms), rows, cpu_ms)
+}
+
+struct Shapes {
+    pair_day: String,
+    pair_latest: String,
+    pair_since: String,
+    all_recent: String,
+    rollup: String,
+    day_summary: String,
+    distinct: String,
+}
+
+fn shapes(last: i64) -> Shapes {
+    let day_start = fmt_ts(last - 86400);
+    let day_end = fmt_ts(last);
+    let ten_min = fmt_ts(last - 600);
+    let cols = "time, open, high, low, close, volume";
+    let pair = "exchange = 'ex1' AND symbol = 'S7USDT'";
+    Shapes {
+        pair_day: format!(
+            "SELECT {cols} FROM c WHERE {pair} AND time >= '{day_start}' AND time <= '{day_end}' ORDER BY time DESC LIMIT 500"
+        ),
+        pair_latest: format!("SELECT {cols} FROM c WHERE {pair} ORDER BY time DESC LIMIT 200"),
+        pair_since: format!(
+            "SELECT {cols} FROM c WHERE {pair} AND time >= '{day_start}' ORDER BY time DESC LIMIT 200"
+        ),
+        all_recent: format!(
+            "SELECT exchange, symbol, {cols} FROM c WHERE time >= '{ten_min}' ORDER BY time DESC LIMIT 100"
+        ),
+        rollup: format!(
+            "SELECT TIME_TRUNC('5m', time), exchange, symbol, FIRST(open ORDER BY time), MAX(high), MIN(low), \
+             LAST(close ORDER BY time), ROUND(SUM(volume), 8) FROM c WHERE time >= '{ten_min}' \
+             GROUP BY TIME_TRUNC('5m', time), exchange, symbol"
+        ),
+        day_summary: format!(
+            "SELECT exchange, symbol, FIRST(open ORDER BY time), LAST(close ORDER BY time), MAX(high), MIN(low) \
+             FROM c WHERE time >= '{day_start}' GROUP BY exchange, symbol"
+        ),
+        distinct: "SELECT DISTINCT exchange, symbol FROM c ORDER BY exchange, symbol".to_string(),
+    }
+}
+
+fn query_set(phase: &str, db: &Database, s: &Shapes) {
+    for (name, sql, n) in [
+        ("pair + day range DESC LIMIT 500", &s.pair_day, 7),
+        ("pair latest DESC LIMIT 200", &s.pair_latest, 7),
+        ("pair + time >= day DESC LIMIT 200", &s.pair_since, 7),
+        ("all pairs last 10 min DESC LIMIT 100", &s.all_recent, 7),
+        ("5m rollup last 10 min", &s.rollup, 5),
+        ("day summary per pair", &s.day_summary, 5),
+        ("DISTINCT pairs", &s.distinct, 3),
+    ] {
+        let (lat, rows, cpu) = timed(db, sql, n);
+        row(
+            phase,
+            name,
+            format!(
+                "p50 {:>9.2} ms  max {:>9.2} ms  cpu {:>8.2} ms  rows={rows}",
+                lat.pct(0.5),
+                lat.max(),
+                cpu
+            ),
+        );
+    }
+}
+
+/// Fire the per-pair "latest" query for every pair across `threads` workers.
+fn fan_out(phase: &str, db: &Database, pairs: i64, threads: usize) {
+    let sqls: Vec<String> = (0..pairs)
+        .map(|p| {
+            format!(
+                "SELECT time, open, high, low, close, volume FROM c WHERE exchange = 'ex{}' AND symbol = 'S{}USDT' \
+                 ORDER BY time DESC LIMIT 200",
+                p % 3,
+                p / 3
+            )
+        })
+        .collect();
+    let sqls = Arc::new(sqls);
+    let next = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let cpu0 = cpu_secs();
+    let wall = Instant::now();
+    let handles: Vec<_> = (0..threads)
+        .map(|_| {
+            let db = db.clone();
+            let sqls = Arc::clone(&sqls);
+            let next = Arc::clone(&next);
+            std::thread::spawn(move || {
+                let mut ms = Vec::new();
+                loop {
+                    let i = next.fetch_add(1, Ordering::Relaxed);
+                    if i >= sqls.len() {
+                        break;
+                    }
+                    let t = Instant::now();
+                    db.query(&sqls[i], ()).unwrap().count();
+                    ms.push(t.elapsed().as_secs_f64() * 1000.0);
+                }
+                ms
+            })
+        })
+        .collect();
+    let mut all = Vec::new();
+    for h in handles {
+        all.extend(h.join().unwrap());
+    }
+    let wall_ms = wall.elapsed().as_secs_f64() * 1000.0;
+    let cpu_ms = (cpu_secs() - cpu0) * 1000.0;
+    let lat = Lat::from_ms(all);
+    row(
+        phase,
+        &format!("fan-out {pairs} pair queries on {threads} threads"),
+        format!(
+            "wall {:>8.0} ms  cpu {:>8.0} ms  p50 {:>8.2} ms  p99 {:>8.2} ms  max {:>8.2} ms",
+            wall_ms,
+            cpu_ms,
+            lat.pct(0.5),
+            lat.pct(0.99),
+            lat.max()
+        ),
+    );
+}
+
+fn main() {
+    let pairs = env_or("PAIRS", 174);
+    let minutes = env_or("MINUTES", 12_500);
+    let threads = env_or("THREADS", 4) as usize;
+    let ckpt = env_or("CKPT", 30);
+    let dir = std::env::temp_dir().join(format!("candle_bench_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let dsn = format!("file://{}?checkpoint_interval={ckpt}", dir.display());
+    println!(
+        "rows={} pairs={pairs} minutes={minutes} threads={threads} checkpoint_interval={ckpt}s",
+        pairs * minutes
+    );
+    row("start", "rss", format!("{:.0} MB", rss_mb()));
+
+    let mut db = Database::open(&dsn).unwrap();
+    db.execute(
+        "CREATE TABLE c (id INTEGER PRIMARY KEY AUTO_INCREMENT, time TIMESTAMP NOT NULL, \
+         exchange TEXT NOT NULL, symbol TEXT NOT NULL, open FLOAT, high FLOAT, low FLOAT, close FLOAT, \
+         volume FLOAT, UNIQUE(exchange, symbol, time))",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX idx_c_time ON c(time) USING BTREE", ())
+        .unwrap();
+
+    // Phase: bulk load in time order, ten minutes of every pair per statement
+    let base = 1_704_067_200i64;
+    let t0 = Instant::now();
+    let cpu0 = cpu_secs();
+    let mut stmt = String::new();
+    for m0 in (0..minutes).step_by(10) {
+        stmt.clear();
+        stmt.push_str(
+            "INSERT INTO c (time, exchange, symbol, open, high, low, close, volume) VALUES ",
+        );
+        let mut first = true;
+        for m in m0..(m0 + 10).min(minutes) {
+            let t = fmt_ts(base + m * 60);
+            for p in 0..pairs {
+                if !first {
+                    stmt.push(',');
+                }
+                first = false;
+                let px = 100.0 + p as f64 + (m % 97) as f64 * 0.01;
+                stmt.push_str(&format!(
+                    "('{t}', 'ex{}', 'S{}USDT', {px}, {}, {}, {}, {})",
+                    p % 3,
+                    p / 3,
+                    px + 0.5,
+                    px - 0.5,
+                    px + 0.1,
+                    1000 + m % 50
+                ));
+            }
+        }
+        db.execute(&stmt, ()).unwrap();
+    }
+    row(
+        "load",
+        "bulk insert",
+        format!(
+            "wall {:>8.0} ms  cpu {:>8.0} ms  rss {:.0} MB",
+            t0.elapsed().as_secs_f64() * 1000.0,
+            (cpu_secs() - cpu0) * 1000.0,
+            rss_mb()
+        ),
+    );
+    let last = base + (minutes - 1) * 60;
+    let s = shapes(last);
+
+    // Phase: first query after load pays any lazy index build
+    let (lat, _, cpu) = timed(&db, &s.pair_day, 1);
+    row(
+        "hot",
+        "first pair query after load",
+        format!("{:>9.2} ms  cpu {:>8.2} ms", lat.max(), cpu),
+    );
+    query_set("hot", &db, &s);
+    fan_out("hot", &db, pairs, threads);
+    row("hot", "rss", format!("{:.0} MB", rss_mb()));
+
+    // Phase: seal while a reader keeps querying; report the stall it sees
+    let stop = Arc::new(AtomicBool::new(false));
+    let reader = {
+        let db = db.clone();
+        let stop = Arc::clone(&stop);
+        let sql = s.pair_since.clone();
+        std::thread::spawn(move || {
+            let mut ms = Vec::new();
+            while !stop.load(Ordering::Relaxed) {
+                let t = Instant::now();
+                db.query(&sql, ()).unwrap().count();
+                ms.push(t.elapsed().as_secs_f64() * 1000.0);
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            ms
+        })
+    };
+    std::thread::sleep(Duration::from_millis(200));
+    let t = Instant::now();
+    let cpu0 = cpu_secs();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    let seal_ms = t.elapsed().as_secs_f64() * 1000.0;
+    let seal_cpu = (cpu_secs() - cpu0) * 1000.0;
+    std::thread::sleep(Duration::from_millis(200));
+    stop.store(true, Ordering::Relaxed);
+    let reader_lat = Lat::from_ms(reader.join().unwrap());
+    row(
+        "seal",
+        "PRAGMA CHECKPOINT of the loaded rows",
+        format!(
+            "wall {seal_ms:>8.0} ms  cpu {seal_cpu:>8.0} ms  rss {:.0} MB",
+            rss_mb()
+        ),
+    );
+    row(
+        "seal",
+        "reader latency during seal",
+        format!(
+            "p50 {:>8.2} ms  p99 {:>8.2} ms  max {:>8.0} ms  ({} queries)",
+            reader_lat.pct(0.5),
+            reader_lat.pct(0.99),
+            reader_lat.max(),
+            reader_lat.0.len()
+        ),
+    );
+
+    // Phase: cold rows, eager columns (as sealed in this process)
+    query_set("cold", &db, &s);
+    fan_out("cold", &db, pairs, threads);
+    row("cold", "rss", format!("{:.0} MB", rss_mb()));
+
+    // Phase: reopen, columns deferred (as after a restart or a cold reload)
+    drop(db);
+    let t = Instant::now();
+    db = Database::open(&dsn).unwrap();
+    row(
+        "reopen",
+        "Database::open",
+        format!(
+            "{:>9.0} ms  rss {:.0} MB",
+            t.elapsed().as_secs_f64() * 1000.0,
+            rss_mb()
+        ),
+    );
+    query_set("reopen", &db, &s);
+    fan_out("reopen", &db, pairs, threads);
+    row("reopen", "rss after queries", format!("{:.0} MB", rss_mb()));
+
+    // Phase: retention delete of the oldest ten minutes
+    let t = Instant::now();
+    let deleted = db
+        .execute(
+            "DELETE FROM c WHERE time < $1",
+            (fmt_ts(base + 600).as_str(),),
+        )
+        .unwrap();
+    row(
+        "delete",
+        "DELETE time < first 10 min",
+        format!(
+            "{:>9.0} ms  rows={deleted}",
+            t.elapsed().as_secs_f64() * 1000.0
+        ),
+    );
+    drop(db);
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/examples/candle_bench.rs
+++ b/examples/candle_bench.rs
@@ -33,11 +33,18 @@ fn env_or(name: &str, default: i64) -> i64 {
         .unwrap_or(default)
 }
 
+#[cfg(unix)]
 fn cpu_secs() -> f64 {
     let mut ru: libc::rusage = unsafe { std::mem::zeroed() };
     unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut ru) };
     let t = |tv: libc::timeval| tv.tv_sec as f64 + tv.tv_usec as f64 / 1e6;
     t(ru.ru_utime) + t(ru.ru_stime)
+}
+
+/// Process CPU time is reported as zero where getrusage is not available.
+#[cfg(not(unix))]
+fn cpu_secs() -> f64 {
+    0.0
 }
 
 fn rss_mb() -> f64 {

--- a/src/storage/index/multi_column.rs
+++ b/src/storage/index/multi_column.rs
@@ -312,6 +312,25 @@ impl MultiColumnIndex {
         grouped
     }
 
+    /// Remove the sorted `ids` from the sorted `rows`, touching only the rows
+    /// from the first removed id onwards: taking the newest rows off a large
+    /// group stays cheap, taking the whole group is one pass.
+    fn subtract_sorted(rows: &mut CompactVec<i64>, ids: &[i64]) {
+        let Some(&first) = ids.first() else {
+            return;
+        };
+        let start = rows.binary_search(&first).unwrap_or_else(|pos| pos);
+        let slice = rows.as_mut_slice();
+        let mut keep = start;
+        for read in start..slice.len() {
+            if ids.binary_search(&slice[read]).is_err() {
+                slice[keep] = slice[read];
+                keep += 1;
+            }
+        }
+        rows.truncate(keep);
+    }
+
     /// Check uniqueness constraint (must be called while holding write lock on value_to_rows)
     fn check_unique_constraint_locked(
         &self,
@@ -796,7 +815,7 @@ impl Index for MultiColumnIndex {
             let mut sorted_values = self.sorted_values.write();
             for (key, ids) in removed {
                 if let Some(rows) = sorted_values.get_mut(&key) {
-                    rows.retain(|id| ids.binary_search(id).is_err());
+                    Self::subtract_sorted(rows, &ids);
                     if rows.is_empty() {
                         sorted_values.remove(&key);
                     }
@@ -811,7 +830,7 @@ impl Index for MultiColumnIndex {
                 let mut prefix_index = self.prefix_indexes[idx].write();
                 for (key, ids) in removed {
                     if let Some(rows) = prefix_index.get_mut(&key) {
-                        rows.retain(|id| ids.binary_search(id).is_err());
+                        Self::subtract_sorted(rows, &ids);
                         if rows.is_empty() {
                             prefix_index.remove(&key);
                         }
@@ -1182,6 +1201,17 @@ mod tests {
         assert_eq!(hits.len(), per_key as usize);
         assert!(hits.windows(2).all(|w| w[0].row_id < w[1].row_id));
 
+        // Taking the newest two rows off the group leaves the rest untouched
+        let newest: Vec<(i64, &[Value])> = all[all.len() - 2..]
+            .iter()
+            .map(|(row_id, values)| (*row_id, values.as_slice()))
+            .collect();
+        index.remove_batch_slice(&newest).unwrap();
+        let hits = index.find(&[Value::Integer(0)]).unwrap();
+        assert_eq!(hits.len(), per_key as usize - 2);
+        assert_eq!(hits.last().map(|h| h.row_id), Some(per_key - 3));
+        all.truncate(all.len() - 2);
+
         // Range use builds the sorted structure too
         assert_eq!(
             index
@@ -1209,7 +1239,7 @@ mod tests {
             start.elapsed()
         );
         let hits = index.find(&[Value::Integer(0)]).unwrap();
-        assert_eq!(hits.len(), per_key as usize / 2);
+        assert_eq!(hits.len(), all.len() - half.len());
         assert!(hits.iter().all(|h| h.row_id % 2 == 1));
 
         let rest: Vec<(i64, &[Value])> = all

--- a/src/storage/index/multi_column.rs
+++ b/src/storage/index/multi_column.rs
@@ -265,8 +265,10 @@ impl MultiColumnIndex {
             return;
         }
 
-        // Build prefix index from row_to_key (read lock prevents concurrent inserts)
-        // Insert in sorted order for O(N+M) merge operations
+        // Build prefix index from row_to_key (read lock prevents concurrent inserts).
+        // Gather each key's row ids unsorted, then sort once: a sorted insert per
+        // row is quadratic in the rows per key.
+        let mut gathered: FxHashMap<CompositeKey, Vec<i64>> = FxHashMap::default();
         for (row_id, arc_values) in row_to_key.iter() {
             if arc_values.len() >= prefix_len {
                 // Dereference CompactArc<Value> to create CompositeKey for prefix
@@ -276,15 +278,38 @@ impl MultiColumnIndex {
                         .map(|a| (**a).clone())
                         .collect(),
                 );
-                let rows = prefix_index.entry(prefix_key).or_default();
-                if let Err(pos) = rows.binary_search(&row_id) {
-                    rows.insert(pos, row_id);
-                }
+                gathered.entry(prefix_key).or_default().push(row_id);
             }
+        }
+        for (prefix_key, mut rows) in gathered {
+            rows.sort_unstable();
+            rows.dedup();
+            prefix_index.insert(prefix_key, CompactVec::from_vec(rows));
         }
 
         // Set flag before releasing locks - subsequent inserts will see prefix_built=true
         self.prefix_built[idx].store(true, AtomicOrdering::Release);
+    }
+
+    /// The row ids of a removal batch grouped by the first `key_len` values,
+    /// each group sorted for binary search.
+    fn group_removed_by_key(
+        entries: &[(i64, &[Value])],
+        key_len: usize,
+    ) -> FxHashMap<CompositeKey, Vec<i64>> {
+        let mut grouped: FxHashMap<CompositeKey, Vec<i64>> = FxHashMap::default();
+        for &(row_id, values) in entries {
+            if values.len() >= key_len {
+                grouped
+                    .entry(CompositeKey(values[..key_len].to_vec()))
+                    .or_default()
+                    .push(row_id);
+            }
+        }
+        for ids in grouped.values_mut() {
+            ids.sort_unstable();
+        }
+        grouped
     }
 
     /// Check uniqueness constraint (must be called while holding write lock on value_to_rows)
@@ -764,15 +789,14 @@ impl Index for MultiColumnIndex {
         drop(value_to_rows);
         drop(row_to_key);
 
-        // Only update BTree if it was built
+        // The sorted and prefix structures are subtracted one key at a time:
+        // a removal per row is quadratic in the rows per key.
         if self.btree_built.load(AtomicOrdering::Acquire) {
+            let removed = Self::group_removed_by_key(entries, self.column_ids.len());
             let mut sorted_values = self.sorted_values.write();
-            for &(row_id, values) in entries {
-                let key = CompositeKey(values.to_vec());
+            for (key, ids) in removed {
                 if let Some(rows) = sorted_values.get_mut(&key) {
-                    if let Ok(pos) = rows.binary_search(&row_id) {
-                        rows.remove(pos);
-                    }
+                    rows.retain(|id| ids.binary_search(id).is_err());
                     if rows.is_empty() {
                         sorted_values.remove(&key);
                     }
@@ -780,21 +804,16 @@ impl Index for MultiColumnIndex {
             }
         }
 
-        // Only update prefix indexes if they were built
         for prefix_len in 1..self.column_ids.len() {
             let idx = prefix_len - 1;
             if self.prefix_built[idx].load(AtomicOrdering::Acquire) {
+                let removed = Self::group_removed_by_key(entries, prefix_len);
                 let mut prefix_index = self.prefix_indexes[idx].write();
-                for &(row_id, values) in entries {
-                    if values.len() >= prefix_len {
-                        let prefix_key = CompositeKey(values[..prefix_len].to_vec());
-                        if let Some(rows) = prefix_index.get_mut(&prefix_key) {
-                            if let Ok(pos) = rows.binary_search(&row_id) {
-                                rows.remove(pos);
-                            }
-                            if rows.is_empty() {
-                                prefix_index.remove(&prefix_key);
-                            }
+                for (key, ids) in removed {
+                    if let Some(rows) = prefix_index.get_mut(&key) {
+                        rows.retain(|id| ids.binary_search(id).is_err());
+                        if rows.is_empty() {
+                            prefix_index.remove(&key);
                         }
                     }
                 }
@@ -1127,6 +1146,79 @@ mod tests {
         index.remove(&[Value::Integer(1)], 100, 0).unwrap();
         let results = index.find(&[Value::Integer(1)]).unwrap();
         assert_eq!(results.len(), 0);
+    }
+
+    /// Building the prefix index and removing a batch stay linear in the rows
+    /// per key. Left out of the default nextest profile as a timing test.
+    #[test]
+    fn test_prefix_build_and_batch_removal_scale() {
+        let index = MultiColumnIndex::new(
+            "scale_idx".to_string(),
+            "scale_table".to_string(),
+            vec!["k".to_string(), "t".to_string()],
+            vec![0, 1],
+            vec![DataType::Integer, DataType::Integer],
+            true,
+            0,
+        );
+        let per_key = 400_000i64;
+        let mut all: Vec<(i64, Vec<Value>)> = Vec::new();
+        for k in 0..1 {
+            for t in 0..per_key {
+                let row_id = k * per_key + t;
+                let values = vec![Value::Integer(k), Value::Integer(t)];
+                index.add(&values, row_id, 0).unwrap();
+                all.push((row_id, values));
+            }
+        }
+
+        let start = std::time::Instant::now();
+        let hits = index.find(&[Value::Integer(0)]).unwrap();
+        assert!(
+            start.elapsed().as_secs() < 3,
+            "prefix build took {:?}",
+            start.elapsed()
+        );
+        assert_eq!(hits.len(), per_key as usize);
+        assert!(hits.windows(2).all(|w| w[0].row_id < w[1].row_id));
+
+        // Range use builds the sorted structure too
+        assert_eq!(
+            index
+                .find_range(
+                    &[Value::Integer(0), Value::Integer(0)],
+                    &[Value::Integer(0), Value::Integer(9)],
+                    true,
+                    true
+                )
+                .unwrap()
+                .len(),
+            10
+        );
+
+        let half: Vec<(i64, &[Value])> = all
+            .iter()
+            .filter(|(row_id, _)| row_id % 2 == 0)
+            .map(|(row_id, values)| (*row_id, values.as_slice()))
+            .collect();
+        let start = std::time::Instant::now();
+        index.remove_batch_slice(&half).unwrap();
+        assert!(
+            start.elapsed().as_secs() < 3,
+            "batch removal took {:?}",
+            start.elapsed()
+        );
+        let hits = index.find(&[Value::Integer(0)]).unwrap();
+        assert_eq!(hits.len(), per_key as usize / 2);
+        assert!(hits.iter().all(|h| h.row_id % 2 == 1));
+
+        let rest: Vec<(i64, &[Value])> = all
+            .iter()
+            .filter(|(row_id, _)| row_id % 2 == 1)
+            .map(|(row_id, values)| (*row_id, values.as_slice()))
+            .collect();
+        index.remove_batch_slice(&rest).unwrap();
+        assert!(index.find(&[Value::Integer(0)]).unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The lazy prefix index of a multi-column index was built with a sorted insert per row, and a removal batch took each row out of the sorted and prefix vectors one at a time. Both are quadratic in the rows per key. On a table with UNIQUE(exchange, symbol, time) holding 2.17M rows over 174 series, the first `WHERE exchange = .. AND symbol = ..` query after a bulk load spent 47.8 s in memmove, and the seal that moved those rows into volumes held its lock for 105 s while every concurrent query waited.

- The prefix build gathers each key's row ids and sorts them once.
- A removal batch is grouped by key and subtracted in one pass per key, for the sorted structure and every built prefix. The pass starts at the position of the first removed id, so taking the newest rows off a large group stays O(log N) as before, and the seal of a whole group is one pass instead of one shift per row.
- The bench reads process CPU time through getrusage on Unix only; libc is a Unix-only dependency and `cargo test` builds the examples on Windows.
- A scale test (one key, 400k rows) guards both paths. It judges wall-clock time, so it is left out of the default nextest profile and runs under `-P full`; on the previous implementation the build alone takes 4.9 s, on this branch the whole test takes 2.6 s in debug.
- `examples/candle_bench.rs` is the workload bench used below: many (key, key, time) series in one table, bulk loaded, sealed, reopened and queried like a market data application, reporting p50/p99/max latency, process CPU time and RSS per phase.

Bench, 2.175M rows, 174 series, 4 threads, same machine:

| phase | main | this branch |
|---|---|---|
| first pair query after load | 47,789 ms (CPU 48.6 s) | 338 ms (CPU 314 ms) |
| query stalled by the seal of the loaded rows | 104,804 ms | reader max 1,844 ms during a 3.0 s seal |
| pair latest DESC LIMIT 200, cold | 10.7 ms | 8.9 ms |
| fan-out 174 pair queries, cold | wall 499 ms, p99 16.5 ms | wall 411 ms, p99 10.4 ms |
| reopen, pair latest DESC LIMIT 200 | 67 ms | 58 ms |
| load RSS | 2582 MB | 2673 MB |

On main the background seal fired during the hot query set, so its hot numbers were partly cold; on this branch the hot phase is truly hot and shows a large unsealed store answering the same pair query in 36 ms against 9 ms once sealed. That, the 1.8 s the seal still holds its lock, and the deferred-column cost after reopen are separate items.

## Test plan

- [x] `cargo nextest run --lib -P full -E 'test(/multi_column/)'`: seven tests including the scale test; the scale test fails on the previous implementation (prefix build 4.9 s against a 3 s bound)
- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run`
