### PR TITLE
perf(index): answer a series' latest rows by walking the multi-column index in key order

### DIFF
--- a/src/storage/index/multi_column.rs
+++ b/src/storage/index/multi_column.rs
@@ -130,7 +130,10 @@ pub struct MultiColumnIndex {
 
     /// Per prefix group, its rows ordered by the column after the prefix:
     /// built when a walk first asks for the group, kept up to date by single
-    /// adds and removes, dropped by a large batch and rebuilt on the next walk
+    /// adds and removes, dropped by a large batch and rebuilt on the next walk.
+    /// Writers touch it last, after the prefix indexes a build reads, and a
+    /// build holds its write lock from that read to the insert, so a row is
+    /// either in the group when it is built or added to it afterwards.
     walk_orders: RwLock<FxHashMap<CompositeKey, BTreeSet<(Value, i64)>>>,
 }
 
@@ -494,13 +497,6 @@ impl Index for MultiColumnIndex {
         drop(value_to_rows);
         drop(row_to_key);
 
-        if self.orders_built() {
-            if let Some(ref old_arc_values) = old_key_for_cleanup {
-                self.order_remove_arcs(old_arc_values, row_id);
-            }
-            self.order_insert(values, row_id);
-        }
-
         // Update BTree only if it was already built
         if btree_needs_update {
             let mut sorted_values = self.sorted_values.write();
@@ -558,6 +554,13 @@ impl Index for MultiColumnIndex {
             }
         }
 
+        if self.orders_built() {
+            if let Some(ref old_arc_values) = old_key_for_cleanup {
+                self.order_remove_arcs(old_arc_values, row_id);
+            }
+            self.order_insert(values, row_id);
+        }
+
         Ok(())
     }
 
@@ -594,10 +597,6 @@ impl Index for MultiColumnIndex {
             row_to_key.remove(row_id);
         }
 
-        if self.orders_built() {
-            self.order_remove(values, row_id);
-        }
-
         // Only update BTree if it was built (row_ids are sorted, use binary search)
         if self.btree_built.load(AtomicOrdering::Acquire) {
             let mut sorted_values = self.sorted_values.write();
@@ -626,6 +625,10 @@ impl Index for MultiColumnIndex {
                     }
                 }
             }
+        }
+
+        if self.orders_built() {
+            self.order_remove(values, row_id);
         }
 
         Ok(())
@@ -761,19 +764,6 @@ impl Index for MultiColumnIndex {
         drop(value_to_rows);
         drop(row_to_key);
 
-        if self.orders_built() {
-            if entries.len() >= Self::WALK_ORDER_BATCH_DROP {
-                self.walk_orders.write().clear();
-            } else {
-                for (row_id, existing_arc_values) in &updates_to_old_key {
-                    self.order_remove_arcs(existing_arc_values, *row_id);
-                }
-                for &(row_id, values) in entries {
-                    self.order_insert(values, row_id);
-                }
-            }
-        }
-
         // Update BTree only if it was already built
         if btree_needs_update {
             let mut sorted_values = self.sorted_values.write();
@@ -835,6 +825,19 @@ impl Index for MultiColumnIndex {
             }
         }
 
+        if self.orders_built() {
+            if entries.len() >= Self::WALK_ORDER_BATCH_DROP {
+                self.walk_orders.write().clear();
+            } else {
+                for (row_id, existing_arc_values) in &updates_to_old_key {
+                    self.order_remove_arcs(existing_arc_values, *row_id);
+                }
+                for &(row_id, values) in entries {
+                    self.order_insert(values, row_id);
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -869,16 +872,6 @@ impl Index for MultiColumnIndex {
             }
         }
 
-        if self.orders_built() {
-            if entries.len() >= Self::WALK_ORDER_BATCH_DROP {
-                self.walk_orders.write().clear();
-            } else {
-                for &(row_id, values) in entries {
-                    self.order_remove(values, row_id);
-                }
-            }
-        }
-
         // The sorted and prefix structures are subtracted one key at a time:
         // a removal per row is quadratic in the rows per key.
         if self.btree_built.load(AtomicOrdering::Acquire) {
@@ -906,6 +899,16 @@ impl Index for MultiColumnIndex {
                             prefix_index.remove(&key);
                         }
                     }
+                }
+            }
+        }
+
+        if self.orders_built() {
+            if entries.len() >= Self::WALK_ORDER_BATCH_DROP {
+                self.walk_orders.write().clear();
+            } else {
+                for &(row_id, values) in entries {
+                    self.order_remove(values, row_id);
                 }
             }
         }
