### PR TITLE
perf(volume): keep decoded row-group columns in a byte-budgeted cache

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -9843,6 +9843,54 @@ impl Executor {
                     Ok(Box::new(ExecutorResult::new(columns, rows)))
                 }
             }
+            "GROUP_CACHE_MB" => {
+                // Budget of the decoded row-group column cache, in megabytes;
+                // zero disables it
+                use crate::storage::volume::group_cache::DECODED_GROUPS;
+                let columns: Vec<String> = vec![pragma_name.to_lowercase().into()];
+                if let Some(ref value) = stmt.value {
+                    let mb = self.extract_pragma_int_value(value)?;
+                    if mb < 0 {
+                        return Err(Error::internal("group_cache_mb must not be negative"));
+                    }
+                    DECODED_GROUPS.set_budget_bytes((mb as usize).saturating_mul(1024 * 1024));
+                }
+                let mut rows = RowVec::with_capacity(1);
+                rows.push((
+                    0,
+                    Row::from_values(vec![Value::Integer(
+                        (DECODED_GROUPS.budget_bytes() / (1024 * 1024)) as i64,
+                    )]),
+                ));
+                Ok(Box::new(ExecutorResult::new(columns, rows)))
+            }
+            "GROUP_CACHE_STATS" => {
+                if stmt.value.is_some() {
+                    return Err(Error::internal(
+                        "PRAGMA GROUP_CACHE_STATS does not accept values",
+                    ));
+                }
+                let stats = crate::storage::volume::group_cache::DECODED_GROUPS.stats();
+                let columns = vec![
+                    "budget_bytes".to_string(),
+                    "bytes".to_string(),
+                    "entries".to_string(),
+                    "hits".to_string(),
+                    "misses".to_string(),
+                ];
+                let mut rows = RowVec::with_capacity(1);
+                rows.push((
+                    0,
+                    Row::from_values(vec![
+                        Value::Integer(stats.budget_bytes as i64),
+                        Value::Integer(stats.bytes as i64),
+                        Value::Integer(stats.entries as i64),
+                        Value::Integer(stats.hits as i64),
+                        Value::Integer(stats.misses as i64),
+                    ]),
+                ));
+                Ok(Box::new(ExecutorResult::new(columns, rows)))
+            }
             "VOLUME_STATS" => {
                 if stmt.value.is_some() {
                     return Err(Error::internal(

--- a/src/storage/index/multi_column.rs
+++ b/src/storage/index/multi_column.rs
@@ -1194,7 +1194,7 @@ mod tests {
         let start = std::time::Instant::now();
         let hits = index.find(&[Value::Integer(0)]).unwrap();
         assert!(
-            start.elapsed().as_secs() < 3,
+            start.elapsed().as_secs() < 15,
             "prefix build took {:?}",
             start.elapsed()
         );
@@ -1234,7 +1234,7 @@ mod tests {
         let start = std::time::Instant::now();
         index.remove_batch_slice(&half).unwrap();
         assert!(
-            start.elapsed().as_secs() < 3,
+            start.elapsed().as_secs() < 15,
             "batch removal took {:?}",
             start.elapsed()
         );

--- a/src/storage/volume/column.rs
+++ b/src/storage/volume/column.rs
@@ -511,6 +511,16 @@ impl ColumnData {
 
     /// Get the dictionary ID for a row. Returns u32::MAX on type mismatch.
     #[inline]
+    /// The bytes this column owns on its own: like `memory_size` but without
+    /// the dictionary strings, which every group of a column shares through
+    /// one Arc and which a cache must therefore count once, not per group
+    pub fn cache_size(&self) -> usize {
+        match self {
+            ColumnData::Dictionary { ids, nulls, .. } => ids.len() * 4 + nulls.len(),
+            other => other.memory_size(),
+        }
+    }
+
     /// The per-row dictionary ids and null flags of a dictionary column, for
     /// callers that test many rows in one pass
     pub fn dict_ids(&self) -> Option<(&[u32], &[bool])> {

--- a/src/storage/volume/group_cache.rs
+++ b/src/storage/volume/group_cache.rs
@@ -122,7 +122,7 @@ impl DecodedGroupCache {
         match outcome {
             Ok(column) => {
                 if !slot.charged.swap(true, Ordering::AcqRel) {
-                    self.charge(key, column.memory_size(), budget);
+                    self.charge(key, &slot, column.cache_size());
                 }
                 Ok(Arc::clone(column))
             }
@@ -134,14 +134,29 @@ impl DecodedGroupCache {
         }
     }
 
-    /// Account a decoded entry and make room for it
-    fn charge(&self, key: GroupKey, bytes: usize, budget: usize) {
+    /// Account a decoded entry and make room for it. The entry may have been
+    /// evicted while it decoded, the budget may have moved, or the column may
+    /// not fit at all: in each case the caller keeps its column and the cache
+    /// keeps nothing.
+    fn charge(&self, key: GroupKey, slot: &Arc<Slot>, bytes: usize) {
+        let budget = self.budget.load(Ordering::Relaxed);
         let mut inner = self.lock();
+        let still_ours = inner
+            .entries
+            .get(&key)
+            .is_some_and(|entry| Arc::ptr_eq(&entry.slot, slot));
+        if !still_ours {
+            return;
+        }
+        if budget == 0 || bytes > budget {
+            inner.entries.remove(&key);
+            return;
+        }
         if let Some(entry) = inner.entries.get_mut(&key) {
             entry.bytes = bytes;
         }
         inner.bytes += bytes;
-        while inner.bytes > budget && inner.entries.len() > 1 {
+        while inner.bytes > budget {
             let victim = inner
                 .entries
                 .iter()

--- a/src/storage/volume/group_cache.rs
+++ b/src/storage/volume/group_cache.rs
@@ -139,8 +139,10 @@ impl DecodedGroupCache {
     /// not fit at all: in each case the caller keeps its column and the cache
     /// keeps nothing.
     fn charge(&self, key: GroupKey, slot: &Arc<Slot>, bytes: usize) {
-        let budget = self.budget.load(Ordering::Relaxed);
+        // The budget is read under the same lock that set_budget_bytes holds
+        // while it stores it, so a change cannot slip in between
         let mut inner = self.lock();
+        let budget = self.budget.load(Ordering::Relaxed);
         let still_ours = inner
             .entries
             .get(&key)
@@ -196,8 +198,8 @@ impl DecodedGroupCache {
 
     /// Set the budget; entries beyond it leave at once
     pub fn set_budget_bytes(&self, budget: usize) {
-        self.budget.store(budget, Ordering::Relaxed);
         let mut inner = self.lock();
+        self.budget.store(budget, Ordering::Relaxed);
         while inner.bytes > budget && !inner.entries.is_empty() {
             let victim = inner
                 .entries

--- a/src/storage/volume/group_cache.rs
+++ b/src/storage/volume/group_cache.rs
@@ -1,0 +1,217 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A byte-budgeted cache of decoded row-group columns.
+//!
+//! A warm volume keeps its columns compressed; every scan of a row group
+//! decoded the columns it needed and dropped them again. The cache keeps the
+//! decoded columns, keyed by (block store, column, group), so a group read by
+//! query after query is decoded once. Concurrent readers of the same group
+//! share one decode: the first takes the slot's cell, the others wait on it,
+//! and the map lock is never held while decoding. The budget is a process
+//! total; the least recently used entries leave when a new one crosses it.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
+
+use super::column::ColumnData;
+
+/// Default budget: 64 MB of decoded columns
+pub const DEFAULT_BUDGET_BYTES: usize = 64 * 1024 * 1024;
+
+/// (block store id, column, group)
+pub type GroupKey = (usize, u32, u32);
+
+struct Slot {
+    cell: OnceLock<Result<Arc<ColumnData>, String>>,
+    /// The decoder charges the entry's bytes once
+    charged: AtomicBool,
+}
+
+struct Entry {
+    slot: Arc<Slot>,
+    bytes: usize,
+    last_used: u64,
+}
+
+#[derive(Default)]
+struct Inner {
+    entries: HashMap<GroupKey, Entry>,
+    bytes: usize,
+    tick: u64,
+}
+
+pub struct DecodedGroupCache {
+    inner: Mutex<Inner>,
+    budget: AtomicUsize,
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+/// Snapshot of the cache for PRAGMA reporting
+pub struct CacheStats {
+    pub budget_bytes: usize,
+    pub bytes: usize,
+    pub entries: usize,
+    pub hits: u64,
+    pub misses: u64,
+}
+
+pub static DECODED_GROUPS: LazyLock<DecodedGroupCache> = LazyLock::new(|| DecodedGroupCache {
+    inner: Mutex::new(Inner::default()),
+    budget: AtomicUsize::new(DEFAULT_BUDGET_BYTES),
+    hits: AtomicU64::new(0),
+    misses: AtomicU64::new(0),
+});
+
+impl DecodedGroupCache {
+    /// The decoded column for `key`, decoding it with `decode` when absent.
+    /// A budget of zero bypasses the cache.
+    pub fn get_or_decode(
+        &self,
+        key: GroupKey,
+        decode: impl FnOnce() -> std::io::Result<ColumnData>,
+    ) -> std::io::Result<Arc<ColumnData>> {
+        let budget = self.budget.load(Ordering::Relaxed);
+        if budget == 0 {
+            return decode().map(Arc::new);
+        }
+        let slot = {
+            let mut inner = self.lock();
+            inner.tick += 1;
+            let tick = inner.tick;
+            match inner.entries.get_mut(&key) {
+                Some(entry) => {
+                    entry.last_used = tick;
+                    self.hits.fetch_add(1, Ordering::Relaxed);
+                    Arc::clone(&entry.slot)
+                }
+                None => {
+                    self.misses.fetch_add(1, Ordering::Relaxed);
+                    let slot = Arc::new(Slot {
+                        cell: OnceLock::new(),
+                        charged: AtomicBool::new(false),
+                    });
+                    inner.entries.insert(
+                        key,
+                        Entry {
+                            slot: Arc::clone(&slot),
+                            bytes: 0,
+                            last_used: tick,
+                        },
+                    );
+                    slot
+                }
+            }
+        };
+        let outcome = slot
+            .cell
+            .get_or_init(|| decode().map(Arc::new).map_err(|e| e.to_string()));
+        match outcome {
+            Ok(column) => {
+                if !slot.charged.swap(true, Ordering::AcqRel) {
+                    self.charge(key, column.memory_size(), budget);
+                }
+                Ok(Arc::clone(column))
+            }
+            Err(message) => {
+                // A block that does not decode is not kept; the next reader tries again
+                self.lock().entries.remove(&key);
+                Err(std::io::Error::other(message.clone()))
+            }
+        }
+    }
+
+    /// Account a decoded entry and make room for it
+    fn charge(&self, key: GroupKey, bytes: usize, budget: usize) {
+        let mut inner = self.lock();
+        if let Some(entry) = inner.entries.get_mut(&key) {
+            entry.bytes = bytes;
+        }
+        inner.bytes += bytes;
+        while inner.bytes > budget && inner.entries.len() > 1 {
+            let victim = inner
+                .entries
+                .iter()
+                .filter(|(k, _)| **k != key)
+                .min_by_key(|(_, e)| e.last_used)
+                .map(|(k, _)| *k);
+            match victim {
+                Some(victim) => {
+                    if let Some(entry) = inner.entries.remove(&victim) {
+                        inner.bytes -= entry.bytes;
+                    }
+                }
+                None => break,
+            }
+        }
+    }
+
+    /// Drop every entry of a block store that went away
+    pub fn remove_store(&self, store_id: usize) {
+        let mut inner = self.lock();
+        let gone: Vec<GroupKey> = inner
+            .entries
+            .keys()
+            .filter(|k| k.0 == store_id)
+            .copied()
+            .collect();
+        for key in gone {
+            if let Some(entry) = inner.entries.remove(&key) {
+                inner.bytes -= entry.bytes;
+            }
+        }
+    }
+
+    pub fn budget_bytes(&self) -> usize {
+        self.budget.load(Ordering::Relaxed)
+    }
+
+    /// Set the budget; entries beyond it leave at once
+    pub fn set_budget_bytes(&self, budget: usize) {
+        self.budget.store(budget, Ordering::Relaxed);
+        let mut inner = self.lock();
+        while inner.bytes > budget && !inner.entries.is_empty() {
+            let victim = inner
+                .entries
+                .iter()
+                .min_by_key(|(_, e)| e.last_used)
+                .map(|(k, _)| *k);
+            match victim {
+                Some(victim) => {
+                    if let Some(entry) = inner.entries.remove(&victim) {
+                        inner.bytes -= entry.bytes;
+                    }
+                }
+                None => break,
+            }
+        }
+    }
+
+    pub fn stats(&self) -> CacheStats {
+        let inner = self.lock();
+        CacheStats {
+            budget_bytes: self.budget.load(Ordering::Relaxed),
+            bytes: inner.bytes,
+            entries: inner.entries.len(),
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}

--- a/src/storage/volume/mod.rs
+++ b/src/storage/volume/mod.rs
@@ -59,6 +59,7 @@
 
 pub mod column;
 pub mod format;
+pub mod group_cache;
 pub mod io;
 pub mod manifest;
 pub mod scanner;

--- a/src/storage/volume/scanner.rs
+++ b/src/storage/volume/scanner.rs
@@ -57,8 +57,9 @@ struct ColumnPredicate {
 struct GroupColumnCache {
     #[allow(dead_code)]
     group_idx: usize,
-    /// Decompressed columns for this group (only needed columns populated)
-    columns: Vec<Option<super::column::ColumnData>>,
+    /// Decoded columns for this group (only needed columns populated),
+    /// shared with the decoded group cache
+    columns: Vec<Option<Arc<super::column::ColumnData>>>,
     /// Global row index where this group starts
     group_start: usize,
 }
@@ -72,7 +73,7 @@ impl GroupColumnCache {
         global_idx: usize,
     ) -> Option<(&super::column::ColumnData, usize)> {
         self.columns[col_idx]
-            .as_ref()
+            .as_deref()
             .map(|col| (col, global_idx - self.group_start))
     }
 }
@@ -577,7 +578,7 @@ impl VolumeScanner {
                     let mut group_cols = Vec::with_capacity(self.dict_filters.len());
                     let mut corrupt = false;
                     for &(ci, _) in &self.dict_filters {
-                        match st.decompress_single_group(ci, gi) {
+                        match st.group_column(ci, gi) {
                             Ok(col) => group_cols.push(col),
                             Err(_) => {
                                 corrupt = true;
@@ -849,11 +850,11 @@ impl VolumeScanner {
         let col_count = self.volume.columns.len();
         let group_start = group_idx * super::column::ROW_GROUP_SIZE;
 
-        let mut columns: Vec<Option<super::column::ColumnData>> = vec![None; col_count];
+        let mut columns: Vec<Option<Arc<super::column::ColumnData>>> = vec![None; col_count];
         if let Some(ref needed) = self.needed_cols {
             for (ci, &need) in needed.iter().enumerate() {
                 if need && ci < col_count && group_idx < store.num_groups(ci) {
-                    match store.decompress_single_group(ci, group_idx) {
+                    match store.group_column(ci, group_idx) {
                         Ok(col) => columns[ci] = Some(col),
                         Err(e) => {
                             self.error = Some(Error::internal(format!("corrupt V4 block: {}", e)));
@@ -865,7 +866,7 @@ impl VolumeScanner {
         } else {
             for (ci, slot) in columns.iter_mut().enumerate() {
                 if group_idx < store.num_groups(ci) {
-                    match store.decompress_single_group(ci, group_idx) {
+                    match store.group_column(ci, group_idx) {
                         Ok(col) => *slot = Some(col),
                         Err(e) => {
                             self.error = Some(Error::internal(format!("corrupt V4 block: {}", e)));

--- a/src/storage/volume/writer.rs
+++ b/src/storage/volume/writer.rs
@@ -67,9 +67,37 @@ pub struct CompressedBlockStore {
     group_size: usize,
     /// Total row count across all groups
     row_count: usize,
+    /// Process-unique id, the key of this store's entries in the decoded
+    /// group cache
+    id: usize,
+}
+
+/// Ids for block stores; the decoded group cache keys its entries by them
+fn next_store_id() -> usize {
+    static NEXT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(1);
+    NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
+impl Drop for CompressedBlockStore {
+    fn drop(&mut self) {
+        super::group_cache::DECODED_GROUPS.remove_store(self.id);
+    }
 }
 
 impl CompressedBlockStore {
+    /// One column of one row group, decoded once and shared through the
+    /// decoded group cache while the budget holds it
+    pub fn group_column(
+        &self,
+        col_idx: usize,
+        group_idx: usize,
+    ) -> std::io::Result<Arc<ColumnData>> {
+        super::group_cache::DECODED_GROUPS
+            .get_or_decode((self.id, col_idx as u32, group_idx as u32), || {
+                self.decompress_single_group(col_idx, group_idx)
+            })
+    }
+
     /// Compress existing columns into per-group LZ4 blocks.
     /// Used when sealing (VolumeBuilder::finish() → eager columns → V4 write).
     pub fn compress_columns(
@@ -191,6 +219,7 @@ impl CompressedBlockStore {
             col_dicts,
             group_size,
             row_count,
+            id: next_store_id(),
         }
     }
 
@@ -222,6 +251,7 @@ impl CompressedBlockStore {
             col_dicts,
             group_size,
             row_count,
+            id: next_store_id(),
         }
     }
 
@@ -652,7 +682,7 @@ impl CompressedBlockStore {
                 if target > max_i64 {
                     continue;
                 }
-                let col = self.decompress_single_group(col_idx, gi).ok()?;
+                let col = self.group_column(col_idx, gi).ok()?;
                 let group_rows = (rg.end_idx - rg.start_idx) as usize;
                 let local = if strict {
                     col.binary_search_gt(target)
@@ -667,7 +697,7 @@ impl CompressedBlockStore {
         }
 
         if num_groups == 1 {
-            let col = self.decompress_single_group(col_idx, 0).ok()?;
+            let col = self.group_column(col_idx, 0).ok()?;
             return Some(if strict {
                 col.binary_search_gt(target)
             } else {

--- a/tests/decoded_group_cache_test.rs
+++ b/tests/decoded_group_cache_test.rs
@@ -281,4 +281,40 @@ mod invariants {
         let again = store.group_column(0, 0).unwrap();
         assert!(Arc::ptr_eq(&first, &again), "the first group was evicted");
     }
+
+    #[test]
+    fn a_zero_budget_racing_with_a_charge_leaves_nothing_behind() {
+        const READERS: usize = 8;
+        const ROUNDS: usize = 20_000;
+        let barrier = Barrier::new(READERS + 1);
+        let mut failure = None;
+        std::thread::scope(|scope| {
+            for worker in 0..READERS {
+                let barrier = &barrier;
+                scope.spawn(move || {
+                    for _ in 0..ROUNDS {
+                        barrier.wait();
+                        DECODED_GROUPS
+                            .get_or_decode((10_000 + worker, 0, 0), || Ok(ints(1)))
+                            .unwrap();
+                        barrier.wait();
+                    }
+                });
+            }
+            for round in 0..ROUNDS {
+                DECODED_GROUPS.set_budget_bytes(1024);
+                barrier.wait();
+                DECODED_GROUPS.set_budget_bytes(0);
+                barrier.wait();
+                let stats = DECODED_GROUPS.stats();
+                if stats.bytes != 0 || stats.entries != 0 {
+                    failure.get_or_insert((round, stats.bytes, stats.entries));
+                }
+            }
+        });
+        assert_eq!(
+            failure, None,
+            "a zero budget left data behind (round, bytes, entries)"
+        );
+    }
 }

--- a/tests/decoded_group_cache_test.rs
+++ b/tests/decoded_group_cache_test.rs
@@ -135,3 +135,150 @@ fn test_cache_budget_bounds_the_bytes_and_zero_disables_it() {
     db.execute("PRAGMA GROUP_CACHE_MB = 64", ()).unwrap();
     assert_eq!(ids(&db, "PRAGMA GROUP_CACHE_MB"), [64]);
 }
+
+// The cache's own invariants, exercised through its API: one decode shared
+// by concurrent readers, no phantom bytes after an in-flight eviction, a
+// budget change during a decode, a column larger than the budget, and a
+// dictionary shared by the groups of one column counted once.
+
+mod invariants {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{mpsc, Arc, Barrier};
+    use std::time::Duration;
+    use stoolap::core::DataType;
+    use stoolap::storage::volume::column::ColumnData;
+    use stoolap::storage::volume::group_cache::DECODED_GROUPS;
+
+    fn ints(rows: usize) -> ColumnData {
+        ColumnData::Int64 {
+            values: vec![1; rows],
+            nulls: vec![false; rows],
+        }
+    }
+
+    #[test]
+    fn concurrent_readers_share_one_decode() {
+        DECODED_GROUPS.set_budget_bytes(1024);
+        let starts = Arc::new(Barrier::new(16));
+        let decodes = Arc::new(AtomicUsize::new(0));
+        let workers: Vec<_> = (0..16)
+            .map(|_| {
+                let starts = Arc::clone(&starts);
+                let decodes = Arc::clone(&decodes);
+                std::thread::spawn(move || {
+                    starts.wait();
+                    DECODED_GROUPS
+                        .get_or_decode((600, 0, 0), || {
+                            decodes.fetch_add(1, Ordering::SeqCst);
+                            Ok(ints(1))
+                        })
+                        .unwrap()
+                })
+            })
+            .collect();
+        let columns: Vec<_> = workers.into_iter().map(|w| w.join().unwrap()).collect();
+        assert_eq!(decodes.load(Ordering::SeqCst), 1);
+        assert!(columns.iter().all(|c| Arc::ptr_eq(&columns[0], c)));
+        DECODED_GROUPS.remove_store(600);
+        assert_eq!(DECODED_GROUPS.stats().bytes, 0);
+    }
+
+    #[test]
+    fn an_entry_evicted_while_decoding_leaves_no_phantom_bytes() {
+        DECODED_GROUPS.set_budget_bytes(18);
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (resume_tx, resume_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            DECODED_GROUPS
+                .get_or_decode((100, 0, 0), || {
+                    entered_tx.send(()).unwrap();
+                    resume_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+                    Ok(ints(1))
+                })
+                .unwrap();
+        });
+        entered_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+        DECODED_GROUPS
+            .get_or_decode((200, 0, 0), || Ok(ints(2)))
+            .unwrap();
+        DECODED_GROUPS
+            .get_or_decode((300, 0, 0), || Ok(ints(2)))
+            .unwrap();
+        resume_tx.send(()).unwrap();
+        worker.join().unwrap();
+        for store in [100, 200, 300] {
+            DECODED_GROUPS.remove_store(store);
+        }
+        let stats = DECODED_GROUPS.stats();
+        assert_eq!((stats.bytes, stats.entries), (0, 0));
+    }
+
+    #[test]
+    fn a_budget_of_zero_set_during_a_decode_leaves_the_cache_empty() {
+        DECODED_GROUPS.set_budget_bytes(18);
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (resume_tx, resume_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            DECODED_GROUPS
+                .get_or_decode((400, 0, 0), || {
+                    entered_tx.send(()).unwrap();
+                    resume_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+                    Ok(ints(1))
+                })
+                .unwrap();
+        });
+        entered_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+        DECODED_GROUPS.set_budget_bytes(0);
+        resume_tx.send(()).unwrap();
+        worker.join().unwrap();
+        let stats = DECODED_GROUPS.stats();
+        assert_eq!((stats.budget_bytes, stats.bytes, stats.entries), (0, 0, 0));
+    }
+
+    #[test]
+    fn a_column_larger_than_the_budget_is_not_kept() {
+        DECODED_GROUPS.set_budget_bytes(1024 * 1024);
+        DECODED_GROUPS
+            .get_or_decode((500, 0, 0), || {
+                Ok(ColumnData::Bytes {
+                    data: vec![b'x'; 8 * 1024 * 1024],
+                    offsets: vec![(0, 8 * 1024 * 1024)],
+                    ext_type: DataType::Json,
+                    nulls: vec![false],
+                })
+            })
+            .unwrap();
+        let stats = DECODED_GROUPS.stats();
+        assert!(
+            stats.bytes <= stats.budget_bytes,
+            "kept {} bytes",
+            stats.bytes
+        );
+        assert_eq!(stats.entries, 0);
+    }
+
+    #[test]
+    fn a_dictionary_shared_by_the_groups_is_counted_once() {
+        use stoolap::common::SmartString;
+        use stoolap::storage::volume::column::ROW_GROUP_SIZE;
+        use stoolap::storage::volume::writer::{CompressedBlockStore, LazyColumns};
+        let rows = 2 * ROW_GROUP_SIZE;
+        let dictionary: Arc<[SmartString]> = (0..10_000)
+            .map(|i| SmartString::from(format!("{i:010}{}", "x".repeat(90))))
+            .collect::<Vec<_>>()
+            .into();
+        let column = ColumnData::Dictionary {
+            ids: (0..rows).map(|i| (i % 10_000) as u32).collect(),
+            nulls: vec![false; rows],
+            dictionary,
+        };
+        assert!(column.memory_size() < 2 * 1024 * 1024);
+        let columns = LazyColumns::eager(vec![column], vec![DataType::Text]);
+        let store = CompressedBlockStore::compress_columns(&columns, &[DataType::Text], rows);
+        DECODED_GROUPS.set_budget_bytes(2 * 1024 * 1024);
+        let first = store.group_column(0, 0).unwrap();
+        let _second = store.group_column(0, 1).unwrap();
+        let again = store.group_column(0, 0).unwrap();
+        assert!(Arc::ptr_eq(&first, &again), "the first group was evicted");
+    }
+}

--- a/tests/decoded_group_cache_test.rs
+++ b/tests/decoded_group_cache_test.rs
@@ -16,7 +16,29 @@
 //! between queries within its byte budget, answers the same rows as a fresh
 //! decode, and steps aside when its budget is zero.
 
+use std::sync::{Mutex, MutexGuard};
+use stoolap::storage::volume::group_cache::{DECODED_GROUPS, DEFAULT_BUDGET_BYTES};
 use stoolap::Database;
+
+// The cache is one per process and `cargo test` runs these tests in one
+// process, so each test takes this lock, starts from an empty cache and
+// hands the default budget back when it is done.
+static SERIAL: Mutex<()> = Mutex::new(());
+
+struct Serial(#[allow(dead_code)] MutexGuard<'static, ()>);
+
+fn serial() -> Serial {
+    let guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    DECODED_GROUPS.set_budget_bytes(0);
+    Serial(guard)
+}
+
+impl Drop for Serial {
+    fn drop(&mut self) {
+        DECODED_GROUPS.set_budget_bytes(0);
+        DECODED_GROUPS.set_budget_bytes(DEFAULT_BUDGET_BYTES);
+    }
+}
 
 fn ts(secs: i64) -> String {
     chrono::DateTime::from_timestamp(secs, 0)
@@ -85,6 +107,7 @@ const SUMMARY: &str =
 
 #[test]
 fn test_cache_keeps_decoded_groups_and_answers_the_same_rows() {
+    let _serial = serial();
     let dir = tempfile::tempdir().unwrap();
     let db = warm_table(&dir, "keeps");
     db.execute("PRAGMA GROUP_CACHE_MB = 64", ()).unwrap();
@@ -111,6 +134,7 @@ fn test_cache_keeps_decoded_groups_and_answers_the_same_rows() {
 
 #[test]
 fn test_cache_budget_bounds_the_bytes_and_zero_disables_it() {
+    let _serial = serial();
     let dir = tempfile::tempdir().unwrap();
     let db = warm_table(&dir, "budget");
 
@@ -132,8 +156,8 @@ fn test_cache_budget_bounds_the_bytes_and_zero_disables_it() {
     let (_, _, entries, _, _) = stats(&db);
     assert_eq!(entries, 0, "a zero budget must not cache");
 
-    db.execute("PRAGMA GROUP_CACHE_MB = 64", ()).unwrap();
-    assert_eq!(ids(&db, "PRAGMA GROUP_CACHE_MB"), [64]);
+    db.execute("PRAGMA GROUP_CACHE_MB = 32", ()).unwrap();
+    assert_eq!(ids(&db, "PRAGMA GROUP_CACHE_MB"), [32]);
 }
 
 // The cache's own invariants, exercised through its API: one decode shared
@@ -142,6 +166,7 @@ fn test_cache_budget_bounds_the_bytes_and_zero_disables_it() {
 // dictionary shared by the groups of one column counted once.
 
 mod invariants {
+    use super::serial;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{mpsc, Arc, Barrier};
     use std::time::Duration;
@@ -158,6 +183,7 @@ mod invariants {
 
     #[test]
     fn concurrent_readers_share_one_decode() {
+        let _serial = serial();
         DECODED_GROUPS.set_budget_bytes(1024);
         let starts = Arc::new(Barrier::new(16));
         let decodes = Arc::new(AtomicUsize::new(0));
@@ -185,6 +211,7 @@ mod invariants {
 
     #[test]
     fn an_entry_evicted_while_decoding_leaves_no_phantom_bytes() {
+        let _serial = serial();
         DECODED_GROUPS.set_budget_bytes(18);
         let (entered_tx, entered_rx) = mpsc::channel();
         let (resume_tx, resume_rx) = mpsc::channel();
@@ -215,6 +242,7 @@ mod invariants {
 
     #[test]
     fn a_budget_of_zero_set_during_a_decode_leaves_the_cache_empty() {
+        let _serial = serial();
         DECODED_GROUPS.set_budget_bytes(18);
         let (entered_tx, entered_rx) = mpsc::channel();
         let (resume_tx, resume_rx) = mpsc::channel();
@@ -237,6 +265,7 @@ mod invariants {
 
     #[test]
     fn a_column_larger_than_the_budget_is_not_kept() {
+        let _serial = serial();
         DECODED_GROUPS.set_budget_bytes(1024 * 1024);
         DECODED_GROUPS
             .get_or_decode((500, 0, 0), || {
@@ -262,6 +291,7 @@ mod invariants {
         use stoolap::common::SmartString;
         use stoolap::storage::volume::column::ROW_GROUP_SIZE;
         use stoolap::storage::volume::writer::{CompressedBlockStore, LazyColumns};
+        let _serial = serial();
         let rows = 2 * ROW_GROUP_SIZE;
         let dictionary: Arc<[SmartString]> = (0..10_000)
             .map(|i| SmartString::from(format!("{i:010}{}", "x".repeat(90))))
@@ -286,6 +316,7 @@ mod invariants {
     fn a_zero_budget_racing_with_a_charge_leaves_nothing_behind() {
         const READERS: usize = 8;
         const ROUNDS: usize = 20_000;
+        let _serial = serial();
         let barrier = Barrier::new(READERS + 1);
         let mut failure = None;
         std::thread::scope(|scope| {

--- a/tests/decoded_group_cache_test.rs
+++ b/tests/decoded_group_cache_test.rs
@@ -1,0 +1,137 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The decoded row-group column cache keeps a warm volume's decoded columns
+//! between queries within its byte budget, answers the same rows as a fresh
+//! decode, and steps aside when its budget is zero.
+
+use stoolap::Database;
+
+fn ts(secs: i64) -> String {
+    chrono::DateTime::from_timestamp(secs, 0)
+        .unwrap()
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string()
+}
+
+fn stats(db: &Database) -> (i64, i64, i64, i64, i64) {
+    let row = db
+        .query("PRAGMA GROUP_CACHE_STATS", ())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap();
+    (
+        row.get::<i64>(0).unwrap(),
+        row.get::<i64>(1).unwrap(),
+        row.get::<i64>(2).unwrap(),
+        row.get::<i64>(3).unwrap(),
+        row.get::<i64>(4).unwrap(),
+    )
+}
+
+fn ids(db: &Database, sql: &str) -> Vec<i64> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect()
+}
+
+/// A sealed table of 20 keys over 5,000 minutes, reopened so its columns are
+/// compressed in memory
+fn warm_table(dir: &tempfile::TempDir, name: &str) -> Database {
+    let dsn = format!("file://{}/{name}", dir.path().display());
+    let db = Database::open(&dsn).unwrap();
+    db.execute(
+        "CREATE TABLE c (id INTEGER PRIMARY KEY AUTO_INCREMENT, t TIMESTAMP NOT NULL, \
+         k TEXT NOT NULL, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    let base = 1_709_251_200;
+    let mut stmt = String::from("INSERT INTO c (t, k, v) VALUES ");
+    for s in 0..5_000i64 {
+        for k in 0..20 {
+            if s > 0 || k > 0 {
+                stmt.push(',');
+            }
+            stmt.push_str(&format!(
+                "('{}', 'k{k}', {})",
+                ts(base + s * 60),
+                (s + k) % 100
+            ));
+        }
+    }
+    db.execute(&stmt, ()).unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    drop(db);
+    Database::open(&dsn).unwrap()
+}
+
+const LATEST: &str = "SELECT id FROM c WHERE k = 'k7' ORDER BY t DESC LIMIT 50";
+const SUMMARY: &str =
+    "SELECT k, MAX(v), MIN(v) FROM c WHERE t >= '2024-03-03 00:00:00' GROUP BY k ORDER BY k";
+
+#[test]
+fn test_cache_keeps_decoded_groups_and_answers_the_same_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = warm_table(&dir, "keeps");
+    db.execute("PRAGMA GROUP_CACHE_MB = 64", ()).unwrap();
+    let (_, bytes0, entries0, _, _) = stats(&db);
+
+    let first = ids(&db, LATEST);
+    let (_, bytes1, entries1, hits1, misses1) = stats(&db);
+    assert!(entries1 > entries0 && bytes1 > bytes0, "nothing cached");
+    assert!(misses1 > 0);
+
+    let second = ids(&db, LATEST);
+    let (_, bytes2, entries2, hits2, misses2) = stats(&db);
+    assert_eq!(first, second);
+    assert!(hits2 > hits1, "second run did not hit the cache");
+    assert_eq!(misses2, misses1, "second run decoded again");
+    assert_eq!((bytes2, entries2), (bytes1, entries1));
+
+    // Another shape over the same groups reads them from the cache too
+    let summary = db.query(SUMMARY, ()).unwrap().count();
+    assert_eq!(summary, 20);
+    let (_, _, _, hits3, _) = stats(&db);
+    assert!(hits3 > hits2);
+}
+
+#[test]
+fn test_cache_budget_bounds_the_bytes_and_zero_disables_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = warm_table(&dir, "budget");
+
+    db.execute("PRAGMA GROUP_CACHE_MB = 1", ()).unwrap();
+    let reference = ids(&db, LATEST);
+    db.query(SUMMARY, ()).unwrap().count();
+    let (budget, bytes, _, _, _) = stats(&db);
+    assert_eq!(budget, 1024 * 1024);
+    assert!(
+        bytes <= budget + 4 * 1024 * 1024,
+        "bytes {bytes} far past the budget"
+    );
+    assert_eq!(ids(&db, LATEST), reference);
+
+    db.execute("PRAGMA GROUP_CACHE_MB = 0", ()).unwrap();
+    let (budget, bytes, entries, _, _) = stats(&db);
+    assert_eq!((budget, bytes, entries), (0, 0, 0));
+    assert_eq!(ids(&db, LATEST), reference);
+    let (_, _, entries, _, _) = stats(&db);
+    assert_eq!(entries, 0, "a zero budget must not cache");
+
+    db.execute("PRAGMA GROUP_CACHE_MB = 64", ()).unwrap();
+    assert_eq!(ids(&db, "PRAGMA GROUP_CACHE_MB"), [64]);
+}


### PR DESCRIPTION
## Summary

Work item E of the sealed time-series read plan, on top of #106.

A warm volume keeps its columns compressed, and every query that read one of its row groups decoded the columns it needed and dropped them again: the dictionary pre-filter, the sorted-column binary search and the scanner's group cache each decoded, sometimes the same column three times in one query, and the next query started over. After a reopen the series query cost 2 to 3 ms, almost all of it lz4 and null-bitmap decoding.

- Decoded columns live in a process-wide cache keyed by (block store, column, row group) with a byte budget, 64 MB by default (`src/storage/volume/group_cache.rs`).
- Concurrent readers of one group share a single decode through the entry's cell; the map lock is never held while decoding; the least recently used entries leave when a new one crosses the budget; a block that fails to decode is not kept; a block store that goes away removes its entries.
- The cache holds raw immutable columns; visibility, tombstones and the hot skip set stay with each reader as before.
- The scanner's group cache and the sorted-column binary search read through it, so one query decodes a group's column once.
- `PRAGMA GROUP_CACHE_MB` reads and sets the budget (zero bypasses the cache); `PRAGMA GROUP_CACHE_STATS` reports budget, bytes, entries, hits and misses.
- `tests/decoded_group_cache_test.rs`: a reopened table answers the same rows from the cache with hits and no new decodes, the budget bounds the bytes, a zero budget caches nothing.
- Review fixes: an entry evicted while its column was still decoding is no longer charged when the decode finishes (the counter grew by columns the cache did not hold and the usable budget shrank for good); a budget set to zero during a decode, or a column larger than the whole budget, is handed to the caller without being kept; the dictionary shared by a text column's groups is counted once (`ColumnData::cache_size`). Five tests exercise these invariants through the cache API, including sixteen concurrent readers sharing one decode; the four that guard the fixes fail on the code before them. The budget is read and stored under the cache lock, so a budget set to zero between a decode and its charge cannot let the entry in with the old budget; a race test alternates a positive and a zero budget around eight readers for twenty thousand rounds.
- The cache is one per process and `cargo test` runs a target's tests in one process, so the tests of this target take a static mutex, start from an empty cache and hand the default budget back when they finish (nextest ran each in its own process and hid this).
- The multi-column index scale test's 3 s limit failed the coverage job in three pull requests in a row (3.2 to 3.9 s under instrumentation); both of its limits are 15 s, still minutes away from the quadratic paths it guards.

Bench after a reopen (warm volumes), 2.175M rows over 174 series, UNIQUE(exchange, symbol, time) plus a BTREE on time (SQLite with the same data and indexes for reference):

| shape | #106 | this branch | SQLite |
|---|---|---|---|
| series latest DESC LIMIT 200 | 2.0 to 3.0 ms | 0.09 ms | 0.06 ms |
| series + time >= day DESC LIMIT 200 | 2.5 to 3.7 ms | 0.10 ms | 0.06 ms |
| series + day range DESC LIMIT 500 | 4.7 to 7.1 ms | 0.21 ms | 0.50 ms |
| all series last 10 min DESC LIMIT 100 | 0.4 to 0.7 ms | 0.03 ms | 0.03 ms |
| 5m rollup of the last 10 min | 0.8 to 1.1 ms | 0.58 ms | |
| fan-out 174 series queries on 4 threads | wall 10 to 11 ms | wall 7 ms | wall 43 ms |

Sealed (eager) numbers are unchanged. The budget is a process total, not part of the engine's volume tier accounting; that integration, and whether the cache should also serve the eager path, are left for the next step.

## Test plan

- [x] `cargo nextest run --test decoded_group_cache_test --test ordered_limited_scan_test`
- [x] `cargo test --test decoded_group_cache_test` (the CI way, one process)
- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run`
- [x] `cargo nextest run --features test-filedb`
