### PR TITLE
perf(volume): test dictionary equalities over a row group's raw ids in one pass

### DIFF
--- a/src/storage/volume/column.rs
+++ b/src/storage/volume/column.rs
@@ -27,6 +27,14 @@ use std::sync::Arc;
 use crate::common::SmartString;
 use crate::core::{DataType, Value};
 
+/// A dictionary column, the local index a caller's window starts at in it,
+/// and the id looked for
+pub type DictFilter<'a> = (&'a ColumnData, usize, u32);
+
+/// A dictionary column's raw ids and nulls, the local index its window
+/// starts at, and the id looked for
+type DictSlice<'a> = (&'a [u32], &'a [bool], usize, u32);
+
 /// Typed column data stored contiguously for cache-friendly access.
 ///
 /// Each variant stores a flat array of the native type plus a null bitmap.
@@ -537,6 +545,45 @@ impl ColumnData {
         }
     }
 
+    /// Appends to `out` the offsets in `0..count` whose rows, read at
+    /// `local + offset` in every column of `filters`, carry the expected
+    /// dictionary id and are not null. One tight pass over the first
+    /// column's raw ids; the other columns are only read for its matches.
+    /// None when a filter column is not a dictionary column.
+    pub fn dict_matching_offsets(
+        filters: &[DictFilter<'_>],
+        count: usize,
+        out: &mut Vec<usize>,
+    ) -> Option<()> {
+        let mut slices: smallvec::SmallVec<[DictSlice<'_>; 4]> =
+            smallvec::SmallVec::with_capacity(filters.len());
+        for &(col, local, expected) in filters {
+            let (ids, nulls) = col.dict_ids()?;
+            if local + count > ids.len() {
+                return None;
+            }
+            slices.push((ids, nulls, local, expected));
+        }
+        let Some(&(first_ids, first_nulls, first_local, first_expected)) = slices.first() else {
+            out.extend(0..count);
+            return Some(());
+        };
+        let window = &first_ids[first_local..first_local + count];
+        for (offset, &id) in window.iter().enumerate() {
+            if id != first_expected || first_nulls[first_local + offset] {
+                continue;
+            }
+            let others = slices[1..].iter().all(|&(ids, nulls, local, expected)| {
+                let at = local + offset;
+                ids[at] == expected && !nulls[at]
+            });
+            if others {
+                out.push(offset);
+            }
+        }
+        Some(())
+    }
+
     // =========================================================================
     // Search operations
     // =========================================================================
@@ -867,6 +914,40 @@ impl ZoneMap {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dict_matching_offsets_reads_every_filter_and_skips_nulls() {
+        let dictionary: Arc<[SmartString]> =
+            vec![SmartString::from("a"), SmartString::from("b")].into();
+        let first = ColumnData::Dictionary {
+            ids: vec![0, 1, 1, 0, 1, 1],
+            dictionary: Arc::clone(&dictionary),
+            nulls: vec![false, false, true, false, false, false],
+        };
+        let second = ColumnData::Dictionary {
+            ids: vec![9, 1, 1, 1, 0, 1],
+            dictionary,
+            nulls: vec![false; 6],
+        };
+        let mut out = Vec::new();
+        // rows 1..6 of `first` against rows 0..5 of `second`: first matches
+        // at offsets 0, 3, 4 (offset 1 is null), second only at offset 3
+        ColumnData::dict_matching_offsets(&[(&first, 1, 1), (&second, 0, 1)], 5, &mut out)
+            .expect("dictionary columns");
+        assert_eq!(out, vec![3]);
+        out.clear();
+        ColumnData::dict_matching_offsets(&[(&first, 1, 1)], 5, &mut out).expect("one column");
+        assert_eq!(out, vec![0, 3, 4]);
+        out.clear();
+        assert!(ColumnData::dict_matching_offsets(&[(&first, 4, 1)], 3, &mut out).is_none());
+        let ints = ColumnData::Int64 {
+            values: vec![1],
+            nulls: vec![false],
+        };
+        assert!(ColumnData::dict_matching_offsets(&[(&ints, 0, 1)], 1, &mut out).is_none());
+        ColumnData::dict_matching_offsets(&[], 3, &mut out).expect("no filters");
+        assert_eq!(out, vec![0, 1, 2]);
+    }
 
     #[test]
     fn test_int64_column() {

--- a/src/storage/volume/scanner.rs
+++ b/src/storage/volume/scanner.rs
@@ -621,23 +621,32 @@ impl VolumeScanner {
                 }
             } else {
                 let mut m = Vec::new();
-                let lo = self.current_idx;
-                let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = self
-                    .dict_filters
-                    .iter()
-                    .map(|&(ci, eid)| (&self.volume.columns[ci], lo, eid))
-                    .collect();
-                if super::column::ColumnData::dict_matching_offsets(
-                    &filters,
-                    self.end_idx - lo,
-                    &mut m,
-                )
-                .is_some()
-                {
-                    for idx in &mut m {
+                // One row group at a time, so a filter that matches most rows
+                // stops at the selectivity cap instead of listing them all
+                let mut lo = self.current_idx;
+                let mut vectorized = true;
+                while lo < self.end_idx && m.len() <= selectivity_cap {
+                    let hi = (lo + super::column::ROW_GROUP_SIZE).min(self.end_idx);
+                    let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = self
+                        .dict_filters
+                        .iter()
+                        .map(|&(ci, eid)| (&self.volume.columns[ci], lo, eid))
+                        .collect();
+                    let first = m.len();
+                    if super::column::ColumnData::dict_matching_offsets(&filters, hi - lo, &mut m)
+                        .is_none()
+                    {
+                        m.truncate(first);
+                        vectorized = false;
+                        break;
+                    }
+                    for idx in &mut m[first..] {
                         *idx += lo;
                     }
-                } else {
+                    lo = hi;
+                }
+                if !vectorized {
+                    m.clear();
                     for i in self.current_idx..self.end_idx {
                         let ok = self.dict_filters.iter().all(|&(ci, eid)| {
                             !self.volume.columns[ci].is_null(i)

--- a/src/storage/volume/scanner.rs
+++ b/src/storage/volume/scanner.rs
@@ -215,30 +215,18 @@ impl VolumeScanner {
     /// over the raw ids of the group; None when a filter column is not a
     /// dictionary column here and the rows must be tested one by one
     fn dictionary_candidates(&self, lo: usize, hi: usize) -> Option<Vec<usize>> {
-        let mut slices: Vec<(&[u32], &[bool], usize, u32)> =
-            Vec::with_capacity(self.dict_filters.len());
-        for &(col_idx, expected) in &self.dict_filters {
-            let (col, local_lo) = self.col_and_idx(col_idx, lo);
-            let (ids, nulls) = col.dict_ids()?;
-            if local_lo + (hi - lo) > ids.len() {
-                return None;
-            }
-            slices.push((ids, nulls, local_lo, expected));
-        }
+        let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = self
+            .dict_filters
+            .iter()
+            .map(|&(col_idx, expected)| {
+                let (col, local_lo) = self.col_and_idx(col_idx, lo);
+                (col, local_lo, expected)
+            })
+            .collect();
         let mut candidates = Vec::new();
-        let (first_ids, first_nulls, first_lo, first_expected) = slices[0];
-        for offset in 0..hi - lo {
-            let local = first_lo + offset;
-            if first_nulls[local] || first_ids[local] != first_expected {
-                continue;
-            }
-            let others_match = slices[1..].iter().all(|&(ids, nulls, base, expected)| {
-                let local = base + offset;
-                !nulls[local] && ids[local] == expected
-            });
-            if others_match {
-                candidates.push(lo + offset);
-            }
+        super::column::ColumnData::dict_matching_offsets(&filters, hi - lo, &mut candidates)?;
+        for idx in &mut candidates {
+            *idx += lo;
         }
         Some(candidates)
     }
@@ -593,13 +581,32 @@ impl VolumeScanner {
                         self.filter = Some(filter);
                         return;
                     }
-                    for i in gs.max(self.current_idx)..ge {
-                        let local = i - gs;
-                        let ok = self.dict_filters.iter().zip(group_cols.iter()).all(
-                            |(&(_, eid), col)| !col.is_null(local) && col.get_dict_id(local) == eid,
-                        );
-                        if ok {
-                            m.push(i);
+                    let lo = gs.max(self.current_idx);
+                    let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = self
+                        .dict_filters
+                        .iter()
+                        .zip(group_cols.iter())
+                        .map(|(&(_, eid), col)| (&**col, lo - gs, eid))
+                        .collect();
+                    let first = m.len();
+                    if super::column::ColumnData::dict_matching_offsets(&filters, ge - lo, &mut m)
+                        .is_none()
+                    {
+                        m.truncate(first);
+                        for i in lo..ge {
+                            let local = i - gs;
+                            let ok = self.dict_filters.iter().zip(group_cols.iter()).all(
+                                |(&(_, eid), col)| {
+                                    !col.is_null(local) && col.get_dict_id(local) == eid
+                                },
+                            );
+                            if ok {
+                                m.push(i);
+                            }
+                        }
+                    } else {
+                        for idx in &mut m[first..] {
+                            *idx += lo;
                         }
                     }
                     if m.len() > selectivity_cap {
@@ -614,16 +621,34 @@ impl VolumeScanner {
                 }
             } else {
                 let mut m = Vec::new();
-                for i in self.current_idx..self.end_idx {
-                    let ok = self.dict_filters.iter().all(|&(ci, eid)| {
-                        !self.volume.columns[ci].is_null(i)
-                            && self.volume.columns[ci].get_dict_id(i) == eid
-                    });
-                    if ok {
-                        m.push(i);
+                let lo = self.current_idx;
+                let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = self
+                    .dict_filters
+                    .iter()
+                    .map(|&(ci, eid)| (&self.volume.columns[ci], lo, eid))
+                    .collect();
+                if super::column::ColumnData::dict_matching_offsets(
+                    &filters,
+                    self.end_idx - lo,
+                    &mut m,
+                )
+                .is_some()
+                {
+                    for idx in &mut m {
+                        *idx += lo;
                     }
-                    if m.len() > selectivity_cap {
-                        break;
+                } else {
+                    for i in self.current_idx..self.end_idx {
+                        let ok = self.dict_filters.iter().all(|&(ci, eid)| {
+                            !self.volume.columns[ci].is_null(i)
+                                && self.volume.columns[ci].get_dict_id(i) == eid
+                        });
+                        if ok {
+                            m.push(i);
+                        }
+                        if m.len() > selectivity_cap {
+                            break;
+                        }
                     }
                 }
                 if m.len() > selectivity_cap {

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -969,8 +969,39 @@ impl SegmentedTable {
                 let current_schema = self.hot.schema();
                 let mapping = self.segment_mgr.get_volume_mapping(*seg_id, current_schema);
 
+                // The rows that pass the dictionary filters, found in one pass
+                // over the raw ids; None walks the whole range
+                let mut candidates: Vec<usize> = Vec::new();
+                let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = dict_filters
+                    .iter()
+                    .map(|&(col_idx, expected)| (&vol.columns[col_idx], start, expected))
+                    .collect();
+                let prefiltered = !filters.is_empty()
+                    && super::column::ColumnData::dict_matching_offsets(
+                        &filters,
+                        end - start,
+                        &mut candidates,
+                    )
+                    .is_some();
+                let mut next_row = {
+                    let mut pos = 0usize;
+                    let mut plain = start;
+                    move || -> Option<usize> {
+                        if prefiltered {
+                            let i = start + *candidates.get(pos)?;
+                            pos += 1;
+                            Some(i)
+                        } else if plain < end {
+                            plain += 1;
+                            Some(plain - 1)
+                        } else {
+                            None
+                        }
+                    }
+                };
+
                 let mut vol_rows = RowVec::new();
-                for i in start..end {
+                while let Some(i) = next_row() {
                     if !cs.is_visible(i) {
                         continue;
                     }
@@ -981,7 +1012,7 @@ impl SegmentedTable {
                         continue;
                     }
 
-                    if !dict_filters.is_empty() {
+                    if !prefiltered && !dict_filters.is_empty() {
                         let mut matches = true;
                         for &(col_idx, expected_id) in &dict_filters {
                             if vol.columns[col_idx].is_null(i)
@@ -5243,6 +5274,7 @@ impl Table for SegmentedTable {
 
                 // Inner loop: per-volume accumulators
                 let mut vol_accums = vec![Accum::default(); agg_count];
+                let mut group_candidates: Vec<usize> = Vec::new();
                 let row_count = vol.meta.row_count;
                 let rg_size = super::column::ROW_GROUP_SIZE;
                 let num_groups = row_count.div_ceil(rg_size);
@@ -5254,7 +5286,45 @@ impl Table for SegmentedTable {
                     let g_start = gi * rg_size;
                     let g_end = ((gi + 1) * rg_size).min(row_count);
 
-                    for i in g_start..g_end {
+                    // Dictionary equalities are answered for the whole group in
+                    // one pass over the raw ids; the other predicates run per
+                    // surviving row
+                    let dict_preds: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> =
+                        phys_preds
+                            .iter()
+                            .filter(|pp| matches!(pp.target, TypedTarget::DictEq(_)))
+                            .map(|pp| {
+                                (
+                                    &vol.columns[pp.phys_col],
+                                    g_start,
+                                    pp.dict_id.unwrap_or(u32::MAX),
+                                )
+                            })
+                            .collect();
+                    group_candidates.clear();
+                    let prefiltered = !dict_preds.is_empty()
+                        && super::column::ColumnData::dict_matching_offsets(
+                            &dict_preds,
+                            g_end - g_start,
+                            &mut group_candidates,
+                        )
+                        .is_some();
+                    let mut pos = 0usize;
+                    let mut plain = g_start;
+                    let mut next_row = || -> Option<usize> {
+                        if prefiltered {
+                            let i = g_start + *group_candidates.get(pos)?;
+                            pos += 1;
+                            Some(i)
+                        } else if plain < g_end {
+                            plain += 1;
+                            Some(plain - 1)
+                        } else {
+                            None
+                        }
+                    };
+
+                    while let Some(i) = next_row() {
                         if !cs.is_visible(i) {
                             continue;
                         }
@@ -5267,6 +5337,9 @@ impl Table for SegmentedTable {
 
                         let mut all_pass = true;
                         for pp in &phys_preds {
+                            if prefiltered && matches!(pp.target, TypedTarget::DictEq(_)) {
+                                continue;
+                            }
                             let col = &vol.columns[pp.phys_col];
                             if col.is_null(i) {
                                 all_pass = false;


### PR DESCRIPTION
The dictionary pre-filter for text equality on cold rows ran row by row: `is_null` plus `get_dict_id`, each a match on the column enum, per row and per filter column. It ran that way in three places: the scanner's pre-scan in `set_filter` (both the group store and the eager branch), the row fetch path in `volume/table.rs` and the aggregation pushdown.

`ColumnData::dict_matching_offsets` takes the filter columns with a window and an expected id, walks the first column's raw id slice in one pass and reads the other columns only for its matches. The scanner's ordered walk already had this shape and now shares the helper. The three call sites apply it per row group or per range and fall back to the row-by-row test only when a filter column is not dictionary encoded. A range without dictionary filters is walked as before, no candidate vector is built for it.

Measured with a probe of a 1m to 3m candle aggregation upsert (4M one-minute candle rows for 174 pairs, sealed, release build):

| shape | main | this PR |
|---|---|---|
| upsert, lookback 7 days | 14.4-15.7 ms | 10.9-13.6 ms |
| upsert, all history | 89-104 ms | 82-93 ms |
| pair `COUNT(*)`, no time filter | 68.5 ms | 61.2 ms |

The gain is modest because the filter was not the main cost of this shape. A sample profile of the pair COUNT in a loop puts 83% of the time in `load_group_cache` decoding LZ4 groups: every needed column of every group is decoded per query, and the 64 MB decoded group cache cannot hold the working set (153 MB here), so nothing survives between queries. With `PRAGMA GROUP_CACHE_MB = 512` the same COUNT drops from 60 ms to 6.4 ms and the full upsert from 88 ms to 31 ms. That is a separate decision.

Tests: a unit test for the helper (nulls, several filters, window offsets, non-dictionary column, no filters); the volume, scan, pushdown and aggregation targets; the in-memory suite and the filedb suite. Clippy with `-D warnings`.