@@ -1077,7 +1080,7 @@ impl Index for MultiColumnIndex {
         lower: Option<(&Value, bool)>,
         upper: Option<(&Value, bool)>,
         ascending: bool,
-        visit: &mut dyn FnMut(i64) -> bool,
+        visit: &mut dyn FnMut(i64, &Value) -> bool,
     ) -> bool {
         let walked = prefix.len();
         if self.closed.load(AtomicOrdering::Acquire)
@@ -1087,13 +1090,13 @@ impl Index for MultiColumnIndex {
             return false;
         }
         let group = CompositeKey(prefix.to_vec());
-        if !self.walk_orders.read().contains_key(&group) {
-            // Built under the row map's read lock, so a row added or removed
-            // meanwhile reaches the order after it is in place. The prefix
-            // index is built first: its build takes the same lock.
-            self.ensure_prefix_built(walked);
-            let row_to_key = self.row_to_key.read();
+        // The prefix index is built outside the row map's lock: its build
+        // takes that lock too
+        self.ensure_prefix_built(walked);
+        let mut orders = self.walk_orders.write();
+        if !orders.contains_key(&group) {
             let ids = self.get_row_ids_equal(prefix);
+            let row_to_key = self.row_to_key.read();
             let mut entries: Vec<(Value, i64)> = Vec::with_capacity(ids.len());
             for row_id in ids.iter() {
                 if let Some(key) = row_to_key.get(*row_id) {
@@ -1103,13 +1106,9 @@ impl Index for MultiColumnIndex {
                 }
             }
             entries.sort_unstable();
-            let order: BTreeSet<(Value, i64)> = entries.into_iter().collect();
-            self.walk_orders
-                .write()
-                .entry(group.clone())
-                .or_insert(order);
+            orders.insert(group.clone(), entries.into_iter().collect());
         }
-        let orders = self.walk_orders.read();
+        let orders = parking_lot::RwLockWriteGuard::downgrade(orders);
         let Some(order) = orders.get(&group) else {
             return true;
         };
@@ -1123,16 +1122,27 @@ impl Index for MultiColumnIndex {
             Some((value, false)) => Bound::Excluded((value.clone(), i64::MIN)),
             None => Bound::Unbounded,
         };
+        // Bounds that cross, or meet with one side open, hold nothing
+        if let (
+            Bound::Included(low) | Bound::Excluded(low),
+            Bound::Included(high) | Bound::Excluded(high),
+        ) = (&start, &end)
+        {
+            let open = matches!(start, Bound::Excluded(_)) || matches!(end, Bound::Excluded(_));
+            if low > high || (low == high && open) {
+                return true;
+            }
+        }
         let range = order.range((start, end));
         if ascending {
-            for (_, row_id) in range {
-                if !visit(*row_id) {
+            for (value, row_id) in range {
+                if !visit(*row_id, value) {
                     break;
                 }
             }
         } else {
-            for (_, row_id) in range.rev() {
-                if !visit(*row_id) {
+            for (value, row_id) in range.rev() {
+                if !visit(*row_id, value) {
                     break;
                 }
             }
@@ -1401,5 +1411,57 @@ mod tests {
         assert!(k1 < k2);
         assert!(k2 < k3);
         assert!(k1 < k3);
+    }
+
+    /// A group built while an add is between the row map and the prefix
+    /// index must still end up holding the added row: the add enters it
+    /// into the group once it gets to the orders, which come last
+    #[test]
+    fn test_walk_order_built_during_an_add_keeps_the_added_row() {
+        use std::sync::Arc;
+        use std::time::{Duration, Instant};
+        let index = Arc::new(MultiColumnIndex::new(
+            "idx".into(),
+            "c".into(),
+            vec!["g".into(), "k".into(), "t".into()],
+            vec![0, 1, 2],
+            vec![DataType::Integer; 3],
+            false,
+            0,
+        ));
+        let row = |t: i64| vec![Value::Integer(1), Value::Integer(2), Value::Integer(t)];
+        index.add(&row(10), 1, 0).unwrap();
+        index.ensure_btree_built();
+        index.ensure_prefix_built(2);
+
+        // The writer stops before the prefix update while this range reader
+        // holds the sorted structure it updates first
+        let range_reader = index.sorted_values.read();
+        let writer_index = Arc::clone(&index);
+        let writer = std::thread::spawn(move || {
+            writer_index.add(&row(20), 2, 0).unwrap();
+        });
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while index.row_to_key.read().get(2).is_none() {
+            if Instant::now() > deadline {
+                drop(range_reader);
+                writer.join().unwrap();
+                panic!("the writer did not reach the row map");
+            }
+            std::thread::yield_now();
+        }
+        let prefix = [Value::Integer(1), Value::Integer(2)];
+        assert!(index.walk_prefix_ordered(&prefix, None, None, true, &mut |_, _| true));
+        drop(range_reader);
+        writer.join().unwrap();
+
+        let mut ordered = Vec::new();
+        assert!(
+            index.walk_prefix_ordered(&prefix, None, None, true, &mut |id, _| {
+                ordered.push(id);
+                true
+            })
+        );
+        assert_eq!(ordered, vec![1, 2]);
     }
 }

--- a/src/storage/index/multi_column.rs
+++ b/src/storage/index/multi_column.rs
@@ -35,7 +35,7 @@
 //! - `prefix_indexes` are built on first partial query per prefix length
 
 use parking_lot::RwLock;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Bound;
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
@@ -127,6 +127,11 @@ pub struct MultiColumnIndex {
     /// Reverse mapping for removal - uses Vec<CompactArc<Value>> for memory efficiency
     /// Arc references are shared with ValueArena (8 bytes per value)
     row_to_key: RwLock<I64Map<Vec<CompactArc<Value>>>>,
+
+    /// Per prefix group, its rows ordered by the column after the prefix:
+    /// built when a walk first asks for the group, kept up to date by single
+    /// adds and removes, dropped by a large batch and rebuilt on the next walk
+    walk_orders: RwLock<FxHashMap<CompositeKey, BTreeSet<(Value, i64)>>>,
 }
 
 impl std::fmt::Debug for MultiColumnIndex {
@@ -186,7 +191,43 @@ impl MultiColumnIndex {
             } else {
                 I64Map::new()
             }),
+            walk_orders: RwLock::new(FxHashMap::default()),
         }
+    }
+
+    /// A batch this large drops the built walk orders; they come back on the
+    /// next walk, cheaper than updating them row by row
+    const WALK_ORDER_BATCH_DROP: usize = 1024;
+
+    /// Rows removed per lock acquisition in a batch removal
+    const REMOVE_CHUNK_ROWS: usize = 8192;
+
+    /// Enter `row_id` into the built order of every prefix group of `values`
+    fn order_insert(&self, values: &[Value], row_id: i64) {
+        let mut orders = self.walk_orders.write();
+        for prefix_len in 1..values.len() {
+            if let Some(order) = orders.get_mut(&CompositeKey(values[..prefix_len].to_vec())) {
+                order.insert((values[prefix_len].clone(), row_id));
+            }
+        }
+    }
+
+    fn order_remove(&self, values: &[Value], row_id: i64) {
+        let mut orders = self.walk_orders.write();
+        for prefix_len in 1..values.len() {
+            if let Some(order) = orders.get_mut(&CompositeKey(values[..prefix_len].to_vec())) {
+                order.remove(&(values[prefix_len].clone(), row_id));
+            }
+        }
+    }
+
+    fn order_remove_arcs(&self, values: &[CompactArc<Value>], row_id: i64) {
+        let owned: Vec<Value> = values.iter().map(|v| (**v).clone()).collect();
+        self.order_remove(&owned, row_id);
+    }
+
+    fn orders_built(&self) -> bool {
+        !self.walk_orders.read().is_empty()
     }
 
     /// Helper to compare stored CompactArc<Value> with input &[Value]
@@ -453,6 +494,13 @@ impl Index for MultiColumnIndex {
         drop(value_to_rows);
         drop(row_to_key);
 
+        if self.orders_built() {
+            if let Some(ref old_arc_values) = old_key_for_cleanup {
+                self.order_remove_arcs(old_arc_values, row_id);
+            }
+            self.order_insert(values, row_id);
+        }
+
         // Update BTree only if it was already built
         if btree_needs_update {
             let mut sorted_values = self.sorted_values.write();
@@ -544,6 +592,10 @@ impl Index for MultiColumnIndex {
 
             // Remove reverse mapping - ALWAYS maintained
             row_to_key.remove(row_id);
+        }
+
+        if self.orders_built() {
+            self.order_remove(values, row_id);
         }
 
         // Only update BTree if it was built (row_ids are sorted, use binary search)
@@ -709,6 +761,19 @@ impl Index for MultiColumnIndex {
         drop(value_to_rows);
         drop(row_to_key);
 
+        if self.orders_built() {
+            if entries.len() >= Self::WALK_ORDER_BATCH_DROP {
+                self.walk_orders.write().clear();
+            } else {
+                for (row_id, existing_arc_values) in &updates_to_old_key {
+                    self.order_remove_arcs(existing_arc_values, *row_id);
+                }
+                for &(row_id, values) in entries {
+                    self.order_insert(values, row_id);
+                }
+            }
+        }
+
         // Update BTree only if it was already built
         if btree_needs_update {
             let mut sorted_values = self.sorted_values.write();
@@ -782,31 +847,37 @@ impl Index for MultiColumnIndex {
             return Err(Error::IndexClosed);
         }
 
-        // Acquire BOTH write locks ONCE for entire batch
-        let mut value_to_rows = self.value_to_rows.write();
-        let mut row_to_key = self.row_to_key.write();
+        // The locks are taken per chunk so a reader waits for one chunk of
+        // a seal's removal, not for all of it
+        for chunk in entries.chunks(Self::REMOVE_CHUNK_ROWS) {
+            let mut value_to_rows = self.value_to_rows.write();
+            let mut row_to_key = self.row_to_key.write();
 
-        // Remove all entries from hash index and reverse mapping
-        for &(row_id, values) in entries {
-            let key = CompositeKey(values.to_vec());
+            for &(row_id, values) in chunk {
+                let key = CompositeKey(values.to_vec());
 
-            // Remove from hash index
-            if let Some(rows) = value_to_rows.get_mut(&key) {
-                if let Ok(pos) = rows.binary_search(&row_id) {
-                    rows.remove(pos);
+                if let Some(rows) = value_to_rows.get_mut(&key) {
+                    if let Ok(pos) = rows.binary_search(&row_id) {
+                        rows.remove(pos);
+                    }
+                    if rows.is_empty() {
+                        value_to_rows.remove(&key);
+                    }
                 }
-                if rows.is_empty() {
-                    value_to_rows.remove(&key);
-                }
+
+                row_to_key.remove(row_id);
             }
-
-            // Remove reverse mapping
-            row_to_key.remove(row_id);
         }
 
-        // Release main locks before updating BTree/prefix indexes
-        drop(value_to_rows);
-        drop(row_to_key);
+        if self.orders_built() {
+            if entries.len() >= Self::WALK_ORDER_BATCH_DROP {
+                self.walk_orders.write().clear();
+            } else {
+                for &(row_id, values) in entries {
+                    self.order_remove(values, row_id);
+                }
+            }
+        }
 
         // The sorted and prefix structures are subtracted one key at a time:
         // a removal per row is quadratic in the rows per key.
@@ -1000,6 +1071,75 @@ impl Index for MultiColumnIndex {
         }
     }
 
+    fn walk_prefix_ordered(
+        &self,
+        prefix: &[Value],
+        lower: Option<(&Value, bool)>,
+        upper: Option<(&Value, bool)>,
+        ascending: bool,
+        visit: &mut dyn FnMut(i64) -> bool,
+    ) -> bool {
+        let walked = prefix.len();
+        if self.closed.load(AtomicOrdering::Acquire)
+            || walked == 0
+            || walked >= self.column_ids.len()
+        {
+            return false;
+        }
+        let group = CompositeKey(prefix.to_vec());
+        if !self.walk_orders.read().contains_key(&group) {
+            // Built under the row map's read lock, so a row added or removed
+            // meanwhile reaches the order after it is in place. The prefix
+            // index is built first: its build takes the same lock.
+            self.ensure_prefix_built(walked);
+            let row_to_key = self.row_to_key.read();
+            let ids = self.get_row_ids_equal(prefix);
+            let mut entries: Vec<(Value, i64)> = Vec::with_capacity(ids.len());
+            for row_id in ids.iter() {
+                if let Some(key) = row_to_key.get(*row_id) {
+                    if let Some(value) = key.get(walked) {
+                        entries.push(((**value).clone(), *row_id));
+                    }
+                }
+            }
+            entries.sort_unstable();
+            let order: BTreeSet<(Value, i64)> = entries.into_iter().collect();
+            self.walk_orders
+                .write()
+                .entry(group.clone())
+                .or_insert(order);
+        }
+        let orders = self.walk_orders.read();
+        let Some(order) = orders.get(&group) else {
+            return true;
+        };
+        let start = match lower {
+            Some((value, true)) => Bound::Included((value.clone(), i64::MIN)),
+            Some((value, false)) => Bound::Excluded((value.clone(), i64::MAX)),
+            None => Bound::Unbounded,
+        };
+        let end = match upper {
+            Some((value, true)) => Bound::Included((value.clone(), i64::MAX)),
+            Some((value, false)) => Bound::Excluded((value.clone(), i64::MIN)),
+            None => Bound::Unbounded,
+        };
+        let range = order.range((start, end));
+        if ascending {
+            for (_, row_id) in range {
+                if !visit(*row_id) {
+                    break;
+                }
+            }
+        } else {
+            for (_, row_id) in range.rev() {
+                if !visit(*row_id) {
+                    break;
+                }
+            }
+        }
+        true
+    }
+
     fn get_row_ids_equal_into(&self, values: &[Value], buffer: &mut Vec<i64>) {
         if self.closed.load(AtomicOrdering::Acquire) {
             return;
@@ -1037,6 +1177,7 @@ impl Index for MultiColumnIndex {
     }
 
     fn clear(&self) -> Result<()> {
+        self.walk_orders.write().clear();
         self.sorted_values.write().clear();
         self.btree_built.store(false, AtomicOrdering::Release);
         self.value_to_rows.write().clear();

--- a/src/storage/index/multi_column.rs
+++ b/src/storage/index/multi_column.rs
@@ -1093,22 +1093,32 @@ impl Index for MultiColumnIndex {
         // The prefix index is built outside the row map's lock: its build
         // takes that lock too
         self.ensure_prefix_built(walked);
-        let mut orders = self.walk_orders.write();
-        if !orders.contains_key(&group) {
-            let ids = self.get_row_ids_equal(prefix);
-            let row_to_key = self.row_to_key.read();
-            let mut entries: Vec<(Value, i64)> = Vec::with_capacity(ids.len());
-            for row_id in ids.iter() {
-                if let Some(key) = row_to_key.get(*row_id) {
-                    if let Some(value) = key.get(walked) {
-                        entries.push(((**value).clone(), *row_id));
+        // A built group is read under the shared lock; a missing one is built
+        // under the exclusive lock, checked again once that is held
+        let orders = {
+            let orders = self.walk_orders.read();
+            if orders.contains_key(&group) {
+                orders
+            } else {
+                drop(orders);
+                let mut orders = self.walk_orders.write();
+                if !orders.contains_key(&group) {
+                    let ids = self.get_row_ids_equal(prefix);
+                    let row_to_key = self.row_to_key.read();
+                    let mut entries: Vec<(Value, i64)> = Vec::with_capacity(ids.len());
+                    for row_id in ids.iter() {
+                        if let Some(key) = row_to_key.get(*row_id) {
+                            if let Some(value) = key.get(walked) {
+                                entries.push(((**value).clone(), *row_id));
+                            }
+                        }
                     }
+                    entries.sort_unstable();
+                    orders.insert(group.clone(), entries.into_iter().collect());
                 }
+                parking_lot::RwLockWriteGuard::downgrade(orders)
             }
-            entries.sort_unstable();
-            orders.insert(group.clone(), entries.into_iter().collect());
-        }
-        let orders = parking_lot::RwLockWriteGuard::downgrade(orders);
+        };
         let Some(order) = orders.get(&group) else {
             return true;
         };

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -7618,6 +7618,23 @@ impl TransactionEngineOperations for EngineOperations {
         (any_committed, commit_error)
     }
 
+    fn begin_publish(&self, txn_id: i64) -> super::version_store::PublishHold {
+        let mut hold = super::version_store::PublishHold::default();
+        let cache = self.txn_version_stores().read().unwrap();
+        if let Some(txn_tables) = cache.get(txn_id) {
+            let stores = self.version_stores().read().unwrap();
+            for (table_name, txn_store) in txn_tables.iter() {
+                if !txn_store.read().unwrap().has_local_changes() {
+                    continue;
+                }
+                if let Some(version_store) = stores.get(table_name.as_str()) {
+                    hold.add(version_store, Arc::clone(txn_store));
+                }
+            }
+        }
+        hold
+    }
+
     fn rollback_all_tables(&self, txn_id: i64) {
         // Collect touched table names BEFORE removing the cache entry,
         // so we only rollback tombstones on tables this txn actually used

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -3001,8 +3001,11 @@ impl Table for MVCCTable {
         if needed == 0 {
             return Ok(Some(RowVec::new()));
         }
-        // Rows this transaction wrote are not in the shared indexes yet
-        if self.txn_versions.read().unwrap().has_local_changes() {
+        // Rows this transaction wrote are not in the shared indexes yet, and
+        // a snapshot may see older versions than the keys the index holds
+        if self.txn_versions.read().unwrap().has_local_changes()
+            || self.version_store.needs_snapshot_isolation(self.txn_id)
+        {
             return Ok(None);
         }
         let Some(expr) = where_expr else {
@@ -3016,15 +3019,24 @@ impl Table for MVCCTable {
         }
         let schema = &self.cached_schema;
         let column_lower = column_name.to_lowercase();
-        let Some(column) = schema.columns.iter().find(|c| c.name_lower == column_lower) else {
+        let Some(col_idx) = schema
+            .columns
+            .iter()
+            .position(|c| c.name_lower == column_lower)
+        else {
             return Ok(None);
         };
+        let column = &schema.columns[col_idx];
         // NULL and NaN sort by rules the key order does not follow
         if column.nullable || column.data_type == DataType::Float {
             return Ok(None);
         }
 
         let mut rows = RowVec::with_capacity(needed.min(1024));
+        // A row whose visible order value differs from its key was changed
+        // between the index and the version this transaction sees: the walk
+        // order does not hold for it, and the full scan answers instead
+        let mut stale = false;
         let walked = plan.index.walk_prefix_ordered(
             &plan.prefix,
             plan.lower
@@ -3034,12 +3046,16 @@ impl Table for MVCCTable {
                 .as_ref()
                 .map(|(value, inclusive)| (value, *inclusive)),
             ascending,
-            &mut |row_id| {
+            &mut |row_id, key_value| {
                 if let Some(version) = self.version_store.get_visible_version(row_id, self.txn_id) {
                     if !version.is_deleted() {
+                        let row = self.normalize_row_to_schema(version.data, schema);
+                        if row.get(col_idx) != Some(key_value) {
+                            stale = true;
+                            return false;
+                        }
                         // The index may be ahead of this transaction's view of
                         // the row, so the whole WHERE is checked on the row
-                        let row = self.normalize_row_to_schema(version.data, schema);
                         if expr.evaluate_fast(&row) {
                             rows.push((row_id, row));
                         }
@@ -3048,7 +3064,7 @@ impl Table for MVCCTable {
                 rows.len() < needed
             },
         );
-        if !walked {
+        if !walked || stale {
             return Ok(None);
         }
         Ok(Some(rows.into_iter().skip(offset).take(limit).collect()))

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -3032,6 +3032,12 @@ impl Table for MVCCTable {
             return Ok(None);
         }
 
+        // A commit updates the indexes before its versions are visible, and
+        // a key moved by it may sit anywhere in the walk: the walk stands
+        // down while a commit publishes, or if one did meanwhile
+        let Some(epoch) = self.version_store.publish_epoch_if_quiet() else {
+            return Ok(None);
+        };
         let mut rows = RowVec::with_capacity(needed.min(1024));
         // A row whose visible order value differs from its key was changed
         // between the index and the version this transaction sees: the walk
@@ -3064,7 +3070,7 @@ impl Table for MVCCTable {
                 rows.len() < needed
             },
         );
-        if !walked || stale {
+        if !walked || stale || self.version_store.publish_epoch_if_quiet() != Some(epoch) {
             return Ok(None);
         }
         Ok(Some(rows.into_iter().skip(offset).take(limit).collect()))

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -3053,18 +3053,19 @@ impl Table for MVCCTable {
                 .map(|(value, inclusive)| (value, *inclusive)),
             ascending,
             &mut |row_id, key_value| {
+                // A version comes back only when it is visible and its
+                // deletion, if any, is not: the raw deleted flag may belong
+                // to an aborted or unfinished transaction
                 if let Some(version) = self.version_store.get_visible_version(row_id, self.txn_id) {
-                    if !version.is_deleted() {
-                        let row = self.normalize_row_to_schema(version.data, schema);
-                        if row.get(col_idx) != Some(key_value) {
-                            stale = true;
-                            return false;
-                        }
-                        // The index may be ahead of this transaction's view of
-                        // the row, so the whole WHERE is checked on the row
-                        if expr.evaluate_fast(&row) {
-                            rows.push((row_id, row));
-                        }
+                    let row = self.normalize_row_to_schema(version.data, schema);
+                    if row.get(col_idx) != Some(key_value) {
+                        stale = true;
+                        return false;
+                    }
+                    // The index may be ahead of this transaction's view of
+                    // the row, so the whole WHERE is checked on the row
+                    if expr.evaluate_fast(&row) {
+                        rows.push((row_id, row));
                     }
                 }
                 rows.len() < needed

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -44,6 +44,34 @@ pub struct MVCCTable {
     cached_schema: CompactArc<Schema>,
 }
 
+/// Where a WHERE conjunction sits on a multi-column index: equalities on the
+/// leading columns and the bounds on the column after them
+struct PrefixPlan {
+    index: Arc<dyn crate::storage::traits::Index>,
+    prefix: Vec<Value>,
+    lower: Option<(Value, bool)>,
+    upper: Option<(Value, bool)>,
+}
+
+/// The comparisons of an AND tree; false when a leaf is not a comparison
+fn collect_conjuncts<'a>(
+    expr: &'a dyn Expression,
+    out: &mut Vec<(&'a str, crate::core::Operator, &'a Value)>,
+) -> bool {
+    if let Some(children) = expr.get_and_operands() {
+        return children
+            .iter()
+            .all(|child| collect_conjuncts(child.as_ref(), out));
+    }
+    match expr.get_comparison_info() {
+        Some(leaf) => {
+            out.push(leaf);
+            true
+        }
+        None => false,
+    }
+}
+
 impl MVCCTable {
     /// Creates a new MVCC table with an owned transaction version store
     /// (wraps it in Arc<RwLock> internally)
@@ -302,6 +330,55 @@ impl MVCCTable {
             .filter(|(row_id, version)| !version.is_deleted() && !present.contains(*row_id))
             .map(|(row_id, _)| row_id)
             .collect()
+    }
+
+    /// A conjunction of equalities on the leading columns of a multi-column
+    /// index, with the bounds the same conjunction puts on the next column
+    fn prefix_plan(&self, expr: &dyn Expression) -> Option<PrefixPlan> {
+        let mut leaves = Vec::new();
+        if !collect_conjuncts(expr, &mut leaves) {
+            return None;
+        }
+        let eq_columns: Vec<&str> = leaves
+            .iter()
+            .filter(|(_, op, value)| matches!(op, crate::core::Operator::Eq) && !value.is_null())
+            .map(|(column, _, _)| *column)
+            .collect();
+        if eq_columns.is_empty() {
+            return None;
+        }
+        let (index, matched) = self.version_store.get_multi_column_index(&eq_columns)?;
+        let columns = index.column_names();
+        let mut prefix = Vec::with_capacity(matched);
+        for column in columns.iter().take(matched) {
+            let (_, _, value) = leaves.iter().find(|(name, op, value)| {
+                matches!(op, crate::core::Operator::Eq)
+                    && !value.is_null()
+                    && name.eq_ignore_ascii_case(column)
+            })?;
+            prefix.push((*value).clone());
+        }
+        let walked = columns.get(matched)?;
+        let mut lower = None;
+        let mut upper = None;
+        for (name, op, value) in &leaves {
+            if !name.eq_ignore_ascii_case(walked) || value.is_null() {
+                continue;
+            }
+            match op {
+                crate::core::Operator::Gt => lower = Some(((*value).clone(), false)),
+                crate::core::Operator::Gte => lower = Some(((*value).clone(), true)),
+                crate::core::Operator::Lt => upper = Some(((*value).clone(), false)),
+                crate::core::Operator::Lte => upper = Some(((*value).clone(), true)),
+                _ => {}
+            }
+        }
+        Some(PrefixPlan {
+            index,
+            prefix,
+            lower,
+            upper,
+        })
     }
 
     fn try_index_lookup(&self, expr: &dyn Expression) -> Option<RowIdVec> {
@@ -2907,6 +2984,74 @@ impl Table for MVCCTable {
         let rows = self.collect_visible_rows(where_expr);
         let scanner = MVCCScanner::from_rows(rows, schema, column_indices.to_vec());
         Ok(Box::new(scanner))
+    }
+
+    /// Answered by walking a multi-column index whose leading columns the
+    /// WHERE pins with equalities and whose next column is the order column:
+    /// the rows come out in key order and the walk stops at the limit
+    fn scan_top_k(
+        &self,
+        where_expr: Option<&dyn Expression>,
+        column_name: &str,
+        ascending: bool,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Option<RowVec>> {
+        let needed = limit.saturating_add(offset);
+        if needed == 0 {
+            return Ok(Some(RowVec::new()));
+        }
+        // Rows this transaction wrote are not in the shared indexes yet
+        if self.txn_versions.read().unwrap().has_local_changes() {
+            return Ok(None);
+        }
+        let Some(expr) = where_expr else {
+            return Ok(None);
+        };
+        let Some(plan) = self.prefix_plan(expr) else {
+            return Ok(None);
+        };
+        if !plan.index.column_names()[plan.prefix.len()].eq_ignore_ascii_case(column_name) {
+            return Ok(None);
+        }
+        let schema = &self.cached_schema;
+        let column_lower = column_name.to_lowercase();
+        let Some(column) = schema.columns.iter().find(|c| c.name_lower == column_lower) else {
+            return Ok(None);
+        };
+        // NULL and NaN sort by rules the key order does not follow
+        if column.nullable || column.data_type == DataType::Float {
+            return Ok(None);
+        }
+
+        let mut rows = RowVec::with_capacity(needed.min(1024));
+        let walked = plan.index.walk_prefix_ordered(
+            &plan.prefix,
+            plan.lower
+                .as_ref()
+                .map(|(value, inclusive)| (value, *inclusive)),
+            plan.upper
+                .as_ref()
+                .map(|(value, inclusive)| (value, *inclusive)),
+            ascending,
+            &mut |row_id| {
+                if let Some(version) = self.version_store.get_visible_version(row_id, self.txn_id) {
+                    if !version.is_deleted() {
+                        // The index may be ahead of this transaction's view of
+                        // the row, so the whole WHERE is checked on the row
+                        let row = self.normalize_row_to_schema(version.data, schema);
+                        if expr.evaluate_fast(&row) {
+                            rows.push((row_id, row));
+                        }
+                    }
+                }
+                rows.len() < needed
+            },
+        );
+        if !walked {
+            return Ok(None);
+        }
+        Ok(Some(rows.into_iter().skip(offset).take(limit).collect()))
     }
 
     fn collect_all_rows(&self, where_expr: Option<&dyn Expression>) -> Result<RowVec> {

--- a/src/storage/mvcc/transaction.rs
+++ b/src/storage/mvcc/transaction.rs
@@ -137,6 +137,13 @@ pub trait TransactionEngineOperations: Send + Sync {
     /// This cleans up the transaction's entries in txn_version_stores
     fn rollback_all_tables(&self, txn_id: i64);
 
+    /// Marks every table the transaction writes as publishing, from before
+    /// its index updates until the transaction is visible or undone
+    fn begin_publish(&self, txn_id: i64) -> super::version_store::PublishHold {
+        let _ = txn_id;
+        super::version_store::PublishHold::default()
+    }
+
     /// Discard the cold-row tombstones the transaction made after a timestamp
     /// (savepoint rollback). Engines without cold storage have none.
     fn rollback_tombstones_after(&self, _txn_id: i64, _timestamp: i64) {}
@@ -449,6 +456,12 @@ impl Transaction for MvccTransaction {
 
             // Phase 1: Start commit - mark transaction as "committing"
             self.registry.start_commit(self.id);
+            // Held until the transaction is visible or undone: readers that
+            // trust an index's order stand down while it publishes
+            let publish = self
+                .engine_operations
+                .as_ref()
+                .map(|ops| ops.begin_publish(self.id));
 
             // Phase 2: Commit all tables - apply local changes to global store
             // This now includes WAL recording internally (before each table commit)
@@ -487,6 +500,10 @@ impl Transaction for MvccTransaction {
                     // but not yet visible (complete_commit hasn't run). Abort so GC
                     // can reclaim the orphaned entries and active_txn_count is correct.
                     // On recovery, WAL has no COMMIT marker → entries are discarded.
+                    // The indexes already describe the aborted rows: take that back
+                    if let Some(hold) = &publish {
+                        hold.undo_index_updates();
+                    }
                     self.registry.abort_transaction(self.id);
                     self.state = TransactionState::RolledBack;
                     self.cleanup();

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -463,16 +463,55 @@ pub struct SealedIndexCleanup {
     snapshot: Option<crate::common::CowBTree<VersionChainEntry>>,
 }
 
-/// Held by a committing transaction while it publishes; see begin_publish
-pub struct PublishGuard<'a> {
-    store: &'a VersionStore,
+/// Held for a table from the first index update of a commit until the
+/// commit is visible or undone; see VersionStore::begin_publish
+pub struct PublishGuard {
+    store: Arc<VersionStore>,
 }
 
-impl Drop for PublishGuard<'_> {
+impl Drop for PublishGuard {
     fn drop(&mut self) {
         self.store.publish_epoch.fetch_add(1, Ordering::SeqCst);
         self.store.publishing.fetch_sub(1, Ordering::SeqCst);
     }
+}
+
+/// What a committing transaction holds while it publishes: a guard per
+/// table it writes, and the tables' stores so their index updates can be
+/// undone if the commit fails after they were applied
+#[derive(Default)]
+pub struct PublishHold {
+    guards: Vec<PublishGuard>,
+    stores: Vec<Arc<std::sync::RwLock<TransactionVersionStore>>>,
+}
+
+impl PublishHold {
+    pub fn add(
+        &mut self,
+        version_store: &Arc<VersionStore>,
+        txn_store: Arc<std::sync::RwLock<TransactionVersionStore>>,
+    ) {
+        self.guards.push(version_store.begin_publish());
+        self.stores.push(txn_store);
+    }
+
+    /// Takes back the index updates of a commit that failed after applying
+    /// them, so the indexes describe the rows that stayed visible
+    pub fn undo_index_updates(&self) {
+        for store in &self.stores {
+            if let Ok(store) = store.read() {
+                store.undo_index_updates();
+            }
+        }
+    }
+}
+
+/// The index entries a commit added and removed for one index, kept until
+/// the commit is visible or undone
+struct IndexUndo {
+    index: Arc<dyn Index>,
+    added: Vec<(i64, Vec<Value>)>,
+    removed: Vec<(i64, Vec<Value>)>,
 }
 
 /// VersionStore tracks the latest committed version of each row for a table
@@ -2027,10 +2066,13 @@ impl VersionStore {
     /// rows committed after this transaction's snapshot point.
     #[inline]
     /// Marks a commit's publish, from its index updates until its versions
-    /// are visible, so a reader that trusts the index order can stand down
-    pub fn begin_publish(&self) -> PublishGuard<'_> {
+    /// are visible or undone, so a reader that trusts the index order can
+    /// stand down
+    pub fn begin_publish(self: &Arc<Self>) -> PublishGuard {
         self.publishing.fetch_add(1, Ordering::SeqCst);
-        PublishGuard { store: self }
+        PublishGuard {
+            store: Arc::clone(self),
+        }
     }
 
     /// The publish epoch while no commit is publishing; None while one is.
@@ -6433,6 +6475,8 @@ pub struct TransactionVersionStore {
     /// Write set for conflict detection
     /// Lazily allocated on first write to avoid allocation overhead for read-only queries
     write_set: Option<I64Map<WriteSetEntry>>,
+    /// Index updates applied by commit, until the commit is visible or undone
+    index_undo: Mutex<Vec<IndexUndo>>,
 }
 
 impl TransactionVersionStore {
@@ -6448,6 +6492,30 @@ impl TransactionVersionStore {
             parent_store,
             txn_id,
             write_set: None,
+            index_undo: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Takes back the index updates of this transaction's commit, in reverse
+    pub fn undo_index_updates(&self) {
+        let undo: Vec<IndexUndo> = std::mem::take(&mut *self.index_undo.lock());
+        for entry in undo.iter().rev() {
+            if !entry.added.is_empty() {
+                let batch: Vec<(i64, &[Value])> = entry
+                    .added
+                    .iter()
+                    .map(|(row_id, values)| (*row_id, values.as_slice()))
+                    .collect();
+                let _ = entry.index.remove_batch_slice(&batch);
+            }
+            if !entry.removed.is_empty() {
+                let batch: Vec<(i64, &[Value])> = entry
+                    .removed
+                    .iter()
+                    .map(|(row_id, values)| (*row_id, values.as_slice()))
+                    .collect();
+                let _ = entry.index.add_batch_slice(&batch);
+            }
         }
     }
 
@@ -6975,7 +7043,6 @@ impl TransactionVersionStore {
         // Rows removed by seal (missing from hot B-tree) are not conflicts —
         // they were moved to cold segments, not modified by another transaction.
         self.detect_conflicts_safe()?;
-        let _publish = self.parent_store.begin_publish();
 
         // Update indexes BEFORE committing versions
         self.update_indexes_on_commit()?;
@@ -7320,6 +7387,18 @@ impl TransactionVersionStore {
             }
         }
 
+        let mut undo = self.index_undo.lock();
+        for (idx, index) in indexes.iter().enumerate() {
+            if add_batches[idx].is_empty() && remove_batches[idx].is_empty() {
+                continue;
+            }
+            undo.push(IndexUndo {
+                index: Arc::clone(index),
+                added: std::mem::take(&mut add_batches[idx]),
+                removed: std::mem::take(&mut remove_batches[idx]),
+            });
+        }
+
         Ok(())
     }
 
@@ -7449,6 +7528,32 @@ impl TransactionVersionStore {
                 }
                 completed_ops.push((idx, true));
             }
+        }
+
+        let mut undo = self.index_undo.lock();
+        for &(idx, is_add) in completed_ops.iter() {
+            let index = &indexes[idx];
+            let source = if is_add {
+                new_row
+            } else {
+                old_row.unwrap_or(new_row)
+            };
+            let values: Vec<Value> = index
+                .column_ids()
+                .iter()
+                .map(|&col_id| {
+                    source
+                        .get(col_id as usize)
+                        .cloned()
+                        .unwrap_or(Value::Null(DataType::Null))
+                })
+                .collect();
+            let entry = vec![(row_id, values)];
+            undo.push(IndexUndo {
+                index: Arc::clone(index),
+                added: if is_add { entry.clone() } else { Vec::new() },
+                removed: if is_add { Vec::new() } else { entry },
+            });
         }
 
         Ok(())

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -28,7 +28,7 @@
 
 use std::fmt;
 use std::num::{NonZeroU64, NonZeroUsize};
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use parking_lot::{Mutex, RwLock};
@@ -463,6 +463,18 @@ pub struct SealedIndexCleanup {
     snapshot: Option<crate::common::CowBTree<VersionChainEntry>>,
 }
 
+/// Held by a committing transaction while it publishes; see begin_publish
+pub struct PublishGuard<'a> {
+    store: &'a VersionStore,
+}
+
+impl Drop for PublishGuard<'_> {
+    fn drop(&mut self) {
+        self.store.publish_epoch.fetch_add(1, Ordering::SeqCst);
+        self.store.publishing.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
 /// VersionStore tracks the latest committed version of each row for a table
 ///
 /// Uses CowBTreeMap (RwLock<CowBTree>) for the version store because:
@@ -515,6 +527,10 @@ pub struct VersionStore {
     /// Only acquired for upsert statements to prevent TOCTOU races.
     /// Plain INSERTs (no ON CONFLICT) proceed lock-free.
     upsert_mutex: Arc<parking_lot::Mutex<()>>,
+    /// Commits between their index updates and their versions being visible
+    publishing: AtomicUsize,
+    /// Publishes completed
+    publish_epoch: AtomicU64,
 }
 
 impl VersionStore {
@@ -550,6 +566,8 @@ impl VersionStore {
             max_version_history: 10, // Default: keep up to 10 previous versions
             committed_row_count: AtomicUsize::new(0),
             upsert_mutex: Arc::new(parking_lot::Mutex::new(())),
+            publishing: AtomicUsize::new(0),
+            publish_epoch: AtomicU64::new(0),
         }
     }
 
@@ -577,6 +595,8 @@ impl VersionStore {
             max_version_history: 10,
             committed_row_count: AtomicUsize::new(0),
             upsert_mutex: Arc::new(parking_lot::Mutex::new(())),
+            publishing: AtomicUsize::new(0),
+            publish_epoch: AtomicU64::new(0),
         }
     }
 
@@ -2006,6 +2026,22 @@ impl VersionStore {
     /// When true, the O(1) committed_row_count is inaccurate because it includes
     /// rows committed after this transaction's snapshot point.
     #[inline]
+    /// Marks a commit's publish, from its index updates until its versions
+    /// are visible, so a reader that trusts the index order can stand down
+    pub fn begin_publish(&self) -> PublishGuard<'_> {
+        self.publishing.fetch_add(1, Ordering::SeqCst);
+        PublishGuard { store: self }
+    }
+
+    /// The publish epoch while no commit is publishing; None while one is.
+    /// Equal values before and after a read mean no publish overlapped it.
+    pub fn publish_epoch_if_quiet(&self) -> Option<u64> {
+        if self.publishing.load(Ordering::SeqCst) != 0 {
+            return None;
+        }
+        Some(self.publish_epoch.load(Ordering::SeqCst))
+    }
+
     pub fn needs_snapshot_isolation(&self, txn_id: i64) -> bool {
         self.visibility_checker
             .as_ref()
@@ -6939,6 +6975,7 @@ impl TransactionVersionStore {
         // Rows removed by seal (missing from hot B-tree) are not conflicts —
         // they were moved to cold segments, not modified by another transaction.
         self.detect_conflicts_safe()?;
+        let _publish = self.parent_store.begin_publish();
 
         // Update indexes BEFORE committing versions
         self.update_indexes_on_commit()?;

--- a/src/storage/traits/index_trait.rs
+++ b/src/storage/traits/index_trait.rs
@@ -167,15 +167,16 @@ pub trait Index: Send + Sync {
 
     /// Visits the row ids whose key starts with `prefix`, in the order of the
     /// key column right after the prefix, within `lower` and `upper` (value,
-    /// inclusive) on that column, ascending or descending. `visit` returns
-    /// false to stop. Returns false when the index cannot walk in that order.
+    /// inclusive) on that column, ascending or descending. `visit` gets the
+    /// row id and that column's value in the key and returns false to stop.
+    /// Returns false when the index cannot walk in that order.
     fn walk_prefix_ordered(
         &self,
         prefix: &[Value],
         lower: Option<(&Value, bool)>,
         upper: Option<(&Value, bool)>,
         ascending: bool,
-        visit: &mut dyn FnMut(i64) -> bool,
+        visit: &mut dyn FnMut(i64, &Value) -> bool,
     ) -> bool {
         let _ = (prefix, lower, upper, ascending, visit);
         false

--- a/src/storage/traits/index_trait.rs
+++ b/src/storage/traits/index_trait.rs
@@ -165,6 +165,22 @@ pub trait Index: Send + Sync {
     /// Vector of matching index entries
     fn find_with_operator(&self, op: Operator, values: &[Value]) -> Result<Vec<IndexEntry>>;
 
+    /// Visits the row ids whose key starts with `prefix`, in the order of the
+    /// key column right after the prefix, within `lower` and `upper` (value,
+    /// inclusive) on that column, ascending or descending. `visit` returns
+    /// false to stop. Returns false when the index cannot walk in that order.
+    fn walk_prefix_ordered(
+        &self,
+        prefix: &[Value],
+        lower: Option<(&Value, bool)>,
+        upper: Option<(&Value, bool)>,
+        ascending: bool,
+        visit: &mut dyn FnMut(i64) -> bool,
+    ) -> bool {
+        let _ = (prefix, lower, upper, ascending, visit);
+        false
+    }
+
     /// Returns row IDs with the given values (convenience method)
     ///
     /// This is a simplified version of `find` that returns only row IDs.

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -3924,13 +3924,19 @@ impl Table for SegmentedTable {
             return Ok(None);
         }
         // Without volumes the hot store answers alone, from its index or not
-        // at all. No seal fence here: a seal registers its volume before it
-        // removes a hot row, so a table seen without volumes still has every
-        // row hot, and a query must not wait out a seal.
+        // at all. No seal fence here, a query must not wait out a seal: a seal
+        // registers its volume before it removes a hot row, so an answer taken
+        // while the generation held saw every row hot; if a seal registered
+        // meanwhile, the path below reads hot and volumes together.
         if !self.segment_mgr.has_segments() {
-            return self
+            let generation = self.segment_mgr.seal_generation();
+            let answer = self
                 .hot
-                .scan_top_k(where_expr, column_name, ascending, limit, offset);
+                .scan_top_k(where_expr, column_name, ascending, limit, offset)?;
+            if self.segment_mgr.seal_generation() == generation && !self.segment_mgr.has_segments()
+            {
+                return Ok(answer);
+            }
         }
         let needed = limit.saturating_add(offset);
         if needed == 0 {

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -3920,9 +3920,17 @@ impl Table for SegmentedTable {
         limit: usize,
         offset: usize,
     ) -> Result<Option<RowVec>> {
-        // Without volumes the hot store's own index paths answer faster
-        if self.snapshot_seq.is_some() || !self.segment_mgr.has_segments() {
+        if self.snapshot_seq.is_some() {
             return Ok(None);
+        }
+        // Without volumes the hot store answers alone, from its index or not
+        // at all. No seal fence here: a seal registers its volume before it
+        // removes a hot row, so a table seen without volumes still has every
+        // row hot, and a query must not wait out a seal.
+        if !self.segment_mgr.has_segments() {
+            return self
+                .hot
+                .scan_top_k(where_expr, column_name, ascending, limit, offset);
         }
         let needed = limit.saturating_add(offset);
         if needed == 0 {
@@ -3944,7 +3952,17 @@ impl Table for SegmentedTable {
             return Ok(None);
         }
 
-        let hot_rows = self.hot.collect_all_rows(where_expr)?;
+        // The hot store answers from an index when it can; then only its
+        // best rows are read, and a sealed copy of a hot row is recognised
+        // per candidate instead of through a set of every matching hot row
+        let hot_top = self
+            .hot
+            .scan_top_k(where_expr, column_name, ascending, needed, 0)?;
+        let sealed_copies_checked = hot_top.is_some();
+        let hot_rows = match hot_top {
+            Some(rows) => rows,
+            None => self.hot.collect_all_rows(where_expr)?,
+        };
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(hot_rows.len(), Default::default());
         let mut keep = TopK::new(needed, col_idx, ascending);
@@ -4087,6 +4105,9 @@ impl Table for SegmentedTable {
                 }
                 while scanner.next() {
                     let (row_id, row) = scanner.take_row_with_id();
+                    if sealed_copies_checked && self.hot.has_row_id(row_id) {
+                        continue;
+                    }
                     keep.offer(row_id, row);
                     if sorted {
                         if let Some(worst) = keep.worst_key() {

--- a/tests/failpoint_io_test.rs
+++ b/tests/failpoint_io_test.rs
@@ -665,3 +665,66 @@ fn test_wal_sync_failure_undoes_the_commit_index_updates() {
     );
     assert!(ids("SELECT id FROM fp_topk WHERE k = 'a' AND t = 0").is_empty());
 }
+
+/// A DELETE aborted at the WAL leaves its delete mark on the row with the
+/// aborted transaction's id; the row stays visible, the index gets its key
+/// back, and every read path, the index-ordered one included, keeps the row
+#[test]
+fn test_wal_sync_failure_on_a_delete_keeps_the_row_everywhere() {
+    let _guard = failpoint_guard();
+    let dir = tempdir().expect("tempdir");
+    let db = Database::open(&format!(
+        "file://{}?sync_mode=full&checkpoint_interval=3600",
+        dir.path().display()
+    ))
+    .expect("open");
+    db.execute(
+        "CREATE TABLE fp_del (id INTEGER PRIMARY KEY, k TEXT NOT NULL, t INTEGER NOT NULL, UNIQUE(k, t))",
+        (),
+    )
+    .expect("create");
+    db.execute("CREATE INDEX fp_del_t ON fp_del(t) USING BTREE", ())
+        .expect("index");
+    db.execute("INSERT INTO fp_del VALUES (1, 'a', 100), (2, 'a', 50)", ())
+        .expect("insert");
+    let ids = |sql: &str| -> Vec<i64> {
+        db.query(sql, ())
+            .expect("query")
+            .map(|r| r.expect("row").get::<i64>(0).expect("id"))
+            .collect()
+    };
+
+    test_failpoints::WAL_SYNC_FAIL.store(true, Ordering::Release);
+    let delete = db.execute("DELETE FROM fp_del WHERE id = 1", ());
+    test_failpoints::WAL_SYNC_FAIL.store(false, Ordering::Release);
+    assert!(
+        delete.is_err(),
+        "the DELETE must abort on the WAL sync failure"
+    );
+
+    assert_eq!(
+        ids("SELECT id FROM fp_del WHERE k = 'a' ORDER BY t DESC, id DESC LIMIT 3"),
+        vec![1, 2]
+    );
+    assert_eq!(
+        ids("SELECT id FROM fp_del WHERE k = 'a' ORDER BY t DESC LIMIT 3"),
+        vec![1, 2]
+    );
+    assert_eq!(
+        ids("SELECT id FROM fp_del WHERE k = 'a' AND t = 100"),
+        vec![1]
+    );
+    assert_eq!(ids("SELECT id FROM fp_del WHERE t = 100"), vec![1]);
+
+    // An aborted INSERT leaves no key behind either
+    test_failpoints::WAL_SYNC_FAIL.store(true, Ordering::Release);
+    let insert = db.execute("INSERT INTO fp_del VALUES (3, 'a', 150)", ());
+    test_failpoints::WAL_SYNC_FAIL.store(false, Ordering::Release);
+    assert!(insert.is_err());
+    assert_eq!(
+        ids("SELECT id FROM fp_del WHERE k = 'a' ORDER BY t DESC LIMIT 3"),
+        vec![1, 2]
+    );
+    assert!(ids("SELECT id FROM fp_del WHERE k = 'a' AND t = 150").is_empty());
+    assert!(ids("SELECT id FROM fp_del WHERE t = 150").is_empty());
+}

--- a/tests/failpoint_io_test.rs
+++ b/tests/failpoint_io_test.rs
@@ -615,3 +615,53 @@ fn test_failpoint_does_not_corrupt_existing_data() {
         );
     }
 }
+
+/// A commit that fails at the WAL after its index updates were applied
+/// takes those updates back, so the indexes describe the rows that stayed
+/// visible and an index-ordered read agrees with the full sort
+#[test]
+fn test_wal_sync_failure_undoes_the_commit_index_updates() {
+    let _guard = failpoint_guard();
+    let dir = tempdir().expect("tempdir");
+    let db = Database::open(&format!(
+        "file://{}?sync_mode=full&checkpoint_interval=3600",
+        dir.path().display()
+    ))
+    .expect("open");
+    db.execute(
+        "CREATE TABLE fp_topk (id INTEGER PRIMARY KEY, k TEXT NOT NULL, t INTEGER NOT NULL, UNIQUE(k, t))",
+        (),
+    )
+    .expect("create");
+    db.execute("INSERT INTO fp_topk VALUES (1, 'a', 100), (2, 'a', 50)", ())
+        .expect("insert");
+
+    test_failpoints::WAL_SYNC_FAIL.store(true, Ordering::Release);
+    let update = db.execute("UPDATE fp_topk SET t = 0 WHERE id = 1", ());
+    test_failpoints::WAL_SYNC_FAIL.store(false, Ordering::Release);
+    assert!(
+        update.is_err(),
+        "the UPDATE must abort on the WAL sync failure"
+    );
+
+    let ids = |sql: &str| -> Vec<i64> {
+        db.query(sql, ())
+            .expect("query")
+            .map(|r| r.expect("row").get::<i64>(0).expect("id"))
+            .collect()
+    };
+    assert_eq!(
+        ids("SELECT id FROM fp_topk WHERE k = 'a' ORDER BY t DESC, id DESC LIMIT 1"),
+        vec![1]
+    );
+    assert_eq!(
+        ids("SELECT id FROM fp_topk WHERE k = 'a' ORDER BY t DESC LIMIT 1"),
+        vec![1]
+    );
+    // The old key is back in the index: an equality on it finds the row
+    assert_eq!(
+        ids("SELECT id FROM fp_topk WHERE k = 'a' AND t = 100"),
+        vec![1]
+    );
+    assert!(ids("SELECT id FROM fp_topk WHERE k = 'a' AND t = 0").is_empty());
+}

--- a/tests/hot_index_top_k_test.rs
+++ b/tests/hot_index_top_k_test.rs
@@ -590,3 +590,73 @@ fn test_built_groups_are_walked_concurrently() {
         "a built group's walk waited for another group's walk"
     );
 }
+
+/// A transaction that writes two tables is visible only once the whole
+/// commit completes; the first table's index is updated long before that,
+/// so its walk must stand down until the transaction is visible
+#[test]
+fn test_top_k_stands_down_until_a_two_table_commit_is_visible() {
+    let db = Database::open("memory://hot_top_k_two_table_commit").unwrap();
+    for table in ["c", "d"] {
+        db.execute(
+            &format!("CREATE TABLE {table} (id INTEGER PRIMARY KEY, k TEXT NOT NULL, t INTEGER NOT NULL, UNIQUE(k, t))"),
+            (),
+        )
+        .unwrap();
+        db.execute(
+            &format!("INSERT INTO {table} VALUES (1, 'a', 100), (2, 'a', 50)"),
+            (),
+        )
+        .unwrap();
+    }
+    let second_store = db.engine().get_version_store("d").unwrap();
+    let (index, _) = second_store.get_multi_column_index(&["k"]).unwrap();
+    let name = index.name().to_string();
+    let (stopped_tx, stopped_rx) = mpsc::channel();
+    let (resume_tx, resume_rx) = mpsc::channel();
+    second_store.add_index(
+        name,
+        Arc::new(StopAfterIndexAdd {
+            inner: index,
+            armed: AtomicBool::new(true),
+            stopped: stopped_tx,
+            resume: Mutex::new(resume_rx),
+        }),
+    );
+    let writer_db = db.clone();
+    let writer = std::thread::spawn(move || {
+        writer_db.execute("BEGIN", ()).unwrap();
+        writer_db
+            .execute("UPDATE c SET t = 0 WHERE id = 1", ())
+            .unwrap();
+        writer_db
+            .execute("UPDATE d SET t = 0 WHERE id = 1", ())
+            .unwrap();
+        writer_db.execute("COMMIT", ()).unwrap();
+    });
+    stopped_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    // c's table commit is done, d's is stopped, the transaction is not visible
+    let full = ids(
+        &db,
+        "SELECT id FROM c WHERE k = 'a' ORDER BY t DESC, id DESC LIMIT 1",
+    );
+    let fast = ids(
+        &db,
+        "SELECT id FROM c WHERE k = 'a' ORDER BY t DESC LIMIT 1",
+    );
+    resume_tx.send(()).unwrap();
+    writer.join().unwrap();
+    assert_eq!(
+        full,
+        vec![1],
+        "c's old row stays visible until the whole transaction commits"
+    );
+    assert_eq!(fast, full);
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM c WHERE k = 'a' ORDER BY t DESC LIMIT 1"
+        ),
+        vec![2]
+    );
+}

--- a/tests/hot_index_top_k_test.rs
+++ b/tests/hot_index_top_k_test.rs
@@ -19,6 +19,11 @@
 //! same transaction, duplicate keys in a non-unique index, and hot rows
 //! mixed with sealed ones.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use stoolap::core::{Operator, Result, Row, Schema, Value};
+use stoolap::storage::expression::{ComparisonExpr, Expression};
+use stoolap::storage::traits::Engine;
 use stoolap::Database;
 
 fn ids(db: &Database, sql: &str) -> Vec<i64> {
@@ -255,4 +260,127 @@ fn test_top_k_over_hot_and_sealed_rows_of_one_key() {
     db.execute("INSERT INTO c (t, g, k, v) VALUES (1004, 'a', 'k3', 6)", ())
         .unwrap();
     check_shapes(&db);
+}
+
+#[test]
+fn test_hot_top_k_with_bounds_that_hold_nothing_is_empty() {
+    let db = Database::open("memory://hot_top_k_empty_bounds").unwrap();
+    fill(&db);
+    for where_clause in [
+        "WHERE g = 'a' AND k = 'k3' AND t > 100 AND t < 50",
+        "WHERE g = 'a' AND k = 'k3' AND t > 50 AND t < 50",
+        "WHERE g = 'a' AND k = 'k3' AND t >= 50 AND t < 50",
+        "WHERE g = 'a' AND k = 'k3' AND t > 50 AND t <= 50",
+    ] {
+        for desc in [true, false] {
+            check(&db, where_clause, desc, 3, 0);
+        }
+    }
+    check(
+        &db,
+        "WHERE g = 'a' AND k = 'k3' AND t >= 50 AND t <= 50",
+        true,
+        3,
+        0,
+    );
+}
+
+/// A snapshot sees the versions of its start; the index holds the keys of
+/// the latest commits, so the walk does not answer for it
+#[test]
+fn test_snapshot_orders_by_the_values_it_sees() {
+    let db = Database::open("memory://hot_top_k_snapshot").unwrap();
+    fill(&db);
+    let reader = db.clone();
+    reader
+        .execute("BEGIN TRANSACTION ISOLATION LEVEL SNAPSHOT", ())
+        .unwrap();
+    check(&reader, "WHERE g = 'a' AND k = 'k3'", true, 3, 0);
+    // The newest row of the series moves to the front of time
+    db.execute(
+        "UPDATE c SET t = 0 WHERE g = 'a' AND k = 'k3' AND t = 1000",
+        (),
+    )
+    .unwrap();
+    check(&reader, "WHERE g = 'a' AND k = 'k3'", true, 3, 0);
+    check(
+        &reader,
+        "WHERE g = 'a' AND k = 'k3' AND t > 900",
+        false,
+        3,
+        0,
+    );
+    reader.execute("ROLLBACK", ()).unwrap();
+    check(&db, "WHERE g = 'a' AND k = 'k3'", true, 3, 0);
+}
+
+/// Runs the first checkpoint from inside the WHERE, at the point where a
+/// concurrent seal can run: after the table saw no volumes, before the hot
+/// index is walked
+#[derive(Clone)]
+struct SealInsideWhere {
+    inner: ComparisonExpr,
+    db: Database,
+    fired: Arc<AtomicBool>,
+}
+
+impl std::fmt::Debug for SealInsideWhere {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SealInsideWhere")
+    }
+}
+
+impl Expression for SealInsideWhere {
+    fn evaluate(&self, row: &Row) -> Result<bool> {
+        self.inner.evaluate(row)
+    }
+    fn evaluate_fast(&self, row: &Row) -> bool {
+        self.inner.evaluate_fast(row)
+    }
+    fn with_aliases(&self, _: &rustc_hash::FxHashMap<String, String>) -> Box<dyn Expression> {
+        self.clone_box()
+    }
+    fn prepare_for_schema(&mut self, schema: &Schema) {
+        self.inner.prepare_for_schema(schema);
+    }
+    fn is_prepared(&self) -> bool {
+        self.inner.is_prepared()
+    }
+    fn clone_box(&self) -> Box<dyn Expression> {
+        Box::new(self.clone())
+    }
+    fn get_comparison_info(&self) -> Option<(&str, Operator, &Value)> {
+        if !self.fired.swap(true, Ordering::SeqCst) {
+            self.db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        }
+        self.inner.get_comparison_info()
+    }
+}
+
+#[test]
+fn test_first_seal_during_the_hot_top_k_keeps_the_series() {
+    let dir = tempfile::tempdir().unwrap();
+    let dsn = format!("file://{}/seal", dir.path().display());
+    let db = Database::open(&dsn).unwrap();
+    db.execute(
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, k TEXT NOT NULL, t INTEGER NOT NULL, UNIQUE(k, t))",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO c VALUES (1, 'a', 100), (2, 'a', 50)", ())
+        .unwrap();
+    let mut tx = db.engine().begin_transaction().unwrap();
+    let table = tx.get_table("c").unwrap();
+    let fired = Arc::new(AtomicBool::new(false));
+    let mut expr = SealInsideWhere {
+        inner: ComparisonExpr::new("k", Operator::Eq, Value::text("a")),
+        db: db.clone(),
+        fired: Arc::clone(&fired),
+    };
+    expr.prepare_for_schema(table.schema());
+    let answer = table.scan_top_k(Some(&expr), "t", false, 1, 0).unwrap();
+    assert!(fired.load(Ordering::SeqCst));
+    let got: Option<Vec<i64>> = answer.map(|rows| rows.into_iter().map(|(id, _)| id).collect());
+    assert_eq!(got, Some(vec![1]));
+    tx.rollback().unwrap();
 }

--- a/tests/hot_index_top_k_test.rs
+++ b/tests/hot_index_top_k_test.rs
@@ -1,0 +1,258 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! ORDER BY one column + LIMIT over hot rows, answered by walking the
+//! multi-column index whose leading columns the WHERE pins, matches the
+//! full sort: ASC and DESC, OFFSET, bounds on the order column, a predicate
+//! the index does not cover, deleted and updated rows, rows written by the
+//! same transaction, duplicate keys in a non-unique index, and hot rows
+//! mixed with sealed ones.
+
+use stoolap::Database;
+
+fn ids(db: &Database, sql: &str) -> Vec<i64> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect()
+}
+
+fn pairs(db: &Database, sql: &str) -> Vec<(i64, Option<i64>)> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|r| {
+            let r = r.unwrap();
+            (r.get::<i64>(0).unwrap(), r.get::<i64>(1).ok())
+        })
+        .collect()
+}
+
+/// The reference sorts every row by (t, id). The top-k must return the same
+/// t sequence; when the t values in the answer are distinct the ids must
+/// agree too (ties leave the order among equal keys to the path).
+fn check(db: &Database, where_clause: &str, desc: bool, limit: usize, offset: usize) {
+    let dir = if desc { "DESC" } else { "ASC" };
+    let reference = pairs(
+        db,
+        &format!("SELECT id, t FROM c {where_clause} ORDER BY t {dir}, id {dir}"),
+    );
+    let expected: Vec<(i64, Option<i64>)> =
+        reference.iter().skip(offset).take(limit).copied().collect();
+    let offset_clause = if offset > 0 {
+        format!(" OFFSET {offset}")
+    } else {
+        String::new()
+    };
+    let query =
+        format!("SELECT id, t FROM c {where_clause} ORDER BY t {dir} LIMIT {limit}{offset_clause}");
+    let actual = pairs(db, &query);
+    let expected_t: Vec<Option<i64>> = expected.iter().map(|(_, t)| *t).collect();
+    let actual_t: Vec<Option<i64>> = actual.iter().map(|(_, t)| *t).collect();
+    assert_eq!(actual_t, expected_t, "{query}");
+    let mut distinct = expected_t.clone();
+    distinct.sort_unstable();
+    distinct.dedup();
+    if distinct.len() == expected_t.len() {
+        assert_eq!(actual, expected, "{query}");
+    }
+}
+
+fn check_shapes(db: &Database) {
+    for desc in [true, false] {
+        check(db, "WHERE g = 'a' AND k = 'k3'", desc, 5, 0);
+        check(db, "WHERE k = 'k3' AND g = 'a'", desc, 5, 3);
+        check(db, "WHERE g = 'a' AND k = 'k3' AND t >= 300", desc, 4, 0);
+        check(db, "WHERE g = 'a' AND k = 'k3' AND t > 300", desc, 4, 0);
+        check(db, "WHERE g = 'a' AND k = 'k3' AND t <= 500", desc, 4, 0);
+        check(db, "WHERE g = 'a' AND k = 'k3' AND t < 500", desc, 4, 2);
+        check(
+            db,
+            "WHERE g = 'a' AND k = 'k3' AND t > 200 AND t < 700",
+            desc,
+            3,
+            0,
+        );
+        // A predicate the index does not cover is checked on each row
+        check(db, "WHERE g = 'a' AND k = 'k3' AND v > 50", desc, 6, 0);
+        // Only the first index column pinned: the walk is over k, not t
+        check(db, "WHERE g = 'b'", desc, 7, 0);
+        // Past the end, and an empty group
+        check(db, "WHERE g = 'a' AND k = 'k3'", desc, 1000, 0);
+        check(db, "WHERE g = 'a' AND k = 'k99'", desc, 3, 0);
+    }
+}
+
+fn fill(db: &Database) {
+    db.execute(
+        "CREATE TABLE c (id INTEGER PRIMARY KEY AUTO_INCREMENT, t INTEGER NOT NULL, \
+         g TEXT NOT NULL, k TEXT NOT NULL, v INTEGER, UNIQUE(g, k, t))",
+        (),
+    )
+    .unwrap();
+    let mut stmt = String::from("INSERT INTO c (t, g, k, v) VALUES ");
+    let mut first = true;
+    for s in 0..100i64 {
+        for k in 0..6 {
+            for g in ["a", "b"] {
+                if !first {
+                    stmt.push(',');
+                }
+                first = false;
+                // Out of time order, so the index order is not the insert order
+                let t = (s * 37) % 1000 + 1;
+                stmt.push_str(&format!("({t}, '{g}', 'k{k}', {})", (s * 7 + k) % 100));
+            }
+        }
+    }
+    db.execute(&stmt, ()).unwrap();
+}
+
+#[test]
+fn test_hot_top_k_matches_the_full_sort() {
+    let db = Database::open("memory://hot_top_k_shapes").unwrap();
+    fill(&db);
+    check_shapes(&db);
+
+    // Deleted rows leave the walk; an update that moves a row to another
+    // key leaves the old group and joins the new one
+    db.execute("DELETE FROM c WHERE g = 'a' AND k = 'k3' AND t > 900", ())
+        .unwrap();
+    db.execute(
+        "UPDATE c SET v = v + 1000 WHERE g = 'a' AND k = 'k3' AND t < 100",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "UPDATE c SET k = 'k7' WHERE g = 'a' AND k = 'k3' AND t BETWEEN 100 AND 150",
+        (),
+    )
+    .unwrap();
+    check_shapes(&db);
+}
+
+#[test]
+fn test_hot_top_k_inside_a_transaction_sees_its_own_rows() {
+    let db = Database::open("memory://hot_top_k_txn").unwrap();
+    fill(&db);
+    db.execute("BEGIN", ()).unwrap();
+    db.execute(
+        "INSERT INTO c (t, g, k, v) VALUES (2, 'a', 'k3', 1), (995, 'a', 'k3', 2)",
+        (),
+    )
+    .unwrap();
+    db.execute("DELETE FROM c WHERE g = 'a' AND k = 'k3' AND t = 38", ())
+        .unwrap();
+    check_shapes(&db);
+    db.execute("COMMIT", ()).unwrap();
+    check_shapes(&db);
+}
+
+#[test]
+fn test_hot_top_k_over_a_non_unique_index_keeps_the_key_order() {
+    let db = Database::open("memory://hot_top_k_dups").unwrap();
+    db.execute(
+        "CREATE TABLE c (id INTEGER PRIMARY KEY AUTO_INCREMENT, t INTEGER NOT NULL, \
+         k TEXT NOT NULL, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX c_k_t ON c (k, t)", ()).unwrap();
+    let mut stmt = String::from("INSERT INTO c (t, k, v) VALUES ");
+    for i in 0..600i64 {
+        if i > 0 {
+            stmt.push(',');
+        }
+        stmt.push_str(&format!("({}, 'k{}', {i})", (i * 13) % 50, i % 3));
+    }
+    db.execute(&stmt, ()).unwrap();
+    // Ties on t: the sequence of t values must match the full sort
+    for desc in [true, false] {
+        let dir = if desc { "DESC" } else { "ASC" };
+        let reference: Vec<i64> = ids(
+            &db,
+            &format!("SELECT t FROM c WHERE k = 'k1' ORDER BY t {dir}, id {dir}"),
+        )
+        .into_iter()
+        .skip(4)
+        .take(25)
+        .collect();
+        let actual = ids(
+            &db,
+            &format!("SELECT t FROM c WHERE k = 'k1' ORDER BY t {dir} LIMIT 25 OFFSET 4"),
+        );
+        assert_eq!(actual, reference, "{dir}");
+        let distinct_rows = ids(
+            &db,
+            &format!("SELECT id FROM c WHERE k = 'k1' ORDER BY t {dir} LIMIT 25 OFFSET 4"),
+        );
+        let mut sorted = distinct_rows.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), distinct_rows.len(), "duplicate ids in {dir}");
+    }
+}
+
+#[test]
+fn test_hot_top_k_declines_a_nullable_order_column() {
+    let db = Database::open("memory://hot_top_k_nullable").unwrap();
+    db.execute(
+        "CREATE TABLE c (id INTEGER PRIMARY KEY AUTO_INCREMENT, t INTEGER, g TEXT NOT NULL, \
+         k TEXT NOT NULL, v INTEGER, UNIQUE(g, k, t))",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO c (t, g, k, v) VALUES (5, 'a', 'k3', 1), (NULL, 'a', 'k3', 2), \
+         (1, 'a', 'k3', 3), (9, 'a', 'k3', 4), (NULL, 'a', 'k3', 5)",
+        (),
+    )
+    .unwrap();
+    for desc in [true, false] {
+        check(&db, "WHERE g = 'a' AND k = 'k3'", desc, 3, 0);
+        check(&db, "WHERE g = 'a' AND k = 'k3'", desc, 3, 2);
+    }
+}
+
+#[test]
+fn test_top_k_over_hot_and_sealed_rows_of_one_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let dsn = format!("file://{}/mixed", dir.path().display());
+    let db = Database::open(&dsn).unwrap();
+    fill(&db);
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    // Newer and older hot rows for the same keys, a sealed row deleted, a
+    // sealed row updated (its new version is hot, its sealed copy stale)
+    db.execute(
+        "INSERT INTO c (t, g, k, v) VALUES (1001, 'a', 'k3', 1), (1002, 'a', 'k3', 2), \
+         (0, 'a', 'k3', 3), (1003, 'b', 'k0', 4)",
+        (),
+    )
+    .unwrap();
+    db.execute("DELETE FROM c WHERE g = 'a' AND k = 'k3' AND t = 38", ())
+        .unwrap();
+    db.execute(
+        "UPDATE c SET v = -1 WHERE g = 'a' AND k = 'k3' AND t = 75",
+        (),
+    )
+    .unwrap();
+    check_shapes(&db);
+    check(&db, "WHERE g = 'a' AND k = 'k3' AND v = -1", true, 3, 0);
+
+    drop(db);
+    let db = Database::open(&dsn).unwrap();
+    check_shapes(&db);
+    db.execute("INSERT INTO c (t, g, k, v) VALUES (1004, 'a', 'k3', 6)", ())
+        .unwrap();
+    check_shapes(&db);
+}

--- a/tests/hot_index_top_k_test.rs
+++ b/tests/hot_index_top_k_test.rs
@@ -20,10 +20,15 @@
 //! mixed with sealed ones.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use stoolap::core::{Operator, Result, Row, Schema, Value};
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::Duration;
+use stoolap::common::I64Map;
+use stoolap::core::{
+    DataType, IndexEntry, IndexType, Operator, Result, Row, RowIdVec, Schema, Value,
+};
 use stoolap::storage::expression::{ComparisonExpr, Expression};
-use stoolap::storage::traits::Engine;
+use stoolap::storage::index::MultiColumnIndex;
+use stoolap::storage::traits::{Engine, Index};
 use stoolap::Database;
 
 fn ids(db: &Database, sql: &str) -> Vec<i64> {
@@ -383,4 +388,205 @@ fn test_first_seal_during_the_hot_top_k_keeps_the_series() {
     let got: Option<Vec<i64>> = answer.map(|rows| rows.into_iter().map(|(id, _)| id).collect());
     assert_eq!(got, Some(vec![1]));
     tx.rollback().unwrap();
+}
+
+/// Hands every call to the real index and, once, stops the caller right
+/// after an add returned: the point in a commit where the index holds the
+/// new key and the new version is not visible yet
+struct StopAfterIndexAdd {
+    inner: Arc<dyn Index>,
+    armed: AtomicBool,
+    stopped: mpsc::Sender<()>,
+    resume: Mutex<mpsc::Receiver<()>>,
+}
+
+impl Index for StopAfterIndexAdd {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+    fn table_name(&self) -> &str {
+        self.inner.table_name()
+    }
+    fn build(&mut self) -> Result<()> {
+        Ok(())
+    }
+    fn add(&self, values: &[Value], row_id: i64, ref_id: i64) -> Result<()> {
+        self.inner.add(values, row_id, ref_id)?;
+        if self.armed.swap(false, Ordering::SeqCst) {
+            self.stopped.send(()).unwrap();
+            self.resume
+                .lock()
+                .unwrap()
+                .recv_timeout(Duration::from_secs(10))
+                .unwrap();
+        }
+        Ok(())
+    }
+    fn add_batch(&self, entries: &I64Map<Vec<Value>>) -> Result<()> {
+        self.inner.add_batch(entries)
+    }
+    fn remove(&self, values: &[Value], row_id: i64, ref_id: i64) -> Result<()> {
+        self.inner.remove(values, row_id, ref_id)
+    }
+    fn remove_batch(&self, entries: &I64Map<Vec<Value>>) -> Result<()> {
+        self.inner.remove_batch(entries)
+    }
+    fn column_ids(&self) -> &[i32] {
+        self.inner.column_ids()
+    }
+    fn column_names(&self) -> &[String] {
+        self.inner.column_names()
+    }
+    fn data_types(&self) -> &[DataType] {
+        self.inner.data_types()
+    }
+    fn index_type(&self) -> IndexType {
+        self.inner.index_type()
+    }
+    fn is_unique(&self) -> bool {
+        self.inner.is_unique()
+    }
+    fn find(&self, values: &[Value]) -> Result<Vec<IndexEntry>> {
+        self.inner.find(values)
+    }
+    fn find_range(
+        &self,
+        min: &[Value],
+        max: &[Value],
+        min_inclusive: bool,
+        max_inclusive: bool,
+    ) -> Result<Vec<IndexEntry>> {
+        self.inner
+            .find_range(min, max, min_inclusive, max_inclusive)
+    }
+    fn find_with_operator(&self, op: Operator, values: &[Value]) -> Result<Vec<IndexEntry>> {
+        self.inner.find_with_operator(op, values)
+    }
+    fn get_filtered_row_ids(&self, expr: &dyn Expression) -> RowIdVec {
+        self.inner.get_filtered_row_ids(expr)
+    }
+    fn walk_prefix_ordered(
+        &self,
+        prefix: &[Value],
+        lower: Option<(&Value, bool)>,
+        upper: Option<(&Value, bool)>,
+        ascending: bool,
+        visit: &mut dyn FnMut(i64, &Value) -> bool,
+    ) -> bool {
+        self.inner
+            .walk_prefix_ordered(prefix, lower, upper, ascending, visit)
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self.inner.as_any()
+    }
+    fn close(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// A commit moves the index key of the newest row before its new version
+/// is visible; a reader in that window must answer from the visible values,
+/// so the walk stands down while a commit publishes
+#[test]
+fn test_top_k_during_a_commit_answers_from_the_visible_versions() {
+    let db = Database::open("memory://hot_top_k_commit_window").unwrap();
+    db.execute(
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, k TEXT NOT NULL, t INTEGER NOT NULL, UNIQUE(k, t))",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO c VALUES (1, 'a', 100), (2, 'a', 50)", ())
+        .unwrap();
+    let store = db.engine().get_version_store("c").unwrap();
+    let (index, _) = store.get_multi_column_index(&["k"]).unwrap();
+    let name = index.name().to_string();
+    let (stopped_tx, stopped_rx) = mpsc::channel();
+    let (resume_tx, resume_rx) = mpsc::channel();
+    store.add_index(
+        name,
+        Arc::new(StopAfterIndexAdd {
+            inner: index,
+            armed: AtomicBool::new(true),
+            stopped: stopped_tx,
+            resume: Mutex::new(resume_rx),
+        }),
+    );
+    let writer_db = db.clone();
+    let writer = std::thread::spawn(move || {
+        writer_db
+            .execute("UPDATE c SET t = 0 WHERE id = 1", ())
+            .unwrap();
+    });
+    stopped_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    let full = ids(
+        &db,
+        "SELECT id FROM c WHERE k = 'a' ORDER BY t DESC, id DESC LIMIT 1",
+    );
+    let fast = ids(
+        &db,
+        "SELECT id FROM c WHERE k = 'a' ORDER BY t DESC LIMIT 1",
+    );
+    resume_tx.send(()).unwrap();
+    writer.join().unwrap();
+    assert_eq!(
+        full,
+        vec![1],
+        "the old version stays visible until the commit completes"
+    );
+    assert_eq!(fast, full);
+    assert_eq!(
+        ids(
+            &db,
+            "SELECT id FROM c WHERE k = 'a' ORDER BY t DESC LIMIT 1"
+        ),
+        vec![2]
+    );
+}
+
+/// Two built groups are walked at the same time: a reader of one group
+/// does not wait for a reader of another
+#[test]
+fn test_built_groups_are_walked_concurrently() {
+    let index = Arc::new(MultiColumnIndex::new(
+        "idx".into(),
+        "c".into(),
+        vec!["k".into(), "t".into()],
+        vec![0, 1],
+        vec![DataType::Integer; 2],
+        false,
+        0,
+    ));
+    for k in [1, 2] {
+        index
+            .add(&[Value::Integer(k), Value::Integer(100)], k, k)
+            .unwrap();
+        assert!(index.walk_prefix_ordered(&[Value::Integer(k)], None, None, true, &mut |_, _| true));
+    }
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let first_index = Arc::clone(&index);
+    let first = std::thread::spawn(move || {
+        first_index.walk_prefix_ordered(&[Value::Integer(1)], None, None, true, &mut |_, _| {
+            entered_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+            false
+        });
+    });
+    entered_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    let (second_tx, second_rx) = mpsc::channel();
+    let second_index = Arc::clone(&index);
+    let second = std::thread::spawn(move || {
+        second_index.walk_prefix_ordered(&[Value::Integer(2)], None, None, true, &mut |_, _| {
+            second_tx.send(()).unwrap();
+            false
+        });
+    });
+    let overlapped = second_rx.recv_timeout(Duration::from_secs(2)).is_ok();
+    release_tx.send(()).unwrap();
+    first.join().unwrap();
+    second.join().unwrap();
+    assert!(
+        overlapped,
+        "a built group's walk waited for another group's walk"
+    );
 }


### PR DESCRIPTION
## Summary

The "latest N of one series" query over hot rows read the whole series. With `UNIQUE(exchange, symbol, time)` and `WHERE exchange = .. AND symbol = .. ORDER BY time DESC LIMIT 200`, the hot store took every row id of the pair from the index prefix, fetched and cloned all 12,500 rows, ran the WHERE on each again, and the executor sorted them to keep 200. `COUNT(*)` of the pair cost the same 35 ms, so the sort was never the problem. In production the newest candles are always hot, so this is the shape the application hits most, and it grows with every row that has not been sealed yet.

- `Index::walk_prefix_ordered`: visits the row ids whose key starts with a prefix, in the order of the next key column, within optional bounds on that column, ascending or descending, stopping when the visitor says so. The multi-column index keeps, per prefix group that a walk has asked for, a `BTreeSet<(value of the walked column, row_id)>`: built from the prefix index and the row-to-key map on the first walk (sorted once, bulk-built), kept up to date by single adds and removes, dropped by a batch of 1024 rows or more (a seal) and rebuilt on the next walk. It holds one value per row, not a copy of the key; a first draft with a BTreeMap over every composite key cost 700 MB and 2 s on 2.175M rows and doubled the seal, and is gone.
- `MVCCTable::scan_top_k`: when the WHERE is a conjunction of comparisons whose equalities pin the leading columns of a multi-column index and the ORDER BY column is the next index column, it walks that index, reads each candidate's visible version, checks the whole WHERE on the row (the shared index can be ahead of a transaction's view of a row) and stops at LIMIT + OFFSET. It declines for a transaction with its own writes (they are not in the shared indexes), a nullable or FLOAT order column, a WHERE it cannot read, or an index that cannot walk.
- `SegmentedTable::scan_top_k`: without volumes it hands the question to the hot store instead of answering None, without taking the seal fence (a seal registers its volume before it removes a hot row, so a table seen without volumes still has every row hot; a draft that took the fence made a reader wait out the whole seal, 1.9 s). With volumes it takes the hot store's top-k when there is one; the sealed copy of a hot row is then recognised per candidate through `has_row_id` instead of a skip set built from every matching hot row.
- The multi-column index's batch removal takes its locks per 8192 rows, so a reader waits for one chunk of a seal's removal, not for all of it.

Review fixes (second push):

- Bounds that cross (`t > 100 AND t < 50`) or meet with one side open (`t > 50 AND t < 50`) hold nothing: the walk answers empty before asking the set for a range, which panicked.
- A snapshot transaction is declined: it sees the versions of its start while the index holds the keys of the latest commits, so the key order is not its order. For every other transaction, a candidate whose visible order value differs from its key (changed between the index and the version seen) stops the walk and the full scan answers instead.
- Without volumes, the hot answer is returned only if the seal generation did not move while it was computed; a first seal that registered its volume meanwhile sends the query through the segment-aware path, which reads hot and volumes together.
- A group's order is built under the orders' write lock, from the prefix index and the row map, and every writer updates the orders last, after the prefix indexes: a row is either in the group when it is built or entered into it afterwards, whichever way an add or remove interleaves with the first walk. The test holds a lock the writer needs between its row-map and prefix updates and builds the group in that window.

Review fixes (third push):

- A commit updates the indexes before its versions are visible, and a key it moved can sit anywhere in the walk, past the LIMIT included, so checking only the visited candidates was not enough. The version store now counts commits that are publishing (`begin_publish`, from the index updates to the versions being visible) and the publishes completed; the walk stands down while a commit publishes and falls back to the full scan when one overlapped it. Writers are never blocked. The test stops a real `UPDATE` commit right after its index add, through an `Index` wrapper installed with `add_index`, and expects the top-k to agree with the full sort until the commit completes.
- A built group is walked under the shared lock; only a missing group takes the exclusive lock, and checks again once it holds it. The test holds a walk of one group inside its visitor and expects a walk of another group to proceed.

Review fixes (fourth push):

- The publish guard now belongs to the transaction, not to one table's commit: `TransactionEngineOperations::begin_publish` marks every table the transaction writes as publishing before the first index update, and the hold lives until the transaction is visible in the registry or undone. A reader of the first table in a two-table commit stands down until the whole transaction is visible.
- A commit that fails at the WAL after its index updates were applied takes them back: both index update paths record what they added and removed, and the WAL failure branch undoes it in reverse before the transaction is aborted. This also fixes an older gap on main, where an equality lookup on the changed column could not find the row after such an abort. The test arms the WAL sync failpoint around an UPDATE and expects the index-ordered read, the full sort, and an equality lookup on the old key to agree.

Review fix (fifth push): the walk no longer re-checks a visible version's raw deleted flag. `get_visible_version` already returns a version only when it is visible and its deletion, if any, is not; the flag can belong to an aborted or unfinished DELETE, and the extra check dropped a row an aborted DELETE had marked. The failpoint test covers an aborted DELETE and an aborted INSERT on top of the aborted UPDATE.

`examples/hot_probe.rs` and `examples/candle_bench.rs` (not committed): 2.175M hot rows, 174 series, release build, p50.

| shape (hot, unsealed) | main | this branch |
|---|---|---|
| pair latest DESC LIMIT 200 | 36.0 ms | 0.011 ms |
| pair latest, a different pair every run | 36 ms | 0.043 ms |
| pair + day range DESC LIMIT 500 | 16.6 ms | 0.03 ms |
| pair + time >= day DESC LIMIT 200 | 5.4 ms | 0.01 ms |
| fan-out 174 series on 4 threads | 2123 ms wall, p50 48 ms | 27 ms wall, p50 0.5 ms |
| all pairs last 10 min (BTREE on time) | 0.11 ms | 0.12 ms |
| pair ORDER BY id DESC LIMIT 200 (not an index column) | 35.4 ms | 33.3 ms |
| COUNT(*) WHERE pair | 34.3 ms | 37.1 ms |
| first query after the load (prefix index build) | 308 ms | 403 ms |
| PRAGMA CHECKPOINT of the loaded rows | 3.2 s | 3.0 s |
| reader latency during the seal, max | 21 ms | 23 ms |

Sealed and reopened shapes are unchanged. The two shapes that still read the whole series are outside this change: `ORDER BY id` is not the index's next column, and COUNT reads every row of the pair.

Not in this change: skipping the WHERE re-check when the index covers it. Indexes are updated at commit and are not versioned, so a reader on an older snapshot can meet a key whose visible row no longer matches; the re-check stays. It costs nothing here, since the walk reads N rows instead of the series.

`tests/hot_index_top_k_test.rs` compares the top-k with the full sort over hot rows: ASC and DESC, OFFSET, every bound form on the order column, a predicate the index does not cover, only the first index column pinned, deleted and updated rows, a transaction's own inserts and deletes, a non-unique index with duplicate keys (the t sequence must match, ids only where t is unique), a nullable order column, hot rows mixed with sealed ones before and after a reopen, bounds that hold nothing, a snapshot reading past a concurrent update of the order column, a first seal fired from inside the WHERE of a hot top-k, a real UPDATE commit stopped between its index update and its versions, a two-table transaction stopped in its second table, and a commit aborted by a WAL sync failure (in `tests/failpoint_io_test.rs`). The multi-column index gets a unit test for the build-during-add interleaving.

## Test plan

- [x] `cargo nextest run --test hot_index_top_k_test --test ordered_limited_scan_test`
- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run`
- [x] `cargo nextest run --features test-filedb`
