### PR TITLE
perf(seal): remove sealed index entries by row id

### DIFF
--- a/src/storage/index/bitmap.rs
+++ b/src/storage/index/bitmap.rs
@@ -630,6 +630,29 @@ impl Index for BitmapIndex {
         Ok(())
     }
 
+    fn remove_batch_ids(&self, row_ids: &[i64]) -> Option<Result<()>> {
+        if self.closed.load(AtomicOrdering::Acquire) {
+            return Some(Err(Error::IndexClosed));
+        }
+        let mut bitmaps = self.bitmaps.write();
+        let mut row_to_value = self.row_to_value.write();
+        for &row_id in row_ids {
+            if row_id < 0 {
+                continue;
+            }
+            if let Some(arc_key) = row_to_value.remove(row_id) {
+                if let Some(bitmap) = bitmaps.get_mut(&arc_key) {
+                    bitmap.remove(row_id as u64);
+                    if bitmap.is_empty() {
+                        bitmaps.remove(&arc_key);
+                        self.distinct_count.fetch_sub(1, AtomicOrdering::Relaxed);
+                    }
+                }
+            }
+        }
+        Some(Ok(()))
+    }
+
     fn column_ids(&self) -> &[i32] {
         &self.column_ids
     }

--- a/src/storage/index/btree.rs
+++ b/src/storage/index/btree.rs
@@ -116,6 +116,44 @@ pub struct BTreeIndex {
 }
 
 impl BTreeIndex {
+    /// Removes `row_ids` (sorted) grouped by key: one linear pass per key
+    /// instead of a shift of the key's row list per row
+    fn remove_sorted_ids(&self, row_ids: &[i64]) -> Result<()> {
+        if row_ids.is_empty() {
+            return Ok(());
+        }
+        self.check_closed()?;
+
+        let mut sorted_values = self.sorted_values.write();
+        let mut row_to_value = self.row_to_value.write();
+
+        let mut by_key: BTreeMap<CompactArc<Value>, Vec<i64>> = BTreeMap::new();
+        for &row_id in row_ids {
+            if let Some(arc_value) = row_to_value.remove(row_id) {
+                by_key.entry(arc_value).or_default().push(row_id);
+            }
+        }
+        let mut any_removed = false;
+        for (arc_value, ids) in by_key {
+            if let Some(rows) = sorted_values.get_mut(&arc_value) {
+                let before = rows.len();
+                rows.retain(|id| ids.binary_search(id).is_err());
+                any_removed |= rows.len() != before;
+                if rows.is_empty() {
+                    sorted_values.remove(&arc_value);
+                }
+            }
+        }
+
+        drop(sorted_values);
+        drop(row_to_value);
+
+        if any_removed {
+            self.invalidate_cache();
+        }
+        Ok(())
+    }
+
     /// Creates a new B-tree index
     ///
     /// # Arguments
@@ -654,42 +692,16 @@ impl Index for BTreeIndex {
     ///
     /// Performance: O(1) lock acquisitions instead of O(N)
     fn remove_batch_slice(&self, entries: &[(i64, &[Value])]) -> Result<()> {
-        if entries.is_empty() {
-            return Ok(());
-        }
+        // The values are not needed: the row map knows each row's key
+        let mut row_ids: Vec<i64> = entries.iter().map(|(row_id, _)| *row_id).collect();
+        row_ids.sort_unstable();
+        self.remove_sorted_ids(&row_ids)
+    }
 
-        self.check_closed()?;
-
-        // Acquire write locks ONCE for entire batch
-        let mut sorted_values = self.sorted_values.write();
-        let mut row_to_value = self.row_to_value.write();
-
-        let mut any_removed = false;
-
-        for &(row_id, _values) in entries {
-            // BTreeIndex looks up by row_id, values aren't used
-            if let Some(arc_value) = row_to_value.remove(row_id) {
-                if let Some(rows) = sorted_values.get_mut(&arc_value) {
-                    if let Ok(pos) = rows.binary_search(&row_id) {
-                        rows.remove(pos);
-                        any_removed = true;
-                    }
-                    if rows.is_empty() {
-                        sorted_values.remove(&arc_value);
-                    }
-                }
-            }
-        }
-
-        // Drop locks before invalidating cache
-        drop(sorted_values);
-        drop(row_to_value);
-
-        if any_removed {
-            self.invalidate_cache();
-        }
-
-        Ok(())
+    fn remove_batch_ids(&self, row_ids: &[i64]) -> Option<Result<()>> {
+        let mut sorted: Vec<i64> = row_ids.to_vec();
+        sorted.sort_unstable();
+        Some(self.remove_sorted_ids(&sorted))
     }
 
     fn column_ids(&self) -> &[i32] {

--- a/src/storage/index/btree.rs
+++ b/src/storage/index/btree.rs
@@ -116,8 +116,8 @@ pub struct BTreeIndex {
 }
 
 impl BTreeIndex {
-    /// Removes `row_ids` (sorted) grouped by key: one linear pass per key
-    /// instead of a shift of the key's row list per row
+    /// Removes `row_ids` (sorted) grouped by key: one pass per key from its
+    /// first removed id instead of a shift of the key's row list per row
     fn remove_sorted_ids(&self, row_ids: &[i64]) -> Result<()> {
         if row_ids.is_empty() {
             return Ok(());
@@ -137,7 +137,7 @@ impl BTreeIndex {
         for (arc_value, ids) in by_key {
             if let Some(rows) = sorted_values.get_mut(&arc_value) {
                 let before = rows.len();
-                rows.retain(|id| ids.binary_search(id).is_err());
+                super::subtract_sorted(rows, &ids);
                 any_removed |= rows.len() != before;
                 if rows.is_empty() {
                     sorted_values.remove(&arc_value);

--- a/src/storage/index/hash.rs
+++ b/src/storage/index/hash.rs
@@ -558,6 +558,35 @@ impl Index for HashIndex {
         Ok(())
     }
 
+    fn remove_batch_ids(&self, row_ids: &[i64]) -> Option<Result<()>> {
+        if self.closed.load(AtomicOrdering::Acquire) {
+            return Some(Err(Error::IndexClosed));
+        }
+        let mut row_to_hash = self.row_to_hash.write();
+        let mut hash_to_values = self.hash_to_values.write();
+        // Group the rows by hash, then subtract each group from its bucket
+        // in one pass per value
+        let mut by_hash: FxHashMap<u64, Vec<i64>> = FxHashMap::default();
+        for &row_id in row_ids {
+            if let Some(hash) = row_to_hash.remove(row_id) {
+                by_hash.entry(hash).or_default().push(row_id);
+            }
+        }
+        for (hash, mut ids) in by_hash {
+            ids.sort_unstable();
+            if let Some(val_entries) = hash_to_values.get_mut(&hash) {
+                for (_, bucket) in val_entries.iter_mut() {
+                    bucket.retain(|id| ids.binary_search(id).is_err());
+                }
+                val_entries.retain(|(_, bucket)| !bucket.is_empty());
+                if val_entries.is_empty() {
+                    hash_to_values.remove(&hash);
+                }
+            }
+        }
+        Some(Ok(()))
+    }
+
     fn column_ids(&self) -> &[i32] {
         &self.column_ids
     }

--- a/src/storage/index/hash.rs
+++ b/src/storage/index/hash.rs
@@ -576,7 +576,7 @@ impl Index for HashIndex {
             ids.sort_unstable();
             if let Some(val_entries) = hash_to_values.get_mut(&hash) {
                 for (_, bucket) in val_entries.iter_mut() {
-                    bucket.retain(|id| ids.binary_search(id).is_err());
+                    super::subtract_sorted(bucket, &ids);
                 }
                 val_entries.retain(|(_, bucket)| !bucket.is_empty());
                 if val_entries.is_empty() {

--- a/src/storage/index/mod.rs
+++ b/src/storage/index/mod.rs
@@ -30,6 +30,25 @@ pub mod hnsw;
 pub mod multi_column;
 pub mod pk;
 
+/// Removes the sorted `ids` from the sorted `rows`, touching only the rows
+/// from the first removed id onwards: taking the newest rows off a large
+/// group stays cheap, taking the whole group is one pass.
+pub(crate) fn subtract_sorted(rows: &mut crate::common::CompactVec<i64>, ids: &[i64]) {
+    let Some(&first) = ids.first() else {
+        return;
+    };
+    let start = rows.binary_search(&first).unwrap_or_else(|pos| pos);
+    let slice = rows.as_mut_slice();
+    let mut keep = start;
+    for read in start..slice.len() {
+        if ids.binary_search(&slice[read]).is_err() {
+            slice[keep] = slice[read];
+            keep += 1;
+        }
+    }
+    rows.truncate(keep);
+}
+
 // Re-export main types
 pub use bitmap::BitmapIndex;
 pub use btree::{

--- a/src/storage/index/multi_column.rs
+++ b/src/storage/index/multi_column.rs
@@ -356,25 +356,6 @@ impl MultiColumnIndex {
         grouped
     }
 
-    /// Remove the sorted `ids` from the sorted `rows`, touching only the rows
-    /// from the first removed id onwards: taking the newest rows off a large
-    /// group stays cheap, taking the whole group is one pass.
-    fn subtract_sorted(rows: &mut CompactVec<i64>, ids: &[i64]) {
-        let Some(&first) = ids.first() else {
-            return;
-        };
-        let start = rows.binary_search(&first).unwrap_or_else(|pos| pos);
-        let slice = rows.as_mut_slice();
-        let mut keep = start;
-        for read in start..slice.len() {
-            if ids.binary_search(&slice[read]).is_err() {
-                slice[keep] = slice[read];
-                keep += 1;
-            }
-        }
-        rows.truncate(keep);
-    }
-
     /// Check uniqueness constraint (must be called while holding write lock on value_to_rows)
     fn check_unique_constraint_locked(
         &self,
@@ -860,7 +841,7 @@ impl Index for MultiColumnIndex {
 
             for (key, ids) in removed {
                 if let Some(rows) = value_to_rows.get_mut(&key) {
-                    Self::subtract_sorted(rows, &ids);
+                    super::subtract_sorted(rows, &ids);
                     if rows.is_empty() {
                         value_to_rows.remove(&key);
                     }
@@ -878,7 +859,7 @@ impl Index for MultiColumnIndex {
             let mut sorted_values = self.sorted_values.write();
             for (key, ids) in removed {
                 if let Some(rows) = sorted_values.get_mut(&key) {
-                    Self::subtract_sorted(rows, &ids);
+                    super::subtract_sorted(rows, &ids);
                     if rows.is_empty() {
                         sorted_values.remove(&key);
                     }
@@ -893,7 +874,7 @@ impl Index for MultiColumnIndex {
                 let mut prefix_index = self.prefix_indexes[idx].write();
                 for (key, ids) in removed {
                     if let Some(rows) = prefix_index.get_mut(&key) {
-                        Self::subtract_sorted(rows, &ids);
+                        super::subtract_sorted(rows, &ids);
                         if rows.is_empty() {
                             prefix_index.remove(&key);
                         }

--- a/src/storage/index/multi_column.rs
+++ b/src/storage/index/multi_column.rs
@@ -853,21 +853,20 @@ impl Index for MultiColumnIndex {
         // The locks are taken per chunk so a reader waits for one chunk of
         // a seal's removal, not for all of it
         for chunk in entries.chunks(Self::REMOVE_CHUNK_ROWS) {
+            // Grouped by key: one subtraction per key instead of a shift per row
+            let removed = Self::group_removed_by_key(chunk, self.column_ids.len());
             let mut value_to_rows = self.value_to_rows.write();
             let mut row_to_key = self.row_to_key.write();
 
-            for &(row_id, values) in chunk {
-                let key = CompositeKey(values.to_vec());
-
+            for (key, ids) in removed {
                 if let Some(rows) = value_to_rows.get_mut(&key) {
-                    if let Ok(pos) = rows.binary_search(&row_id) {
-                        rows.remove(pos);
-                    }
+                    Self::subtract_sorted(rows, &ids);
                     if rows.is_empty() {
                         value_to_rows.remove(&key);
                     }
                 }
-
+            }
+            for &(row_id, _) in chunk {
                 row_to_key.remove(row_id);
             }
         }
@@ -914,6 +913,29 @@ impl Index for MultiColumnIndex {
         }
 
         Ok(())
+    }
+
+    fn remove_batch_ids(&self, row_ids: &[i64]) -> Option<Result<()>> {
+        // The keys come from the row map; the batch path then removes them
+        let owned: Vec<(i64, Vec<Value>)> = {
+            let row_to_key = self.row_to_key.read();
+            row_ids
+                .iter()
+                .filter_map(|&row_id| {
+                    row_to_key
+                        .get(row_id)
+                        .map(|key| (row_id, key.iter().map(|v| (**v).clone()).collect()))
+                })
+                .collect()
+        };
+        if owned.is_empty() {
+            return Some(Ok(()));
+        }
+        let borrowed: Vec<(i64, &[Value])> = owned
+            .iter()
+            .map(|(row_id, values)| (*row_id, values.as_slice()))
+            .collect();
+        Some(self.remove_batch_slice(&borrowed))
     }
 
     fn column_ids(&self) -> &[i32] {

--- a/src/storage/index/pk.rs
+++ b/src/storage/index/pk.rs
@@ -397,6 +397,14 @@ impl Index for PkIndex {
         Ok(())
     }
 
+    fn remove_batch_ids(&self, row_ids: &[i64]) -> Option<Result<()>> {
+        let mut inner = self.data.write();
+        for &row_id in row_ids {
+            inner.remove(row_id);
+        }
+        Some(Ok(()))
+    }
+
     fn column_ids(&self) -> &[i32] {
         std::slice::from_ref(&self.column_id)
     }

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -5915,7 +5915,7 @@ impl MVCCEngine {
                         mgr.clear_seal_overlap();
 
                         for cleanup in index_cleanups {
-                            store.remove_sealed_index_entries(cleanup);
+                            store.remove_sealed_index_entries(cleanup, &all_rows);
                         }
 
                         // Clear tombstones for sealed row_ids INSIDE the fence.

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -458,9 +458,6 @@ pub struct ExtractionSnapshot {
 pub struct SealedIndexCleanup {
     /// Row IDs that were removed from the version store.
     pub removed_ids: Vec<i64>,
-    /// CowBTree snapshot taken BEFORE version removal. Contains the row data
-    /// needed to compute index values for removal.
-    snapshot: Option<crate::common::CowBTree<VersionChainEntry>>,
 }
 
 /// Held for a table from the first index update of a commit until the
@@ -5490,10 +5487,6 @@ impl VersionStore {
             return (0, SealedIndexCleanup::default(), Vec::new());
         }
 
-        // Snapshot version data BEFORE removal for later index cleanup.
-        // O(1) Arc clone of CowBTree.
-        let snapshot = self.versions.read().clone();
-
         // Remove rows in small sub-batches to reduce write lock hold time.
         // Each sub-batch acquires versions.write() briefly, then releases it,
         // giving concurrent commits a chance to proceed between sub-batches.
@@ -5543,27 +5536,18 @@ impl VersionStore {
         }
 
         let count = removed_ids.len();
-        (
-            count,
-            SealedIndexCleanup {
-                removed_ids,
-                snapshot: Some(snapshot),
-            },
-            skipped_ids,
-        )
+        (count, SealedIndexCleanup { removed_ids }, skipped_ids)
     }
 
     /// Remove stale hot index entries for sealed rows (phase 2 of seal).
     /// Called while the table's seal fence is still held so INSERT cannot race
     /// between cold constraint checks and hot-index cleanup.
-    pub fn remove_sealed_index_entries(&self, cleanup: SealedIndexCleanup) {
+    /// Indexes that keep a row-to-key map remove by row id; the others get
+    /// their values from `rows`, the sealed rows.
+    pub fn remove_sealed_index_entries(&self, cleanup: SealedIndexCleanup, rows: &RowVec) {
         if cleanup.removed_ids.is_empty() {
             return;
         }
-
-        let Some(ref snap) = cleanup.snapshot else {
-            return;
-        };
 
         let indexes = self.indexes.read();
         let hot_only_indexes: Vec<_> = indexes
@@ -5577,31 +5561,39 @@ impl VersionStore {
             return;
         }
 
+        let mut by_id: Option<I64Map<usize>> = None;
         for index in &hot_only_indexes {
-            let col_ids = index.column_ids();
-            let mut owned_entries: Vec<(i64, Vec<crate::core::Value>)> =
-                Vec::with_capacity(cleanup.removed_ids.len());
-
-            for &row_id in &cleanup.removed_ids {
-                let Some(entry) = snap.get(row_id) else {
-                    continue;
-                };
-                let row = &entry.version.data;
-                let values: Vec<crate::core::Value> = col_ids
-                    .iter()
-                    .map(|&col_id| {
-                        row.get(col_id as usize)
-                            .cloned()
-                            .unwrap_or(crate::core::Value::Null(crate::core::DataType::Null))
-                    })
-                    .collect();
-                owned_entries.push((row_id, values));
+            if index.remove_batch_ids(&cleanup.removed_ids).is_some() {
+                continue;
             }
-
+            let positions = by_id.get_or_insert_with(|| {
+                let mut map = I64Map::with_capacity(rows.len());
+                for (pos, (row_id, _)) in rows.iter().enumerate() {
+                    map.insert(*row_id, pos);
+                }
+                map
+            });
+            let col_ids = index.column_ids();
+            let owned_entries: Vec<(i64, Vec<crate::core::Value>)> = cleanup
+                .removed_ids
+                .iter()
+                .filter_map(|&row_id| {
+                    let pos = *positions.get(row_id)?;
+                    let row = &rows[pos].1;
+                    let values: Vec<crate::core::Value> = col_ids
+                        .iter()
+                        .map(|&col_id| {
+                            row.get(col_id as usize)
+                                .cloned()
+                                .unwrap_or(crate::core::Value::Null(crate::core::DataType::Null))
+                        })
+                        .collect();
+                    Some((row_id, values))
+                })
+                .collect();
             if owned_entries.is_empty() {
                 continue;
             }
-
             let borrowed_entries: Vec<(i64, &[crate::core::Value])> = owned_entries
                 .iter()
                 .map(|(row_id, values)| (*row_id, values.as_slice()))

--- a/src/storage/traits/index_trait.rs
+++ b/src/storage/traits/index_trait.rs
@@ -165,6 +165,13 @@ pub trait Index: Send + Sync {
     /// Vector of matching index entries
     fn find_with_operator(&self, op: Operator, values: &[Value]) -> Result<Vec<IndexEntry>>;
 
+    /// Removes the entries of `row_ids` using the index's own row-to-key map,
+    /// so the caller needs no row values. None when the index cannot.
+    fn remove_batch_ids(&self, row_ids: &[i64]) -> Option<Result<()>> {
+        let _ = row_ids;
+        None
+    }
+
     /// Visits the row ids whose key starts with `prefix`, in the order of the
     /// key column right after the prefix, within `lower` and `upper` (value,
     /// inclusive) on that column, ascending or descending. `visit` gets the


### PR DESCRIPTION
The seal's hot removal did three things per sealed row that scale badly at volume size:

- it cloned the whole version tree (an O(1) CowBTree clone, but every later index cleanup then re-read the row data through it and rebuilt a `Vec<Value>` per row per index);
- `BTreeIndex` and `MultiColumnIndex` removed each row from its key's row list with a shift, so a key with many rows paid a quadratic removal (a `k` column with a few hundred distinct values over a million-row seal);
- the hash and bitmap indexes went through the same value-based path even though they already know each row's key.

This PR removes sealed index entries by row id. `Index` gets `remove_batch_ids`, which every built-in index implements from its own row-to-key map: BTREE, hash and the multi-column index group the ids by key and subtract each group from the key's row list in one linear pass; bitmap and PK remove directly. The default returns `None`, and `remove_sealed_index_entries` then falls back to the values from the sealed rows themselves (the same `RowVec` that built the volume), so an index type without the fast path still works. `remove_sealed_rows` no longer takes a snapshot of the version tree for the cleanup and `SealedIndexCleanup` is just the removed ids.

Nothing changes in what the seal keeps or skips: claimed rows and rows whose head changed since extraction still stay hot and are tombstoned as before.

Measured with a probe (2M rows per round, 200 distinct `k` values, UNIQUE(k, t) plus BTREE on `k` and on `t`, PRAGMA CHECKPOINT per round, release build):

| round | seal main | seal this PR |
|---|---|---|
| 1 | 4045 ms | 2524 ms |
| 2 | 4098 ms | 2489 ms |
| 3 | 4125 ms | 2561 ms |

Verification: clippy with `-D warnings`, the seal-related suites (`sealed_index_visibility_test`, `volume_checkpoint_test`, `snapshot_cold_test`, `volume_concurrency_test`, `arena_slot_reuse_test`, `hot_index_top_k_test`, `ordered_limited_scan_test`, `failpoint_io_test`), the in-memory suite and the filedb suite.
