### PR TITLE
feat(storage): hot size limits, exact hot byte counters, PRAGMA MEMORY_STATS

### DIFF
--- a/src/api/database.rs
+++ b/src/api/database.rs
@@ -546,6 +546,22 @@ impl Database {
                         })?;
                         config.persistence.target_volume_rows = rows.max(65_536);
                     }
+                    // Early seal trigger per table: hot_max_rows=262144 (0 = off)
+                    "hot_max_rows" => {
+                        config.persistence.hot_max_rows = value.parse::<usize>().map_err(|_| {
+                            Error::invalid_argument(format!("invalid hot_max_rows: '{}'", value))
+                        })?;
+                    }
+                    // Commit wait above this many hot bytes per table: hot_max_bytes=0 (off)
+                    "hot_max_bytes" => {
+                        config.persistence.hot_max_bytes =
+                            value.parse::<usize>().map_err(|_| {
+                                Error::invalid_argument(format!(
+                                    "invalid hot_max_bytes: '{}'",
+                                    value
+                                ))
+                            })?;
+                    }
                     // Checkpoint on close: checkpoint_on_close=off
                     // Set to off to simulate crashes in tests (WAL not truncated)
                     "checkpoint_on_close" => {

--- a/src/common/smart_string.rs
+++ b/src/common/smart_string.rs
@@ -242,6 +242,18 @@ impl SmartString {
         }
     }
 
+    /// Bytes a heap string owns beyond the SmartString itself: the String's
+    /// capacity, which `from_string` keeps as it came. Zero when inline.
+    #[inline]
+    pub fn heap_capacity(&self) -> usize {
+        if self.tag.is_heap() {
+            // SAFETY: heap strings hold a valid Arc<String> pointer
+            unsafe { (*self.get_arc_ptr()).capacity() }
+        } else {
+            0
+        }
+    }
+
     /// Returns the length of the string in bytes.
     #[inline(always)]
     pub fn len(&self) -> usize {

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -9783,6 +9783,77 @@ impl Executor {
                     Ok(Box::new(ExecutorResult::new(columns, rows)))
                 }
             }
+            "HOT_MAX_ROWS" | "HOT_MAX_BYTES" => {
+                let config = self.engine.config();
+                let columns: Vec<String> = vec![pragma_name.to_lowercase().into()];
+                let is_rows = pragma_name == "HOT_MAX_ROWS";
+
+                if let Some(ref value) = stmt.value {
+                    let new_value = self.extract_pragma_int_value(value)?;
+                    if new_value < 0 {
+                        return Err(Error::internal(format!(
+                            "{} must be non-negative",
+                            pragma_name.to_lowercase()
+                        )));
+                    }
+                    let mut new_config = config.clone();
+                    if is_rows {
+                        new_config.persistence.hot_max_rows = new_value as usize;
+                    } else {
+                        new_config.persistence.hot_max_bytes = new_value as usize;
+                    }
+                    self.engine.update_engine_config(new_config)?;
+                    let mut rows = RowVec::with_capacity(1);
+                    rows.push((0, Row::from_values(vec![Value::Integer(new_value)])));
+                    Ok(Box::new(ExecutorResult::new(columns, rows)))
+                } else {
+                    let current = if is_rows {
+                        config.persistence.hot_max_rows
+                    } else {
+                        config.persistence.hot_max_bytes
+                    };
+                    let mut rows = RowVec::with_capacity(1);
+                    rows.push((0, Row::from_values(vec![Value::Integer(current as i64)])));
+                    Ok(Box::new(ExecutorResult::new(columns, rows)))
+                }
+            }
+            "MEMORY_STATS" => {
+                if stmt.value.is_some() {
+                    return Err(Error::internal(
+                        "PRAGMA MEMORY_STATS does not accept values",
+                    ));
+                }
+
+                let columns = vec![
+                    "table_name".to_string(),
+                    "hot_rows".to_string(),
+                    "hot_bytes".to_string(),
+                    "arena_slots".to_string(),
+                    "arena_capacity_bytes".to_string(),
+                    "chain_entries".to_string(),
+                    "volume_bytes".to_string(),
+                    "admission_waits".to_string(),
+                ];
+
+                let stats = self.engine.memory_stats();
+                let mut rows = RowVec::with_capacity(stats.len());
+                for (i, stat) in stats.into_iter().enumerate() {
+                    rows.push((
+                        i as i64,
+                        Row::from_values(vec![
+                            Value::text(&stat.table_name),
+                            Value::Integer(stat.hot_rows as i64),
+                            Value::Integer(stat.hot_bytes as i64),
+                            Value::Integer(stat.arena_slots as i64),
+                            Value::Integer(stat.arena_capacity_bytes as i64),
+                            Value::Integer(stat.chain_entries as i64),
+                            Value::Integer(stat.volume_bytes as i64),
+                            Value::Integer(stat.admission_waits as i64),
+                        ]),
+                    ));
+                }
+                Ok(Box::new(ExecutorResult::new(columns, rows)))
+            }
             "SYNC_MODE" => {
                 let config = self.engine.config();
                 let columns: Vec<String> = vec![pragma_name.to_lowercase().into()];

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -108,6 +108,16 @@ pub struct PersistenceConfig {
     /// reduce per-volume metadata overhead.
     /// Default: 1,048,576 (1M rows = ~16 row groups of 64K each)
     pub target_volume_rows: usize,
+
+    /// Committed hot rows of one table that ask for a seal right away
+    /// instead of at the next checkpoint interval. 0 disables the trigger.
+    /// Default: 262,144 (four row groups)
+    pub hot_max_rows: usize,
+
+    /// Hot row bytes of one table above which commits wait for a seal to
+    /// bring the table back under the limit. 0 disables the wait.
+    /// Default: 0
+    pub hot_max_bytes: usize,
 }
 
 impl Default for PersistenceConfig {
@@ -128,6 +138,8 @@ impl Default for PersistenceConfig {
             keep_snapshots: 3,              // Keep 3 backup snapshots per table
             checkpoint_on_close: true,      // Seal all data on clean shutdown
             target_volume_rows: 1_048_576,  // 1M rows per volume (~16 row groups)
+            hot_max_rows: 262_144,          // Seal a table early at four row groups
+            hot_max_bytes: 0,               // No admission wait
         }
     }
 }
@@ -156,6 +168,8 @@ impl PersistenceConfig {
             keep_snapshots: 3,
             checkpoint_on_close: true,
             target_volume_rows: 1_048_576,
+            hot_max_rows: 262_144,
+            hot_max_bytes: 0,
         }
     }
 
