### PR TITLE
perf(scan): walk a sorted volume from the bound and stop on the raw key

### DIFF
--- a/src/storage/volume/column.rs
+++ b/src/storage/volume/column.rs
@@ -511,6 +511,15 @@ impl ColumnData {
 
     /// Get the dictionary ID for a row. Returns u32::MAX on type mismatch.
     #[inline]
+    /// The per-row dictionary ids and null flags of a dictionary column, for
+    /// callers that test many rows in one pass
+    pub fn dict_ids(&self) -> Option<(&[u32], &[bool])> {
+        match self {
+            ColumnData::Dictionary { ids, nulls, .. } => Some((ids, nulls)),
+            _ => None,
+        }
+    }
+
     pub fn get_dict_id(&self, idx: usize) -> u32 {
         match self {
             ColumnData::Dictionary { ids, .. } => ids[idx],

--- a/src/storage/volume/scanner.rs
+++ b/src/storage/volume/scanner.rs
@@ -151,9 +151,175 @@ pub struct VolumeScanner {
     /// integer division in the slow-path scan loop. Recomputed only on group
     /// boundary crossings. 0 means "not yet initialized".
     next_group_boundary: usize,
+    /// Walk the range from its end down to its start
+    reverse: bool,
+    /// The caller consumes rows in the volume's order and may stop early, so
+    /// the eager dictionary pre-scan over the whole range is not done
+    ordered_walk: bool,
+    /// Stop when the raw key of the row under the cursor is past this bound:
+    /// (physical column, key, ascending). Only meaningful on a sorted column.
+    stop_key: Option<(usize, i64, bool)>,
+    /// Rows of the current group that pass the dictionary filters, ascending,
+    /// found in one pass over the raw ids; consumed from the back on a
+    /// reverse walk
+    group_candidates: Vec<usize>,
+    /// The group `group_candidates` was computed for
+    candidates_group: Option<usize>,
 }
 
 impl VolumeScanner {
+    /// Rows in the volume's order, from the start (ascending) or from the end
+    /// (descending), without the eager dictionary pre-scan over the range
+    pub fn set_ordered_walk(&mut self, ascending: bool) {
+        self.ordered_walk = true;
+        self.reverse = !ascending;
+    }
+
+    /// Stop as soon as the row under the cursor has a key past `bound`
+    /// (below it walking backwards, above it walking forwards). The column
+    /// must be sorted in the volume; only integer and timestamp keys count.
+    pub fn set_stop_key(&mut self, col_idx: usize, bound: &Value, ascending: bool) {
+        let target = match (bound, self.volume.columns.data_type(col_idx)) {
+            (Value::Integer(v), crate::core::DataType::Integer) => *v,
+            (Value::Timestamp(dt), crate::core::DataType::Timestamp) => {
+                dt.timestamp_nanos_opt().unwrap_or_else(|| {
+                    dt.timestamp()
+                        .saturating_mul(1_000_000_000)
+                        .saturating_add(dt.timestamp_subsec_nanos() as i64)
+                })
+            }
+            _ => return,
+        };
+        self.stop_key = Some((col_idx, target, ascending));
+    }
+
+    /// True when the row at `idx` lies past the stop key
+    fn past_stop_key(&self, idx: usize) -> bool {
+        let Some((col_idx, target, ascending)) = self.stop_key else {
+            return false;
+        };
+        let (col, local) = self.col_and_idx(col_idx, idx);
+        if col.is_null(local) {
+            return false;
+        }
+        let key = col.get_i64(local);
+        if ascending {
+            key > target
+        } else {
+            key < target
+        }
+    }
+
+    /// The rows in `[lo, hi)` that pass every dictionary filter, in one pass
+    /// over the raw ids of the group; None when a filter column is not a
+    /// dictionary column here and the rows must be tested one by one
+    fn dictionary_candidates(&self, lo: usize, hi: usize) -> Option<Vec<usize>> {
+        let mut slices: Vec<(&[u32], &[bool], usize, u32)> =
+            Vec::with_capacity(self.dict_filters.len());
+        for &(col_idx, expected) in &self.dict_filters {
+            let (col, local_lo) = self.col_and_idx(col_idx, lo);
+            let (ids, nulls) = col.dict_ids()?;
+            if local_lo + (hi - lo) > ids.len() {
+                return None;
+            }
+            slices.push((ids, nulls, local_lo, expected));
+        }
+        let mut candidates = Vec::new();
+        let (first_ids, first_nulls, first_lo, first_expected) = slices[0];
+        for offset in 0..hi - lo {
+            let local = first_lo + offset;
+            if first_nulls[local] || first_ids[local] != first_expected {
+                continue;
+            }
+            let others_match = slices[1..].iter().all(|&(ids, nulls, base, expected)| {
+                let local = base + offset;
+                !nulls[local] && ids[local] == expected
+            });
+            if others_match {
+                candidates.push(lo + offset);
+            }
+        }
+        Some(candidates)
+    }
+
+    /// The reverse walk: the newest row of the range first. Row groups are
+    /// entered from their end; a pruned group is skipped whole; with
+    /// dictionary filters the group's candidates are found in one pass.
+    fn next_reverse(&mut self) -> bool {
+        let use_group_cache = self.volume.columns.should_use_group_cache();
+        while self.current_idx < self.end_idx {
+            let idx = self.end_idx - 1;
+            let group_idx = idx / super::column::ROW_GROUP_SIZE;
+            let group_start = group_idx * super::column::ROW_GROUP_SIZE;
+            let cached = self.group_cache.as_ref().map(|c| c.group_idx);
+            if cached != Some(group_idx) {
+                if let Some(ref skips) = self.row_group_skips {
+                    if group_idx < skips.len() && skips[group_idx] {
+                        self.end_idx = group_start.max(self.current_idx);
+                        continue;
+                    }
+                }
+                if use_group_cache {
+                    self.load_group_cache(group_idx);
+                    if self.error.is_some() {
+                        self.has_current = false;
+                        return false;
+                    }
+                }
+            }
+            if !self.dict_filters.is_empty() && self.candidates_group != Some(group_idx) {
+                let lo = group_start.max(self.current_idx);
+                match self.dictionary_candidates(lo, self.end_idx) {
+                    Some(candidates) => {
+                        self.group_candidates = candidates;
+                        self.candidates_group = Some(group_idx);
+                    }
+                    None => {
+                        self.group_candidates.clear();
+                        self.candidates_group = None;
+                    }
+                }
+            }
+            let idx = if self.candidates_group == Some(group_idx) {
+                match self.group_candidates.pop() {
+                    Some(idx) => idx,
+                    None => {
+                        // The group holds no more candidates: leave it whole
+                        self.end_idx = group_start.max(self.current_idx);
+                        continue;
+                    }
+                }
+            } else {
+                idx
+            };
+            if self.past_stop_key(idx) {
+                self.end_idx = self.current_idx;
+                self.has_current = false;
+                return false;
+            }
+            self.end_idx = idx;
+            if self.should_skip_row(idx) {
+                continue;
+            }
+            if self.candidates_group != Some(group_idx)
+                && !self.dict_filters.is_empty()
+                && self.dict_filters_reject(idx)
+            {
+                continue;
+            }
+            if !self.typed_predicates.is_empty() && !self.evaluate_typed_predicates(idx) {
+                continue;
+            }
+            if !self.materialize_row(idx) {
+                continue;
+            }
+            self.current_rid = self.volume.meta.row_ids[idx];
+            self.has_current = true;
+            return true;
+        }
+        self.has_current = false;
+        false
+    }
     /// Compute whether `project_cols` is an identity mapping over all volume columns.
     /// Extracted as a helper so both constructors share the same logic.
     #[inline]
@@ -199,6 +365,11 @@ impl VolumeScanner {
             row_group_skips: None,
             group_cache: None,
             next_group_boundary: 0,
+            reverse: false,
+            ordered_walk: false,
+            stop_key: None,
+            group_candidates: Vec::new(),
+            candidates_group: None,
         };
         if !s.is_full_projection && s.volume.columns.should_use_group_cache() {
             let mut mask = vec![false; s.volume.columns.len()];
@@ -251,6 +422,11 @@ impl VolumeScanner {
             row_group_skips: None,
             group_cache: None,
             next_group_boundary: 0,
+            reverse: false,
+            ordered_walk: false,
+            stop_key: None,
+            group_candidates: Vec::new(),
+            candidates_group: None,
         };
         if !s.is_full_projection && s.volume.columns.should_use_group_cache() {
             let mut mask = vec![false; s.volume.columns.len()];
@@ -335,6 +511,11 @@ impl VolumeScanner {
             row_group_skips: None,
             group_cache: None,
             next_group_boundary: 0,
+            reverse: false,
+            ordered_walk: false,
+            stop_key: None,
+            group_candidates: Vec::new(),
+            candidates_group: None,
         }
     }
 
@@ -377,7 +558,9 @@ impl VolumeScanner {
         // Pre-compute matching row indices from dictionary filters.
         // Skip pre-computation when match rate is too high (>10%) to avoid
         // large Vec allocation — use streaming dict filter in the slow path instead.
-        if !self.dict_filters.is_empty() {
+        // An ordered walk may stop after a few rows, so it never pays for the
+        // whole range up front.
+        if !self.dict_filters.is_empty() && !self.ordered_walk {
             let scan_range = self.end_idx - self.current_idx;
             let selectivity_cap = scan_range / 10; // 10% threshold
             let matches = if let Some(st) = store {
@@ -862,6 +1045,9 @@ impl Scanner for VolumeScanner {
             self.has_current = false;
             return false;
         }
+        if self.reverse {
+            return self.next_reverse();
+        }
 
         // Fast path: use pre-computed matching indices (from dictionary filters).
         let use_group_cache_fast = self.volume.columns.should_use_group_cache();
@@ -934,6 +1120,12 @@ impl Scanner for VolumeScanner {
                         return false;
                     }
                 }
+            }
+
+            if self.stop_key.is_some() && self.past_stop_key(self.current_idx) {
+                self.current_idx = self.end_idx;
+                self.has_current = false;
+                return false;
             }
 
             if self.should_skip_row(self.current_idx) {

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -711,44 +711,55 @@ impl SegmentedTable {
                             None
                         };
                         match op {
+                            // A search that hits a block it cannot decode
+                            // leaves the range as it is: the scan then reaches
+                            // the block and reports the error
                             crate::core::Operator::Gte => {
                                 let idx = if let Some(st) = store {
                                     st.binary_search_ge(col_idx, target, &vol.meta.row_groups)
                                 } else {
-                                    vol.columns[col_idx].binary_search_ge(target)
+                                    Some(vol.columns[col_idx].binary_search_ge(target))
                                 };
-                                if idx > start {
-                                    start = idx;
+                                if let Some(idx) = idx {
+                                    if idx > start {
+                                        start = idx;
+                                    }
                                 }
                             }
                             crate::core::Operator::Gt => {
                                 let idx = if let Some(st) = store {
                                     st.binary_search_gt(col_idx, target, &vol.meta.row_groups)
                                 } else {
-                                    vol.columns[col_idx].binary_search_gt(target)
+                                    Some(vol.columns[col_idx].binary_search_gt(target))
                                 };
-                                if idx > start {
-                                    start = idx;
+                                if let Some(idx) = idx {
+                                    if idx > start {
+                                        start = idx;
+                                    }
                                 }
                             }
                             crate::core::Operator::Lte => {
                                 let idx = if let Some(st) = store {
                                     st.binary_search_gt(col_idx, target, &vol.meta.row_groups)
                                 } else {
-                                    vol.columns[col_idx].binary_search_gt(target)
+                                    Some(vol.columns[col_idx].binary_search_gt(target))
                                 };
-                                if idx < end {
-                                    end = idx;
+                                if let Some(idx) = idx {
+                                    if idx < end {
+                                        end = idx;
+                                    }
                                 }
                             }
                             crate::core::Operator::Lt => {
                                 let idx = if let Some(st) = store {
                                     st.binary_search_ge(col_idx, target, &vol.meta.row_groups)
                                 } else {
-                                    vol.columns[col_idx].binary_search_ge(target)
+                                    Some(vol.columns[col_idx].binary_search_ge(target))
                                 };
-                                if idx < end {
-                                    end = idx;
+                                if let Some(idx) = idx {
+                                    if idx < end {
+                                        end = idx;
+                                    }
                                 }
                             }
                             _ => {}
@@ -3991,7 +4002,8 @@ impl Table for SegmentedTable {
                 break;
             }
             let (seg_id, cs) = &volumes[i];
-            let (should_skip, _, _) = Self::prune_volume(&cs.volume, &comparisons, &bloom_hashes);
+            let (should_skip, mut narrow_start, mut narrow_end) =
+                Self::prune_volume(&cs.volume, &comparisons, &bloom_hashes);
             if should_skip {
                 continue;
             }
@@ -4001,14 +4013,14 @@ impl Table for SegmentedTable {
                     Some(v) => v,
                     None => continue,
                 };
+                // Only a loaded volume can narrow the range through the sorted
+                // columns' binary search; a warm one already did above
+                (_, narrow_start, narrow_end) =
+                    Self::prune_volume(&loaded, &comparisons, &bloom_hashes);
                 &loaded
             } else {
                 &cs.volume
             };
-            // On a loaded volume the prune also narrows the range through the
-            // sorted columns' binary search
-            let (_, narrow_start, narrow_end) =
-                Self::prune_volume(vol, &comparisons, &bloom_hashes);
             let sorted = vol.is_sorted(vcol);
             // Row groups in bound order, clipped to the narrowed range; a
             // volume without group metadata is one group

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -126,6 +126,14 @@ impl TopK {
         }
     }
 
+    /// The key a row must beat once k rows are held
+    fn worst_key(&self) -> Option<&Value> {
+        if self.heap.len() < self.k {
+            return None;
+        }
+        self.heap.peek().map(|r| &r.key)
+    }
+
     /// True once k rows are held and no row bounded by `bound` can beat the worst
     fn cannot_improve(&self, bound: &Value) -> bool {
         if self.heap.len() < self.k {
@@ -3997,7 +4005,13 @@ impl Table for SegmentedTable {
             } else {
                 &cs.volume
             };
-            // Row groups in bound order; a volume without group metadata is one group
+            // On a loaded volume the prune also narrows the range through the
+            // sorted columns' binary search
+            let (_, narrow_start, narrow_end) =
+                Self::prune_volume(vol, &comparisons, &bloom_hashes);
+            let sorted = vol.is_sorted(vcol);
+            // Row groups in bound order, clipped to the narrowed range; a
+            // volume without group metadata is one group
             let mut groups: Vec<(usize, usize, Option<&Value>)> = vol
                 .meta
                 .row_groups
@@ -4013,6 +4027,11 @@ impl Table for SegmentedTable {
             if groups.is_empty() {
                 groups.push((0, vol.meta.row_count, None));
             }
+            for group in &mut groups {
+                group.0 = group.0.max(narrow_start);
+                group.1 = group.1.min(narrow_end);
+            }
+            groups.retain(|g| g.0 < g.1);
             // Bound order, not physical order: a volume written out of time order
             // has its best group anywhere. A group without a bound goes first.
             groups.sort_by(|a, b| match (&a.2, &b.2) {
@@ -4042,12 +4061,25 @@ impl Table for SegmentedTable {
                 scanner.set_column_mapping(
                     self.segment_mgr.get_volume_mapping(*seg_id, current_schema),
                 );
+                // In a sorted volume the rows come in key order: walk from the
+                // best end and stop at the first key the heap cannot use
+                if sorted {
+                    scanner.set_ordered_walk(ascending);
+                    if let Some(worst) = keep.worst_key() {
+                        scanner.set_stop_key(vcol, worst, ascending);
+                    }
+                }
                 if let Some(filter) = &prepared_filter {
                     scanner.set_filter(filter.clone_box());
                 }
                 while scanner.next() {
                     let (row_id, row) = scanner.take_row_with_id();
                     keep.offer(row_id, row);
+                    if sorted {
+                        if let Some(worst) = keep.worst_key() {
+                            scanner.set_stop_key(vcol, worst, ascending);
+                        }
+                    }
                 }
                 if let Some(e) = scanner.err() {
                     return Err(crate::core::Error::internal(format!("scan error: {}", e)));

--- a/src/storage/volume/writer.rs
+++ b/src/storage/volume/writer.rs
@@ -603,13 +603,15 @@ impl CompressedBlockStore {
 
     /// Binary search on a sorted column using row-group zone maps.
     /// Decompresses only the group(s) containing the target value.
-    /// Returns global row index (same as ColumnData::binary_search_ge/gt).
+    /// Returns global row index (same as ColumnData::binary_search_ge/gt),
+    /// or None when a block fails to decode: the caller must then keep the
+    /// range unnarrowed so the scan reaches the block and reports the error.
     pub fn binary_search_ge(
         &self,
         col_idx: usize,
         target: i64,
         row_groups: &[super::column::RowGroupMeta],
-    ) -> usize {
+    ) -> Option<usize> {
         self.binary_search_impl(col_idx, target, row_groups, false)
     }
 
@@ -618,7 +620,7 @@ impl CompressedBlockStore {
         col_idx: usize,
         target: i64,
         row_groups: &[super::column::RowGroupMeta],
-    ) -> usize {
+    ) -> Option<usize> {
         self.binary_search_impl(col_idx, target, row_groups, true)
     }
 
@@ -628,7 +630,7 @@ impl CompressedBlockStore {
         target: i64,
         row_groups: &[super::column::RowGroupMeta],
         strict: bool,
-    ) -> usize {
+    ) -> Option<usize> {
         let num_groups = self.blocks[col_idx].len();
 
         // Use zone maps to find the group containing the target.
@@ -650,10 +652,7 @@ impl CompressedBlockStore {
                 if target > max_i64 {
                     continue;
                 }
-                let col = match self.decompress_single_group(col_idx, gi) {
-                    Ok(c) => c,
-                    Err(_) => return 0, // corrupt block: scan from start (conservative)
-                };
+                let col = self.decompress_single_group(col_idx, gi).ok()?;
                 let group_rows = (rg.end_idx - rg.start_idx) as usize;
                 let local = if strict {
                     col.binary_search_gt(target)
@@ -661,26 +660,23 @@ impl CompressedBlockStore {
                     col.binary_search_ge(target)
                 };
                 if local < group_rows {
-                    return rg.start_idx as usize + local;
+                    return Some(rg.start_idx as usize + local);
                 }
             }
-            return self.row_count;
+            return Some(self.row_count);
         }
 
         if num_groups == 1 {
-            let col = match self.decompress_single_group(col_idx, 0) {
-                Ok(c) => c,
-                Err(_) => return 0,
-            };
-            return if strict {
+            let col = self.decompress_single_group(col_idx, 0).ok()?;
+            return Some(if strict {
                 col.binary_search_gt(target)
             } else {
                 col.binary_search_ge(target)
-            };
+            });
         }
 
         // Fallback: full column (shouldn't happen for V4 with zone maps)
-        self.row_count
+        Some(self.row_count)
     }
 
     /// Number of groups for a given column.

--- a/tests/ordered_limited_scan_test.rs
+++ b/tests/ordered_limited_scan_test.rs
@@ -213,7 +213,7 @@ fn test_top_k_over_volumes_sorted_by_time() {
         check_all(&db);
     }
     // A bigger sealed batch spanning several row groups
-    insert_sorted(&db, base + 12_000 * 60, 10_000, 20, 60);
+    insert_sorted(&db, base + 12_000 * 60, 5_000, 20, 60);
     db.execute("PRAGMA CHECKPOINT", ()).unwrap();
     db.execute("DELETE FROM c WHERE v = 99", ()).unwrap();
     check_all(&db);
@@ -343,4 +343,71 @@ fn test_top_k_on_the_memory_engine_and_after_reopen() {
     drop(db);
     let db = Database::open(&dsn).unwrap();
     check_all(&db);
+}
+
+#[test]
+fn test_top_k_reports_a_block_it_cannot_decode_instead_of_an_empty_answer() {
+    // A valid file whose column block fails to decode: the sorted-column
+    // binary search must not narrow the range to nothing and hide the error
+    use std::sync::Arc;
+    use stoolap::core::{Operator, Row, Value};
+    use stoolap::storage::expression::ComparisonExpr;
+    use stoolap::storage::traits::{Engine, Table};
+    use stoolap::storage::volume::io::{read_volume_from_disk, write_volume_to_disk};
+    use stoolap::storage::volume::manifest::{SegmentManager, SegmentMeta};
+    use stoolap::storage::volume::table::SegmentedTable;
+    use stoolap::storage::volume::writer::VolumeBuilder;
+
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open("memory://ordered_limited_scan_corrupt_block").unwrap();
+    db.execute("CREATE TABLE c (t INTEGER NOT NULL)", ())
+        .unwrap();
+    let tx = db.engine().begin_transaction().unwrap();
+    let hot = tx.get_table("c").unwrap();
+    let schema = hot.schema().clone();
+    let mut builder = VolumeBuilder::new(&schema);
+    builder.add_row(1, &Row::from_values(vec![Value::Integer(10)]));
+    builder.add_row(2, &Row::from_values(vec![Value::Integer(20)]));
+    let volume = builder.finish();
+    let path = write_volume_to_disk(dir.path(), "c", 1, &volume).unwrap();
+
+    // Keep the framing, metadata and CRC valid; replace the column block
+    let original = std::fs::read(&path).unwrap();
+    let meta_len = u32::from_le_bytes(original[16..20].try_into().unwrap()) as usize;
+    let index_offset = 20 + meta_len;
+    let mut bytes = original[..index_offset].to_vec();
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    bytes.extend_from_slice(&100u64.to_le_bytes());
+    bytes.push(0xff);
+    let crc = crc32fast::hash(&bytes);
+    bytes.extend_from_slice(&crc.to_le_bytes());
+    std::fs::write(&path, &bytes).unwrap();
+    let loaded = read_volume_from_disk(&path).unwrap();
+    assert!(loaded
+        .columns
+        .compressed_store()
+        .unwrap()
+        .decompress_single_group(0, 0)
+        .is_err());
+
+    let mgr = Arc::new(SegmentManager::new("c", Some(dir.path().to_path_buf())));
+    mgr.register_segment(
+        1,
+        Arc::new(volume.to_cold()),
+        SegmentMeta {
+            segment_id: 1,
+            file_path: path,
+            row_count: 2,
+            min_row_id: 1,
+            max_row_id: 2,
+            schema_version: 0,
+            creation_lsn: 0,
+            seal_seq: 0,
+        },
+        Some(&schema),
+    );
+    let table = SegmentedTable::new(hot, mgr);
+    let filter = ComparisonExpr::new("t", Operator::Lt, Value::Integer(15));
+    let result = table.scan_top_k(Some(&filter), "t", false, 1, 0);
+    assert!(result.is_err(), "corrupt column accepted: {result:?}");
 }

--- a/tests/ordered_limited_scan_test.rs
+++ b/tests/ordered_limited_scan_test.rs
@@ -180,6 +180,58 @@ fn test_top_k_matches_the_full_sort_across_layouts() {
     check_all(&db);
 }
 
+/// Rows in time order, every key once per step, as a market data feed writes them
+fn insert_sorted(db: &Database, from: i64, steps: i64, keys: i64, step_secs: i64) {
+    let mut stmt = String::from("INSERT INTO c (t, k, v) VALUES ");
+    for s in 0..steps {
+        for k in 0..keys {
+            if s > 0 || k > 0 {
+                stmt.push(',');
+            }
+            stmt.push_str(&format!(
+                "('{}', 'k{k}', {})",
+                ts(from + s * step_secs),
+                (s * 7 + k) % 100
+            ));
+        }
+    }
+    db.execute(&stmt, ()).unwrap();
+}
+
+#[test]
+fn test_top_k_over_volumes_sorted_by_time() {
+    // Sorted volumes take the ordered walk that stops on the raw key
+    let dir = tempfile::tempdir().unwrap();
+    let (db, _) = setup(&format!("file://{}/sorted", dir.path().display()));
+    let base = 1_709_251_200;
+    // Three sealed batches of 20 keys x 4,000 minutes, then deletes, then hot rows
+    for i in 0..3 {
+        insert_sorted(&db, base + i * 4_000 * 60, 4_000, 20, 60);
+        db.execute(&format!("DELETE FROM c WHERE v = {}", 10 + i), ())
+            .unwrap();
+        db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        check_all(&db);
+    }
+    // A bigger sealed batch spanning several row groups
+    insert_sorted(&db, base + 12_000 * 60, 10_000, 20, 60);
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    db.execute("DELETE FROM c WHERE v = 99", ()).unwrap();
+    check_all(&db);
+    // Hot rows newer than the sealed ones, and a key that stopped producing
+    insert_sorted(&db, base + 22_000 * 60, 300, 19, 60);
+    check_all(&db);
+    db.execute("BEGIN", ()).unwrap();
+    let newest = ids(
+        &db,
+        "SELECT id FROM c WHERE k = 'k3' AND t < '2024-03-10 00:00:00' ORDER BY t DESC LIMIT 1",
+    );
+    db.execute(&format!("DELETE FROM c WHERE id = {}", newest[0]), ())
+        .unwrap();
+    check_all(&db);
+    db.execute("ROLLBACK", ()).unwrap();
+    check_all(&db);
+}
+
 #[test]
 fn test_top_k_over_a_volume_written_out_of_time_order() {
     // Three row groups of 65,536 rows whose time bounds run high, low, medium


### PR DESCRIPTION
## Summary

Work items A, B and the group part of C from the sealed time-series read plan, on top of #105.

The top-k scan of #105 opened each row group with the ordinary scanner: the scanner pre-scanned the whole group for the dictionary filters row by row (through the column's dynamic dispatch) before the first row came out, every row paid the stop test through boxed Values in the heap, and only a group's zone-map bound could end the work early. The profile of "series latest DESC LIMIT 200" on a sealed table was 80% `VolumeScanner::set_filter`.

- **Enter the group at the bound.** On a volume sorted by the ORDER BY column the row groups are clipped to the range the prune's sorted-column binary search already computes from the WHERE's time comparisons; groups outside it are not opened.
- **Ordered walk with a raw-key stop.** The scanner gains an ordered walk (backwards for DESC, forwards for ASC) that skips the eager pre-scan, and a stop key: it stops as soon as the column value under the cursor is past the heap's worst, checked before any row is built. The top-k updates the stop key after each row it keeps. Volumes not sorted on the column keep today's forward walk and the bound test per group.
- **Candidates of a group in one pass.** With dictionary filters the walk finds a group's candidate rows in one pass over the raw ids and null flags (`ColumnData::dict_ids`), then visits only those from the back. The typed predicates and the residual filter still run on every candidate; the NULL mask is honoured.
- Review fixes: the compressed binary search returned 0 when a block failed to decode, which as an upper bound emptied the range and, once the groups were clipped to it, turned a corrupt block into an empty answer; it now returns None and the prune leaves the range whole, so the scan reaches the block and reports it (a fault-injection test writes a valid file with an undecodable block). The prune, and its binary search, no longer runs twice on a warm volume; only a volume that had to be loaded is pruned again.
- The differential test gains time-sorted volumes with deletes before sealing, a multi-group volume, hot rows newer than the sealed ones, a series that stopped producing, and a sealed row deleted in a transaction; the unsorted, backfill, alias, star and NaN cases stay.

Bench, sealed, 2.175M rows over 174 series, UNIQUE(exchange, symbol, time) plus a BTREE on time, same machine (SQLite with the same data and indexes for reference):

| shape | #105 | this branch | SQLite |
|---|---|---|---|
| series latest DESC LIMIT 200 | 0.63 ms | 0.18 ms | 0.06 ms |
| series + time >= day DESC LIMIT 200 | 0.53 ms | 0.19 ms | 0.06 ms |
| series + day range DESC LIMIT 500 | 1.55 ms | 0.48 ms | 0.50 ms |
| all series last 10 min DESC LIMIT 100 | 0.51 ms | 0.05 ms | 0.03 ms |
| fan-out 174 series queries on 4 threads | wall 17 ms, p99 0.8 ms | wall 8 ms, p99 0.5 ms | wall 43 ms, p99 3.2 ms |

After a reopen (warm volumes) the same shapes measure 2.0 to 3.0 ms across runs: the decompression of the touched group dominates there and is untouched by this change. What remains on the sealed series query is the one pass over the last group's 65,536 ids; a per-series posting list per group would remove it.

## Test plan

- [x] `cargo nextest run --test ordered_limited_scan_test` (six tests)
- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run`
- [x] `cargo nextest run --features test-filedb`
