### PR TITLE
fix(volume): the top-k scan reads an added column's default from older volumes

### DIFF
--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -3991,6 +3991,7 @@ impl Table for SegmentedTable {
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let hot_skip_arc = Arc::new(hot_skip);
         let current_schema = self.hot.schema();
+        let all_cols: Vec<usize> = (0..current_schema.columns.len()).collect();
         let prepared_filter = where_expr.map(|expr| {
             let mut filter = expr.with_aliases(&Default::default());
             filter.prepare_for_schema(current_schema);
@@ -4066,7 +4067,7 @@ impl Table for SegmentedTable {
                     }
                 }
                 let mut scanner =
-                    VolumeScanner::with_range(Arc::clone(vol), Vec::new(), start, end, None);
+                    VolumeScanner::with_range(Arc::clone(vol), all_cols.clone(), start, end, None);
                 scanner.set_skip_sets(Arc::clone(&tombstones_arc), Arc::clone(&hot_skip_arc));
                 scanner.set_visibility_bitmap(cs.visible.clone());
                 scanner.snapshot_seq = self.snapshot_seq;

--- a/tests/top_k_added_column_test.rs
+++ b/tests/top_k_added_column_test.rs
@@ -1,0 +1,76 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A column added after a volume was sealed reads as its default from that
+//! volume on every path, including the filtered ORDER BY + LIMIT scan.
+
+use stoolap::Database;
+
+fn column(db: &Database, sql: &str, idx: usize) -> Vec<String> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap().get_value(idx).unwrap().to_string())
+        .collect()
+}
+
+#[test]
+fn test_top_k_reads_the_added_column_default_from_an_older_volume() {
+    let dir = tempfile::tempdir().unwrap();
+    let dsn = format!("file://{}/added", dir.path().display());
+    let db = Database::open(&dsn).unwrap();
+    db.execute("CREATE TABLE c (t INTEGER NOT NULL, k TEXT NOT NULL)", ())
+        .unwrap();
+    db.execute(
+        "INSERT INTO c VALUES (1, 'k'), (2, 'k'), (3, 'k'), (4, 'j')",
+        (),
+    )
+    .unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    db.execute("ALTER TABLE c ADD COLUMN note TEXT DEFAULT 'kept'", ())
+        .unwrap();
+    db.execute("INSERT INTO c VALUES (5, 'k', 'new')", ())
+        .unwrap();
+
+    // The filtered top-k over the older volume, ASC and DESC, with the full
+    // row and with the added column alone
+    assert_eq!(
+        column(
+            &db,
+            "SELECT * FROM c WHERE k = 'k' ORDER BY t ASC LIMIT 2",
+            2
+        ),
+        ["kept", "kept"]
+    );
+    assert_eq!(
+        column(
+            &db,
+            "SELECT note FROM c WHERE k = 'k' ORDER BY t DESC LIMIT 3",
+            0
+        ),
+        ["new", "kept", "kept"]
+    );
+    // The other scan paths agree
+    assert_eq!(
+        column(&db, "SELECT note FROM c WHERE k = 'k' ORDER BY t", 0),
+        ["kept", "kept", "kept", "new"]
+    );
+    assert_eq!(
+        column(
+            &db,
+            "SELECT note, COUNT(*) FROM c GROUP BY note ORDER BY note",
+            1
+        ),
+        ["4", "1"]
+    );
+}


### PR DESCRIPTION
## Summary

A column added with `ALTER TABLE ... ADD COLUMN ... DEFAULT` read as NULL instead of its default from volumes sealed before the change, on one path: the filtered ORDER BY + LIMIT scan of #105.

`scan_top_k` handed the volume scanner an empty projection, which the scanner took as the volume's own column count. Its filter path built the needed-column mask from that count, so the added position was never marked and came out as a typed NULL. The streaming and collect paths name every column of the current schema and were right; the top-k scan now does the same. Two lines in `src/storage/volume/table.rs`.

`tests/top_k_added_column_test.rs` seals a table, adds a column with a default, inserts a hot row, and checks the filtered top-k ASC and DESC (with `SELECT *` and with the added column alone) against the other scan paths. It fails on main with `NULL` where `kept` is expected.

Found while measuring column projection on the sealed read path; that experiment is on hold, this fix stands on its own.

## Test plan

- [x] `cargo nextest run --test top_k_added_column_test --test ordered_limited_scan_test`
- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`
- [x] the guard fails on the code before the fix