@@ -177,6 +191,8 @@ impl PersistenceConfig {
             keep_snapshots: 3,
             checkpoint_on_close: true,
             target_volume_rows: 2_097_152, // 2M rows for fast mode
+            hot_max_rows: 262_144,
+            hot_max_bytes: 0,
         }
     }
 

--- a/src/storage/mvcc/arena.rs
+++ b/src/storage/mvcc/arena.rs
@@ -28,9 +28,24 @@
 //! - Guarantee atomic insert operations
 
 use parking_lot::{Mutex, RwLock};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::common::CompactArc;
 use crate::core::{Row, Value};
+
+/// Bytes a row holds: the values in place plus what text and extension
+/// values keep on the heap
+pub fn row_bytes(values: &[Value]) -> usize {
+    let mut bytes = 16 + std::mem::size_of_val(values);
+    for value in values {
+        match value {
+            Value::Text(s) if s.is_heap() => bytes += 40 + s.len(),
+            Value::Extension(bytes_ref) => bytes += 16 + bytes_ref.len(),
+            _ => {}
+        }
+    }
+    bytes
+}
 
 /// Metadata for a row stored in the arena
 ///
@@ -79,6 +94,8 @@ pub struct RowArena {
     /// Free list of cleared slot indices for reuse (separate lock, write-path only)
     /// This prevents unbounded arena growth during insert/delete cycles
     free_list: Mutex<Vec<usize>>,
+    /// Bytes of the rows in live slots, kept exact by every mutation
+    bytes: AtomicUsize,
 }
 
 impl RowArena {
@@ -98,6 +115,7 @@ impl RowArena {
                 meta: Vec::new(),
             }),
             free_list: Mutex::new(Vec::new()),
+            bytes: AtomicUsize::new(0),
         }
     }
 
@@ -109,6 +127,7 @@ impl RowArena {
                 meta: Vec::with_capacity(row_capacity),
             }),
             free_list: Mutex::new(Vec::new()),
+            bytes: AtomicUsize::new(0),
         }
     }
 
@@ -125,6 +144,7 @@ impl RowArena {
 
         // Convert values to CompactArc<[Value]>
         let arc_data: CompactArc<[Value]> = CompactArc::from(values.to_vec());
+        self.bytes.fetch_add(row_bytes(values), Ordering::Relaxed);
 
         let meta = ArenaRowMeta {
             row_id,
@@ -166,6 +186,8 @@ impl RowArena {
                 CompactArc::from(values)
             }
         };
+        self.bytes
+            .fetch_add(row_bytes(&arc_data), Ordering::Relaxed);
 
         let meta = ArenaRowMeta {
             row_id,
@@ -211,6 +233,8 @@ impl RowArena {
                 CompactArc::from(values)
             }
         };
+        self.bytes
+            .fetch_add(row_bytes(&arc_data), Ordering::Relaxed);
 
         let meta = ArenaRowMeta {
             row_id,
@@ -241,6 +265,8 @@ impl RowArena {
         let reuse_idx = self.free_list.lock().pop();
 
         let mut inner = self.inner.write();
+        self.bytes
+            .fetch_add(row_bytes(&arc_data), Ordering::Relaxed);
 
         let meta = ArenaRowMeta {
             row_id,
@@ -280,6 +306,8 @@ impl RowArena {
         let cleared = {
             let mut inner = self.inner.write();
             if arena_idx < inner.meta.len() {
+                self.bytes
+                    .fetch_sub(row_bytes(&inner.data[arena_idx]), Ordering::Relaxed);
                 // Replace data with empty Arc to release memory
                 inner.data[arena_idx] = CompactArc::from(Vec::<Value>::new());
                 // Mark metadata as cleared (txn_id = 0 is the cleared sentinel;
@@ -319,13 +347,16 @@ impl RowArena {
                 deleted_at_txn_id: 0,
             };
 
+            let mut freed = 0usize;
             for &arena_idx in arena_indices {
                 if arena_idx < inner.meta.len() {
+                    freed += row_bytes(&inner.data[arena_idx]);
                     inner.data[arena_idx] = CompactArc::clone(&empty_data);
                     inner.meta[arena_idx] = cleared_meta;
                     cleared_indices.push(arena_idx);
                 }
             }
+            self.bytes.fetch_sub(freed, Ordering::Relaxed);
         }
 
         // Add to free list for reuse (separate lock, after releasing inner lock)
@@ -353,6 +384,10 @@ impl RowArena {
     ) -> bool {
         let mut inner = self.inner.write();
         if arena_idx < inner.meta.len() {
+            let old = row_bytes(&inner.data[arena_idx]);
+            self.bytes
+                .fetch_add(row_bytes(&arc_data), Ordering::Relaxed);
+            self.bytes.fetch_sub(old, Ordering::Relaxed);
             inner.data[arena_idx] = arc_data;
             inner.meta[arena_idx] = ArenaRowMeta {
                 row_id,
@@ -373,12 +408,26 @@ impl RowArena {
         inner.data = Vec::new();
         inner.meta = Vec::new();
         self.free_list.lock().clear();
+        self.bytes.store(0, Ordering::Relaxed);
     }
 
     /// Get the number of rows (including deleted)
     #[inline]
     pub fn len(&self) -> usize {
         self.inner.read().meta.len()
+    }
+
+    /// Bytes of the rows in live slots
+    #[inline]
+    pub fn bytes(&self) -> usize {
+        self.bytes.load(Ordering::Relaxed)
+    }
+
+    /// Bytes the slot vectors reserve, used or not
+    pub fn capacity_bytes(&self) -> usize {
+        let inner = self.inner.read();
+        inner.data.capacity() * std::mem::size_of::<CompactArc<[Value]>>()
+            + inner.meta.capacity() * std::mem::size_of::<ArenaRowMeta>()
     }
 
     /// Check if the arena is empty
@@ -466,6 +515,33 @@ impl<'a> ArenaReadGuard<'a> {
 mod tests {
     use super::*;
     use crate::core::Value;
+
+    #[test]
+    fn bytes_follow_inserts_updates_and_clears() {
+        let arena = RowArena::new();
+        assert_eq!(arena.bytes(), 0);
+        let short = vec![Value::Integer(1), Value::text("inline")];
+        let long = vec![
+            Value::Integer(1),
+            Value::text("a text value that lives on the heap"),
+        ];
+        let idx = arena.insert(1, 1, &short);
+        assert_eq!(arena.bytes(), row_bytes(&short));
+        assert!(row_bytes(&long) > row_bytes(&short));
+        arena.update_at(idx, 1, 2, CompactArc::from(long.clone()));
+        assert_eq!(arena.bytes(), row_bytes(&long));
+        let other = arena.insert(2, 2, &short);
+        assert_eq!(arena.bytes(), row_bytes(&long) + row_bytes(&short));
+        arena.clear_batch(&[idx]);
+        assert_eq!(arena.bytes(), row_bytes(&short));
+        assert!(arena.clear_at(other));
+        assert_eq!(arena.bytes(), 0);
+        let reused = arena.insert(3, 3, &long);
+        assert_eq!(arena.bytes(), row_bytes(&long));
+        arena.clear_all();
+        assert_eq!(arena.bytes(), 0);
+        assert!(reused < 2);
+    }
 
     #[test]
     fn test_arena_insert_and_iterate() {

--- a/src/storage/mvcc/arena.rs
+++ b/src/storage/mvcc/arena.rs
@@ -39,7 +39,7 @@ pub fn row_bytes(values: &[Value]) -> usize {
     let mut bytes = 16 + std::mem::size_of_val(values);
     for value in values {
         match value {
-            Value::Text(s) if s.is_heap() => bytes += 40 + s.len(),
+            Value::Text(s) if s.is_heap() => bytes += 40 + s.heap_capacity(),
             Value::Extension(bytes_ref) => bytes += 16 + bytes_ref.len(),
             _ => {}
         }
@@ -525,6 +525,16 @@ mod tests {
             Value::Integer(1),
             Value::text("a text value that lives on the heap"),
         ];
+        let mut spacious = String::with_capacity(4096);
+        spacious.push_str("a text value that lives on the heap");
+        let spacious = vec![
+            Value::Integer(1),
+            Value::Text(crate::common::SmartString::from_string(spacious)),
+        ];
+        assert!(
+            row_bytes(&spacious) >= row_bytes(&long) + 4096 - 64,
+            "a String's spare capacity is memory the row owns"
+        );
         let idx = arena.insert(1, 1, &short);
         assert_eq!(arena.bytes(), row_bytes(&short));
         assert!(row_bytes(&long) > row_bytes(&short));

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -21,8 +21,8 @@ use crate::common::{CompactArc, I64Map, SmartString, StringMap};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use std::borrow::Cow;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, Mutex, RwLock};
 
 use std::path::Path;
 
@@ -405,6 +405,44 @@ impl ViewDefinition {
 /// Arc-wrapped so lookups are a ref-count bump (no Vec clone on every FK check).
 type FkReverseCache = (u64, StringMap<Arc<Vec<(String, ForeignKeyConstraint)>>>);
 
+/// `hot_max_rows` / `hot_max_bytes` mirrored from the config so the commit
+/// path reads them without the config lock, the seal request a commit
+/// raises when a table passes them, and the wait of commits over the byte
+/// limit until a seal cycle brings the table back under
+struct HotLimits {
+    max_rows: AtomicUsize,
+    max_bytes: AtomicUsize,
+    seal_requested: AtomicBool,
+    admission: (Mutex<()>, Condvar),
+    admission_waits: AtomicU64,
+}
+
+impl HotLimits {
+    fn new(config: &crate::storage::config::PersistenceConfig) -> Self {
+        Self {
+            max_rows: AtomicUsize::new(config.hot_max_rows),
+            max_bytes: AtomicUsize::new(config.hot_max_bytes),
+            seal_requested: AtomicBool::new(false),
+            admission: (Mutex::new(()), Condvar::new()),
+            admission_waits: AtomicU64::new(0),
+        }
+    }
+}
+
+/// One PRAGMA MEMORY_STATS row: a table's hot and cold footprint, or the
+/// process totals when `table_name` is `*`
+#[derive(Debug, Default, Clone)]
+pub struct MemoryStat {
+    pub table_name: String,
+    pub hot_rows: usize,
+    pub hot_bytes: usize,
+    pub arena_slots: usize,
+    pub arena_capacity_bytes: usize,
+    pub chain_entries: usize,
+    pub volume_bytes: usize,
+    pub admission_waits: u64,
+}
+
 /// MVCC Storage Engine
 ///
 /// Provides multi-version concurrency control with snapshot isolation.
@@ -456,6 +494,8 @@ pub struct MVCCEngine {
     /// When true, seal_hot_buffers bypasses thresholds and seals all rows.
     /// Set during close_engine to ensure all data is in volumes before shutdown.
     force_seal_all: AtomicBool,
+    /// Hot size limits and the seal request they raise, shared with commits
+    hot_limits: Arc<HotLimits>,
     /// Prevents concurrent checkpoint cycles (background thread vs PRAGMA SNAPSHOT).
     /// Without this, two concurrent seal+compact runs can each read the same old
     /// segments, produce overlapping compacted volumes, and delete each other's data.
@@ -523,6 +563,7 @@ impl MVCCEngine {
     /// Creates a new MVCC engine with the given configuration
     pub fn new(config: Config) -> Self {
         let path = config.path.clone().unwrap_or_default();
+        let hot_limits = Arc::new(HotLimits::new(&config.persistence));
 
         // Initialize persistence manager if path is provided and persistence is enabled
         let persistence = if !path.is_empty() && config.persistence.enabled {
@@ -560,6 +601,7 @@ impl MVCCEngine {
             snapshot_timestamps: RwLock::new(FxHashMap::default()),
             segment_managers: Arc::new(RwLock::new(FxHashMap::default())),
             force_seal_all: AtomicBool::new(false),
+            hot_limits,
             checkpoint_mutex: Mutex::new(()),
             seal_fence: Arc::new(parking_lot::RwLock::new(())),
             compaction_running: Arc::new(AtomicBool::new(false)),
@@ -823,7 +865,10 @@ impl MVCCEngine {
 
                 let check_interval = std::time::Duration::from_millis(100);
                 let mut elapsed = std::time::Duration::ZERO;
-                while elapsed < loop_interval && !stop_flag_clone.load(Ordering::Acquire) {
+                while elapsed < loop_interval
+                    && !stop_flag_clone.load(Ordering::Acquire)
+                    && !engine.hot_limits.seal_requested.load(Ordering::Acquire)
+                {
                     thread::sleep(check_interval);
                     elapsed += check_interval;
                 }
@@ -833,7 +878,7 @@ impl MVCCEngine {
                 }
 
                 // Perform cleanup at the original cleanup interval
-                time_since_cleanup += loop_interval;
+                time_since_cleanup += elapsed;
                 if time_since_cleanup >= interval {
                     time_since_cleanup = std::time::Duration::ZERO;
                     let _txn_count = engine.cleanup_old_transactions(txn_retention);
@@ -841,8 +886,13 @@ impl MVCCEngine {
                     let _prev_version_count = engine.cleanup_old_previous_versions();
                 }
 
-                // Auto-checkpoint using the cached interval
-                if !current_checkpoint_interval.is_zero() {
+                // Auto-checkpoint using the cached interval, or right away
+                // when a commit asked for a seal
+                let requested = engine
+                    .hot_limits
+                    .seal_requested
+                    .swap(false, Ordering::AcqRel);
+                if requested || !current_checkpoint_interval.is_zero() {
                     if let Some(ref pm) = *engine.persistence {
                         let last = pm.last_checkpoint_time();
                         let now = std::time::SystemTime::now()
@@ -851,7 +901,10 @@ impl MVCCEngine {
                             .unwrap_or(0);
                         let elapsed_nanos = now.saturating_sub(last);
                         let interval_nanos = current_checkpoint_interval.as_nanos() as i64;
-                        if elapsed_nanos >= interval_nanos {
+                        if requested
+                            || (!current_checkpoint_interval.is_zero()
+                                && elapsed_nanos >= interval_nanos)
+                        {
                             // Call checkpoint_cycle_inner directly (not
                             // checkpoint_cycle) so compaction is spawned on
                             // a separate thread instead of running synchronously.
@@ -2191,8 +2244,61 @@ impl MVCCEngine {
         }
         drop(current);
 
+        self.hot_limits
+            .max_rows
+            .store(config.persistence.hot_max_rows, Ordering::Relaxed);
+        self.hot_limits
+            .max_bytes
+            .store(config.persistence.hot_max_bytes, Ordering::Relaxed);
         *self.config.write().unwrap() = config;
         Ok(())
+    }
+
+    /// Per-table memory figures for PRAGMA MEMORY_STATS, plus a final `*`
+    /// row with the totals and the number of commits that waited for a seal.
+    pub fn memory_stats(&self) -> Vec<MemoryStat> {
+        let mut volume_bytes: FxHashMap<String, usize> = FxHashMap::default();
+        for (table, _, _, _, mem, _, _) in self.volume_stats() {
+            *volume_bytes.entry(table).or_default() += mem;
+        }
+        let stores: Vec<(String, Arc<VersionStore>)> = {
+            let stores = self.version_stores.read().unwrap();
+            let mut names: Vec<&String> = stores.keys().collect();
+            names.sort();
+            names
+                .into_iter()
+                .filter_map(|name| stores.get(name).map(|s| (name.clone(), Arc::clone(s))))
+                .collect()
+        };
+        let mut result = Vec::with_capacity(stores.len() + 1);
+        let mut total = MemoryStat {
+            table_name: "*".to_string(),
+            admission_waits: self.hot_limits.admission_waits.load(Ordering::Relaxed),
+            ..Default::default()
+        };
+        for (name, store) in stores {
+            let (arena_slots, arena_capacity_bytes) = store.arena_footprint();
+            let stat = MemoryStat {
+                hot_rows: store.committed_row_count(),
+                hot_bytes: store.hot_bytes(),
+                arena_slots,
+                arena_capacity_bytes,
+                chain_entries: store.chain_entries(),
+                volume_bytes: volume_bytes.remove(&name).unwrap_or(0),
+                table_name: name,
+                admission_waits: 0,
+            };
+            total.hot_rows += stat.hot_rows;
+            total.hot_bytes += stat.hot_bytes;
+            total.arena_slots += stat.arena_slots;
+            total.arena_capacity_bytes += stat.arena_capacity_bytes;
+            total.chain_entries += stat.chain_entries;
+            total.volume_bytes += stat.volume_bytes;
+            result.push(stat);
+        }
+        total.volume_bytes += volume_bytes.values().sum::<usize>();
+        result.push(total);
+        result
     }
 
     /// Returns the transaction registry
@@ -5016,6 +5122,8 @@ impl MVCCEngine {
             self.force_seal_all.store(false, Ordering::Release);
         }
 
+        self.hot_limits.admission.1.notify_all();
+
         // Step 3: Brief fence — block commits just long enough to check if all
         // hot buffers are empty and capture checkpoint_lsn. NO disk I/O inside
         // the fence. Previously this ran a full seal_hot_buffers() (with volume
@@ -5686,8 +5794,16 @@ impl MVCCEngine {
     fn seal_hot_buffers(&self) -> Result<()> {
         const SEAL_ROW_THRESHOLD: usize = 100_000;
         const SEAL_INCREMENTAL_THRESHOLD: usize = 10_000;
-        let seal_row_threshold = SEAL_ROW_THRESHOLD;
-        let seal_incremental_threshold = SEAL_INCREMENTAL_THRESHOLD;
+        let hot_max_rows = self.hot_limits.max_rows.load(Ordering::Relaxed);
+        let bounded = |threshold: usize| {
+            if hot_max_rows > 0 {
+                threshold.min(hot_max_rows)
+            } else {
+                threshold
+            }
+        };
+        let seal_row_threshold = bounded(SEAL_ROW_THRESHOLD);
+        let seal_incremental_threshold = bounded(SEAL_INCREMENTAL_THRESHOLD);
         let target_volume_rows = self
             .config
             .read()
@@ -6694,6 +6810,8 @@ struct EngineOperations {
         Arc<RwLock<FxHashMap<String, Arc<crate::storage::volume::manifest::SegmentManager>>>>,
     /// Seal fence for WAL truncation safety
     seal_fence: Arc<parking_lot::RwLock<()>>,
+    /// Hot size limits shared with the engine
+    hot_limits: Arc<HotLimits>,
 }
 
 // EngineOperations is Send + Sync because all fields are Arc-wrapped thread-safe types
@@ -6709,6 +6827,7 @@ impl EngineOperations {
             loading_from_disk: Arc::clone(&engine.loading_from_disk),
             segment_managers: Arc::clone(&engine.segment_managers),
             seal_fence: Arc::clone(&engine.seal_fence),
+            hot_limits: Arc::clone(&engine.hot_limits),
         }
     }
 
@@ -7545,6 +7664,12 @@ impl TransactionEngineOperations for EngineOperations {
             }
 
             any_committed = true;
+            let hot_max_rows = self.hot_limits.max_rows.load(Ordering::Relaxed);
+            if hot_max_rows > 0 && version_store.committed_row_count() >= hot_max_rows {
+                self.hot_limits
+                    .seal_requested
+                    .store(true, Ordering::Release);
+            }
         }
 
         // Always cleanup txn_version_stores to prevent memory leak,
@@ -7696,6 +7821,51 @@ impl TransactionEngineOperations for EngineOperations {
 
     fn acquire_seal_fence(&self) -> Option<SealFenceGuard> {
         Some(SealFenceGuard::new(Arc::clone(&self.seal_fence)))
+    }
+
+    fn wait_for_hot_admission(&self, txn_id: i64) {
+        let limits = &self.hot_limits;
+        let limit = limits.max_bytes.load(Ordering::Relaxed);
+        if limit == 0
+            || !self
+                .persistence
+                .as_ref()
+                .as_ref()
+                .is_some_and(|pm| pm.is_enabled())
+        {
+            return;
+        }
+        let stores: Vec<Arc<VersionStore>> = {
+            let cache = self.txn_version_stores().read().unwrap();
+            let Some(txn_tables) = cache.get(txn_id) else {
+                return;
+            };
+            let stores = self.version_stores().read().unwrap();
+            txn_tables
+                .iter()
+                .filter_map(|(table_name, _)| stores.get(table_name.as_str()).cloned())
+                .collect()
+        };
+        let over = || stores.iter().any(|store| store.hot_bytes() >= limit);
+        if !over() {
+            return;
+        }
+        limits.admission_waits.fetch_add(1, Ordering::Relaxed);
+        limits.seal_requested.store(true, Ordering::Release);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut guard = limits.admission.0.lock().unwrap();
+        while over() {
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                break;
+            }
+            guard = limits
+                .admission
+                .1
+                .wait_timeout(guard, deadline - now)
+                .unwrap()
+                .0;
+        }
     }
 }
 

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -5122,7 +5122,12 @@ impl MVCCEngine {
             self.force_seal_all.store(false, Ordering::Release);
         }
 
-        self.hot_limits.admission.1.notify_all();
+        {
+            // Under the mutex, so a writer between its check and its wait
+            // cannot miss this wakeup
+            let _admission = self.hot_limits.admission.0.lock().unwrap();
+            self.hot_limits.admission.1.notify_all();
+        }
 
         // Step 3: Brief fence — block commits just long enough to check if all
         // hot buffers are empty and capture checkpoint_lsn. NO disk I/O inside
@@ -7664,12 +7669,6 @@ impl TransactionEngineOperations for EngineOperations {
             }
 
             any_committed = true;
-            let hot_max_rows = self.hot_limits.max_rows.load(Ordering::Relaxed);
-            if hot_max_rows > 0 && version_store.committed_row_count() >= hot_max_rows {
-                self.hot_limits
-                    .seal_requested
-                    .store(true, Ordering::Release);
-            }
         }
 
         // Always cleanup txn_version_stores to prevent memory leak,
@@ -7823,6 +7822,15 @@ impl TransactionEngineOperations for EngineOperations {
         Some(SealFenceGuard::new(Arc::clone(&self.seal_fence)))
     }
 
+    fn request_seal_if_over(&self, hold: &super::version_store::PublishHold) {
+        let max_rows = self.hot_limits.max_rows.load(Ordering::Relaxed);
+        if max_rows > 0 && hold.any_table_at(max_rows) {
+            self.hot_limits
+                .seal_requested
+                .store(true, Ordering::Release);
+        }
+    }
+
     fn wait_for_hot_admission(&self, txn_id: i64) {
         let limits = &self.hot_limits;
         let limit = limits.max_bytes.load(Ordering::Relaxed);
@@ -7835,6 +7843,8 @@ impl TransactionEngineOperations for EngineOperations {
         {
             return;
         }
+        // A table whose existing rows this transaction claimed is left out:
+        // the seal skips claimed rows, so the wait could not end
         let stores: Vec<Arc<VersionStore>> = {
             let cache = self.txn_version_stores().read().unwrap();
             let Some(txn_tables) = cache.get(txn_id) else {
@@ -7843,6 +7853,7 @@ impl TransactionEngineOperations for EngineOperations {
             let stores = self.version_stores().read().unwrap();
             txn_tables
                 .iter()
+                .filter(|(_, txn_store)| txn_store.read().is_ok_and(|s| !s.holds_hot_rows()))
                 .filter_map(|(table_name, _)| stores.get(table_name.as_str()).cloned())
                 .collect()
         };

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -7824,7 +7824,8 @@ impl TransactionEngineOperations for EngineOperations {
 
     fn request_seal_if_over(&self, hold: &super::version_store::PublishHold) {
         let max_rows = self.hot_limits.max_rows.load(Ordering::Relaxed);
-        if max_rows > 0 && hold.any_table_at(max_rows) {
+        let max_bytes = self.hot_limits.max_bytes.load(Ordering::Relaxed);
+        if hold.any_table_at(max_rows, max_bytes) {
             self.hot_limits
                 .seal_requested
                 .store(true, Ordering::Release);

--- a/src/storage/mvcc/transaction.rs
+++ b/src/storage/mvcc/transaction.rs
@@ -150,6 +150,12 @@ pub trait TransactionEngineOperations: Send + Sync {
         let _ = txn_id;
     }
 
+    /// Asks for a seal when a table the now visible commit wrote is at the
+    /// hot row limit
+    fn request_seal_if_over(&self, hold: &super::version_store::PublishHold) {
+        let _ = hold;
+    }
+
     /// Discard the cold-row tombstones the transaction made after a timestamp
     /// (savepoint rollback). Engines without cold storage have none.
     fn rollback_tombstones_after(&self, _txn_id: i64, _timestamp: i64) {}
@@ -522,6 +528,9 @@ impl Transaction for MvccTransaction {
 
             // Phase 4: Complete commit - make changes visible in registry
             self.registry.complete_commit(self.id);
+            if let (Some(ops), Some(hold)) = (&self.engine_operations, &publish) {
+                ops.request_seal_if_over(hold);
+            }
         } else {
             // Read-only transaction - just mark as committed in registry
             self.registry.complete_commit(self.id);

--- a/src/storage/mvcc/transaction.rs
+++ b/src/storage/mvcc/transaction.rs
@@ -151,7 +151,7 @@ pub trait TransactionEngineOperations: Send + Sync {
     }
 
     /// Asks for a seal when a table the now visible commit wrote is at the
-    /// hot row limit
+    /// hot row or byte limit
     fn request_seal_if_over(&self, hold: &super::version_store::PublishHold) {
         let _ = hold;
     }
@@ -487,6 +487,9 @@ impl Transaction for MvccTransaction {
                         // Partial commit: some tables already committed.
                         // We MUST complete the commit to avoid orphaning those rows.
                         self.registry.complete_commit(self.id);
+                        if let Some(hold) = &publish {
+                            ops.request_seal_if_over(hold);
+                        }
                         // Record commit marker so WAL recovery sees committed state
                         ops.record_commit(self.id)?;
                         self.state = TransactionState::Committed;

--- a/src/storage/mvcc/transaction.rs
+++ b/src/storage/mvcc/transaction.rs
@@ -144,6 +144,12 @@ pub trait TransactionEngineOperations: Send + Sync {
         super::version_store::PublishHold::default()
     }
 
+    /// Waits while a table the transaction writes holds more hot bytes than
+    /// its limit allows, so a seal can bring it back under. No fence is held.
+    fn wait_for_hot_admission(&self, txn_id: i64) {
+        let _ = txn_id;
+    }
+
     /// Discard the cold-row tombstones the transaction made after a timestamp
     /// (savepoint rollback). Engines without cold storage have none.
     fn rollback_tombstones_after(&self, _txn_id: i64, _timestamp: i64) {}
@@ -445,6 +451,9 @@ impl Transaction for MvccTransaction {
 
         // Two-phase commit protocol
         if !is_read_only {
+            if let Some(ops) = &self.engine_operations {
+                ops.wait_for_hot_admission(self.id);
+            }
             // Acquire seal fence shared lock. This signals to the checkpoint
             // micro-seal that a commit is in-flight. The micro-seal waits for
             // all in-flight commits to finish before draining hot rows.

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -492,6 +492,17 @@ impl PublishHold {
         self.stores.push(txn_store);
     }
 
+    /// True when a table this commit wrote holds `max_rows` committed hot
+    /// rows or more; asked once the commit is visible, so the seal it
+    /// requests can extract the rows
+    pub fn any_table_at(&self, max_rows: usize) -> bool {
+        self.stores.iter().any(|store| {
+            store
+                .read()
+                .is_ok_and(|s| s.parent_store.committed_row_count() >= max_rows)
+        })
+    }
+
     /// Takes back the index updates of a commit that failed after applying
     /// them, so the indexes describe the rows that stayed visible
     pub fn undo_index_updates(&self) {
@@ -6893,6 +6904,14 @@ impl TransactionVersionStore {
         self.local_versions
             .as_ref()
             .is_some_and(|lv| lv.contains_key(row_id))
+    }
+
+    /// True when the transaction claimed rows that already exist in the hot
+    /// store: a seal skips those, so waiting for it cannot free them
+    pub fn holds_hot_rows(&self) -> bool {
+        self.write_set
+            .as_ref()
+            .is_some_and(|ws| ws.values().any(|e| e.read_version.is_some()))
     }
 
     /// Returns true if this transaction has any uncommitted local changes

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -2026,6 +2026,27 @@ impl VersionStore {
         self.committed_row_count.load(Ordering::Relaxed)
     }
 
+    /// Bytes of the rows the arena holds, kept exact by every mutation
+    #[inline]
+    pub fn hot_bytes(&self) -> usize {
+        self.arena.bytes()
+    }
+
+    /// Arena slots in use (deleted and cleared ones included) and the bytes
+    /// its slot vectors reserve
+    pub fn arena_footprint(&self) -> (usize, usize) {
+        (self.arena.len(), self.arena.capacity_bytes())
+    }
+
+    /// Previous versions kept alive by the version chains
+    pub fn chain_entries(&self) -> usize {
+        let versions = self.versions.read().clone();
+        versions
+            .iter()
+            .map(|(_, chain)| count_chain_depth(chain).saturating_sub(1))
+            .sum()
+    }
+
     /// Check if a row_id exists in the committed version store (B-tree).
     /// Used during WAL replay to distinguish sealed INSERTs from post-seal UPDATEs.
     pub fn has_committed_row(&self, row_id: i64) -> bool {

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -493,13 +493,15 @@ impl PublishHold {
     }
 
     /// True when a table this commit wrote holds `max_rows` committed hot
-    /// rows or more; asked once the commit is visible, so the seal it
-    /// requests can extract the rows
-    pub fn any_table_at(&self, max_rows: usize) -> bool {
+    /// rows or `max_bytes` hot bytes or more (0 = no limit); asked once the
+    /// commit is visible, so the seal it requests can extract the rows
+    pub fn any_table_at(&self, max_rows: usize, max_bytes: usize) -> bool {
         self.stores.iter().any(|store| {
-            store
-                .read()
-                .is_ok_and(|s| s.parent_store.committed_row_count() >= max_rows)
+            store.read().is_ok_and(|s| {
+                let parent = &s.parent_store;
+                (max_rows > 0 && parent.committed_row_count() >= max_rows)
+                    || (max_bytes > 0 && parent.hot_bytes() >= max_bytes)
+            })
         })
     }
 

--- a/tests/hot_limits_test.rs
+++ b/tests/hot_limits_test.rs
@@ -216,6 +216,46 @@ fn an_update_over_the_byte_limit_does_not_wait_on_its_own_claims() {
     assert_eq!(int(&db, "SELECT COUNT(*) FROM u WHERE t = 'changed'"), 1500);
 }
 
+#[test]
+fn updates_that_grow_past_the_byte_limit_request_a_seal() {
+    let dir = tempdir().expect("tempdir");
+    let db = Database::open(&format!(
+        "file://{}?checkpoint_interval=3600&hot_max_rows=0",
+        dir.path().display()
+    ))
+    .expect("open");
+    db.execute("CREATE TABLE g (id INTEGER PRIMARY KEY, t TEXT)", ())
+        .expect("create");
+    insert_batch(&db, "g", 1, 2000);
+    let bytes_at_rest = memory_stats(&db, "g").1;
+    db.execute(
+        &format!("PRAGMA HOT_MAX_BYTES = {}", bytes_at_rest + 20_000),
+        (),
+    )
+    .expect("limit");
+    for _ in 0..4 {
+        db.execute("UPDATE g SET t = t || ' grown by an update'", ())
+            .expect("update");
+    }
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut volumes = 0;
+    while volumes == 0 && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+        volumes = db
+            .query("PRAGMA VOLUME_STATS", ())
+            .expect("volume stats")
+            .count();
+    }
+    assert!(
+        volumes > 0,
+        "no seal was requested for a table grown by UPDATEs"
+    );
+    assert_eq!(
+        int(&db, "SELECT COUNT(*) FROM g WHERE t LIKE '%grown%'"),
+        2000
+    );
+}
+
 /// Under `test-filedb` a memory DSN opens a file database, which can seal
 #[cfg(not(feature = "test-filedb"))]
 #[test]

--- a/tests/hot_limits_test.rs
+++ b/tests/hot_limits_test.rs
@@ -193,6 +193,29 @@ fn hot_max_bytes_makes_commits_wait_for_the_seal() {
     assert_eq!(int(&db, "SELECT SUM(id) FROM w"), 30_000 * 30_001 / 2);
 }
 
+#[test]
+fn an_update_over_the_byte_limit_does_not_wait_on_its_own_claims() {
+    let dir = tempdir().expect("tempdir");
+    let db = Database::open(&format!(
+        "file://{}?checkpoint_interval=3600&hot_max_rows=0",
+        dir.path().display()
+    ))
+    .expect("open");
+    db.execute("CREATE TABLE u (id INTEGER PRIMARY KEY, t TEXT)", ())
+        .expect("create");
+    insert_batch(&db, "u", 1, 2000);
+    db.execute("PRAGMA HOT_MAX_BYTES = 1", ()).expect("limit");
+    let started = Instant::now();
+    db.execute("UPDATE u SET t = 'changed' WHERE id <= 1500", ())
+        .expect("update");
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "the UPDATE waited {:?} for a seal its own claims block",
+        started.elapsed()
+    );
+    assert_eq!(int(&db, "SELECT COUNT(*) FROM u WHERE t = 'changed'"), 1500);
+}
+
 /// Under `test-filedb` a memory DSN opens a file database, which can seal
 #[cfg(not(feature = "test-filedb"))]
 #[test]

--- a/tests/hot_limits_test.rs
+++ b/tests/hot_limits_test.rs
@@ -1,0 +1,212 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Hot size limits: `hot_max_rows` asks for a seal as soon as a commit
+//! passes it, `hot_max_bytes` makes commits wait for that seal, and
+//! PRAGMA MEMORY_STATS reports what the hot store holds.
+
+use std::time::{Duration, Instant};
+use stoolap::Database;
+use tempfile::tempdir;
+
+fn int(db: &Database, sql: &str) -> i64 {
+    db.query(sql, ())
+        .expect("query")
+        .next()
+        .expect("one row")
+        .expect("row")
+        .get::<i64>(0)
+        .expect("integer")
+}
+
+/// (hot_rows, hot_bytes, chain_entries, admission_waits of the `*` row)
+fn memory_stats(db: &Database, table: &str) -> (i64, i64, i64, i64) {
+    let mut hot_rows = -1;
+    let mut hot_bytes = -1;
+    let mut chain_entries = -1;
+    let mut waits = -1;
+    for row in db.query("PRAGMA MEMORY_STATS", ()).expect("memory stats") {
+        let row = row.expect("row");
+        let name: String = row.get(0).expect("table_name");
+        if name == table {
+            hot_rows = row.get(1).expect("hot_rows");
+            hot_bytes = row.get(2).expect("hot_bytes");
+            chain_entries = row.get(5).expect("chain_entries");
+        } else if name == "*" {
+            waits = row.get(7).expect("admission_waits");
+        }
+    }
+    (hot_rows, hot_bytes, chain_entries, waits)
+}
+
+fn insert_batch(db: &Database, table: &str, from: i64, count: i64) {
+    let mut sql = format!("INSERT INTO {table} VALUES ");
+    for i in from..from + count {
+        if i != from {
+            sql.push(',');
+        }
+        sql.push_str(&format!("({i}, 'row number {i} with a longer text value')"));
+    }
+    db.execute(&sql, ()).expect("insert");
+}
+
+#[test]
+fn hot_limit_pragmas_read_the_dsn_and_accept_new_values() {
+    let dir = tempdir().expect("tempdir");
+    let db = Database::open(&format!(
+        "file://{}?checkpoint_interval=3600&hot_max_rows=5000&hot_max_bytes=123456",
+        dir.path().display()
+    ))
+    .expect("open");
+    assert_eq!(int(&db, "PRAGMA HOT_MAX_ROWS"), 5000);
+    assert_eq!(int(&db, "PRAGMA HOT_MAX_BYTES"), 123456);
+    db.execute("PRAGMA HOT_MAX_ROWS = 0", ()).expect("set rows");
+    db.execute("PRAGMA HOT_MAX_BYTES = 0", ())
+        .expect("set bytes");
+    assert_eq!(int(&db, "PRAGMA HOT_MAX_ROWS"), 0);
+    assert_eq!(int(&db, "PRAGMA HOT_MAX_BYTES"), 0);
+    assert!(db.execute("PRAGMA HOT_MAX_ROWS = -1", ()).is_err());
+}
+
+#[test]
+fn memory_stats_follow_inserts_updates_and_vacuum() {
+    let db = Database::open("memory://hot_limits_memory_stats").expect("open");
+    db.execute("CREATE TABLE m (id INTEGER PRIMARY KEY, t TEXT)", ())
+        .expect("create");
+    let (rows, bytes, chains, _) = memory_stats(&db, "m");
+    assert_eq!((rows, bytes, chains), (0, 0, 0));
+
+    insert_batch(&db, "m", 1, 100);
+    let (rows, bytes_after_insert, chains, _) = memory_stats(&db, "m");
+    assert_eq!(rows, 100);
+    assert_eq!(chains, 0);
+    // 100 rows of two 16-byte values plus a heap string each
+    assert!(
+        bytes_after_insert > 100 * 48,
+        "hot_bytes {bytes_after_insert}"
+    );
+
+    db.execute(
+        "UPDATE m SET t = t || ' and some more text appended to it' WHERE id <= 50",
+        (),
+    )
+    .expect("update");
+    let (rows, bytes_after_update, chains, _) = memory_stats(&db, "m");
+    assert_eq!(rows, 100);
+    assert_eq!(chains, 50, "each updated row keeps one previous version");
+    assert!(
+        bytes_after_update > bytes_after_insert,
+        "longer values must count: {bytes_after_update} <= {bytes_after_insert}"
+    );
+
+    db.execute("DELETE FROM m", ()).expect("delete");
+    db.execute("VACUUM", ()).expect("vacuum");
+    let (rows, bytes, _, _) = memory_stats(&db, "m");
+    assert_eq!(rows, 0);
+    assert_eq!(bytes, 0, "cleared slots must give their bytes back");
+}
+
+#[test]
+fn hot_max_rows_seals_the_table_without_waiting_for_the_interval() {
+    let dir = tempdir().expect("tempdir");
+    let db = Database::open(&format!(
+        "file://{}?checkpoint_interval=3600&hot_max_rows=20000",
+        dir.path().display()
+    ))
+    .expect("open");
+    db.execute("CREATE TABLE s (id INTEGER PRIMARY KEY, t TEXT)", ())
+        .expect("create");
+    for batch in 0..25 {
+        insert_batch(&db, "s", batch * 2000 + 1, 2000);
+    }
+    assert_eq!(int(&db, "SELECT COUNT(*) FROM s"), 50_000);
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut hot_rows = memory_stats(&db, "s").0;
+    while hot_rows >= 20_000 && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+        hot_rows = memory_stats(&db, "s").0;
+    }
+    assert!(
+        hot_rows >= 0,
+        "PRAGMA MEMORY_STATS has no row for the table"
+    );
+    assert!(
+        hot_rows < 20_000,
+        "the hot store still holds {hot_rows} rows: no seal was requested"
+    );
+    let volumes = db
+        .query("PRAGMA VOLUME_STATS", ())
+        .expect("volume stats")
+        .count();
+    assert!(volumes > 0, "the early seal must have written a volume");
+    assert!(
+        int(&db, "SELECT COUNT(*) FROM s") == 50_000,
+        "the sealed rows must still be readable"
+    );
+    assert_eq!(int(&db, "SELECT MIN(id) FROM s"), 1);
+    assert_eq!(int(&db, "SELECT MAX(id) FROM s"), 50_000);
+    assert!(
+        int(
+            &db,
+            "SELECT COUNT(*) FROM s WHERE id BETWEEN 19990 AND 20010"
+        ) == 21,
+        "rows on both sides of the trigger must be there"
+    );
+}
+
+#[test]
+fn hot_max_bytes_makes_commits_wait_for_the_seal() {
+    let dir = tempdir().expect("tempdir");
+    let db = Database::open(&format!(
+        "file://{}?checkpoint_interval=3600&hot_max_rows=0&hot_max_bytes=200000",
+        dir.path().display()
+    ))
+    .expect("open");
+    db.execute("CREATE TABLE w (id INTEGER PRIMARY KEY, t TEXT)", ())
+        .expect("create");
+    let mut peak_bytes = 0;
+    for batch in 0..30 {
+        insert_batch(&db, "w", batch * 1000 + 1, 1000);
+        peak_bytes = peak_bytes.max(memory_stats(&db, "w").1);
+    }
+    let (_, _, _, waits) = memory_stats(&db, "w");
+    assert!(waits > 0, "no commit waited for admission");
+    // One batch is well under 100 KB, so the hot store never holds more
+    // than the limit plus the batch that crossed it
+    assert!(
+        peak_bytes < 300_000,
+        "hot bytes reached {peak_bytes} with a 200000 byte limit"
+    );
+    assert_eq!(int(&db, "SELECT COUNT(*) FROM w"), 30_000);
+    assert_eq!(int(&db, "SELECT SUM(id) FROM w"), 30_000 * 30_001 / 2);
+}
+
+/// Under `test-filedb` a memory DSN opens a file database, which can seal
+#[cfg(not(feature = "test-filedb"))]
+#[test]
+fn a_memory_database_ignores_the_byte_limit() {
+    let db = Database::open("memory://hot_limits_no_persistence").expect("open");
+    db.execute("PRAGMA HOT_MAX_BYTES = 1", ()).expect("set");
+    db.execute("CREATE TABLE n (id INTEGER PRIMARY KEY, t TEXT)", ())
+        .expect("create");
+    let started = Instant::now();
+    insert_batch(&db, "n", 1, 500);
+    insert_batch(&db, "n", 501, 500);
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "a commit waited although nothing can seal"
+    );
+    assert_eq!(memory_stats(&db, "n").3, 0);
+}


### PR DESCRIPTION
Second step of the hot store work: the hot store gets size limits, exact byte counters and a way to see them. Nothing changes in the seal itself; this PR decides when it runs and lets a writer wait for it.

**Limits**

- `hot_max_rows` (default 262,144): a commit that takes a table's committed hot rows past it raises a seal request. The checkpoint thread, which polls every 100 ms, runs the seal cycle on its next tick instead of waiting for `checkpoint_interval`. The seal's own thresholds are bounded by the same value, so a table over the limit is always sealed by that cycle. 0 turns the trigger off and leaves today's behaviour.
- `hot_max_bytes` (default 0, off): a commit whose table holds at least this many hot bytes raises the same request and waits, before it takes the seal fence, until the seal brings the table back under. The wait is bounded at 10 seconds and counted, so a long snapshot that pins rows cannot hang writers; an in-memory database never waits because nothing can seal.
- Both are DSN keys (`hot_max_rows=`, `hot_max_bytes=`) and read/write PRAGMAs (`HOT_MAX_ROWS`, `HOT_MAX_BYTES`), mirrored into atomics so the commit path never touches the config lock.

**Counters**

The arena keeps an exact byte count of the rows it holds: 16 bytes per value in place plus what heap text and extension values own, added on every insert, moved on `update_at`, taken back on `clear_at`, `clear_batch` and `clear_all`. One atomic add per row; no per-row allocation.

**PRAGMA MEMORY_STATS**

One row per table plus a `*` row with the totals:

| column | meaning |
|---|---|
| hot_rows | committed rows in the hot store |
| hot_bytes | bytes of the rows the arena holds |
| arena_slots | slots in use, deleted and cleared ones included |
| arena_capacity_bytes | what the slot vectors reserve |
| chain_entries | previous versions kept alive by version chains |
| volume_bytes | memory of the table's loaded volumes |
| admission_waits | (`*` row) commits that waited for a seal |

**Tests** (`tests/hot_limits_test.rs`, each fails on main): DSN and PRAGMA round trip; MEMORY_STATS following inserts, longer UPDATEs, chain entries and VACUUM back to zero; `hot_max_rows` sealing 50k rows with `checkpoint_interval=3600` while every row stays readable; `hot_max_bytes` keeping the peak under the limit plus one batch with waits counted; an in-memory database ignoring the byte limit. Plus an arena unit test for the byte counter.

The default trigger changes when a bulk load seals: every 262,144 rows instead of once at the next interval. Measured with the candle load probe (2.175M rows in 10-minute batches, `checkpoint_interval=3600`, release build):

| phase | main | this PR |
|---|---|---|
| bulk load | 7976 ms | 10293 ms |
| PRAGMA CHECKPOINT after the load | 3334 ms | 801 ms |
| load + checkpoint | 11310 ms | 11094 ms |

The load pays for the eight seals it now runs; the checkpoint at the end has little left to do. RSS is not lower yet: the sealed volumes stay in the eager tier and the arena keeps its capacity for reuse, which the chunked arena and the memory budget steps address.

Verification: clippy with `-D warnings`, the storage suites (`sealed_index_visibility_test`, `volume_checkpoint_test`, `snapshot_cold_test`, `volume_concurrency_test`, `arena_slot_reuse_test`, `hot_index_top_k_test`, `ordered_limited_scan_test`, `wal_truncation_test`, `failpoint_io_test`), the in-memory suite and the filedb suite.
