### PR TITLE
Preserve cold read errors and complete transaction rollback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,20 @@ jobs:
     - name: Differential oracle tests (Stoolap vs SQLite)
       run: cargo test --test differential_oracle_test --features sqlite
 
+    - name: Volume reader unit tests with failpoints
+      run: >-
+        cargo test --lib --features test-failpoints storage::volume::
+        -- --test-threads=1
+
     - name: Failpoint I/O tests
-      run: cargo test --test failpoint_io_test --features test-failpoints -- --test-threads=1
+      run: >-
+        cargo test --features test-failpoints
+        --test failpoint_io_test
+        --test cold_read_error_test
+        --test statement_atomicity_test
+        --test phase1_review_correlated_error_test
+        --test phase1_review_grouped_error_test
+        -- --test-threads=1
 
   coverage:
     name: Code Coverage
@@ -134,7 +146,7 @@ jobs:
       uses: taiki-e/install-action@cargo-llvm-cov
 
     - name: Generate coverage
-      run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info -- --test-threads=1
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5

--- a/design/storage/contracts.md
+++ b/design/storage/contracts.md
@@ -1,6 +1,6 @@
 # Storage lifecycle contracts
 
-Status: Phase 0 design under review. Baseline: `9cf15ea4`.
+Status: Phase 0 independently reviewed and accepted. Baseline: `9cf15ea4`.
 The accepted scope and phase boundaries are in [plan.md](plan.md).
 This document selects the protocols used to implement K1–K8. It does not
 declare an unimplemented budget or benchmark target achieved.

--- a/design/storage/progress.md
+++ b/design/storage/progress.md
@@ -7,7 +7,7 @@ with no engine caller does not count as an implemented phase.
 | Phase | Deliverable | Status | PR |
 |---|---|---|---|
 | 0 | Lifecycle contracts and validation rules | Design accepted | [#115](https://github.com/stoolap/stoolap/pull/115) |
-| 1 | Fallible cold access and statement rollback | Engine implementation present; cleanup verification in progress | [#116](https://github.com/stoolap/stoolap/pull/116) |
+| 1 | Fallible cold access and statement rollback | Cleanup verified; SQL statement rollback proven against parent | [#116](https://github.com/stoolap/stoolap/pull/116) |
 | 2 | Releasable chunks and retained hot accounting | Engine implementation present; dependency cleanup and verification in progress | [#117](https://github.com/stoolap/stoolap/pull/117) |
 | 3 | Coherent hot/cold reads | Draft; cleanup and final abort-publication correction remain | [#118](https://github.com/stoolap/stoolap/pull/118) |
 | 4 | Bounded streaming seal | Incomplete; unintegrated V5 prototype withdrawn | [#119](https://github.com/stoolap/stoolap/pull/119) |

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -1230,20 +1230,13 @@ impl Executor {
                         );
 
                         // Process the correlated expression with the outer row context
-                        let result = match self.process_correlated_expression(expr, &correlated_ctx)
-                        {
-                            Ok(processed_expr) => {
-                                // Evaluate the processed expression
-                                let mut corr_eval = CompiledEvaluator::new(&self.function_registry)
-                                    .with_context(&correlated_ctx);
-                                corr_eval.init_columns(&agg_columns);
-                                corr_eval.set_row_array(&row);
-                                corr_eval
-                                    .evaluate(&processed_expr)
-                                    .unwrap_or(Value::null_unknown())
-                            }
-                            Err(_) => Value::null_unknown(),
-                        };
+                        let processed_expr =
+                            self.process_correlated_expression(expr, &correlated_ctx)?;
+                        let mut corr_eval = CompiledEvaluator::new(&self.function_registry)
+                            .with_context(&correlated_ctx);
+                        corr_eval.init_columns(&agg_columns);
+                        corr_eval.set_row_array(&row);
+                        let result = corr_eval.evaluate(&processed_expr)?;
 
                         // Take back map for reuse
                         outer_row_map = correlated_ctx.outer_row.take().unwrap_or_default();
@@ -5430,7 +5423,7 @@ impl Executor {
                 "COUNT" => {
                     if agg.distinct {
                         // COUNT(DISTINCT col) - try to get count from index without cloning values
-                        if let Some(count) = table.get_partition_count(&agg.column_lower) {
+                        if let Some(count) = table.get_partition_count(&agg.column_lower)? {
                             // get_partition_count already excludes NULL values per SQL standard
                             result_values.push(Value::Integer(count as i64));
                         } else {
@@ -5439,7 +5432,7 @@ impl Executor {
                         }
                     } else if agg.column == "*" {
                         // COUNT(*) - use row_count
-                        let count = table.row_count();
+                        let count = table.row_count()?;
                         result_values.push(Value::Integer(count as i64));
                     } else {
                         // COUNT(col) - need to count non-null values, can't pushdown easily
@@ -5449,7 +5442,7 @@ impl Executor {
                 "SUM" => {
                     let col_idx = col_index_map.get(&agg.column_lower).copied();
                     if let Some(idx) = col_idx {
-                        if let Some((sum, count)) = table.sum_column(idx) {
+                        if let Some((sum, count)) = table.sum_column(idx)? {
                             if count == 0 {
                                 result_values.push(Value::null(crate::core::DataType::Float));
                             } else {
@@ -5471,7 +5464,7 @@ impl Executor {
                 "AVG" => {
                     let col_idx = col_index_map.get(&agg.column_lower).copied();
                     if let Some(idx) = col_idx {
-                        if let Some((sum, count)) = table.avg_column(idx) {
+                        if let Some((sum, count)) = table.avg_column(idx)? {
                             if count == 0 {
                                 result_values.push(Value::null(crate::core::DataType::Float));
                             } else {
@@ -5487,7 +5480,7 @@ impl Executor {
                 "MIN" => {
                     let col_idx = col_index_map.get(&agg.column_lower).copied();
                     if let Some(idx) = col_idx {
-                        if let Some(min_val) = table.min_column(idx) {
+                        if let Some(min_val) = table.min_column(idx)? {
                             result_values
                                 .push(min_val.unwrap_or_else(|| {
                                     Value::null(crate::core::DataType::Integer)
@@ -5502,7 +5495,7 @@ impl Executor {
                 "MAX" => {
                     let col_idx = col_index_map.get(&agg.column_lower).copied();
                     if let Some(idx) = col_idx {
-                        if let Some(max_val) = table.max_column(idx) {
+                        if let Some(max_val) = table.max_column(idx)? {
                             result_values
                                 .push(max_val.unwrap_or_else(|| {
                                     Value::null(crate::core::DataType::Integer)
@@ -5699,7 +5692,7 @@ impl Executor {
 
         // --- Call storage-level filtered aggregation ---
 
-        let values = match table.compute_filtered_aggregates(&agg_ops, storage_expr.as_ref()) {
+        let values = match table.compute_filtered_aggregates(&agg_ops, storage_expr.as_ref())? {
             Some(v) => v,
             None => return Ok(None),
         };
@@ -5822,7 +5815,7 @@ impl Executor {
                     "COUNT" => {
                         if agg.column == "*" {
                             // COUNT(*) - use row_count()
-                            Some(Value::Integer(table.row_count() as i64))
+                            Some(Value::Integer(table.row_count()? as i64))
                         } else {
                             // COUNT(col) - need scanner for NULL checking
                             // Could optimize with a dedicated count_non_null method
@@ -5831,7 +5824,7 @@ impl Executor {
                     }
                     "SUM" => {
                         if let Some(idx) = col_idx {
-                            if let Some((sum, count)) = table.sum_column(idx) {
+                            if let Some((sum, count)) = table.sum_column(idx)? {
                                 if count == 0 {
                                     Some(Value::null(crate::core::DataType::Float))
                                 } else if sum.fract() == 0.0 && sum.abs() < i64::MAX as f64 {
@@ -5848,7 +5841,7 @@ impl Executor {
                     }
                     "AVG" => {
                         if let Some(idx) = col_idx {
-                            if let Some((sum, count)) = table.avg_column(idx) {
+                            if let Some((sum, count)) = table.avg_column(idx)? {
                                 if count == 0 {
                                     Some(Value::null(crate::core::DataType::Float))
                                 } else {
@@ -5861,16 +5854,18 @@ impl Executor {
                             None
                         }
                     }
-                    "MIN" => col_idx.and_then(|idx| {
-                        table.min_column(idx).map(|min_opt| {
+                    "MIN" => match col_idx {
+                        Some(idx) => table.min_column(idx)?.map(|min_opt| {
                             min_opt.unwrap_or_else(|| Value::null(crate::core::DataType::Integer))
-                        })
-                    }),
-                    "MAX" => col_idx.and_then(|idx| {
-                        table.max_column(idx).map(|max_opt| {
+                        }),
+                        None => None,
+                    },
+                    "MAX" => match col_idx {
+                        Some(idx) => table.max_column(idx)?.map(|max_opt| {
                             max_opt.unwrap_or_else(|| Value::null(crate::core::DataType::Integer))
-                        })
-                    }),
+                        }),
+                        None => None,
+                    },
                     _ => None,
                 };
 
@@ -6550,33 +6545,33 @@ impl Executor {
         stmt: &SelectStatement,
         all_columns: &[String],
         classification: &QueryClassification,
-    ) -> Option<Box<dyn QueryResult>> {
+    ) -> Result<Option<Box<dyn QueryResult>>> {
         use crate::parser::ast::GroupByModifier;
         use crate::storage::mvcc::version_store::AggregateOp;
 
         if Self::aggregates_hold_subquery(stmt) {
-            return None;
+            return Ok(None);
         }
 
         // Only for GROUP BY without WHERE or HAVING
         if classification.has_where || !classification.has_group_by || classification.has_having {
-            return None;
+            return Ok(None);
         }
 
         // Only for simple GROUP BY (no ROLLUP, CUBE, or GROUPING SETS)
         if !matches!(stmt.group_by.modifier, GroupByModifier::None) {
-            return None;
+            return Ok(None);
         }
 
         // Only for simple GROUP BY expressions (column references)
         let group_by_cols = &stmt.group_by.columns;
         if group_by_cols.is_empty() {
-            return None;
+            return Ok(None);
         }
 
         // Only for single-column GROUP BY (multi-column causes Vec allocation per row)
         if group_by_cols.len() != 1 {
-            return None;
+            return Ok(None);
         }
 
         // Build column name -> index map
@@ -6597,10 +6592,10 @@ impl Executor {
                         group_by_indices.push(idx);
                         group_by_col_names.push(col_name);
                     } else {
-                        return None; // Unknown column
+                        return Ok(None); // Unknown column
                     }
                 }
-                _ => return None, // Non-column GROUP BY not supported
+                _ => return Ok(None), // Non-column GROUP BY not supported
             }
         }
 
@@ -6617,11 +6612,11 @@ impl Executor {
                     // This must be a GROUP BY column
                     let col_name_lower = ident.value.to_lowercase().to_string();
                     if !group_by_col_names.contains(&col_name_lower) {
-                        return None; // Column not in GROUP BY
+                        return Ok(None); // Column not in GROUP BY
                     }
                     if seen_aggregate {
                         // GROUP BY columns must come before aggregates for this optimization
-                        return None;
+                        return Ok(None);
                     }
                     select_group_count += 1;
                     result_columns.push(ident.value.to_string());
@@ -6629,7 +6624,7 @@ impl Executor {
                 Expression::FunctionCall(fc) => {
                     // Don't support FILTER clause or DISTINCT for this optimization
                     if fc.filter.is_some() || fc.is_distinct {
-                        return None;
+                        return Ok(None);
                     }
                     seen_aggregate = true;
                     let func_name = fc.function.to_uppercase();
@@ -6645,10 +6640,10 @@ impl Executor {
                                 if let Some(&idx) = col_map.get(col_name.as_str()) {
                                     (AggregateOp::Count, idx)
                                 } else {
-                                    return None;
+                                    return Ok(None);
                                 }
                             } else {
-                                return None;
+                                return Ok(None);
                             }
                         }
                         "SUM" => {
@@ -6657,10 +6652,10 @@ impl Executor {
                                 if let Some(&idx) = col_map.get(col_name.as_str()) {
                                     (AggregateOp::Sum, idx)
                                 } else {
-                                    return None;
+                                    return Ok(None);
                                 }
                             } else {
-                                return None;
+                                return Ok(None);
                             }
                         }
                         "AVG" => {
@@ -6669,10 +6664,10 @@ impl Executor {
                                 if let Some(&idx) = col_map.get(col_name.as_str()) {
                                     (AggregateOp::Avg, idx)
                                 } else {
-                                    return None;
+                                    return Ok(None);
                                 }
                             } else {
-                                return None;
+                                return Ok(None);
                             }
                         }
                         "MIN" => {
@@ -6681,10 +6676,10 @@ impl Executor {
                                 if let Some(&idx) = col_map.get(col_name.as_str()) {
                                     (AggregateOp::Min, idx)
                                 } else {
-                                    return None;
+                                    return Ok(None);
                                 }
                             } else {
-                                return None;
+                                return Ok(None);
                             }
                         }
                         "MAX" => {
@@ -6693,13 +6688,13 @@ impl Executor {
                                 if let Some(&idx) = col_map.get(col_name.as_str()) {
                                     (AggregateOp::Max, idx)
                                 } else {
-                                    return None;
+                                    return Ok(None);
                                 }
                             } else {
-                                return None;
+                                return Ok(None);
                             }
                         }
-                        _ => return None, // Unsupported aggregate
+                        _ => return Ok(None), // Unsupported aggregate
                     };
                     aggregates.push((op, col_idx));
 
@@ -6717,10 +6712,10 @@ impl Executor {
                     if let Expression::Identifier(ident) = aliased.expression.as_ref() {
                         let col_name_lower = ident.value.to_lowercase().to_string();
                         if !group_by_col_names.contains(&col_name_lower) {
-                            return None; // Column not in GROUP BY
+                            return Ok(None); // Column not in GROUP BY
                         }
                         if seen_aggregate {
-                            return None;
+                            return Ok(None);
                         }
                         select_group_count += 1;
                         result_columns.push(aliased.alias.value.to_string());
@@ -6729,7 +6724,7 @@ impl Executor {
                     else if let Expression::FunctionCall(fc) = aliased.expression.as_ref() {
                         // Don't support FILTER clause or DISTINCT for this optimization
                         if fc.filter.is_some() || fc.is_distinct {
-                            return None;
+                            return Ok(None);
                         }
                         seen_aggregate = true;
                         let func_name = fc.function.to_uppercase();
@@ -6746,10 +6741,10 @@ impl Executor {
                                     if let Some(&idx) = col_map.get(col_name.as_str()) {
                                         (AggregateOp::Count, idx)
                                     } else {
-                                        return None;
+                                        return Ok(None);
                                     }
                                 } else {
-                                    return None;
+                                    return Ok(None);
                                 }
                             }
                             "SUM" => {
@@ -6758,10 +6753,10 @@ impl Executor {
                                     if let Some(&idx) = col_map.get(col_name.as_str()) {
                                         (AggregateOp::Sum, idx)
                                     } else {
-                                        return None;
+                                        return Ok(None);
                                     }
                                 } else {
-                                    return None;
+                                    return Ok(None);
                                 }
                             }
                             "AVG" => {
@@ -6770,10 +6765,10 @@ impl Executor {
                                     if let Some(&idx) = col_map.get(col_name.as_str()) {
                                         (AggregateOp::Avg, idx)
                                     } else {
-                                        return None;
+                                        return Ok(None);
                                     }
                                 } else {
-                                    return None;
+                                    return Ok(None);
                                 }
                             }
                             "MIN" => {
@@ -6782,10 +6777,10 @@ impl Executor {
                                     if let Some(&idx) = col_map.get(col_name.as_str()) {
                                         (AggregateOp::Min, idx)
                                     } else {
-                                        return None;
+                                        return Ok(None);
                                     }
                                 } else {
-                                    return None;
+                                    return Ok(None);
                                 }
                             }
                             "MAX" => {
@@ -6794,37 +6789,40 @@ impl Executor {
                                     if let Some(&idx) = col_map.get(col_name.as_str()) {
                                         (AggregateOp::Max, idx)
                                     } else {
-                                        return None;
+                                        return Ok(None);
                                     }
                                 } else {
-                                    return None;
+                                    return Ok(None);
                                 }
                             }
-                            _ => return None,
+                            _ => return Ok(None),
                         };
                         aggregates.push((op, col_idx));
                         result_columns.push(aliased.alias.value.to_string());
                     } else {
-                        return None; // Other aliased expression not supported
+                        return Ok(None); // Other aliased expression not supported
                     }
                 }
-                _ => return None, // Unsupported expression type
+                _ => return Ok(None), // Unsupported expression type
             }
         }
 
         // Must have at least one aggregate
         if aggregates.is_empty() {
-            return None;
+            return Ok(None);
         }
 
         // SELECT must include at least all GROUP BY columns (can have more)
         // but for simplicity, require exact match with GROUP BY column count
         if select_group_count != group_by_col_names.len() {
-            return None;
+            return Ok(None);
         }
 
         // Call storage-level aggregation
-        let results = table.compute_grouped_aggregates(&group_by_indices, &aggregates)?;
+        let Some(results) = table.compute_grouped_aggregates(&group_by_indices, &aggregates)?
+        else {
+            return Ok(None);
+        };
 
         // Convert to rows
         let mut rows = RowVec::new();
@@ -6837,7 +6835,7 @@ impl Executor {
             ));
         }
 
-        Some(Box::new(ExecutorResult::new(result_columns, rows)))
+        Ok(Some(Box::new(ExecutorResult::new(result_columns, rows))))
     }
 
     /// Try fast COUNT(DISTINCT col) using compiled cache
@@ -6901,7 +6899,7 @@ impl Executor {
         let table = tx.get_table(&cd.table_name)?;
 
         let count = table
-            .get_partition_count(&cd.column_name)
+            .get_partition_count(&cd.column_name)?
             .ok_or_else(|| crate::core::Error::internal("Index no longer available for column"))?;
 
         // Build result
@@ -7080,8 +7078,9 @@ impl Executor {
         // value: a second call could return None (e.g. seal overlap or a
         // cold-volume reload failure) and an unwrap would panic.
         let count = match table.get_partition_count(&column_name) {
-            Some(c) => c,
-            None => {
+            Ok(Some(c)) => c,
+            Err(e) => return Some(Err(e)),
+            Ok(None) => {
                 *compiled_guard = CompiledExecution::NotOptimizable(self.engine.schema_epoch());
                 return None;
             }
@@ -7170,7 +7169,7 @@ impl Executor {
         let tx = self.engine.begin_transaction()?;
         let table = tx.get_table(&cs.table_name)?;
 
-        let count = table.row_count();
+        let count = table.row_count()?;
 
         // Build result
         let mut result_values = CompactVec::with_capacity(1);
@@ -7388,7 +7387,10 @@ impl Executor {
         };
 
         // Get the count
-        let count = table.row_count();
+        let count = match table.row_count() {
+            Ok(count) => count,
+            Err(e) => return Some(Err(e)),
+        };
 
         // Cache the compiled state
         let compiled_cs = CompiledCountStar {

--- a/src/executor/context.rs
+++ b/src/executor/context.rs
@@ -348,7 +348,7 @@ pub type RowFetcher = Box<dyn Fn(&[i64]) -> crate::core::Result<crate::core::Row
 
 /// Type alias for row counter function used in COUNT(*) optimization.
 /// This only counts visible rows without cloning their data.
-pub type RowCounter = Box<dyn Fn(&[i64]) -> usize + Send + Sync>;
+pub type RowCounter = Box<dyn Fn(&[i64]) -> crate::core::Result<usize> + Send + Sync>;
 
 // Cache for EXISTS row fetchers to avoid repeated version store lookups.
 // The key is the table name, the value is the row fetcher function.

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -448,6 +448,14 @@ impl Executor {
         stmt: &InsertStatement,
         ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        self.with_statement_rollback(|| self.execute_insert_inner(stmt, ctx))
+    }
+
+    fn execute_insert_inner(
+        &self,
+        stmt: &InsertStatement,
+        ctx: &ExecutionContext,
+    ) -> Result<Box<dyn QueryResult>> {
         // OPTIMIZATION: Use pre-computed lowercase name to avoid allocation per query
         let table_name = &stmt.table_name.value_lower;
 
@@ -1280,16 +1288,38 @@ impl Executor {
         ctx: &ExecutionContext,
         compiled_cache: &Arc<RwLock<CompiledExecution>>,
     ) -> Result<Box<dyn QueryResult>> {
-        // Conflict handling requires special handling - fall back to non-cached path
         if stmt.on_duplicate || stmt.do_nothing {
             return self.execute_insert(stmt, ctx);
         }
+        // Reuse the mutex guard needed to select the transaction. Autocommit
+        // does not need a second lock just to discover there is no checkpoint.
+        let mut active_tx = self.active_transaction.lock().unwrap();
+        let checkpoint = match active_tx.as_mut() {
+            Some(tx) => tx.transaction.begin_statement()?,
+            None => false,
+        };
+        let result =
+            self.execute_insert_with_compiled_cache_inner(stmt, ctx, compiled_cache, active_tx);
+        if checkpoint {
+            let Ok(mut active) = self.active_transaction.lock() else {
+                panic!("active transaction lock is poisoned during statement cleanup");
+            };
+            if let Some(tx) = active.as_mut() {
+                tx.transaction.finish_statement(result.is_ok());
+            }
+        }
+        result
+    }
 
+    fn execute_insert_with_compiled_cache_inner(
+        &self,
+        stmt: &InsertStatement,
+        ctx: &ExecutionContext,
+        compiled_cache: &Arc<RwLock<CompiledExecution>>,
+        mut active_tx: std::sync::MutexGuard<'_, Option<super::ActiveTransaction>>,
+    ) -> Result<Box<dyn QueryResult>> {
         // OPTIMIZATION: Use pre-computed lowercase name to avoid allocation per query
         let table_name = &stmt.table_name.value_lower;
-
-        // Check if there's an active explicit transaction
-        let mut active_tx = self.active_transaction.lock().unwrap();
 
         let (mut table, should_auto_commit, standalone_tx) =
             if let Some(ref mut tx_state) = *active_tx {
@@ -1727,6 +1757,14 @@ impl Executor {
         stmt: &UpdateStatement,
         ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        self.with_statement_rollback(|| self.execute_update_inner(stmt, ctx))
+    }
+
+    fn execute_update_inner(
+        &self,
+        stmt: &UpdateStatement,
+        ctx: &ExecutionContext,
+    ) -> Result<Box<dyn QueryResult>> {
         // A WITH clause is run first, so the subqueries can read it
         let ctx_with_ctes;
         let ctx = match &stmt.with {
@@ -2129,7 +2167,7 @@ impl Executor {
                             } else {
                                 evaluator.evaluate_bool(mem_where)
                             };
-                            if !matches!(held, Ok(true)) {
+                            if !held? {
                                 continue;
                             }
                         }
@@ -2225,7 +2263,7 @@ impl Executor {
                         } else {
                             evaluator.evaluate_bool(where_clause)
                         };
-                        if !matches!(held, Ok(true)) {
+                        if !held? {
                             outer_row_map = correlated_ctx.outer_row.take().unwrap_or_default();
                             continue;
                         }
@@ -2235,34 +2273,28 @@ impl Executor {
                 // Evaluate all update expressions
                 let mut new_values: Vec<(usize, Value)> = Vec::with_capacity(update_indices.len());
                 for (idx, col_type, vec_dims, expr, is_correlated) in update_indices.iter() {
-                    let evaluated = if *is_correlated {
-                        // Process correlated expression - this executes the subquery
-                        match self.process_correlated_expression(expr, &correlated_ctx) {
-                            Ok(processed_expr) => {
-                                // Now evaluate the processed expression (subquery replaced with value)
-                                let mut eval = CompiledEvaluator::new(function_registry)
-                                    .with_context(&correlated_ctx);
-                                eval.init_columns_arc(CompactArc::clone(&column_names));
-                                eval.set_row_array(row);
-                                eval.evaluate(&processed_expr).ok()
-                            }
-                            Err(_) => None,
-                        }
+                    let new_value = if *is_correlated {
+                        // A failed subquery must abort the entire statement;
+                        // skipping its SET value would report a partial update.
+                        let processed_expr =
+                            self.process_correlated_expression(expr, &correlated_ctx)?;
+                        let mut eval =
+                            CompiledEvaluator::new(function_registry).with_context(&correlated_ctx);
+                        eval.init_columns_arc(CompactArc::clone(&column_names));
+                        eval.set_row_array(row);
+                        eval.evaluate(&processed_expr)?
                     } else {
-                        evaluator.evaluate(expr).ok()
+                        evaluator.evaluate(expr)?
                     };
-
-                    if let Some(new_value) = evaluated {
-                        let coerced = new_value.coerce_to_type(*col_type);
-                        validate_coercion(
-                            &new_value,
-                            &coerced,
-                            &schema.columns[*idx].name,
-                            *col_type,
-                            *vec_dims,
-                        )?;
-                        new_values.push((*idx, coerced));
-                    }
+                    let coerced = new_value.coerce_to_type(*col_type);
+                    validate_coercion(
+                        &new_value,
+                        &coerced,
+                        &schema.columns[*idx].name,
+                        *col_type,
+                        *vec_dims,
+                    )?;
+                    new_values.push((*idx, coerced));
                 }
 
                 // Take back the map for reuse (zero-copy transfer)
@@ -2271,6 +2303,9 @@ impl Executor {
                 if !new_values.is_empty() {
                     precomputed.insert(pk_value, new_values);
                 }
+            }
+            if let Some(error) = scanner.err() {
+                return Err(error.clone());
             }
             drop(scanner);
 
@@ -2481,7 +2516,7 @@ impl Executor {
                             } else {
                                 evaluator.evaluate_bool(where_expr)
                             };
-                            if !matches!(held, Ok(true)) {
+                            if !held? {
                                 return Ok((row, false));
                             }
                         }
@@ -2702,6 +2737,14 @@ impl Executor {
 
     /// Execute a DELETE statement
     pub(crate) fn execute_delete(
+        &self,
+        stmt: &DeleteStatement,
+        ctx: &ExecutionContext,
+    ) -> Result<Box<dyn QueryResult>> {
+        self.with_statement_rollback(|| self.execute_delete_inner(stmt, ctx))
+    }
+
+    fn execute_delete_inner(
         &self,
         stmt: &DeleteStatement,
         ctx: &ExecutionContext,
@@ -2976,25 +3019,14 @@ impl Executor {
                             );
 
                             // Process correlated subquery with outer context
-                            match self.process_correlated_where(where_expr, &correlated_ctx) {
-                                Ok(processed) => {
-                                    // OPTIMIZATION: Take ownership instead of cloning
-                                    evaluator.set_outer_row_owned(
-                                        correlated_ctx.outer_row.take().unwrap_or_default(),
-                                    );
-                                    let result =
-                                        evaluator.evaluate_bool(&processed).unwrap_or(false);
-                                    // Take back map for reuse instead of clearing
-                                    outer_row_map = evaluator.take_outer_row();
-                                    result
-                                }
-                                Err(_) => {
-                                    // Take back map from context even on error
-                                    outer_row_map =
-                                        correlated_ctx.outer_row.take().unwrap_or_default();
-                                    false
-                                }
-                            }
+                            let processed =
+                                self.process_correlated_where(where_expr, &correlated_ctx)?;
+                            evaluator.set_outer_row_owned(
+                                correlated_ctx.outer_row.take().unwrap_or_default(),
+                            );
+                            let result = evaluator.evaluate_bool(&processed)?;
+                            outer_row_map = evaluator.take_outer_row();
+                            result
                         } else if let Some(ref program) = memory_where_program {
                             let mut exec_ctx =
                                 ExecuteContext::new(row).with_transaction_id(transaction_id);
@@ -3006,7 +3038,7 @@ impl Executor {
                             }
                             delete_vm.execute_bool(program, &exec_ctx)
                         } else {
-                            matches!(evaluator.evaluate_bool(where_expr), Ok(true))
+                            evaluator.evaluate_bool(where_expr)?
                         }
                     } else {
                         true
@@ -3037,6 +3069,9 @@ impl Executor {
                 }
             }
             // Drop scanner to release borrow
+            if let Some(error) = scanner.err() {
+                return Err(error.clone());
+            }
             drop(scanner);
 
             // FK enforcement: check/cascade referencing child tables before deleting
@@ -3674,6 +3709,9 @@ impl Executor {
             None
         };
 
+        if let Some(error) = scanner.err() {
+            return Err(error.clone());
+        }
         scanner.close()?;
         Ok(result)
     }

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -193,7 +193,7 @@ impl Executor {
         }
 
         // Use table's row_count method (O(1) instead of O(n))
-        let count = table.row_count();
+        let count = table.row_count()?;
 
         // Build result - wrap columns in CompactArc once for zero-copy sharing
         let col_name = alias.unwrap_or_else(|| "COUNT(*)".to_string());
@@ -259,7 +259,7 @@ impl Executor {
 
         // Try to use index-ordered scan
         if let Some(rows) =
-            table.collect_rows_ordered_by_index(&column_name, ascending, limit, offset)
+            table.collect_rows_ordered_by_index(&column_name, ascending, limit, offset)?
         {
             // Project rows according to SELECT expressions
             let projected_rows = self.project_rows(&stmt.columns, rows, all_columns, ctx)?;
@@ -1163,7 +1163,7 @@ impl Executor {
 
                 // Iterate through row_ids and collect non-excluded ones
                 // Row IDs are typically 1-based and sequential
-                let row_count = table.row_count();
+                let row_count = table.row_count()?;
                 for row_id in 1..=(row_count as i64) {
                     if !exclusion_set.contains(row_id) {
                         all_row_ids.push(row_id);

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -335,6 +335,9 @@ impl Executor {
         sql: &str,
         params: &[Value],
     ) -> Option<Result<Box<dyn QueryResult>>> {
+        if let Err(error) = self.engine.check_health() {
+            return Some(Err(error));
+        }
         // Quick reject: if in explicit transaction, skip fast path
         {
             let active_tx = match self.active_transaction.try_lock() {
@@ -398,6 +401,7 @@ impl Executor {
     /// If found, it uses the cached AST. Otherwise, it parses the query
     /// and caches the result for future use.
     fn execute_cached(&self, sql: &str, ctx: &ExecutionContext) -> Result<Box<dyn QueryResult>> {
+        self.engine.check_health()?;
         // Try to get from cache
         if let Some(cached) = self.query_cache.get(sql) {
             // Validate parameter count if query has parameters
@@ -616,6 +620,7 @@ impl Executor {
             &std::sync::OnceLock<Arc<query_classification::QueryClassification>>,
         >,
     ) -> Result<Box<dyn QueryResult>> {
+        self.engine.check_health()?;
         // If there's an active transaction, inject the transaction ID into the context
         // This enables CURRENT_TRANSACTION_ID() function to return the correct value
         let ctx_with_txn;
@@ -678,6 +683,34 @@ impl Executor {
             Statement::Vacuum(stmt) => self.execute_vacuum(stmt, ctx),
             Statement::Copy(stmt) => self.execute_copy(stmt, ctx),
         }
+    }
+
+    /// Explicit transactions retain earlier successful statements on an error.
+    /// Autocommit already owns an entire disposable storage transaction.
+    fn with_statement_rollback<F>(&self, action: F) -> Result<Box<dyn QueryResult>>
+    where
+        F: FnOnce() -> Result<Box<dyn QueryResult>>,
+    {
+        let checkpoint = {
+            let mut active = self
+                .active_transaction
+                .lock()
+                .map_err(|_| Error::internal("active transaction lock is poisoned"))?;
+            match active.as_mut() {
+                Some(tx) => tx.transaction.begin_statement()?,
+                None => false,
+            }
+        };
+        let result = action();
+        if checkpoint {
+            let Ok(mut active) = self.active_transaction.lock() else {
+                panic!("active transaction lock is poisoned during statement cleanup");
+            };
+            if let Some(tx) = active.as_mut() {
+                tx.transaction.finish_statement(result.is_ok());
+            }
+        }
+        result
     }
 
     /// Install an external storage transaction as the active transaction.
@@ -753,6 +786,7 @@ impl Executor {
         plan: &CachedPlanRef,
         ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        self.engine.check_health()?;
         // Validate parameter count
         if plan.has_params {
             let provided = ctx.params().len();

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -2176,12 +2176,16 @@ impl Executor {
         }
 
         // Try to get distinct values from the index
-        let distinct_values = table.get_partition_values(&column_name).or_else(|| {
-            // Fallback: dictionary-based extraction from cold volumes
-            let schema = table.schema();
-            let col_idx = *schema.column_index_map().get(&column_name)?;
-            table.compute_distinct_values(col_idx)
-        });
+        let distinct_values = match table.get_partition_values(&column_name)? {
+            Some(values) => Some(values),
+            None => {
+                let schema = table.schema();
+                match schema.column_index_map().get(&column_name) {
+                    Some(&col_idx) => table.compute_distinct_values(col_idx)?,
+                    None => None,
+                }
+            }
+        };
 
         if let Some(distinct_values) = distinct_values {
             // Build output column name (use alias if present)
@@ -2331,9 +2335,12 @@ impl Executor {
             // Try storage-level GROUP BY aggregation (no WHERE clause)
             // This computes aggregates directly from arena without materializing Row objects
             if classification.has_group_by && !classification.has_where {
-                if let Some(result) =
-                    self.try_storage_aggregation(table.as_ref(), stmt, &all_columns, classification)
-                {
+                if let Some(result) = self.try_storage_aggregation(
+                    table.as_ref(),
+                    stmt,
+                    &all_columns,
+                    classification,
+                )? {
                     let columns = CompactArc::new(result.columns().to_vec());
                     return Ok((result, columns, false, None));
                 }
@@ -3432,6 +3439,9 @@ impl Executor {
                     while scanner.next() {
                         all_rows.push(scanner.take_row_with_id());
                     }
+                    if let Some(error) = scanner.err() {
+                        return Err(error.clone());
+                    }
                     all_rows
                 };
 
@@ -3677,6 +3687,9 @@ impl Executor {
                         }
                     }
                 }
+                if let Some(error) = scanner.err() {
+                    return Err(error.clone());
+                }
                 (rows, None, None)
             }
         } else if storage_expr.is_some() {
@@ -3736,18 +3749,18 @@ impl Executor {
                                         &all_columns,
                                         &partition_col,
                                         limit_val,
-                                    );
-                                if let Ok(query_result) = result {
+                                    )?;
+                                if let Some(query_result) = result {
                                     let columns = CompactArc::new(query_result.columns().to_vec());
                                     return Ok((query_result, columns, false, None));
                                 }
-                                // Fall through to regular path if optimization fails
+                                // Fall back only when this table does not support partition fetching.
                             }
                         }
 
                         // Regular path: Fetch rows grouped by partition (no hash grouping needed)
                         if let Some(grouped_data) =
-                            table.collect_rows_grouped_by_partition(&partition_col)
+                            table.collect_rows_grouped_by_partition(&partition_col)?
                         {
                             // Flatten rows and build partition map
                             let mut all_rows = RowVec::new();
@@ -3825,7 +3838,7 @@ impl Executor {
                             ascending,
                             fetch_limit,
                             0,
-                        ) {
+                        )? {
                             (
                                 sorted_rows,
                                 Some(WindowPreSortedState {

--- a/src/executor/statistics.rs
+++ b/src/executor/statistics.rs
@@ -155,7 +155,7 @@ impl Executor {
         let schema = table.schema().clone();
 
         // Get row count
-        let row_count = table.row_count();
+        let row_count = table.row_count()?;
 
         // Collect all rows for zone map building (zone maps need complete data)
         let mut all_rows = table.collect_all_rows(None)?;

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -570,7 +570,7 @@ impl Executor {
         // If there's no additional predicate, check if at least one row is visible
         // Note: Index may contain row_ids for deleted rows, so we must verify visibility
         if correlation.additional_predicate.is_none() {
-            let row_fetcher = match self.get_or_create_row_fetcher(&correlation.inner_table) {
+            let row_fetcher = match self.get_or_create_row_fetcher(&correlation.inner_table)? {
                 Some(f) => f,
                 None => return Ok(None), // Fall back if fetcher creation fails
             };
@@ -678,7 +678,7 @@ impl Executor {
         let predicate_filter = predicate_filter.with_context(ctx);
 
         // Get or create a cached row fetcher for this table
-        let row_fetcher = match self.get_or_create_row_fetcher(&correlation.inner_table) {
+        let row_fetcher = match self.get_or_create_row_fetcher(&correlation.inner_table)? {
             Some(f) => f,
             None => return Ok(None), // Fall back if fetcher creation fails
         };
@@ -933,7 +933,7 @@ impl Executor {
             // Use row_counter for COUNT (avoids cloning row data)
             let row_counter = match get_cached_count_counter(&correlation.inner_table) {
                 Some(c) => c,
-                None => match self.get_or_create_row_counter(&correlation.inner_table) {
+                None => match self.get_or_create_row_counter(&correlation.inner_table)? {
                     Some(c) => c,
                     None => {
                         // Fall back to row_fetcher if counter not available
@@ -941,7 +941,7 @@ impl Executor {
                         {
                             Some(f) => f,
                             None => {
-                                match self.get_or_create_row_fetcher(&correlation.inner_table) {
+                                match self.get_or_create_row_fetcher(&correlation.inner_table)? {
                                     Some(f) => f,
                                     None => return Ok(None),
                                 }
@@ -953,7 +953,7 @@ impl Executor {
                 },
             };
             // Count visible rows without cloning
-            let count = row_counter(&row_ids);
+            let count = row_counter(&row_ids)?;
             return Ok(Some(count as i64));
         }
 
@@ -1280,17 +1280,13 @@ impl Executor {
     fn get_or_create_row_fetcher(
         &self,
         table_name: &str,
-    ) -> Option<std::sync::Arc<super::context::RowFetcher>> {
-        if let Some(f) = get_cached_exists_fetcher(table_name) {
-            return Some(f);
+    ) -> Result<Option<std::sync::Arc<super::context::RowFetcher>>> {
+        if let Some(cached) = get_cached_exists_fetcher(table_name) {
+            return Ok(Some(cached));
         }
-
-        let fetcher = match self.engine.get_row_fetcher(table_name) {
-            Ok(f) => f,
-            Err(_) => return None, // Fall back if fetcher creation fails
-        };
+        let fetcher = self.engine.get_row_fetcher(table_name)?;
         cache_exists_fetcher(table_name.to_string(), fetcher);
-        get_cached_exists_fetcher(table_name)
+        Ok(get_cached_exists_fetcher(table_name))
     }
 
     /// Get or create a cached row counter for a table.
@@ -1300,25 +1296,13 @@ impl Executor {
     fn get_or_create_row_counter(
         &self,
         table_name: &str,
-    ) -> Option<std::sync::Arc<super::context::RowCounter>> {
-        if let Some(c) = get_cached_count_counter(table_name) {
-            return Some(c);
+    ) -> Result<Option<std::sync::Arc<super::context::RowCounter>>> {
+        if let Some(cached) = get_cached_count_counter(table_name) {
+            return Ok(Some(cached));
         }
-
-        let counter = match self.engine.get_row_counter(table_name) {
-            Ok(c) => c,
-            Err(_e) => {
-                // Fall back to slower path if counter creation fails
-                #[cfg(debug_assertions)]
-                eprintln!(
-                    "[WARN] get_row_counter failed for '{}': {:?}",
-                    table_name, _e
-                );
-                return None;
-            }
-        };
+        let counter = self.engine.get_row_counter(table_name)?;
         cache_count_counter(table_name.to_string(), counter);
-        get_cached_count_counter(table_name)
+        Ok(get_cached_count_counter(table_name))
     }
 
     /// Extract correlation pair from two expressions.

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -1130,7 +1130,7 @@ impl Executor {
         base_columns: &[String],
         partition_col: &str,
         limit: usize,
-    ) -> Result<Box<dyn QueryResult>> {
+    ) -> Result<Option<Box<dyn QueryResult>>> {
         // Parse window functions from SELECT list
         let mut window_functions = self.parse_window_functions(stmt, base_columns)?;
         self.fold_window_control_arguments(&mut window_functions, ctx)?;
@@ -1168,9 +1168,9 @@ impl Executor {
             select_items.iter().map(|i| i.output_name.clone()).collect();
 
         // Get partition values from the index (lazy iteration key!)
-        let partition_values = match table.get_partition_values(partition_col) {
+        let partition_values = match table.get_partition_values(partition_col)? {
             Some(values) => values,
-            None => return Err(Error::internal("Failed to get partition values from index")),
+            None => return Ok(None),
         };
 
         // Process partitions one at a time, stopping when we have enough rows
@@ -1189,7 +1189,7 @@ impl Executor {
             let partition_rows =
                 match table.get_rows_for_partition_value(partition_col, &partition_value)? {
                     Some(rows) => rows,
-                    None => continue,
+                    None => return Ok(None),
                 };
 
             if partition_rows.is_empty() {
@@ -1341,7 +1341,10 @@ impl Executor {
             }
         }
 
-        Ok(Box::new(ExecutorResult::new(result_columns, result_rows)))
+        Ok(Some(Box::new(ExecutorResult::new(
+            result_columns,
+            result_rows,
+        ))))
     }
 
     /// Parse SELECT list to determine output order and sources

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -175,7 +175,7 @@ fn try_parse_default_literal(expr: &str, data_type: DataType) -> Option<Value> {
 
 /// Register a virtual PkIndex on an INTEGER PRIMARY KEY column.
 /// This allows the optimizer to find the PK index via `get_index_by_column()`.
-fn register_pk_index(schema: &Schema, version_store: &Arc<VersionStore>) {
+fn register_pk_index(schema: &Schema, version_store: &Arc<VersionStore>) -> Result<()> {
     if let Some(pk_idx) = schema.pk_column_index() {
         let pk_col = &schema.columns[pk_idx];
         let index_name = format!("__pk_{}_{}", schema.table_name_lower, pk_col.name);
@@ -185,8 +185,9 @@ fn register_pk_index(schema: &Schema, version_store: &Arc<VersionStore>) {
             pk_col.id as i32,
             pk_col.name.clone(),
         ));
-        version_store.add_index(index_name, pk_index);
+        version_store.add_index(index_name, pk_index)?;
     }
+    Ok(())
 }
 
 // ============================================================================
@@ -460,6 +461,8 @@ pub struct MVCCEngine {
     registry: Arc<TransactionRegistry>,
     /// Whether the engine is open
     open: AtomicBool,
+    /// Shared terminal failure gate for publication undo failures.
+    execution_failed: Arc<AtomicBool>,
     /// Cache of transaction version stores per (txn_id, table_name) for proper commit/rollback
     /// (Arc-wrapped for safe sharing with transactions)
     txn_version_stores: Arc<RwLock<TxnVersionStoreMap>>,
@@ -589,6 +592,7 @@ impl MVCCEngine {
             version_stores: Arc::new(RwLock::new(FxHashMap::default())),
             registry: Arc::new(TransactionRegistry::new()),
             open: AtomicBool::new(false),
+            execution_failed: Arc::new(AtomicBool::new(false)),
             txn_version_stores: Arc::new(RwLock::new(I64Map::new())),
             views: RwLock::new(FxHashMap::default()),
             persistence: Arc::new(persistence),
@@ -1109,7 +1113,7 @@ impl MVCCEngine {
         ));
 
         // Register virtual PkIndex for INTEGER PRIMARY KEY
-        register_pk_index(&schema, &version_store);
+        register_pk_index(&schema, &version_store)?;
 
         // Load all rows from the snapshot
         reader.for_each(|row_id, mut version| {
@@ -1168,7 +1172,7 @@ impl MVCCEngine {
                 schema.clone(),
                 registry_as_visibility_checker(&self.registry),
             ));
-            register_pk_index(&schema, &version_store);
+            register_pk_index(&schema, &version_store)?;
 
             // Store schema and version store
             {
@@ -1209,7 +1213,7 @@ impl MVCCEngine {
             schema.clone(),
             registry_as_visibility_checker(&self.registry),
         ));
-        register_pk_index(&schema, &version_store);
+        register_pk_index(&schema, &version_store)?;
 
         // Build a frozen volume from the snapshot rows
         let mut builder = crate::storage::volume::writer::VolumeBuilder::new(&schema);
@@ -1505,7 +1509,7 @@ impl MVCCEngine {
                             let mut has_null = false;
                             for &ci in col_indices {
                                 let v = if ci < vol.columns.len() {
-                                    vol.columns[ci].get_value(i)
+                                    vol.columns.get(ci)?.get_value(i)
                                 } else {
                                     crate::core::Value::Null(crate::core::DataType::Null)
                                 };
@@ -1622,7 +1626,7 @@ impl MVCCEngine {
                     ));
 
                     // Register virtual PkIndex for INTEGER PRIMARY KEY
-                    register_pk_index(&schema, &version_store);
+                    register_pk_index(&schema, &version_store)?;
 
                     let table_name = schema.table_name_lower.clone();
 
@@ -1731,7 +1735,7 @@ impl MVCCEngine {
                 if let Ok(index_name) = String::from_utf8(entry.data.clone()) {
                     let table_name = entry.table_name.to_lowercase();
                     if let Ok(store) = self.get_version_store(&table_name) {
-                        let _ = store.drop_index(&index_name);
+                        store.drop_index(&index_name)?;
                     }
                 }
             }
@@ -1740,7 +1744,7 @@ impl MVCCEngine {
                 if let Ok(row_version) = deserialize_row_version(&entry.data) {
                     let table_name = entry.table_name.to_lowercase();
                     let mgr = self.get_or_create_segment_manager(&table_name);
-                    let in_volume = mgr.is_row_id_in_volume(entry.row_id);
+                    let in_volume = mgr.is_row_id_in_volume(entry.row_id)?;
 
                     if in_volume {
                         // Row exists in a cold volume. Two cases:
@@ -1788,7 +1792,7 @@ impl MVCCEngine {
                 // If the deleted row_id lives in a cold segment, add a tombstone
                 // so it is excluded from scans and point lookups.
                 let mgr = self.get_or_create_segment_manager(&table_name);
-                if mgr.is_row_id_in_volume(entry.row_id) {
+                if mgr.is_row_id_in_volume(entry.row_id)? {
                     // Recovery tombstones get commit_seq=0, which is always visible
                     // to all new snapshots (any begin_seq > 0). This is correct:
                     // these tombstones were committed before the restart.
@@ -2133,7 +2137,7 @@ impl MVCCEngine {
         // in volumes so startup is fast and doesn't depend on WAL replay.
         // Skipped when checkpoint_on_close is false (crash simulation in tests).
         let checkpoint_on_close = self.config.read().unwrap().persistence.checkpoint_on_close;
-        if checkpoint_on_close {
+        if checkpoint_on_close && self.check_execution_health().is_ok() {
             if let Some(ref pm) = *self.persistence {
                 if pm.is_enabled() {
                     // Retry checkpoint until all hot buffers are empty.
@@ -2198,6 +2202,21 @@ impl MVCCEngine {
     /// Returns whether the engine is open
     pub fn is_open(&self) -> bool {
         self.open.load(Ordering::Acquire)
+    }
+
+    fn check_execution_health(&self) -> Result<()> {
+        if self.execution_failed.load(Ordering::Acquire)
+            || self
+                .persistence
+                .as_ref()
+                .as_ref()
+                .is_some_and(PersistenceManager::has_indeterminate_commit)
+        {
+            return Err(Error::internal(
+                "transaction outcome is unresolved; close and reopen the database",
+            ));
+        }
+        Ok(())
     }
 
     /// Per-table, per-volume statistics for PRAGMA VOLUME_STATS.
@@ -2742,6 +2761,7 @@ impl MVCCEngine {
 
     /// Creates a new table
     pub fn create_table(&self, schema: Schema) -> Result<Schema> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -2759,7 +2779,7 @@ impl MVCCEngine {
         ));
 
         // Register virtual PkIndex for INTEGER PRIMARY KEY
-        register_pk_index(&schema, &version_store);
+        register_pk_index(&schema, &version_store)?;
 
         // Prepare WAL data before locks (avoids holding lock during serialization)
         let schema_data = Self::serialize_schema(&schema);
@@ -2793,6 +2813,7 @@ impl MVCCEngine {
 
     /// Drops a table
     pub fn drop_table_internal(&self, name: &str) -> Result<()> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -2852,6 +2873,7 @@ impl MVCCEngine {
 
     /// Gets a version store for a table
     pub fn get_version_store(&self, name: &str) -> Result<Arc<VersionStore>> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -2873,6 +2895,7 @@ impl MVCCEngine {
         data_type: DataType,
         nullable: bool,
     ) -> Result<()> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -2938,6 +2961,7 @@ impl MVCCEngine {
         default_expr: Option<String>,
         vector_dimensions: u16,
     ) -> Result<()> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -2998,6 +3022,7 @@ impl MVCCEngine {
     /// Refresh the engine's schema cache for a table from the version store
     /// This is used after DDL operations that modify the table's schema directly
     pub fn refresh_schema_cache(&self, table_name: &str) -> Result<()> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -3450,6 +3475,7 @@ impl MVCCEngine {
 
     /// Drops a column from a table
     pub fn drop_column(&self, table_name: &str, column_name: &str) -> Result<()> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -3507,6 +3533,7 @@ impl MVCCEngine {
 
     /// Renames a column in a table
     pub fn rename_column(&self, table_name: &str, old_name: &str, new_name: &str) -> Result<()> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -3601,6 +3628,7 @@ impl MVCCEngine {
         data_type: DataType,
         nullable: bool,
     ) -> Result<()> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -3661,6 +3689,7 @@ impl MVCCEngine {
         nullable: bool,
         vector_dimensions: u16,
     ) -> Result<()> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -3714,6 +3743,7 @@ impl MVCCEngine {
 
     /// Renames a table
     pub fn rename_table(&self, old_name: &str, new_name: &str) -> Result<()> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -3861,6 +3891,7 @@ impl MVCCEngine {
     pub fn create_view(&self, name: &str, query: String, if_not_exists: bool) -> Result<()> {
         use crate::storage::mvcc::wal_manager::WALOperationType;
 
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -3907,6 +3938,7 @@ impl MVCCEngine {
     pub fn drop_view(&self, name: &str, if_exists: bool) -> Result<()> {
         use crate::storage::mvcc::wal_manager::WALOperationType;
 
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -3939,6 +3971,7 @@ impl MVCCEngine {
     /// Use this when you already have a lowercase name to avoid allocation
     #[inline]
     pub fn view_exists_lowercase(&self, name_lower: &str) -> Result<bool> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -3957,6 +3990,7 @@ impl MVCCEngine {
     /// Returns Arc clone (cheap pointer copy, no data clone).
     #[inline]
     pub fn get_view_lowercase(&self, name_lower: &str) -> Result<Option<Arc<ViewDefinition>>> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -3967,6 +4001,7 @@ impl MVCCEngine {
 
     /// List all view names
     pub fn list_views(&self) -> Result<Vec<String>> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -3989,6 +4024,7 @@ impl MVCCEngine {
     /// timestamped snapshot files. The keep_snapshots config limits how many backup
     /// files are retained per table.
     fn create_backup_snapshot(&self) -> Result<()> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -4196,9 +4232,9 @@ impl MVCCEngine {
                         }
 
                         let mut row = if mapping.is_identity {
-                            vol.get_row(i)
+                            vol.get_row(i)?
                         } else {
-                            vol.get_row_mapped(i, &mapping)
+                            vol.get_row_mapped(i, &mapping)?
                         };
 
                         if row.len() < schema_cols {
@@ -4608,6 +4644,7 @@ impl MVCCEngine {
 
     /// Restore the database from a backup snapshot, replacing all current data.
     fn restore_from_snapshot(&self, timestamp: Option<&str>) -> Result<String> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -5078,6 +5115,7 @@ impl MVCCEngine {
     /// regardless of threshold (used by PRAGMA CHECKPOINT and close_engine).
     /// When false, respects the normal seal thresholds (used by background thread).
     fn checkpoint_cycle_inner(&self, force: bool) -> Result<()> {
+        self.check_execution_health()?;
         if let Some(ref pm) = *self.persistence {
             if !pm.is_enabled() {
                 return Ok(());
@@ -5516,21 +5554,20 @@ impl MVCCEngine {
                     .iter()
                     .map(|&i| manifest.segments[i].segment_id)
                     .collect();
-                let mut vols: Vec<(u64, Arc<crate::storage::volume::writer::FrozenVolume>)> =
-                    merge_indices
-                        .iter()
-                        .filter_map(|&i| {
-                            let seg = &manifest.segments[i];
-                            let vol = segs.get(&seg.segment_id)?;
-                            if vol.volume.is_cold() {
-                                // Load only this merge candidate from disk.
-                                let loaded = mgr.ensure_volume(seg.segment_id).ok()??;
-                                Some((seg.segment_id, loaded))
-                            } else {
-                                Some((seg.segment_id, Arc::clone(&vol.volume)))
-                            }
-                        })
-                        .collect();
+                let mut vols = Vec::with_capacity(merge_indices.len());
+                for &i in &merge_indices {
+                    let seg = &manifest.segments[i];
+                    let Some(vol) = segs.get(&seg.segment_id) else {
+                        continue;
+                    };
+                    if vol.volume.is_cold() {
+                        if let Some(loaded) = mgr.ensure_volume(seg.segment_id)? {
+                            vols.push((seg.segment_id, loaded));
+                        }
+                    } else {
+                        vols.push((seg.segment_id, Arc::clone(&vol.volume)));
+                    }
+                }
                 drop(segs);
 
                 // Every manifest entry must have a loaded volume.
@@ -5666,9 +5703,9 @@ impl MVCCEngine {
                     let vol = &volumes[vol_idx].1;
                     let mapping = &vol_mappings[vol_idx];
                     let row = if mapping.is_identity {
-                        vol.get_row(row_idx)
+                        vol.get_row(row_idx)?
                     } else {
-                        vol.get_row_mapped(row_idx, mapping)
+                        vol.get_row_mapped(row_idx, mapping)?
                     };
                     builder.add_row(row_id, &row);
                 }
@@ -5690,7 +5727,7 @@ impl MVCCEngine {
                             let stores = self.version_stores.read().unwrap();
                             if let Some(store) = stores.get(table_name) {
                                 for (col_indices, _) in store.get_unique_non_pk_index_columns() {
-                                    compacted.prebuild_unique_index(&col_indices);
+                                    compacted.prebuild_unique_index(&col_indices)?;
                                 }
                             }
                         }
@@ -5978,7 +6015,7 @@ impl MVCCEngine {
                         if let Some(store) = stores.get(&table_name) {
                             for (col_indices, _) in store.get_unique_non_pk_index_columns() {
                                 for (vol, _, _) in &sealed_volumes {
-                                    vol.prebuild_unique_index(&col_indices);
+                                    vol.prebuild_unique_index(&col_indices)?;
                                 }
                             }
                         }
@@ -6091,6 +6128,10 @@ impl MVCCEngine {
 }
 
 impl Engine for MVCCEngine {
+    fn check_health(&self) -> Result<()> {
+        self.check_execution_health()
+    }
+
     fn open(&mut self) -> Result<()> {
         MVCCEngine::open_engine(self)
     }
@@ -6104,6 +6145,7 @@ impl Engine for MVCCEngine {
     }
 
     fn begin_transaction_with_level(&self, level: IsolationLevel) -> Result<Box<dyn Transaction>> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -6140,6 +6182,7 @@ impl Engine for MVCCEngine {
     }
 
     fn table_exists(&self, table_name: &str) -> Result<bool> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -6150,6 +6193,7 @@ impl Engine for MVCCEngine {
     }
 
     fn index_exists(&self, index_name: &str, table_name: &str) -> Result<bool> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -6159,6 +6203,7 @@ impl Engine for MVCCEngine {
     }
 
     fn get_index(&self, table_name: &str, index_name: &str) -> Result<Box<dyn Index>> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -6180,6 +6225,7 @@ impl Engine for MVCCEngine {
     }
 
     fn get_table_schema(&self, table_name: &str) -> Result<CompactArc<Schema>> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -6198,6 +6244,7 @@ impl Engine for MVCCEngine {
     }
 
     fn list_table_indexes(&self, table_name: &str) -> Result<FxHashMap<String, String>> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -6211,6 +6258,7 @@ impl Engine for MVCCEngine {
     }
 
     fn get_all_indexes(&self, table_name: &str) -> Result<Vec<std::sync::Arc<dyn Index>>> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -6235,6 +6283,7 @@ impl Engine for MVCCEngine {
     }
 
     fn set_isolation_level(&mut self, level: IsolationLevel) -> Result<()> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -6542,6 +6591,7 @@ impl Engine for MVCCEngine {
     }
 
     fn fetch_rows_by_ids(&self, table_name: &str, row_ids: &[i64]) -> Result<crate::core::RowVec> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -6573,6 +6623,7 @@ impl Engine for MVCCEngine {
         &self,
         table_name: &str,
     ) -> Result<Box<dyn Fn(&[i64]) -> Result<crate::core::RowVec> + Send + Sync>> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -6582,7 +6633,19 @@ impl Engine for MVCCEngine {
         let schema = store.schema().clone();
         let read_txn_id = INVALID_TRANSACTION_ID + 1;
 
+        let execution_failed = Arc::clone(&self.execution_failed);
+        let persistence = Arc::clone(&self.persistence);
         Ok(Box::new(move |row_ids: &[i64]| {
+            if execution_failed.load(Ordering::Acquire)
+                || persistence
+                    .as_ref()
+                    .as_ref()
+                    .is_some_and(PersistenceManager::has_indeterminate_commit)
+            {
+                return Err(Error::internal(
+                    "transaction outcome is unresolved; reopen the database",
+                ));
+            }
             let mut result = store.get_visible_versions_batch(row_ids, read_txn_id);
             if result.len() < row_ids.len() && mgr.has_segments() {
                 let found_ids: rustc_hash::FxHashSet<i64> =
@@ -6604,7 +6667,8 @@ impl Engine for MVCCEngine {
     fn get_row_counter(
         &self,
         table_name: &str,
-    ) -> Result<Box<dyn Fn(&[i64]) -> usize + Send + Sync>> {
+    ) -> Result<Box<dyn Fn(&[i64]) -> Result<usize> + Send + Sync>> {
+        self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
@@ -6613,16 +6677,28 @@ impl Engine for MVCCEngine {
         let mgr = self.get_or_create_segment_manager(table_name);
         let read_txn_id = INVALID_TRANSACTION_ID + 1;
 
+        let execution_failed = Arc::clone(&self.execution_failed);
+        let persistence = Arc::clone(&self.persistence);
         Ok(Box::new(move |row_ids: &[i64]| {
+            if execution_failed.load(Ordering::Acquire)
+                || persistence
+                    .as_ref()
+                    .as_ref()
+                    .is_some_and(PersistenceManager::has_indeterminate_commit)
+            {
+                return Err(Error::internal(
+                    "transaction outcome is unresolved; reopen the database",
+                ));
+            }
             let mut count = store.count_visible_versions_batch(row_ids, read_txn_id);
             if count < row_ids.len() && mgr.has_segments() {
                 for &rid in row_ids {
-                    if !store.has_committed_row(rid) && mgr.row_exists(rid) {
+                    if !store.has_committed_row(rid) && mgr.row_exists(rid)? {
                         count += 1;
                     }
                 }
             }
-            count
+            Ok(count)
         }))
     }
 }
@@ -6798,6 +6874,7 @@ impl Drop for CleanupHandle {
 /// Holds Arc references to shared engine state, allowing safe access
 /// from transactions without raw pointers.
 struct EngineOperations {
+    execution_failed: Arc<AtomicBool>,
     /// Shared reference to schemas (each schema is Arc-wrapped to avoid cloning on lookup)
     schemas: Arc<RwLock<FxHashMap<String, CompactArc<Schema>>>>,
     /// Shared reference to version stores
@@ -6824,6 +6901,7 @@ struct EngineOperations {
 impl EngineOperations {
     fn new(engine: &MVCCEngine) -> Self {
         Self {
+            execution_failed: Arc::clone(&engine.execution_failed),
             schemas: Arc::clone(&engine.schemas),
             version_stores: Arc::clone(&engine.version_stores),
             registry: Arc::clone(&engine.registry),
@@ -7073,6 +7151,39 @@ impl EngineOperations {
 }
 
 impl TransactionEngineOperations for EngineOperations {
+    fn check_health(&self) -> Result<()> {
+        if self.execution_failed.load(Ordering::Acquire)
+            || self
+                .persistence
+                .as_ref()
+                .as_ref()
+                .is_some_and(PersistenceManager::has_indeterminate_commit)
+        {
+            return Err(Error::internal(
+                "transaction outcome is unresolved; close and reopen the database",
+            ));
+        }
+        Ok(())
+    }
+
+    fn handle_commit_marker_failure(&self, _error: &Error) -> bool {
+        let unresolved = self
+            .persistence
+            .as_ref()
+            .as_ref()
+            .is_some_and(PersistenceManager::has_indeterminate_commit);
+        if unresolved {
+            self.execution_failed.store(true, Ordering::Release);
+            self.registry.stop_accepting_transactions();
+        }
+        unresolved
+    }
+
+    fn handle_publication_undo_failure(&self, _error: &Error) {
+        self.execution_failed.store(true, Ordering::Release);
+        self.registry.stop_accepting_transactions();
+    }
+
     fn get_table_for_transaction(&self, txn_id: i64, table_name: &str) -> Result<Box<dyn Table>> {
         // Use Cow to avoid allocation when table_name is already lowercase (common case)
         let table_name_lower = to_lowercase_cow(table_name);
@@ -7171,7 +7282,7 @@ impl TransactionEngineOperations for EngineOperations {
         ));
 
         // Register PkIndex if table has a primary key
-        register_pk_index(&schema, &version_store);
+        register_pk_index(&schema, &version_store)?;
 
         // Atomically check-and-insert under write lock to prevent TOCTOU race
         {
@@ -7502,244 +7613,217 @@ impl TransactionEngineOperations for EngineOperations {
         false
     }
 
-    fn commit_all_tables(&self, txn_id: i64) -> (bool, Option<crate::core::Error>) {
-        // Get the commit_seq for this transaction. start_commit() was called before us,
-        // so the commit_seq is in the registry. Used for versioned tombstones: snapshot
-        // isolation transactions only see tombstones with commit_seq <= their begin_seq.
-        let commit_seq = self.registry.get_committing_sequence(txn_id) as u64;
-
-        // Collect table data under the read lock, then drop the lock before WAL I/O.
-        // This prevents blocking concurrent get_table_for_transaction (which needs
-        // a write lock on txn_version_stores) during potentially slow WAL writes.
-        let tables_to_commit: Vec<(
-            crate::common::SmartString,
-            Arc<RwLock<TransactionVersionStore>>,
-            Arc<VersionStore>,
-        )>;
-        {
-            let cache = self.txn_version_stores().read().unwrap();
-            tables_to_commit = if let Some(txn_tables) = cache.get(txn_id) {
-                let stores = self.version_stores().read().unwrap();
-                txn_tables
-                    .iter()
-                    .filter(|(_, txn_store)| {
-                        let store = txn_store.read().unwrap();
-                        store.has_local_changes()
-                    })
-                    .filter_map(|(table_name, txn_store)| {
-                        stores
-                            .get(table_name.as_str())
-                            .cloned()
-                            .map(|vs| (table_name.clone(), Arc::clone(txn_store), vs))
-                    })
-                    .collect()
-            } else {
-                Vec::new()
-            };
-            // cache (read lock) and stores (read lock) dropped here
+    fn statement_checkpoint(&self, txn_id: i64) -> Result<super::transaction::StatementCheckpoint> {
+        let mut checkpoint = super::transaction::StatementCheckpoint::default();
+        let cache = self
+            .txn_version_stores()
+            .read()
+            .map_err(|_| Error::internal("transaction store cache is poisoned"))?;
+        let managers = self
+            .segment_managers
+            .read()
+            .map_err(|_| Error::internal("segment manager catalog is poisoned"))?;
+        if let Some(tables) = cache.get(txn_id) {
+            for (name, store) in tables {
+                checkpoint.tables.push((
+                    name.clone(),
+                    store
+                        .read()
+                        .map_err(|_| Error::internal("transaction store is poisoned"))?
+                        .statement_checkpoint(),
+                    managers
+                        .get(name.as_str())
+                        .map_or(0, |mgr| mgr.pending_statement_checkpoint(txn_id)),
+                ));
+            }
         }
+        Ok(checkpoint)
+    }
 
-        let mut commit_error: Option<crate::core::Error> = None;
-        let mut any_committed = false;
-        let mut tombstones_wal_recorded: rustc_hash::FxHashSet<String> =
-            rustc_hash::FxHashSet::default();
+    fn finish_statement(
+        &self,
+        txn_id: i64,
+        checkpoint: super::transaction::StatementCheckpoint,
+        success: bool,
+    ) {
+        let Ok(cache) = self.txn_version_stores().read() else {
+            panic!("transaction store cache is poisoned during statement cleanup");
+        };
+        let Ok(managers) = self.segment_managers.read() else {
+            panic!("segment manager catalog is poisoned during statement cleanup");
+        };
+        if let Some(tables) = cache.get(txn_id) {
+            // Build one checkpoint lookup only when table order changed during the statement.
+            let reordered = checkpoint
+                .tables
+                .iter()
+                .zip(tables.iter())
+                .any(|((before, _, _), (current, _))| before != current);
+            let lookup: Option<rustc_hash::FxHashMap<_, _>> = reordered.then(|| {
+                checkpoint
+                    .tables
+                    .iter()
+                    .map(|(name, hot, cold)| (name.as_str(), (*hot, *cold)))
+                    .collect()
+            });
+            for (position, (name, store)) in tables.iter().enumerate() {
+                let (hot, cold) = match &lookup {
+                    Some(lookup) => lookup.get(name.as_str()).copied().unwrap_or((0, 0)),
+                    None => checkpoint
+                        .tables
+                        .get(position)
+                        .map_or((0, 0), |(_, hot, cold)| (*hot, *cold)),
+                };
+                if let Some(mgr) = managers.get(name.as_str()) {
+                    mgr.finish_pending_statement(txn_id, cold, success);
+                }
+                let Ok(mut store) = store.write() else {
+                    panic!("transaction store is poisoned during statement cleanup");
+                };
+                store.finish_statement(hot, success);
+            }
+        }
+    }
 
-        // Check if WAL recording is needed (persistence enabled and not in recovery)
-        let should_record_wal = !self.should_skip_wal()
-            && self
-                .persistence()
-                .as_ref()
-                .is_some_and(|pm| pm.is_enabled());
+    fn finish_publication(&self, txn_id: i64, committed: bool) -> Result<()> {
+        let Ok(cache) = self.txn_version_stores().read() else {
+            panic!("transaction store cache is poisoned during publication cleanup");
+        };
+        let Ok(managers) = self.segment_managers.read() else {
+            panic!("segment manager catalog is poisoned during publication cleanup");
+        };
+        if let Some(tables) = cache.get(txn_id) {
+            for (name, store) in tables {
+                // Undo cold state before releasing its row claims.
+                if let Some(mgr) = managers.get(name.as_str()) {
+                    mgr.finish_tombstone_publication(txn_id, committed);
+                    mgr.clear_txn_seal_generation(txn_id);
+                }
+                let Ok(mut store) = store.write() else {
+                    panic!("transaction store is poisoned during publication cleanup");
+                };
+                store.finish_publication(committed)?;
+            }
+        }
+        drop(managers);
+        drop(cache);
+        self.txn_version_stores().write().unwrap().remove(txn_id);
+        Ok(())
+    }
 
-        // Collect Arc clones of segment managers, then drop the read lock
-        // before WAL I/O to avoid blocking seal/compaction writes.
-        let commit_mgrs: ahash::AHashMap<
-            String,
-            Arc<crate::storage::volume::manifest::SegmentManager>,
-        > = {
-            let mgrs = self.segment_managers.read().unwrap();
-            mgrs.iter()
-                .map(|(k, v)| (k.clone(), Arc::clone(v)))
+    fn commit_all_tables(&self, txn_id: i64) -> (bool, Option<crate::core::Error>) {
+        let commit_seq = self.registry.get_committing_sequence(txn_id) as u64;
+        let mut tables: smallvec::SmallVec<[_; 1]> = {
+            let cache = self.txn_version_stores().read().unwrap();
+            let stores = self.version_stores().read().unwrap();
+            let managers = self.segment_managers.read().unwrap();
+            cache
+                .get(txn_id)
+                .into_iter()
+                .flat_map(|tables| tables.iter())
+                .filter_map(|(name, local)| {
+                    stores.get(name.as_str()).map(|parent| {
+                        (
+                            name.clone(),
+                            Arc::clone(local),
+                            Arc::clone(parent),
+                            managers.get(name.as_str()).cloned(),
+                        )
+                    })
+                })
                 .collect()
         };
-
-        // WAL I/O and table commits happen here with NO lock on txn_version_stores
-        for (table_name, txn_store, version_store) in &tables_to_commit {
-            // Record cold tombstone DELETEs to WAL FIRST.
-            // These must come before hot INSERTs so that on replay,
-            // the tombstone marks the cold row as superseded BEFORE
-            // the new hot version is encountered.
-            if should_record_wal {
-                if let Some(mgr) = commit_mgrs.get(table_name.as_str()) {
-                    let pending = mgr.get_pending_tombstones(txn_id);
-                    if !pending.is_empty() {
-                        if let Some(ref pm) = *self.persistence() {
-                            for &row_id in &pending {
-                                let version = crate::storage::mvcc::version_store::RowVersion {
-                                    txn_id,
-                                    deleted_at_txn_id: txn_id,
-                                    data: crate::core::Row::new(),
-                                    create_time: 0,
-                                };
-                                if let Err(e) = pm.record_dml_operation(
-                                    txn_id,
-                                    table_name,
-                                    row_id,
-                                    crate::storage::mvcc::wal_manager::WALOperationType::Delete,
-                                    &version,
-                                ) {
-                                    commit_error = Some(e);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-                if commit_error.is_some() {
-                    break;
-                }
-            }
-
-            // Create table and commit through it (updates indexes)
-            let mut table = MVCCTable::new_with_shared_store(
-                txn_id,
-                Arc::clone(version_store),
-                Arc::clone(txn_store),
-            );
-
-            // Record hot pending versions to WAL (after tombstone DELETEs)
-            if should_record_wal {
-                if let Err(e) = self.record_table_to_wal(txn_id, &table) {
-                    commit_error = Some(e);
-                    break;
-                }
-            }
-
-            // Commit-time seal coordination:
-            // 1. Always take fence for tables with segments (prevents concurrent
-            //    seal from removing index entries during commit validation).
-            // 2. If seal_generation changed since our INSERT, revalidate pending
-            //    rows against cold (catches rows sealed before this commit).
-            // Fall back to live lookup if the manager was created after our snapshot
-            // (first seal on a previously hot-only table).
-            let mgr_for_commit = commit_mgrs.get(table_name.as_str()).cloned().or_else(|| {
-                self.segment_managers
-                    .read()
-                    .unwrap()
-                    .get(table_name.as_str())
-                    .cloned()
-            });
-            // Always take fence if manager exists — even before first seal
-            // completes, the manager may exist without has_segments() being
-            // true yet (created before register_volume publishes the flag).
-            let _seal_guard = mgr_for_commit.as_ref().map(|mgr| mgr.acquire_seal_read());
-
-            // Cold revalidation: only when a seal happened since our INSERT.
-            if let Some(mgr) = mgr_for_commit.as_ref() {
-                let recorded = mgr.get_txn_seal_generation(txn_id);
-                let needs_recheck = match recorded {
-                    Some(gen) => gen != mgr.seal_generation(),
-                    // No recorded generation but segments exist: txn started
-                    // before first seal or used hot-only path. Must recheck.
-                    None => mgr.has_segments(),
-                };
-                if needs_recheck {
-                    if let Err(e) =
-                        self.validate_pending_against_cold(txn_id, txn_store, version_store, mgr)
-                    {
-                        commit_error = Some(e);
-                        break;
-                    }
-                }
-            }
-
-            if let Err(e) = table.commit() {
-                commit_error = Some(e);
-                break;
-            }
-
-            // txn_seal_gens cleanup handled in the tail loop below
-
-            // Mark tombstones as WAL-recorded ONLY after table.commit() succeeds.
-            // Before this fix, the mark was set before commit, so a failed commit
-            // would still apply tombstones in the tail loop — hiding cold rows
-            // without the update version to replace them.
-            if should_record_wal {
-                tombstones_wal_recorded.insert(table_name.to_string());
-            }
-
-            any_committed = true;
-        }
-
-        // Always cleanup txn_version_stores to prevent memory leak,
-        // even if commit failed partway through
-        let mut cache = self.txn_version_stores().write().unwrap();
-        cache.remove(txn_id);
-        drop(cache);
-
-        drop(tables_to_commit);
-
-        // Commit or rollback pending tombstones on all segment managers.
-        // For tables with hot changes, tombstone WAL entries were already
-        // recorded in the per-table loop above. For cold-only changes
-        // (no hot), record tombstones here.
-        //
-        // On partial failure: tables whose hot changes were already committed
-        // (tracked in tombstones_wal_recorded) must have their tombstones
-        // committed too, not rolled back. Rolling back tombstones on an
-        // already-committed table would leave stale cold rows visible.
-        {
-            let should_record_wal = commit_error.is_none()
-                && !self.should_skip_wal()
-                && self
-                    .persistence()
-                    .as_ref()
-                    .is_some_and(|pm| pm.is_enabled());
-
-            // Reuse the commit_mgrs read lock acquired before the commit loop
-            for (table_name, mgr) in commit_mgrs.iter() {
-                if commit_error.is_none() {
-                    // Record cold-only tombstones to WAL (tables not already handled above)
-                    if should_record_wal && !tombstones_wal_recorded.contains(table_name.as_str()) {
-                        let pending = mgr.get_pending_tombstones(txn_id);
-                        if !pending.is_empty() {
-                            if let Some(ref pm) = *self.persistence() {
-                                for &row_id in &pending {
+        tables.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        let result = (|| -> Result<()> {
+            // Complete all fallible WAL writes and cold validation before the
+            // first table changes global versions. No cache lock spans I/O.
+            for (name, local, parent, mgr) in &tables {
+                if !self.should_skip_wal() {
+                    if let Some(ref pm) = self.persistence() {
+                        if pm.is_enabled() {
+                            if let Some(mgr) = mgr {
+                                for row_id in mgr.get_pending_tombstones(txn_id) {
                                     let version = crate::storage::mvcc::version_store::RowVersion {
                                         txn_id,
                                         deleted_at_txn_id: txn_id,
                                         data: crate::core::Row::new(),
                                         create_time: 0,
                                     };
-                                    if let Err(e) = pm.record_dml_operation(
+                                    pm.record_dml_operation(
                                         txn_id,
-                                        table_name,
+                                        name,
                                         row_id,
                                         crate::storage::mvcc::wal_manager::WALOperationType::Delete,
                                         &version,
-                                    ) {
-                                        commit_error = Some(e);
-                                        break;
-                                    }
+                                    )?;
                                 }
                             }
                         }
                     }
-                    if commit_error.is_some() {
-                        mgr.rollback_pending_tombstones(txn_id);
-                    } else {
-                        mgr.commit_pending_tombstones(txn_id, commit_seq);
-                    }
-                } else if tombstones_wal_recorded.contains(table_name.as_str()) {
-                    mgr.commit_pending_tombstones(txn_id, commit_seq);
-                } else {
-                    mgr.rollback_pending_tombstones(txn_id);
+                    let table = MVCCTable::new_with_shared_store(
+                        txn_id,
+                        Arc::clone(parent),
+                        Arc::clone(local),
+                    );
+                    self.record_table_to_wal(txn_id, &table)?;
                 }
-                mgr.clear_txn_seal_generation(txn_id);
             }
-        }
-
-        (any_committed, commit_error)
+            // Retain baseline seal exclusion through validation and apply;
+            // COMMIT marker I/O happens after these guards are released.
+            let _fences: smallvec::SmallVec<[_; 4]> = tables
+                .iter()
+                .filter_map(|(_, _, _, mgr)| mgr.as_ref().map(|mgr| mgr.acquire_seal_read()))
+                .collect();
+            for (_, local, parent, mgr) in &tables {
+                if let Some(mgr) = mgr {
+                    let needs_recheck = mgr.get_txn_seal_generation(txn_id).map_or_else(
+                        || mgr.has_segments(),
+                        |generation| generation != mgr.seal_generation(),
+                    );
+                    if needs_recheck {
+                        self.validate_pending_against_cold(txn_id, local, parent, mgr)?;
+                    }
+                }
+                local
+                    .write()
+                    .map_err(|_| Error::internal("transaction store is poisoned"))?
+                    .prepare_publication()?;
+                if let Some(mgr) = mgr {
+                    // Retain only projected keys while processing one cold original at a time.
+                    let requires_keys = local
+                        .read()
+                        .map_err(|_| Error::internal("transaction store is poisoned"))?
+                        .requires_cold_unique_reservations();
+                    if requires_keys {
+                        let schema = parent.schema();
+                        for row_id in mgr.get_pending_tombstones(txn_id) {
+                            if let Some(row) = mgr.get_cold_row_normalized(row_id, &schema)? {
+                                local
+                                    .write()
+                                    .map_err(|_| Error::internal("transaction store is poisoned"))?
+                                    .reserve_cold_unique_keys(&row)?;
+                            }
+                        }
+                    }
+                    mgr.prepare_tombstone_publication(txn_id, commit_seq);
+                }
+            }
+            for (_, local, _, mgr) in &tables {
+                #[cfg(any(test, feature = "test-failpoints"))]
+                if crate::test_failpoints::should_fail_table_publish() {
+                    return Err(Error::internal("failpoint: table publication"));
+                }
+                local
+                    .write()
+                    .map_err(|_| Error::internal("transaction store is poisoned"))?
+                    .apply_prepared_publication()?;
+                if let Some(mgr) = mgr {
+                    mgr.commit_pending_tombstones(txn_id, commit_seq);
+                }
+            }
+            Ok(())
+        })();
+        (result.is_ok() && !tables.is_empty(), result.err())
     }
 
     fn begin_publish(&self, txn_id: i64) -> super::version_store::PublishHold {

--- a/src/storage/mvcc/persistence.rs
+++ b/src/storage/mvcc/persistence.rs
@@ -377,6 +377,13 @@ impl PersistenceManager {
         self.enabled.load(Ordering::Acquire)
     }
 
+    /// A failed WAL suffix rollback requires recovery before further reads.
+    pub fn has_indeterminate_commit(&self) -> bool {
+        self.wal
+            .as_ref()
+            .is_some_and(WALManager::has_indeterminate_commit)
+    }
+
     /// Start persistence operations
     pub fn start(&self) -> Result<()> {
         if !self.is_enabled() {

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -2649,8 +2649,8 @@ impl Table for MVCCTable {
         self.version_store.collect_row_ids_into(dest);
     }
 
-    fn has_row_id(&self, row_id: i64) -> bool {
-        self.version_store.has_committed_row(row_id)
+    fn has_row_id(&self, row_id: i64) -> Result<bool> {
+        Ok(self.version_store.has_committed_row(row_id))
     }
 
     fn try_claim_row(&self, row_id: i64) -> Result<()> {
@@ -3235,6 +3235,24 @@ impl Table for MVCCTable {
         is_unique: bool,
         index_type: Option<IndexType>,
     ) -> Result<()> {
+        self.create_index_with_type_and_finalizer(
+            name,
+            columns,
+            is_unique,
+            index_type,
+            &mut |_, install| install(),
+        )
+    }
+
+    fn create_index_with_type_and_finalizer(
+        &self,
+        name: &str,
+        columns: &[&str],
+        is_unique: bool,
+        index_type: Option<IndexType>,
+        finalize: &mut crate::storage::traits::table::IndexBuildFinalizer<'_>,
+    ) -> Result<()> {
+        let catalog_build = self.version_store.begin_index_build()?;
         if columns.is_empty() {
             return Err(Error::internal("index must have at least one column"));
         }
@@ -3485,7 +3503,19 @@ impl Table for MVCCTable {
         }
 
         // Add to version store
-        self.version_store.add_index(name.to_string(), index);
+        let mut installed = false;
+        finalize(&index, &mut || {
+            self.version_store.add_index_under_build(
+                name.to_string(),
+                Arc::clone(&index),
+                &catalog_build,
+            )?;
+            installed = true;
+            Ok(())
+        })?;
+        if !installed {
+            return Err(Error::internal("index finalizer did not install the index"));
+        }
 
         Ok(())
     }
@@ -3500,6 +3530,30 @@ impl Table for MVCCTable {
         ef_search: usize,
         metric: crate::storage::index::HnswDistanceMetric,
     ) -> Result<()> {
+        self.create_hnsw_index_with_finalizer(
+            name,
+            column,
+            is_unique,
+            m,
+            ef_construction,
+            ef_search,
+            metric,
+            &mut |_, install| install(),
+        )
+    }
+
+    fn create_hnsw_index_with_finalizer(
+        &self,
+        name: &str,
+        column: &str,
+        is_unique: bool,
+        m: usize,
+        ef_construction: usize,
+        ef_search: usize,
+        metric: crate::storage::index::HnswDistanceMetric,
+        finalize: &mut crate::storage::traits::table::IndexBuildFinalizer<'_>,
+    ) -> Result<()> {
+        let catalog_build = self.version_store.begin_index_build()?;
         let schema = self.version_store.schema();
         let (col_idx, col) = schema
             .find_column(column)
@@ -3581,7 +3635,19 @@ impl Table for MVCCTable {
             index.add_batch_slice(&entry_refs)?;
         }
 
-        self.version_store.add_index(name.to_string(), index);
+        let mut installed = false;
+        finalize(&index, &mut || {
+            self.version_store.add_index_under_build(
+                name.to_string(),
+                Arc::clone(&index),
+                &catalog_build,
+            )?;
+            installed = true;
+            Ok(())
+        })?;
+        if !installed {
+            return Err(Error::internal("index finalizer did not install the index"));
+        }
         Ok(())
     }
 
@@ -3592,7 +3658,7 @@ impl Table for MVCCTable {
         }
 
         // Remove from version store
-        self.version_store.remove_index(name);
+        self.version_store.remove_index(name)?;
         Ok(())
     }
 
@@ -3683,6 +3749,22 @@ impl Table for MVCCTable {
         is_unique: bool,
         custom_name: Option<&str>,
     ) -> Result<()> {
+        self.create_btree_index_with_finalizer(
+            column_name,
+            is_unique,
+            custom_name,
+            &mut |_, install| install(),
+        )
+    }
+
+    fn create_btree_index_with_finalizer(
+        &self,
+        column_name: &str,
+        is_unique: bool,
+        custom_name: Option<&str>,
+        finalize: &mut crate::storage::traits::table::IndexBuildFinalizer<'_>,
+    ) -> Result<()> {
+        let catalog_build = self.version_store.begin_index_build()?;
         // Find the column
         let schema = self.version_store.schema();
         let (col_idx, col) = schema
@@ -3774,7 +3856,20 @@ impl Table for MVCCTable {
         }
 
         // Add to version store
-        self.version_store.add_index(index_name, Arc::new(index));
+        let index: Arc<dyn Index> = Arc::new(index);
+        let mut installed = false;
+        finalize(&index, &mut || {
+            self.version_store.add_index_under_build(
+                index_name.clone(),
+                Arc::clone(&index),
+                &catalog_build,
+            )?;
+            installed = true;
+            Ok(())
+        })?;
+        if !installed {
+            return Err(Error::internal("index finalizer did not install the index"));
+        }
 
         Ok(())
     }
@@ -3786,6 +3881,22 @@ impl Table for MVCCTable {
         columns: &[&str],
         is_unique: bool,
     ) -> Result<()> {
+        self.create_multi_column_index_with_finalizer(
+            name,
+            columns,
+            is_unique,
+            &mut |_, install| install(),
+        )
+    }
+
+    fn create_multi_column_index_with_finalizer(
+        &self,
+        name: &str,
+        columns: &[&str],
+        is_unique: bool,
+        finalize: &mut crate::storage::traits::table::IndexBuildFinalizer<'_>,
+    ) -> Result<()> {
+        let catalog_build = self.version_store.begin_index_build()?;
         let schema = self.version_store.schema();
 
         // Validate and collect column info
@@ -3876,8 +3987,20 @@ impl Table for MVCCTable {
         }
 
         // Add to version store
-        self.version_store
-            .add_index(name.to_string(), Arc::new(index));
+        let index: Arc<dyn Index> = Arc::new(index);
+        let mut installed = false;
+        finalize(&index, &mut || {
+            self.version_store.add_index_under_build(
+                name.to_string(),
+                Arc::clone(&index),
+                &catalog_build,
+            )?;
+            installed = true;
+            Ok(())
+        })?;
+        if !installed {
+            return Err(Error::internal("index finalizer did not install the index"));
+        }
 
         Ok(())
     }
@@ -3895,7 +4018,7 @@ impl Table for MVCCTable {
         }
 
         // Remove from version store
-        self.version_store.remove_index(&index_name);
+        self.version_store.remove_index(&index_name)?;
         Ok(())
     }
 
@@ -3915,13 +4038,13 @@ impl Table for MVCCTable {
         None
     }
 
-    fn row_count(&self) -> usize {
+    fn row_count(&self) -> Result<usize> {
         // Try O(1) fast path first
         if let Some(count) = MVCCTable::fast_row_count(self) {
-            return count;
+            return Ok(count);
         }
         // Fall back to optimized single-pass counting
-        MVCCTable::row_count(self)
+        Ok(MVCCTable::row_count(self))
     }
 
     fn row_count_hint(&self) -> usize {
@@ -3929,8 +4052,8 @@ impl Table for MVCCTable {
         self.version_store.committed_row_count()
     }
 
-    fn fast_row_count(&self) -> Option<usize> {
-        MVCCTable::fast_row_count(self)
+    fn fast_row_count(&self) -> Result<Option<usize>> {
+        Ok(MVCCTable::fast_row_count(self))
     }
 
     fn collect_rows_ordered_by_index(
@@ -3939,14 +4062,14 @@ impl Table for MVCCTable {
         ascending: bool,
         limit: usize,
         offset: usize,
-    ) -> Option<RowVec> {
+    ) -> Result<Option<RowVec>> {
         // If transaction has local changes (inserts/updates/deletes), fall back to
         // the regular path which correctly merges local changes via collect_visible_rows.
         // This optimization only reads from the global version store and indexes.
         {
             let txn_versions = self.txn_versions.read().unwrap();
             if txn_versions.has_local_changes() {
-                return None;
+                return Ok(None);
             }
         }
 
@@ -3956,17 +4079,19 @@ impl Table for MVCCTable {
         if let Some(pk_idx) = self.cached_schema.pk_column_index() {
             let pk_col = &self.cached_schema.columns[pk_idx];
             if pk_col.name_lower == column_name.to_lowercase() {
-                return self.version_store.collect_rows_pk_ordered(
+                return Ok(self.version_store.collect_rows_pk_ordered(
                     self.txn_id,
                     ascending,
                     limit,
                     offset,
-                );
+                ));
             }
         }
 
         // Check if column has an index
-        let index = self.version_store.get_index_by_column(column_name)?;
+        let Some(index) = self.version_store.get_index_by_column(column_name) else {
+            return Ok(None);
+        };
 
         // Try using the efficient ordered iteration method (available in B-tree indexes)
         // We request more row IDs than needed to account for invisible rows
@@ -4000,7 +4125,7 @@ impl Table for MVCCTable {
 
                     // Check if we've reached the limit
                     if rows.len() >= limit {
-                        return Some(rows);
+                        return Ok(Some(rows));
                     }
                 }
             }
@@ -4008,17 +4133,17 @@ impl Table for MVCCTable {
             // If we got all needed rows, return them
             // If not, we may need to fetch more (rare case with many invisible rows)
             if !rows.is_empty() {
-                return Some(rows);
+                return Ok(Some(rows));
             }
         }
 
         // Fallback path: Get all values and sort (for non-B-tree indexes)
         let all_values = index.get_all_values();
 
-        // If the index doesn't support get_all_values (returns empty), return None
+        // If the index doesn't support get_all_values (returns empty), return Ok(None)
         // to let the regular query execution path handle ORDER BY + LIMIT
         if all_values.is_empty() {
-            return None;
+            return Ok(None);
         }
 
         // Sort values using partial_cmp (Value implements PartialOrd)
@@ -4059,13 +4184,13 @@ impl Table for MVCCTable {
 
                     // Check if we've reached the limit
                     if rows.len() >= limit {
-                        return Some(rows);
+                        return Ok(Some(rows));
                     }
                 }
             }
         }
 
-        Some(rows)
+        Ok(Some(rows))
     }
 
     fn collect_rows_pk_keyset(
@@ -4097,22 +4222,27 @@ impl Table for MVCCTable {
         ))
     }
 
-    fn collect_rows_grouped_by_partition(&self, column_name: &str) -> Option<Vec<(Value, RowVec)>> {
+    fn collect_rows_grouped_by_partition(
+        &self,
+        column_name: &str,
+    ) -> Result<Option<Vec<(Value, RowVec)>>> {
         // If transaction has local changes, fall back to regular path
         {
             let txn_versions = self.txn_versions.read().unwrap();
             if txn_versions.has_local_changes() {
-                return None;
+                return Ok(None);
             }
         }
 
         // Check if column has an index
-        let index = self.version_store.get_index_by_column(column_name)?;
+        let Some(index) = self.version_store.get_index_by_column(column_name) else {
+            return Ok(None);
+        };
 
         // Get all unique values from the index (partition keys)
         let all_values = index.get_all_values();
         if all_values.is_empty() {
-            return Some(Vec::new());
+            return Ok(Some(Vec::new()));
         }
 
         // Collect rows grouped by partition value
@@ -4139,36 +4269,40 @@ impl Table for MVCCTable {
             }
         }
 
-        Some(result)
+        Ok(Some(result))
     }
 
-    fn get_partition_values(&self, column_name: &str) -> Option<Vec<Value>> {
+    fn get_partition_values(&self, column_name: &str) -> Result<Option<Vec<Value>>> {
         // Only use index-based distinct values if no uncommitted local changes
         // (local changes are in txn_versions, not reflected in the index)
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
-            return None;
+            return Ok(None);
         }
         drop(txn_versions);
 
         // Get index for the column
-        let index = self.version_store.get_index_by_column(column_name)?;
+        let Some(index) = self.version_store.get_index_by_column(column_name) else {
+            return Ok(None);
+        };
         // Return all distinct values from the index
-        Some(index.get_all_values())
+        Ok(Some(index.get_all_values()))
     }
 
-    fn get_partition_count(&self, column_name: &str) -> Option<usize> {
+    fn get_partition_count(&self, column_name: &str) -> Result<Option<usize>> {
         // Only use index-based count if no uncommitted local changes
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
-            return None;
+            return Ok(None);
         }
         drop(txn_versions);
 
         // Get index for the column
-        let index = self.version_store.get_index_by_column(column_name)?;
+        let Some(index) = self.version_store.get_index_by_column(column_name) else {
+            return Ok(None);
+        };
         // Return count of distinct non-null values without cloning
-        index.get_distinct_count_excluding_null()
+        Ok(index.get_distinct_count_excluding_null())
     }
 
     fn get_rows_for_partition_value(
@@ -4671,54 +4805,55 @@ impl Table for MVCCTable {
             .get_segments_to_scan(column, operator, value)
     }
 
-    fn sum_column(&self, col_idx: usize) -> Option<(f64, usize)> {
+    fn sum_column(&self, col_idx: usize) -> Result<Option<(f64, usize)>> {
         // Only use deferred aggregation if no uncommitted local changes
         // (local changes are in txn_versions, not the main version_store)
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
-            return None;
+            return Ok(None);
         }
         drop(txn_versions);
 
-        Some(self.version_store.sum_column(self.txn_id, col_idx))
+        Ok(Some(self.version_store.sum_column(self.txn_id, col_idx)))
     }
 
-    fn min_column(&self, col_idx: usize) -> Option<Option<Value>> {
+    fn min_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
         // Only use deferred aggregation if no uncommitted local changes
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
-            return None;
+            return Ok(None);
         }
         drop(txn_versions);
 
-        Some(self.version_store.min_column(self.txn_id, col_idx))
+        Ok(Some(self.version_store.min_column(self.txn_id, col_idx)))
     }
 
-    fn max_column(&self, col_idx: usize) -> Option<Option<Value>> {
+    fn max_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
         // Only use deferred aggregation if no uncommitted local changes
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
-            return None;
+            return Ok(None);
         }
         drop(txn_versions);
 
-        Some(self.version_store.max_column(self.txn_id, col_idx))
+        Ok(Some(self.version_store.max_column(self.txn_id, col_idx)))
     }
 
     fn compute_grouped_aggregates(
         &self,
         group_by_indices: &[usize],
         aggregates: &[(crate::storage::mvcc::version_store::AggregateOp, usize)],
-    ) -> Option<Vec<crate::storage::mvcc::version_store::GroupedAggregateResult>> {
+    ) -> Result<Option<Vec<crate::storage::mvcc::version_store::GroupedAggregateResult>>> {
         // Only use storage-level aggregation if no uncommitted local changes
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
-            return None;
+            return Ok(None);
         }
         drop(txn_versions);
 
-        self.version_store
-            .compute_grouped_aggregates(self.txn_id, group_by_indices, aggregates)
+        Ok(self
+            .version_store
+            .compute_grouped_aggregates(self.txn_id, group_by_indices, aggregates))
     }
 }
 

--- a/src/storage/mvcc/transaction.rs
+++ b/src/storage/mvcc/transaction.rs
@@ -57,6 +57,12 @@ pub enum TransactionState {
     RolledBack,
 }
 
+/// Journal positions, without copying prior transaction writes.
+#[derive(Default)]
+pub struct StatementCheckpoint {
+    pub(crate) tables: smallvec::SmallVec<[(crate::common::SmartString, usize, usize); 1]>,
+}
+
 /// MVCC Transaction implementation
 pub struct MvccTransaction {
     /// Transaction ID
@@ -77,6 +83,7 @@ pub struct MvccTransaction {
     engine_operations: Option<Arc<dyn TransactionEngineOperations>>,
     /// Savepoints in creation order; the same name may appear more than once
     savepoints: Vec<(String, SavepointState)>,
+    statement_checkpoint: Option<Box<StatementCheckpoint>>,
     /// Tables created in this transaction (for rollback)
     created_tables: Vec<String>,
     /// Tables dropped in this transaction (for rollback - stores name and schema)
@@ -121,17 +128,25 @@ pub trait TransactionEngineOperations: Send + Sync {
     /// Check if transaction has any pending DML changes (without allocating)
     fn has_pending_dml_changes(&self, txn_id: i64) -> bool;
 
-    /// Commit all tables for a transaction at once (includes WAL recording).
-    ///
-    /// Returns `(any_committed, optional_error)`:
-    /// - `(false, None)`: no tables had changes, nothing to do
-    /// - `(true, None)`: all tables committed successfully
-    /// - `(true, Some(e))`: partial commit - some tables committed before error
-    /// - `(false, Some(e))`: error before any table committed
-    ///
-    /// Callers MUST complete_commit if any_committed is true, even on error,
-    /// to avoid orphaning already-committed rows.
+    /// Prepare every table, then apply changes while retaining complete undo.
+    /// Any error requires finish_publication(false), never a partial commit.
     fn commit_all_tables(&self, txn_id: i64) -> (bool, Option<crate::core::Error>);
+
+    fn statement_checkpoint(&self, _txn_id: i64) -> Result<StatementCheckpoint> {
+        Ok(StatementCheckpoint::default())
+    }
+    fn finish_statement(&self, _txn_id: i64, _checkpoint: StatementCheckpoint, _success: bool) {}
+    fn finish_publication(&self, _txn_id: i64, _committed: bool) -> Result<()> {
+        Ok(())
+    }
+    fn check_health(&self) -> Result<()> {
+        Ok(())
+    }
+    fn handle_publication_undo_failure(&self, _error: &Error) {}
+    /// Fence access and return true for an indeterminate WAL marker outcome.
+    fn handle_commit_marker_failure(&self, _error: &Error) -> bool {
+        false
+    }
 
     /// Rollback all tables for a transaction at once
     /// This cleans up the transaction's entries in txn_version_stores
@@ -228,6 +243,7 @@ impl MvccTransaction {
             last_table_name: None,
             engine_operations: None,
             savepoints: Vec::new(),
+            statement_checkpoint: None,
             created_tables: Vec::new(),
             dropped_tables: Vec::new(),
         }
@@ -256,6 +272,9 @@ impl MvccTransaction {
 
     /// Check if transaction is active
     fn check_active(&self) -> Result<()> {
+        if let Some(ops) = &self.engine_operations {
+            ops.check_health()?;
+        }
         if self.state != TransactionState::Active {
             return Err(Error::TransactionClosed);
         }
@@ -481,30 +500,18 @@ impl Transaction for MvccTransaction {
             // Phase 2: Commit all tables - apply local changes to global store
             // This now includes WAL recording internally (before each table commit)
             if let Some(ops) = &self.engine_operations {
-                let (any_committed, error) = ops.commit_all_tables(self.id);
-                if let Some(e) = error {
-                    if any_committed {
-                        // Partial commit: some tables already committed.
-                        // We MUST complete the commit to avoid orphaning those rows.
-                        self.registry.complete_commit(self.id);
-                        if let Some(hold) = &publish {
-                            ops.request_seal_if_over(hold);
-                        }
-                        // Record commit marker so WAL recovery sees committed state
-                        ops.record_commit(self.id)?;
-                        self.state = TransactionState::Committed;
-                        self.cleanup();
-                        return Err(e);
-                    } else {
-                        // Nothing committed yet - safe to abort cleanly.
-                        // Release uncommitted_writes claims and remove from
-                        // txn_version_stores to prevent permanent row blocking.
-                        self.registry.abort_transaction(self.id);
-                        ops.rollback_all_tables(self.id);
+                let (_, error) = ops.commit_all_tables(self.id);
+                if let Some(error) = error {
+                    self.registry.abort_transaction(self.id);
+                    if let Err(undo_error) = ops.finish_publication(self.id, false) {
+                        ops.handle_publication_undo_failure(&undo_error);
                         self.state = TransactionState::RolledBack;
-                        self.cleanup();
-                        return Err(e);
+                        return Err(undo_error);
                     }
+                    ops.rollback_all_tables(self.id);
+                    self.state = TransactionState::RolledBack;
+                    self.cleanup();
+                    return Err(error);
                 }
             }
 
@@ -513,24 +520,30 @@ impl Transaction for MvccTransaction {
             // before complete_commit(). WAL is only read during recovery, so writing
             // the marker before visibility doesn't affect normal operation.
             if let Some(ops) = &self.engine_operations {
-                if let Err(e) = ops.record_commit(self.id) {
-                    // WAL commit marker failed. Phase 2 data is in the version store
-                    // but not yet visible (complete_commit hasn't run). Abort so GC
-                    // can reclaim the orphaned entries and active_txn_count is correct.
-                    // On recovery, WAL has no COMMIT marker → entries are discarded.
-                    // The indexes already describe the aborted rows: take that back
-                    if let Some(hold) = &publish {
-                        hold.undo_index_updates();
+                if let Err(error) = ops.record_commit(self.id) {
+                    if ops.handle_commit_marker_failure(&error) {
+                        // Leave published state and transaction outcome unresolved.
+                        // Engine health fencing prevents reads/writes until recovery.
+                        return Err(error);
                     }
                     self.registry.abort_transaction(self.id);
+                    if let Err(undo_error) = ops.finish_publication(self.id, false) {
+                        ops.handle_publication_undo_failure(&undo_error);
+                        self.state = TransactionState::RolledBack;
+                        return Err(undo_error);
+                    }
+                    ops.rollback_all_tables(self.id);
                     self.state = TransactionState::RolledBack;
                     self.cleanup();
-                    return Err(e);
+                    return Err(error);
                 }
             }
 
             // Phase 4: Complete commit - make changes visible in registry
             self.registry.complete_commit(self.id);
+            if let Some(ops) = &self.engine_operations {
+                ops.finish_publication(self.id, true)?;
+            }
             if let (Some(ops), Some(hold)) = (&self.engine_operations, &publish) {
                 ops.request_seal_if_over(hold);
             }
@@ -585,6 +598,27 @@ impl Transaction for MvccTransaction {
         self.state = TransactionState::RolledBack;
         self.cleanup();
         Ok(())
+    }
+
+    fn begin_statement(&mut self) -> Result<bool> {
+        self.check_active()?;
+        if self.statement_checkpoint.is_some() {
+            return Ok(false);
+        }
+        let checkpoint = match &self.engine_operations {
+            Some(ops) => ops.statement_checkpoint(self.id)?,
+            None => StatementCheckpoint::default(),
+        };
+        self.statement_checkpoint = Some(Box::new(checkpoint));
+        Ok(true)
+    }
+
+    fn finish_statement(&mut self, success: bool) {
+        if let Some(checkpoint) = self.statement_checkpoint.take() {
+            if let Some(ops) = &self.engine_operations {
+                ops.finish_statement(self.id, *checkpoint, success);
+            }
+        }
     }
 
     fn create_savepoint(&mut self, name: &str) -> Result<()> {

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -507,12 +507,13 @@ impl PublishHold {
 
     /// Takes back the index updates of a commit that failed after applying
     /// them, so the indexes describe the rows that stayed visible
-    pub fn undo_index_updates(&self) {
+    pub fn undo_index_updates(&self) -> Result<(), Error> {
         for store in &self.stores {
             if let Ok(store) = store.read() {
-                store.undo_index_updates();
+                store.undo_index_updates()?;
             }
         }
+        Ok(())
     }
 }
 
@@ -578,6 +579,8 @@ pub struct VersionStore {
     upsert_mutex: Arc<parking_lot::Mutex<()>>,
     /// Commits between their index updates and their versions being visible
     publishing: AtomicUsize,
+    publication_keys: Mutex<ahash::AHashMap<PublicationKey, i64>>,
+    index_catalog: Arc<AtomicUsize>,
     /// Publishes completed
     publish_epoch: AtomicU64,
 }
@@ -616,6 +619,8 @@ impl VersionStore {
             committed_row_count: AtomicUsize::new(0),
             upsert_mutex: Arc::new(parking_lot::Mutex::new(())),
             publishing: AtomicUsize::new(0),
+            publication_keys: Mutex::new(ahash::AHashMap::new()),
+            index_catalog: Arc::new(AtomicUsize::new(0)),
             publish_epoch: AtomicU64::new(0),
         }
     }
@@ -645,6 +650,8 @@ impl VersionStore {
             committed_row_count: AtomicUsize::new(0),
             upsert_mutex: Arc::new(parking_lot::Mutex::new(())),
             publishing: AtomicUsize::new(0),
+            publication_keys: Mutex::new(ahash::AHashMap::new()),
+            index_catalog: Arc::new(AtomicUsize::new(0)),
             publish_epoch: AtomicU64::new(0),
         }
     }
@@ -4732,16 +4739,42 @@ impl VersionStore {
         parking_lot::Mutex::lock_arc(&self.upsert_mutex)
     }
 
-    /// Add an index
-    pub fn add_index(&self, name: String, index: Arc<dyn Index>) {
-        let mut indexes = self.indexes.write();
-        indexes.insert(name, index);
+    /// Exclude publishers for the complete index build, before scanning rows.
+    pub(crate) fn begin_index_build(&self) -> Result<IndexCatalogLease, Error> {
+        IndexCatalogLease::try_acquire(&self.index_catalog, true).ok_or_else(|| {
+            Error::internal("write conflict: index catalog has an unresolved publisher")
+        })
+    }
+
+    pub(crate) fn add_index_under_build(
+        &self,
+        name: String,
+        index: Arc<dyn Index>,
+        build: &IndexCatalogLease,
+    ) -> Result<(), Error> {
+        if !build.exclusive || !Arc::ptr_eq(&build.state, &self.index_catalog) {
+            return Err(Error::internal(
+                "index build lease belongs to another catalog",
+            ));
+        }
+        self.indexes.write().insert(name, index);
+        Ok(())
+    }
+
+    /// Add an already-built index during initialization or recovery.
+    pub fn add_index(&self, name: String, index: Arc<dyn Index>) -> Result<(), Error> {
+        let catalog = self.begin_index_build()?;
+        self.add_index_under_build(name, index, &catalog)
     }
 
     /// Remove an index
-    pub fn remove_index(&self, name: &str) -> Option<Arc<dyn Index>> {
+    pub fn remove_index(&self, name: &str) -> Result<Option<Arc<dyn Index>>, Error> {
+        let _catalog =
+            IndexCatalogLease::try_acquire(&self.index_catalog, true).ok_or_else(|| {
+                Error::internal("write conflict: index catalog has an unresolved publisher")
+            })?;
         let mut indexes = self.indexes.write();
-        indexes.remove(name)
+        Ok(indexes.remove(name))
     }
 
     /// Get an index by name
@@ -5056,7 +5089,7 @@ impl VersionStore {
     }
 
     /// Drop an index by name (alias for remove_index)
-    pub fn drop_index(&self, name: &str) -> Option<Arc<dyn Index>> {
+    pub fn drop_index(&self, name: &str) -> Result<Option<Arc<dyn Index>>, Error> {
         self.remove_index(name)
     }
 
@@ -5279,7 +5312,7 @@ impl VersionStore {
                 }
             }
 
-            self.add_index(meta.name.clone(), index);
+            self.add_index(meta.name.clone(), index)?;
         } else {
             // Multi-column index: use MultiColumnIndex
             let index = crate::storage::index::MultiColumnIndex::new(
@@ -5325,7 +5358,7 @@ impl VersionStore {
                 }
             }
 
-            self.add_index(meta.name.clone(), index);
+            self.add_index(meta.name.clone(), index)?;
         }
 
         Ok(())
@@ -5677,86 +5710,92 @@ impl VersionStore {
         // before removing it to prevent data loss.
         // Arena indices are read directly from the live entry under the write lock
         // to avoid index misalignment with the rows_to_delete vector.
-        let mut actually_deleted = Vec::with_capacity(rows_to_delete.len());
-        let mut actual_arena_indices = Vec::with_capacity(rows_to_delete.len());
-        {
-            let mut versions = self.versions.write();
-            for &row_id in &rows_to_delete {
-                // Re-check: the row must still exist AND still be deleted
-                if let Some(entry) = versions.get(row_id) {
-                    if entry.version.is_deleted() {
+        const SUB_BATCH_SIZE: usize = 2_000;
+        let mut deleted_count = 0;
+        let mut actually_deleted = Vec::with_capacity(rows_to_delete.len().min(SUB_BATCH_SIZE));
+        let mut actual_arena_indices = Vec::with_capacity(actually_deleted.capacity());
+        for chunk in rows_to_delete.chunks(SUB_BATCH_SIZE) {
+            actually_deleted.clear();
+            actual_arena_indices.clear();
+            // Claims outlive registry abort until publication undo is complete.
+            // Hold this guard through index and arena removal as well: otherwise
+            // an INSERT could claim the removed ID and have its new state cleared.
+            // Match truncate/seal ordering: claims -> versions -> index/arena.
+            let uncommitted = self.uncommitted_writes.read();
+            {
+                let mut live = self.versions.write();
+                for &row_id in chunk {
+                    if uncommitted.contains_key(row_id) {
+                        continue;
+                    }
+                    if let Some(entry) = live.get(row_id) {
+                        // Index cleanup below uses the candidate snapshot. Only
+                        // remove that exact head, never a newer DELETE of this ID.
+                        if !entry.version.is_deleted()
+                            || versions.get(row_id).is_none_or(|candidate| {
+                                candidate.version.txn_id != entry.version.txn_id
+                            })
+                            || !self.can_safely_remove(&entry.version)
+                        {
+                            continue;
+                        }
                         if let Some(idx) = unpack_arena_idx(entry.arena_idx) {
                             actual_arena_indices.push(idx);
                         }
-                        versions.remove(row_id);
+                        live.remove(row_id);
                         actually_deleted.push(row_id);
                     }
                 }
             }
-        }
-
-        if actually_deleted.is_empty() {
-            return 0;
-        }
-
-        // Third pass: remove from indexes using batch operations (single lock per index)
-        // This runs AFTER the version store removal so we use the snapshot data
-        // (which is still valid for the rows we confirmed were deleted).
-        {
-            let indexes = self.indexes.read();
-
-            for index in indexes.values() {
-                let column_ids = index.column_ids();
-                if column_ids.is_empty() {
-                    continue;
-                }
-
-                // Collect all entries for this index
-                let mut entries: Vec<(i64, Vec<crate::core::Value>)> =
-                    Vec::with_capacity(actually_deleted.len());
-
-                for &row_id in &actually_deleted {
-                    if let Some(entry) = versions.get(row_id) {
-                        let version = &entry.version;
-                        if column_ids.len() == 1 {
-                            // Single-column index
-                            let col_id = column_ids[0] as usize;
-                            if let Some(value) = version.data.get(col_id) {
-                                entries.push((row_id, vec![value.clone()]));
-                            }
-                        } else {
-                            // Multi-column index
-                            let values: Vec<crate::core::Value> = column_ids
+            if actually_deleted.is_empty() {
+                continue;
+            }
+            {
+                let indexes = self.indexes.read();
+                for index in indexes.values() {
+                    let column_ids = index.column_ids();
+                    if column_ids.is_empty() {
+                        continue;
+                    }
+                    let entries: Vec<(i64, Vec<Value>)> = actually_deleted
+                        .iter()
+                        .filter_map(|&row_id| {
+                            let entry = versions.get(row_id)?;
+                            let values = column_ids
                                 .iter()
-                                .map(|&col_id| {
-                                    version.data.get(col_id as usize).cloned().unwrap_or(
-                                        crate::core::Value::Null(crate::core::DataType::Null),
-                                    )
+                                .map(|&column_id| {
+                                    entry
+                                        .version
+                                        .data
+                                        .get(column_id as usize)
+                                        .cloned()
+                                        .unwrap_or_else(Value::null_unknown)
                                 })
                                 .collect();
-                            entries.push((row_id, values));
-                        }
+                            Some((row_id, values))
+                        })
+                        .collect();
+                    if !entries.is_empty() {
+                        let batch: Vec<_> = entries
+                            .iter()
+                            .map(|(id, values)| (*id, values.as_slice()))
+                            .collect();
+                        let _ = index.remove_batch_slice(&batch);
                     }
                 }
-
-                if !entries.is_empty() {
-                    // Convert to slice format for remove_batch_slice
-                    let batch: Vec<(i64, &[crate::core::Value])> = entries
-                        .iter()
-                        .map(|(row_id, values)| (*row_id, values.as_slice()))
-                        .collect();
-                    let _ = index.remove_batch_slice(&batch);
-                }
-
-                // Let index-specific maintenance run (e.g., HNSW graph compaction)
+            }
+            self.arena.clear_batch(&actual_arena_indices);
+            deleted_count += actually_deleted.len() as i32;
+            drop(uncommitted);
+        }
+        // Index-specific maintenance does not remove row mappings, so it need
+        // not delay new row claims while compacting structures such as HNSW.
+        if deleted_count != 0 {
+            for index in self.indexes.read().values() {
                 let _ = index.cleanup();
             }
         }
-
-        // Clear arena slots only for rows we actually removed
-        self.arena.clear_batch(&actual_arena_indices);
-
-        actually_deleted.len() as i32
+        deleted_count
     }
 
     /// Check if a version can be safely removed (not visible to any active transaction)
@@ -5836,78 +5875,84 @@ impl VersionStore {
         // This prevents the race where a concurrent commit adds a new HEAD between
         // the snapshot read and the write — we always work on the current live entry.
         let mut cleaned = 0;
-        let mut versions = self.versions.write();
+        for chunk in candidate_row_ids.chunks(2_000) {
+            let uncommitted = self.uncommitted_writes.read();
+            let mut versions = self.versions.write();
 
-        for row_id in candidate_row_ids {
-            let Some(chain_entry) = versions.get(row_id) else {
-                continue; // Row was removed between passes
-            };
+            for &row_id in chunk {
+                if uncommitted.contains_key(row_id) {
+                    continue;
+                }
+                let Some(chain_entry) = versions.get(row_id) else {
+                    continue; // Row was removed between passes
+                };
 
-            // Collect previous versions from the LIVE entry
-            let mut prev_versions: Vec<Arc<VersionChainEntry>> = Vec::new();
-            let mut current = chain_entry.prev.as_ref();
-            while let Some(prev_entry) = current {
-                prev_versions.push(prev_entry.clone());
-                current = prev_entry.prev.as_ref();
-            }
+                // Collect previous versions from the LIVE entry
+                let mut prev_versions: Vec<Arc<VersionChainEntry>> = Vec::new();
+                let mut current = chain_entry.prev.as_ref();
+                while let Some(prev_entry) = current {
+                    prev_versions.push(prev_entry.clone());
+                    current = prev_entry.prev.as_ref();
+                }
 
-            if prev_versions.is_empty() {
-                continue;
-            }
+                if prev_versions.is_empty() {
+                    continue;
+                }
 
-            // Check each previous version independently — do NOT assume monotonic
-            // visibility. With rapid updates, a newer prev version may be invisible
-            // to an active txn while an older one IS visible (e.g., HEAD seq=120,
-            // prev_0 seq=110, prev_1 seq=80, active txn snapshot at seq=100 needs prev_1).
-            let mut keep_count = 0;
-            for (i, prev_entry) in prev_versions.iter().enumerate() {
-                let mut keep = false;
+                // Check each previous version independently — do NOT assume monotonic
+                // visibility. With rapid updates, a newer prev version may be invisible
+                // to an active txn while an older one IS visible (e.g., HEAD seq=120,
+                // prev_0 seq=110, prev_1 seq=80, active txn snapshot at seq=100 needs prev_1).
+                let mut keep_count = 0;
+                for (i, prev_entry) in prev_versions.iter().enumerate() {
+                    let mut keep = false;
 
-                // Rule 1: Keep if needed by any active transaction
-                for &txn_id in &active_txns {
-                    if checker.is_visible(prev_entry.version.txn_id, txn_id) {
+                    // Rule 1: Keep if needed by any active transaction
+                    for &txn_id in &active_txns {
+                        if checker.is_visible(prev_entry.version.txn_id, txn_id) {
+                            keep = true;
+                            break;
+                        }
+                    }
+
+                    // Rule 2: Keep if within retention period
+                    if !keep && prev_entry.version.create_time >= retention_cutoff {
                         keep = true;
-                        break;
+                    }
+
+                    if keep {
+                        // Keep this version and all newer ones (indices 0..=i)
+                        keep_count = i + 1;
                     }
                 }
 
-                // Rule 2: Keep if within retention period
-                if !keep && prev_entry.version.create_time >= retention_cutoff {
-                    keep = true;
-                }
+                // If we need to prune some versions, modify the live entry
+                if keep_count < prev_versions.len() {
+                    let to_remove = prev_versions.len() - keep_count;
+                    cleaned += to_remove as i32;
 
-                if keep {
-                    // Keep this version and all newer ones (indices 0..=i)
-                    keep_count = i + 1;
-                }
-            }
+                    // Clone the LIVE entry (not stale snapshot) and modify
+                    let mut modified_entry = chain_entry.clone();
 
-            // If we need to prune some versions, modify the live entry
-            if keep_count < prev_versions.len() {
-                let to_remove = prev_versions.len() - keep_count;
-                cleaned += to_remove as i32;
+                    if keep_count == 0 {
+                        modified_entry.prev = None;
+                    } else {
+                        // Rebuild chain with only kept versions
+                        let kept_versions: Vec<_> =
+                            prev_versions.into_iter().take(keep_count).collect();
 
-                // Clone the LIVE entry (not stale snapshot) and modify
-                let mut modified_entry = chain_entry.clone();
-
-                if keep_count == 0 {
-                    modified_entry.prev = None;
-                } else {
-                    // Rebuild chain with only kept versions
-                    let kept_versions: Vec<_> =
-                        prev_versions.into_iter().take(keep_count).collect();
-
-                    // Build chain from oldest to newest (reversed)
-                    let mut new_prev: Option<Arc<VersionChainEntry>> = None;
-                    for entry in kept_versions.into_iter().rev() {
-                        let mut cloned = (*entry).clone();
-                        cloned.prev = new_prev;
-                        new_prev = Some(Arc::new(cloned));
+                        // Build chain from oldest to newest (reversed)
+                        let mut new_prev: Option<Arc<VersionChainEntry>> = None;
+                        for entry in kept_versions.into_iter().rev() {
+                            let mut cloned = (*entry).clone();
+                            cloned.prev = new_prev;
+                            new_prev = Some(Arc::new(cloned));
+                        }
+                        modified_entry.prev = new_prev;
                     }
-                    modified_entry.prev = new_prev;
-                }
 
-                versions.insert(row_id, modified_entry);
+                    versions.insert(row_id, modified_entry);
+                }
             }
         }
 
@@ -6487,6 +6532,97 @@ impl fmt::Debug for VersionStore {
     }
 }
 
+/// One mutation's pre-statement state. Existing history owns the payloads.
+struct LocalMutationUndo {
+    row_id: i64,
+    versions_len: usize,
+    had_write: bool,
+}
+
+/// Reservations protect removed UNIQUE keys as well as additions until undo
+/// is no longer possible. Arc clones share the projected key allocation.
+type PublicationKey = (usize, Arc<[Value]>);
+
+/// Called with the ownership mutex held. A conflicting key leaves every
+/// reservation unchanged, including the common single-key INSERT case.
+#[inline]
+fn try_reserve_publication_keys(
+    owners: &mut AHashMap<PublicationKey, i64>,
+    keys: &[PublicationKey],
+    txn_id: i64,
+) -> bool {
+    if let [key] = keys {
+        return match owners.entry(key.clone()) {
+            std::collections::hash_map::Entry::Occupied(entry) => *entry.get() == txn_id,
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(txn_id);
+                true
+            }
+        };
+    }
+    if keys
+        .iter()
+        .any(|key| owners.get(key).is_some_and(|owner| *owner != txn_id))
+    {
+        return false;
+    }
+    owners.reserve(keys.len());
+    for key in keys {
+        owners.insert(key.clone(), txn_id);
+    }
+    true
+}
+
+/// A movable, nonblocking DDL lease. Publishers share the low-bit count;
+/// index replacement requires the exclusive high bit and fails while any
+/// publisher can still undo. No thread-owned lock survives COMMIT I/O.
+pub(crate) struct IndexCatalogLease {
+    state: Arc<AtomicUsize>,
+    exclusive: bool,
+}
+
+impl IndexCatalogLease {
+    const EXCLUSIVE: usize = 1usize << (usize::BITS - 1);
+
+    fn try_acquire(state: &Arc<AtomicUsize>, exclusive: bool) -> Option<Self> {
+        if exclusive {
+            state
+                .compare_exchange(0, Self::EXCLUSIVE, Ordering::Acquire, Ordering::Relaxed)
+                .ok()?;
+        } else {
+            state
+                .fetch_update(Ordering::Acquire, Ordering::Relaxed, |current| {
+                    (current < Self::EXCLUSIVE - 1).then_some(current + 1)
+                })
+                .ok()?;
+        }
+        Some(Self {
+            state: Arc::clone(state),
+            exclusive,
+        })
+    }
+}
+
+impl Drop for IndexCatalogLease {
+    fn drop(&mut self) {
+        if self.exclusive {
+            self.state.store(0, Ordering::Release);
+        } else {
+            self.state.fetch_sub(1, Ordering::Release);
+        }
+    }
+}
+
+#[derive(Default)]
+struct TransactionMutation {
+    statement_undo: SmallVec<[LocalMutationUndo; 1]>,
+    publication_undo: SmallVec<[(i64, Option<VersionChainEntry>); 1]>,
+    publication_applied: bool,
+    reserved_keys: SmallVec<[PublicationKey; 2]>,
+    reserved_indexes: SmallVec<[Arc<dyn Index>; 4]>,
+    index_catalog_lease: Option<IndexCatalogLease>,
+}
+
 /// Transaction-local version store for uncommitted changes
 pub struct TransactionVersionStore {
     /// Local versions for this transaction - stores version history per row for savepoint support
@@ -6503,6 +6639,8 @@ pub struct TransactionVersionStore {
     write_set: Option<I64Map<WriteSetEntry>>,
     /// Index updates applied by commit, until the commit is visible or undone
     index_undo: Mutex<Vec<IndexUndo>>,
+    /// Read-only table handles pay one pointer, not inline write-side buffers.
+    mutation: Option<Box<TransactionMutation>>,
 }
 
 impl TransactionVersionStore {
@@ -6519,11 +6657,62 @@ impl TransactionVersionStore {
             txn_id,
             write_set: None,
             index_undo: Mutex::new(Vec::new()),
+            mutation: None,
         }
     }
 
+    pub fn statement_checkpoint(&self) -> usize {
+        self.mutation
+            .as_ref()
+            .map_or(0, |mutation| mutation.statement_undo.len())
+    }
+
+    fn record_local_mutation(&mut self, row_id: i64) {
+        let undo = LocalMutationUndo {
+            row_id,
+            versions_len: self
+                .local_versions
+                .as_ref()
+                .and_then(|v| v.get(row_id))
+                .map_or(0, |v| v.len()),
+            had_write: self
+                .write_set
+                .as_ref()
+                .is_some_and(|w| w.contains_key(row_id)),
+        };
+        self.mutation
+            .get_or_insert_with(|| Box::new(TransactionMutation::default()))
+            .statement_undo
+            .push(undo);
+    }
+
+    pub fn finish_statement(&mut self, checkpoint: usize, success: bool) {
+        let Some(mutation) = self.mutation.as_mut() else {
+            return;
+        };
+        if !success {
+            for undo in mutation.statement_undo.drain(..).skip(checkpoint).rev() {
+                if let Some(local) = self.local_versions.as_mut() {
+                    if undo.versions_len == 0 {
+                        local.remove(undo.row_id);
+                    } else if let Some(versions) = local.get_mut(undo.row_id) {
+                        versions.truncate(undo.versions_len);
+                    }
+                }
+                if !undo.had_write {
+                    if let Some(write_set) = self.write_set.as_mut() {
+                        write_set.remove(undo.row_id);
+                    }
+                    self.parent_store
+                        .release_row_claim(undo.row_id, self.txn_id);
+                }
+            }
+        }
+        mutation.statement_undo.clear();
+    }
+
     /// Takes back the index updates of this transaction's commit, in reverse
-    pub fn undo_index_updates(&self) {
+    pub fn undo_index_updates(&self) -> Result<(), Error> {
         let undo: Vec<IndexUndo> = std::mem::take(&mut *self.index_undo.lock());
         for entry in undo.iter().rev() {
             if !entry.added.is_empty() {
@@ -6532,7 +6721,7 @@ impl TransactionVersionStore {
                     .iter()
                     .map(|(row_id, values)| (*row_id, values.as_slice()))
                     .collect();
-                let _ = entry.index.remove_batch_slice(&batch);
+                entry.index.remove_batch_slice(&batch)?;
             }
             if !entry.removed.is_empty() {
                 let batch: Vec<(i64, &[Value])> = entry
@@ -6540,9 +6729,10 @@ impl TransactionVersionStore {
                     .iter()
                     .map(|(row_id, values)| (*row_id, values.as_slice()))
                     .collect();
-                let _ = entry.index.add_batch_slice(&batch);
+                entry.index.add_batch_slice(&batch)?;
             }
         }
+        Ok(())
     }
 
     /// Returns the transaction ID
@@ -6576,6 +6766,7 @@ impl TransactionVersionStore {
 
     /// Put adds or updates a row in the transaction's local store
     pub fn put(&mut self, row_id: i64, data: Row, is_delete: bool) -> Result<(), Error> {
+        self.record_local_mutation(row_id);
         // Convert to Shared (Arc) storage immediately for efficient Arc sharing:
         // - get_arc() will return cheap Arc clones (no value cloning)
         // - into_arc() at commit time returns the existing Arc (no clone)
@@ -6662,6 +6853,7 @@ impl TransactionVersionStore {
         original_version: RowVersion,
         is_delete: bool,
     ) -> Result<(), Error> {
+        self.record_local_mutation(row_id);
         // Convert to Shared (Arc) storage immediately for efficient Arc sharing
         let data = Row::from_arc(data.into_arc());
 
@@ -6732,6 +6924,7 @@ impl TransactionVersionStore {
         let now = get_fast_timestamp();
 
         for (row_id, data, original_version) in rows {
+            self.record_local_mutation(row_id);
             // Convert to Shared (Arc) storage immediately for efficient Arc sharing
             let data = Row::from_arc(data.into_arc());
 
@@ -6792,6 +6985,7 @@ impl TransactionVersionStore {
         let timestamp = get_fast_timestamp();
 
         for (row_id, data) in rows {
+            self.record_local_mutation(row_id);
             // Check if we already have a local version
             let has_local = self
                 .local_versions
@@ -6859,6 +7053,7 @@ impl TransactionVersionStore {
         let timestamp = get_fast_timestamp();
 
         for (row_id, data, original_version) in rows {
+            self.record_local_mutation(row_id);
             // Create deleted row version with pre-computed timestamp
             let mut rv = RowVersion::new_with_timestamp(self.txn_id, data, timestamp);
             rv.deleted_at_txn_id = self.txn_id;
@@ -7073,55 +7268,261 @@ impl TransactionVersionStore {
     /// RowVersion values, avoiding expensive clones. The transaction is
     /// consumed after commit anyway, so this is safe.
     pub fn commit(&mut self) -> Result<(), Error> {
-        // OCC validation: detect concurrent write conflicts.
-        // Rows removed by seal (missing from hot B-tree) are not conflicts —
-        // they were moved to cold segments, not modified by another transaction.
+        if let Err(error) = self
+            .prepare_publication()
+            .and_then(|()| self.apply_prepared_publication())
+        {
+            self.finish_publication(false)?;
+            return Err(error);
+        }
+        self.finish_publication(true)
+    }
+
+    /// Prepares row and UNIQUE-key ownership and captures only changed heads.
+    /// The engine prepares every table before applying any of them.
+    pub fn prepare_publication(&mut self) -> Result<(), Error> {
+        if self.mutation.is_none() {
+            return Ok(());
+        }
+        let lease = self.index_catalog_lease()?;
+        self.mutation
+            .as_mut()
+            .ok_or_else(|| Error::internal("publication mutation is missing"))?
+            .index_catalog_lease = Some(lease);
+        if let Some(write_set) = self.write_set.as_ref() {
+            for row_id in write_set.keys() {
+                self.parent_store.try_claim_row(row_id, self.txn_id)?;
+            }
+        }
         self.detect_conflicts_safe()?;
+        let mut keys: SmallVec<[PublicationKey; 2]> = SmallVec::new();
+        let indexes = self.parent_store.get_all_indexes();
+        for index in &indexes {
+            if !index.is_unique() || index.index_type() == crate::core::IndexType::PrimaryKey {
+                continue;
+            }
+            let identity = Arc::as_ptr(index) as *const () as usize;
+            for (_, version, old_row) in self.iter_local_with_old() {
+                if !version.is_deleted()
+                    && old_row.is_some_and(|old| {
+                        index
+                            .column_ids()
+                            .iter()
+                            .all(|&id| old.get(id as usize) == version.data.get(id as usize))
+                    })
+                {
+                    continue;
+                }
+                for row in old_row
+                    .into_iter()
+                    .chain((!version.is_deleted()).then_some(&version.data))
+                {
+                    let values: Arc<[Value]> = index
+                        .column_ids()
+                        .iter()
+                        .map(|&id| {
+                            row.get(id as usize)
+                                .cloned()
+                                .unwrap_or_else(Value::null_unknown)
+                        })
+                        .collect();
+                    if values.iter().any(Value::is_null) {
+                        continue;
+                    }
+                    keys.push((identity, values));
+                }
+            }
+        }
+        let undo = {
+            let versions = self.parent_store.versions.read();
+            self.iter_local()
+                .map(|(row_id, _)| (row_id, versions.get(row_id).cloned()))
+                .collect()
+        };
+        let mutation = self
+            .mutation
+            .as_mut()
+            .ok_or_else(|| Error::internal("publication mutation is missing"))?;
+        if !keys.is_empty() {
+            let mut owners = self.parent_store.publication_keys.lock();
+            if !try_reserve_publication_keys(&mut owners, &keys, self.txn_id) {
+                return Err(Error::internal(
+                    "write conflict: unique key is being published",
+                ));
+            }
+        }
+        mutation.reserved_keys = keys;
+        mutation.reserved_indexes = indexes;
+        mutation.publication_undo = undo;
+        Ok(())
+    }
 
-        // Update indexes BEFORE committing versions
-        self.update_indexes_on_commit()?;
+    fn index_catalog_lease(&self) -> Result<IndexCatalogLease, Error> {
+        IndexCatalogLease::try_acquire(&self.parent_store.index_catalog, false)
+            .ok_or_else(|| Error::internal("write conflict: index catalog is changing"))
+    }
 
-        // Commit local versions to parent store
-        if let Some(local_versions) = self.local_versions.as_mut() {
-            if local_versions.len() == 1 {
-                // Single-row fast path: avoid Vec allocation
-                if let Some((row_id, mut versions)) = local_versions.drain().next() {
-                    if let Some(version) = versions.pop() {
-                        self.parent_store.add_version_single(row_id, version);
+    pub fn requires_cold_unique_reservations(&self) -> bool {
+        self.mutation.as_ref().is_some_and(|mutation| {
+            mutation.reserved_indexes.iter().any(|index| {
+                index.is_unique() && index.index_type() != crate::core::IndexType::PrimaryKey
+            })
+        })
+    }
+
+    /// Cold-only deletes have no local version or hot predecessor. Reserve
+    /// their old keys before a pending tombstone can hide them from writers.
+    pub fn reserve_cold_unique_keys(&mut self, row: &Row) -> Result<(), Error> {
+        let mutation = self
+            .mutation
+            .as_mut()
+            .ok_or_else(|| Error::internal("cold reservation before prepare"))?;
+        let mut keys: SmallVec<[PublicationKey; 2]> = SmallVec::new();
+        for index in &mutation.reserved_indexes {
+            if !index.is_unique() || index.index_type() == crate::core::IndexType::PrimaryKey {
+                continue;
+            }
+            let values: Arc<[Value]> = index
+                .column_ids()
+                .iter()
+                .map(|&id| {
+                    row.get(id as usize)
+                        .cloned()
+                        .unwrap_or_else(Value::null_unknown)
+                })
+                .collect();
+            if values.iter().any(Value::is_null) {
+                continue;
+            }
+            keys.push((Arc::as_ptr(index) as *const () as usize, values));
+        }
+        if keys.is_empty() {
+            return Ok(());
+        }
+        let mut owners = self.parent_store.publication_keys.lock();
+        if !try_reserve_publication_keys(&mut owners, &keys, self.txn_id) {
+            return Err(Error::internal(
+                "write conflict: cold unique key is being published",
+            ));
+        }
+        mutation.reserved_keys.extend(keys);
+        Ok(())
+    }
+
+    pub fn apply_prepared_publication(&mut self) -> Result<(), Error> {
+        let indexes = self
+            .mutation
+            .as_ref()
+            .map_or(&[][..], |mutation| mutation.reserved_indexes.as_slice());
+        self.update_indexes_on_commit(indexes)?;
+        if let Some(mutation) = self.mutation.as_mut() {
+            mutation.publication_applied = true;
+        }
+        let Some(local) = self.local_versions.as_ref() else {
+            return Ok(());
+        };
+        if local.len() == 1 {
+            if let Some((row_id, versions)) = local.iter().next() {
+                if let Some(version) = versions.last() {
+                    self.parent_store
+                        .add_version_single(row_id, version.clone());
+                }
+            }
+        } else {
+            let mut batch: Vec<_> = local
+                .iter()
+                .filter_map(|(row_id, versions)| {
+                    versions.last().map(|version| (row_id, version.clone()))
+                })
+                .collect();
+            batch.sort_unstable_by_key(|(row_id, _)| *row_id);
+            self.parent_store.add_versions_batch(batch);
+        }
+        Ok(())
+    }
+
+    pub fn finish_publication(&mut self, committed: bool) -> Result<(), Error> {
+        let Some(mut mutation) = self.mutation.take() else {
+            return Ok(());
+        };
+        if !committed {
+            if let Err(error) = self.undo_index_updates() {
+                self.mutation = Some(mutation);
+                return Err(error);
+            }
+            if mutation.publication_applied {
+                let mut versions = self.parent_store.versions.write();
+                for (row_id, previous) in mutation.publication_undo.drain(..) {
+                    let Some(current) = versions
+                        .get(row_id)
+                        .filter(|entry| entry.version.txn_id == self.txn_id)
+                    else {
+                        continue;
+                    };
+                    let current_live = !current.version.is_deleted();
+                    let current_slot = unpack_arena_idx(current.arena_idx);
+                    let previous_live = previous
+                        .as_ref()
+                        .is_some_and(|entry| !entry.version.is_deleted());
+                    let previous_slot = previous
+                        .as_ref()
+                        .and_then(|entry| unpack_arena_idx(entry.arena_idx));
+                    if let Some(slot) = current_slot.filter(|slot| Some(*slot) != previous_slot) {
+                        self.parent_store.arena.clear_at(slot);
+                    }
+                    if let Some(entry) = previous {
+                        if let Some(slot) = previous_slot {
+                            self.parent_store.arena.update_at(
+                                slot,
+                                row_id,
+                                entry.version.txn_id,
+                                entry.version.data.clone().into_arc(),
+                            );
+                            if entry.version.is_deleted() {
+                                self.parent_store
+                                    .arena
+                                    .mark_deleted(slot, entry.version.deleted_at_txn_id);
+                            }
+                        }
+                        versions.insert(row_id, entry);
+                    } else {
+                        versions.remove(row_id);
+                    }
+                    if current_live && !previous_live {
+                        self.parent_store
+                            .committed_row_count
+                            .fetch_sub(1, Ordering::Relaxed);
+                    } else if previous_live && !current_live {
+                        self.parent_store
+                            .committed_row_count
+                            .fetch_add(1, Ordering::Relaxed);
                     }
                 }
-            } else {
-                // Multi-row path: collect into Vec
-                let mut batch: Vec<(i64, RowVersion)> = local_versions
-                    .drain()
-                    .filter_map(|(row_id, mut versions)| versions.pop().map(|v| (row_id, v)))
-                    .collect();
-
-                // Sort by row_id to ensure deterministic locking order
-                batch.sort_by_key(|(row_id, _)| *row_id);
-
-                self.parent_store.add_versions_batch(batch);
             }
         }
-
-        // Release ALL claims from write_set (includes both local and external claims).
-        // Must drain the entire write_set — external claims from track_external_claim()
-        // have no corresponding local_versions entry.
-        if let Some(write_set) = self.write_set.as_mut() {
-            if write_set.len() == 1 {
-                // Single-claim fast path: avoid Vec allocation
-                if let Some((row_id, _)) = write_set.drain().next() {
-                    self.parent_store.release_row_claim(row_id, self.txn_id);
+        mutation.publication_undo.clear();
+        mutation.publication_applied = false;
+        self.index_undo.lock().clear();
+        if !mutation.reserved_keys.is_empty() {
+            let mut owners = self.parent_store.publication_keys.lock();
+            for key in mutation.reserved_keys.drain(..) {
+                if owners.get(&key) == Some(&self.txn_id) {
+                    owners.remove(&key);
                 }
-            } else {
-                let mut row_ids: Vec<i64> = write_set.drain().map(|(row_id, _)| row_id).collect();
-                // Sort by row_id to ensure deterministic locking order
-                row_ids.sort_unstable();
-                self.parent_store
-                    .release_row_claims_batch(&row_ids, self.txn_id);
             }
         }
-
+        mutation.reserved_indexes.clear();
+        self.release_all_claims();
+        // Drain only after the outcome and any undo. Besides dropping values,
+        // I64Map's drain releases capacity inherited from a much larger prior
+        // batch, so pooled maps do not tax every later single-row operation.
+        if let Some(write_set) = self.write_set.as_mut() {
+            drop(write_set.drain());
+        }
+        if let Some(local) = self.local_versions.as_mut() {
+            drop(local.drain());
+        }
+        mutation.statement_undo.clear();
         Ok(())
     }
 
@@ -7137,7 +7538,7 @@ impl TransactionVersionStore {
     /// - Multi-row batch path: Collects changes, then applies in batch (reduces lock acquisitions)
     ///
     /// Returns an error if a unique constraint is violated.
-    fn update_indexes_on_commit(&self) -> Result<(), Error> {
+    fn update_indexes_on_commit(&self, indexes: &[Arc<dyn Index>]) -> Result<(), Error> {
         // Early exit if no local changes
         let Some(local_versions) = self.local_versions.as_ref() else {
             return Ok(());
@@ -7147,9 +7548,7 @@ impl TransactionVersionStore {
             return Ok(());
         }
 
-        // Get all indexes - early exit if none
-        let indexes: SmallVec<[Arc<dyn Index>; 4]> =
-            self.parent_store.get_all_indexes().into_iter().collect();
+        // Apply exactly the catalog snapshot whose ownership was reserved.
         if indexes.is_empty() {
             return Ok(());
         }
@@ -7157,12 +7556,12 @@ impl TransactionVersionStore {
         // FAST PATH: Single-row commit (most common case for auto-commit INSERT/UPDATE/DELETE)
         // Uses SmallVec to avoid heap allocation for 1-2 column indexes
         if local_versions.len() == 1 {
-            return self.update_indexes_single_row(&indexes);
+            return self.update_indexes_single_row(indexes);
         }
 
         // BATCH PATH: Multi-row commit
         // Sort indexes by name for deterministic lock ordering (prevents deadlocks)
-        let mut indexes: Vec<_> = indexes.into_vec();
+        let mut indexes: Vec<_> = indexes.to_vec();
         indexes.sort_by(|a, b| a.name().cmp(b.name()));
 
         let num_indexes = indexes.len();
@@ -7583,10 +7982,15 @@ impl TransactionVersionStore {
                 })
                 .collect();
             let entry = vec![(row_id, values)];
+            let (added, removed) = if is_add {
+                (entry, Vec::new())
+            } else {
+                (Vec::new(), entry)
+            };
             undo.push(IndexUndo {
                 index: Arc::clone(index),
-                added: if is_add { entry.clone() } else { Vec::new() },
-                removed: if is_add { Vec::new() } else { entry },
+                added,
+                removed,
             });
         }
 
@@ -7679,6 +8083,7 @@ impl TransactionVersionStore {
     /// TransactionVersionStore's put methods. Without tracking, these claims
     /// leak because commit() only releases claims found in write_set.
     pub fn track_external_claim(&mut self, row_id: i64) {
+        self.record_local_mutation(row_id);
         let write_set = self.ensure_write_set();
         // Only add if not already tracked (idempotent).
         // Use empty read_version since this is a cold-only claim — the actual
@@ -7721,6 +8126,12 @@ impl TransactionVersionStore {
         let Some(write_set) = self.write_set.as_ref() else {
             return;
         };
+        if write_set.len() <= 1 {
+            if let Some(row_id) = write_set.keys().next() {
+                self.parent_store.release_row_claim(row_id, self.txn_id);
+            }
+            return;
+        }
         // OPTIMIZATION: Collect row_ids first, then batch release
         // Avoids holding write_set iterator while accessing parent_store
         let mut row_ids: Vec<i64> = write_set.keys().collect();
@@ -7733,6 +8144,16 @@ impl TransactionVersionStore {
 
 impl Drop for TransactionVersionStore {
     fn drop(&mut self) {
+        if let Some(mutation) = &self.mutation {
+            if !mutation.reserved_keys.is_empty() {
+                let mut owners = self.parent_store.publication_keys.lock();
+                for key in &mutation.reserved_keys {
+                    if owners.get(key) == Some(&self.txn_id) {
+                        owners.remove(key);
+                    }
+                }
+            }
+        }
         // Release any row claims still held by this transaction.
         // This is a safety net for cases where drop happens without explicit
         // commit/rollback (e.g., transaction panics, implicit drop on scope exit).
@@ -8777,7 +9198,7 @@ mod tests {
             false,
             0,
         ));
-        store.add_index("idx_test".to_string(), index);
+        store.add_index("idx_test".to_string(), index).unwrap();
 
         assert!(store.index_exists("idx_test"));
         assert_eq!(store.list_indexes().len(), 1);
@@ -8790,7 +9211,7 @@ mod tests {
         assert!(store.get_index_by_column("test_col").is_some());
 
         // Remove index
-        let removed = store.remove_index("idx_test");
+        let removed = store.remove_index("idx_test").unwrap();
         assert!(removed.is_some());
         assert!(!store.index_exists("idx_test"));
     }
@@ -9508,7 +9929,7 @@ mod tests {
             true, // is_unique
             0,
         ));
-        store.add_index("idx_u".to_string(), index);
+        store.add_index("idx_u".to_string(), index).unwrap();
 
         // Initial data: (1, 10), (2, 20)
         let mut txn1 = TransactionVersionStore::new(Arc::clone(&store), 1);
@@ -9542,6 +9963,197 @@ mod tests {
     }
 
     #[test]
+    fn publication_releases_oversized_maps_after_a_small_transaction() {
+        for committed in [false, true] {
+            let parent = Arc::new(VersionStore::with_visibility_checker(
+                "pooled_capacity",
+                test_schema(),
+                Arc::new(TestVisibilityChecker::new()),
+            ));
+            let mut bulk = TransactionVersionStore::new(Arc::clone(&parent), 1);
+            for id in 1..=512 {
+                bulk.put(id, Row::from(vec![Value::Integer(id)]), false)
+                    .unwrap();
+            }
+            bulk.commit().unwrap();
+            let old_capacity = bulk.local_versions.as_ref().unwrap().capacity();
+            assert!(old_capacity >= 512);
+            // Move the emptied maps exactly as the transaction pool does,
+            // without depending on other parallel tests' global pool traffic.
+            let mut small = TransactionVersionStore::new(Arc::clone(&parent), 2);
+            small.local_versions = bulk.local_versions.take();
+            small.write_set = bulk.write_set.take();
+            small
+                .put(1024, Row::from(vec![Value::Integer(1024)]), false)
+                .unwrap();
+            small.prepare_publication().unwrap();
+            small.apply_prepared_publication().unwrap();
+            // Publication still owns its undo and the maps before the outcome.
+            assert_eq!(
+                small.local_versions.as_ref().unwrap().capacity(),
+                old_capacity
+            );
+            small.finish_publication(committed).unwrap();
+            assert!(small.local_versions.as_ref().unwrap().capacity() < old_capacity);
+            assert!(small.write_set.as_ref().unwrap().capacity() < old_capacity);
+            assert_eq!(parent.committed_row_count(), 512 + usize::from(committed));
+            assert!(parent.try_claim_row(1024, 3).is_ok());
+        }
+    }
+
+    #[test]
+    fn statement_undo_releases_only_new_claims_and_restores_repeated_updates() {
+        let store = Arc::new(VersionStore::with_visibility_checker(
+            "statement_undo",
+            test_schema(),
+            Arc::new(TestVisibilityChecker::new()),
+        ));
+        let mut local = TransactionVersionStore::new(Arc::clone(&store), 10);
+        local
+            .put(1, Row::from(vec![Value::Integer(1)]), false)
+            .unwrap();
+        store.try_claim_row(11, 10).unwrap();
+        local.track_external_claim(11);
+        local.finish_statement(0, true);
+        let checkpoint = local.statement_checkpoint();
+        local
+            .put(1, Row::from(vec![Value::Integer(2)]), false)
+            .unwrap();
+        local
+            .put(1, Row::from(vec![Value::Integer(3)]), false)
+            .unwrap();
+        // The cold key read fails at this point, before any put/tombstone.
+        store.try_claim_row(12, 10).unwrap();
+        local.track_external_claim(12);
+        local.finish_statement(checkpoint, false);
+        assert_eq!(
+            local.get_latest_local(1).unwrap().data.get(0),
+            Some(&Value::Integer(1))
+        );
+        assert!(store.try_claim_row(12, 20).is_ok());
+        assert!(store.try_claim_row(11, 20).is_err());
+        assert_eq!(local.local_count(), 1);
+    }
+
+    #[test]
+    fn publication_key_conflict_preserves_free_prefix_and_existing_owners() {
+        let free_key: PublicationKey = (1, Arc::from([Value::Integer(30)]));
+        let conflicting_key: PublicationKey = (1, Arc::from([Value::Integer(10)]));
+        let unrelated_key: PublicationKey = (2, Arc::from([Value::Integer(10)]));
+        let mut owners = AHashMap::new();
+        owners.insert(conflicting_key.clone(), 10);
+        owners.insert(unrelated_key.clone(), 30);
+        let before = owners.clone();
+
+        // Explicit order catches an implementation that reserves its free
+        // prefix before discovering another transaction's conflicting key.
+        assert!(!try_reserve_publication_keys(
+            &mut owners,
+            &[free_key.clone(), conflicting_key.clone()],
+            20,
+        ));
+        assert_eq!(owners, before);
+        assert!(!try_reserve_publication_keys(
+            &mut owners,
+            std::slice::from_ref(&conflicting_key),
+            20,
+        ));
+        assert_eq!(owners, before);
+        assert!(try_reserve_publication_keys(
+            &mut owners,
+            std::slice::from_ref(&conflicting_key),
+            10,
+        ));
+        assert_eq!(owners, before);
+        assert!(try_reserve_publication_keys(
+            &mut owners,
+            std::slice::from_ref(&free_key),
+            20,
+        ));
+        let mut expected = before;
+        expected.insert(free_key, 20);
+        assert_eq!(owners, expected);
+    }
+
+    #[test]
+    fn publication_reserves_removed_unique_keys_until_undo_finishes() {
+        use crate::storage::index::HashIndex;
+        let schema = SchemaBuilder::new("reserved_keys")
+            .column("id", DataType::Integer, false, true)
+            .column("u", DataType::Integer, false, false)
+            .build();
+        let store = Arc::new(VersionStore::with_visibility_checker(
+            "reserved_keys",
+            schema,
+            Arc::new(TestVisibilityChecker::new()),
+        ));
+        let index = Arc::new(HashIndex::new(
+            "idx_u".into(),
+            "reserved_keys".into(),
+            vec!["u".into()],
+            vec![1],
+            vec![DataType::Integer],
+            true,
+            0,
+        ));
+        store.add_index("idx_u".into(), index.clone()).unwrap();
+        let mut seed = TransactionVersionStore::new(Arc::clone(&store), 1);
+        seed.put(1, Row::from(vec![1.into(), 10.into()]), false)
+            .unwrap();
+        seed.commit().unwrap();
+        let original_bytes = store.hot_bytes();
+        let mut first = TransactionVersionStore::new(Arc::clone(&store), 2);
+        first
+            .put(1, Row::from(vec![1.into(), 20.into()]), false)
+            .unwrap();
+        first.prepare_publication().unwrap();
+        // An unchanged cold key may also appear among the local replacement's
+        // keys; reserving it again must retain this transaction's ownership.
+        first
+            .reserve_cold_unique_keys(&Row::from(vec![1.into(), 20.into()]))
+            .unwrap();
+        first.apply_prepared_publication().unwrap();
+        assert!(
+            store.remove_index("idx_u").is_err(),
+            "DDL cannot replace the reserved catalog"
+        );
+        assert!(store.add_index("idx_u".into(), index.clone()).is_err());
+        assert!(index.get_row_ids_equal(&[10.into()]).is_empty());
+        let mut second = TransactionVersionStore::new(Arc::clone(&store), 3);
+        second
+            .put(2, Row::from(vec![2.into(), 10.into()]), false)
+            .unwrap();
+        second
+            .put(4, Row::from(vec![4.into(), 30.into()]), false)
+            .unwrap();
+        assert!(
+            second.prepare_publication().is_err(),
+            "another publisher cannot take the removed key"
+        );
+        let mut unrelated = TransactionVersionStore::new(Arc::clone(&store), 4);
+        unrelated
+            .put(3, Row::from(vec![3.into(), 30.into()]), false)
+            .unwrap();
+        // The failed two-key preparation must not reserve its free key.
+        unrelated.commit().unwrap();
+        first.finish_publication(false).unwrap();
+        assert_eq!(index.get_row_ids_equal(&[10.into()]).as_slice(), &[1]);
+        assert!(index.get_row_ids_equal(&[20.into()]).is_empty());
+        assert_eq!(
+            store.get_visible_version(1, 9).unwrap().data.get(1),
+            Some(&10.into())
+        );
+        assert_eq!(
+            store.get_visible_version(3, 9).unwrap().data.get(1),
+            Some(&30.into())
+        );
+        assert_eq!(store.committed_row_count(), 2);
+        assert_eq!(store.hot_bytes(), original_bytes * 2);
+        second.finish_publication(false).unwrap();
+        assert!(store.publication_keys.lock().is_empty());
+    }
+
+    #[test]
     fn test_unique_constraint_performance_bulk_update() {
         use crate::core::DataType;
         use crate::storage::index::HashIndex;
@@ -9570,7 +10182,7 @@ mod tests {
             true, // is_unique
             0,
         ));
-        store.add_index("idx_u".to_string(), index);
+        store.add_index("idx_u".to_string(), index).unwrap();
 
         let row_count = 30000;
         let mut txn1 = TransactionVersionStore::new(Arc::clone(&store), 1);

--- a/src/storage/mvcc/wal_manager.rs
+++ b/src/storage/mvcc/wal_manager.rs
@@ -962,6 +962,9 @@ pub struct WALManager {
     /// Set after a WAL write failure; all further appends/flushes fail.
     /// See flush_and_maybe_sync for why retrying is never safe.
     poisoned: AtomicBool,
+    /// A failed suffix rollback left transaction durability unresolved.
+    /// Readers as well as writers must reopen before trusting this state.
+    indeterminate_commit: AtomicBool,
     /// Pending commits (legacy, kept for API compatibility)
     #[allow(dead_code)]
     pending_commits: AtomicI32,
@@ -1230,6 +1233,7 @@ impl WALManager {
             sync_mode,
             running: AtomicBool::new(true),
             poisoned: AtomicBool::new(false),
+            indeterminate_commit: AtomicBool::new(false),
             pending_commits: AtomicI32::new(0),
             last_sync_time: AtomicI64::new(now),
             commit_batch_size,
@@ -1405,22 +1409,42 @@ impl WALManager {
         Ok(())
     }
 
-    /// Poison the WAL and truncate the file back to the last fsynced
-    /// offset, so no unsynced marker of a failed commit can ever become
-    /// durable (via a later sync or plain kernel writeback). In Full mode
-    /// everything above the floor is unacknowledged by construction; in
-    /// Normal mode it is within the documented sync-interval loss window.
-    /// Truncation is best-effort: if it fails too, the torn-tail recovery
-    /// scan is the fallback.
+    /// Poison the WAL and durably truncate it to the last fsynced offset.
+    /// Full mode loses only unacknowledged writes; Normal mode retains its
+    /// documented sync-interval loss window. If truncation or its sync fails,
+    /// fence execution until recovery resolves the commit outcome.
     fn poison_and_truncate(&self, wal_file: &mut Option<File>, e: Error) -> Error {
         self.poisoned.store(true, Ordering::Release);
         let floor = self.synced_position.load(Ordering::Acquire);
-        if let Some(file) = wal_file.as_mut() {
-            let _ = file.set_len(floor);
-            let _ = file.sync_all();
+        let rollback = (|| -> io::Result<()> {
+            #[cfg(any(test, feature = "test-failpoints"))]
+            if crate::test_failpoints::WAL_ROLLBACK_FAIL.load(Ordering::Acquire) {
+                return Err(io::Error::other("failpoint: WAL suffix rollback"));
+            }
+            let file = wal_file
+                .as_mut()
+                .ok_or_else(|| io::Error::other("WAL file is closed"))?;
+            file.set_len(floor)?;
+            file.sync_all()
+        })();
+        match rollback {
+            Ok(()) => {
+                self.current_file_position.store(floor, Ordering::Release);
+                e
+            }
+            Err(rollback_error) => {
+                self.indeterminate_commit.store(true, Ordering::Release);
+                Error::internal(format!(
+                    "commit durability is indeterminate; reopen the database: {e}; \
+                     WAL rollback failed: {rollback_error}"
+                ))
+            }
         }
-        self.current_file_position.store(floor, Ordering::Release);
-        e
+    }
+
+    /// Whether a failed write could still be recovered as committed.
+    pub fn has_indeterminate_commit(&self) -> bool {
+        self.indeterminate_commit.load(Ordering::Acquire)
     }
 
     /// Get previous LSN (last written entry's LSN)

--- a/src/storage/traits/engine.rs
+++ b/src/storage/traits/engine.rs
@@ -41,6 +41,12 @@ use crate::storage::traits::{Index, Transaction};
 /// engine.close()?;
 /// ```
 pub trait Engine: Send + Sync {
+    /// Check whether execution can safely observe the current engine state.
+    /// Implementations with uncertain durable transaction outcomes fail closed.
+    fn check_health(&self) -> Result<()> {
+        Ok(())
+    }
+
     /// Opens the storage engine
     ///
     /// This initializes the engine, opens the database path (if any),
@@ -304,7 +310,7 @@ pub trait Engine: Send + Sync {
     fn get_row_counter(
         &self,
         table_name: &str,
-    ) -> Result<Box<dyn Fn(&[i64]) -> usize + Send + Sync>> {
+    ) -> Result<Box<dyn Fn(&[i64]) -> Result<usize> + Send + Sync>> {
         let _ = table_name;
         Err(crate::core::Error::internal(
             "get_row_counter not supported by this engine",

--- a/src/storage/traits/table.rs
+++ b/src/storage/traits/table.rs
@@ -23,6 +23,12 @@ use crate::storage::expression::Expression;
 use crate::storage::mvcc::version_store::{AggregateOp, GroupedAggregateResult};
 use crate::storage::traits::{Index, QueryResult, Scanner};
 
+/// Completes a detached index under the catalog build lease. Cold storage
+/// validates/populates first, then invokes installation under a short
+/// generation fence. Any error before installation leaves the catalog intact.
+pub type IndexBuildFinalizer<'a> =
+    dyn FnMut(&std::sync::Arc<dyn Index>, &mut dyn FnMut() -> Result<()>) -> Result<()> + 'a;
+
 /// Describes the access method that will be used for a table scan
 ///
 /// This is used by EXPLAIN to show users how their queries will be executed.
@@ -399,8 +405,8 @@ pub trait Table: Send + Sync {
 
     /// Check if a specific row_id exists in the hot buffer.
     /// O(log n) lookup instead of collecting all row_ids.
-    fn has_row_id(&self, _row_id: i64) -> bool {
-        false
+    fn has_row_id(&self, _row_id: i64) -> Result<bool> {
+        Ok(false)
     }
 
     /// Claim a row for update to prevent concurrent cold-row modifications.
@@ -646,6 +652,61 @@ pub trait Table: Send + Sync {
         self.create_index(name, columns, is_unique)
     }
 
+    /// Build a detached index, then let the storage wrapper finish it before installation.
+    fn create_index_with_type_and_finalizer(
+        &self,
+        _name: &str,
+        _columns: &[&str],
+        _is_unique: bool,
+        _index_type: Option<IndexType>,
+        _finalize: &mut IndexBuildFinalizer<'_>,
+    ) -> Result<()> {
+        Err(Error::internal(
+            "table does not support detached index construction",
+        ))
+    }
+
+    fn create_btree_index_with_finalizer(
+        &self,
+        _column_name: &str,
+        _is_unique: bool,
+        _custom_name: Option<&str>,
+        _finalize: &mut IndexBuildFinalizer<'_>,
+    ) -> Result<()> {
+        Err(Error::internal(
+            "table does not support detached BTree construction",
+        ))
+    }
+
+    fn create_multi_column_index_with_finalizer(
+        &self,
+        _name: &str,
+        _columns: &[&str],
+        _is_unique: bool,
+        _finalize: &mut IndexBuildFinalizer<'_>,
+    ) -> Result<()> {
+        Err(Error::internal(
+            "table does not support detached multi-column index construction",
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn create_hnsw_index_with_finalizer(
+        &self,
+        _name: &str,
+        _column: &str,
+        _is_unique: bool,
+        _m: usize,
+        _ef_construction: usize,
+        _ef_search: usize,
+        _metric: crate::storage::index::HnswDistanceMetric,
+        _finalize: &mut IndexBuildFinalizer<'_>,
+    ) -> Result<()> {
+        Err(Error::internal(
+            "table does not support detached HNSW construction",
+        ))
+    }
+
     /// Creates an HNSW index with custom parameters
     ///
     /// # Arguments
@@ -865,8 +926,8 @@ pub trait Table: Send + Sync {
     ///
     /// # Returns
     /// The number of visible rows in the table
-    fn row_count(&self) -> usize {
-        0 // Default implementation - override in concrete tables
+    fn row_count(&self) -> Result<usize> {
+        Ok(0) // Default implementation - override in concrete tables
     }
 
     /// Fast O(1) row count hint for optimizer decisions
@@ -874,7 +935,7 @@ pub trait Table: Send + Sync {
     /// Returns an upper bound estimate without expensive visibility checks.
     /// Use for cache eligibility and similar decisions where exact count isn't needed.
     fn row_count_hint(&self) -> usize {
-        self.row_count() // Default falls back to row_count
+        0 // Metadata hint only; exact row_count may require fallible reads
     }
 
     /// Fast O(1) exact row count for COUNT(*) queries
@@ -884,8 +945,8 @@ pub trait Table: Send + Sync {
     ///
     /// This is different from row_count_hint() because it returns the EXACT count,
     /// not an estimate. It's designed for COUNT(*) without WHERE clause.
-    fn fast_row_count(&self) -> Option<usize> {
-        None // Default: no fast path available
+    fn fast_row_count(&self) -> Result<Option<usize>> {
+        Ok(None) // Default: no fast path available
     }
 
     /// Collects rows sorted by an indexed column with limit (ORDER BY + LIMIT pushdown)
@@ -908,9 +969,9 @@ pub trait Table: Send + Sync {
         ascending: bool,
         limit: usize,
         offset: usize,
-    ) -> Option<RowVec> {
+    ) -> Result<Option<RowVec>> {
         let _ = (column_name, ascending, limit, offset);
-        None // Default implementation - override in concrete tables
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// The first `limit` rows after `offset` in the order of `column_name`,
@@ -966,9 +1027,12 @@ pub trait Table: Send + Sync {
     /// # Returns
     /// Some(Vec<(Value, RowVec)>) where each tuple is (partition_value, rows_in_partition)
     /// Returns None if the column has no index
-    fn collect_rows_grouped_by_partition(&self, column_name: &str) -> Option<Vec<(Value, RowVec)>> {
+    fn collect_rows_grouped_by_partition(
+        &self,
+        column_name: &str,
+    ) -> Result<Option<Vec<(Value, RowVec)>>> {
         let _ = column_name;
-        None // Default implementation - override in concrete tables
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// Get distinct partition values from an indexed column.
@@ -979,9 +1043,9 @@ pub trait Table: Send + Sync {
     ///
     /// # Returns
     /// Some(Vec<Value>) with distinct values, or None if column has no index
-    fn get_partition_values(&self, column_name: &str) -> Option<Vec<Value>> {
+    fn get_partition_values(&self, column_name: &str) -> Result<Option<Vec<Value>>> {
         let _ = column_name;
-        None // Default implementation - override in concrete tables
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// Compute distinct non-null values for a column by exploiting cold volume
@@ -994,8 +1058,8 @@ pub trait Table: Send + Sync {
     ///
     /// # Returns
     /// Some(Vec<Value>) with distinct non-null values, or None if fast path unavailable
-    fn compute_distinct_values(&self, _col_idx: usize) -> Option<Vec<Value>> {
-        None
+    fn compute_distinct_values(&self, _col_idx: usize) -> Result<Option<Vec<Value>>> {
+        Ok(None)
     }
 
     /// Get the count of distinct non-null values from an indexed column.
@@ -1006,9 +1070,9 @@ pub trait Table: Send + Sync {
     ///
     /// # Returns
     /// Some(count) excluding NULL values, or None if column has no index
-    fn get_partition_count(&self, column_name: &str) -> Option<usize> {
+    fn get_partition_count(&self, column_name: &str) -> Result<Option<usize>> {
         let _ = column_name;
-        None // Default implementation - override in concrete tables
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// Get rows for a specific partition value.
@@ -1196,8 +1260,8 @@ pub trait Table: Send + Sync {
     ///
     /// # Arguments
     /// * `col_idx` - Column index to sum
-    fn sum_column(&self, _col_idx: usize) -> Option<(f64, usize)> {
-        None // Default implementation - override in concrete tables
+    fn sum_column(&self, _col_idx: usize) -> Result<Option<(f64, usize)>> {
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// Compute AVG of a column without materializing rows (deferred aggregation)
@@ -1207,7 +1271,7 @@ pub trait Table: Send + Sync {
     ///
     /// # Arguments
     /// * `col_idx` - Column index to average
-    fn avg_column(&self, _col_idx: usize) -> Option<(f64, usize)> {
+    fn avg_column(&self, _col_idx: usize) -> Result<Option<(f64, usize)>> {
         // Default: use sum_column if available
         self.sum_column(_col_idx)
     }
@@ -1219,8 +1283,8 @@ pub trait Table: Send + Sync {
     ///
     /// # Arguments
     /// * `col_idx` - Column index to find minimum
-    fn min_column(&self, _col_idx: usize) -> Option<Option<Value>> {
-        None // Default implementation - override in concrete tables
+    fn min_column(&self, _col_idx: usize) -> Result<Option<Option<Value>>> {
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// Compute MAX of a column without materializing rows (deferred aggregation)
@@ -1230,8 +1294,8 @@ pub trait Table: Send + Sync {
     ///
     /// # Arguments
     /// * `col_idx` - Column index to find maximum
-    fn max_column(&self, _col_idx: usize) -> Option<Option<Value>> {
-        None // Default implementation - override in concrete tables
+    fn max_column(&self, _col_idx: usize) -> Result<Option<Option<Value>>> {
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// Compute aggregates with a WHERE filter at the storage level.
@@ -1250,8 +1314,8 @@ pub trait Table: Send + Sync {
         &self,
         _aggregates: &[(AggregateOp, usize)],
         _where_expr: &dyn Expression,
-    ) -> Option<Vec<crate::core::Value>> {
-        None // Default: not supported
+    ) -> Result<Option<Vec<crate::core::Value>>> {
+        Ok(None) // Default: not supported
     }
 
     /// Compute grouped aggregates at the storage level.
@@ -1269,8 +1333,8 @@ pub trait Table: Send + Sync {
         &self,
         _group_by_indices: &[usize],
         _aggregates: &[(AggregateOp, usize)],
-    ) -> Option<Vec<GroupedAggregateResult>> {
-        None // Default: not supported
+    ) -> Result<Option<Vec<GroupedAggregateResult>>> {
+        Ok(None) // Default: not supported
     }
 }
 

--- a/src/storage/traits/transaction.rs
+++ b/src/storage/traits/transaction.rs
@@ -55,6 +55,15 @@ pub trait Transaction: Send {
     /// Rolls back the transaction
     fn rollback(&mut self) -> Result<()>;
 
+    /// Starts an internal statement checkpoint. False means a surrounding
+    /// statement already owns one, or the engine needs none.
+    fn begin_statement(&mut self) -> Result<bool> {
+        Ok(false)
+    }
+
+    /// Restore only this statement's changes when success is false.
+    fn finish_statement(&mut self, _success: bool) {}
+
     /// Creates a savepoint with the given name
     ///
     /// Records the current state so it can be rolled back to later.

--- a/src/storage/volume/column.rs
+++ b/src/storage/volume/column.rs
@@ -33,7 +33,7 @@ pub type DictFilter<'a> = (&'a ColumnData, usize, u32);
 
 /// A dictionary column's raw ids and nulls, the local index its window
 /// starts at, and the id looked for
-type DictSlice<'a> = (&'a [u32], &'a [bool], usize, u32);
+type DictSlice<'a> = (&'a [u32], &'a [bool], u32);
 
 /// Typed column data stored contiguously for cache-friendly access.
 ///
@@ -547,8 +547,8 @@ impl ColumnData {
 
     /// Appends to `out` the offsets in `0..count` whose rows, read at
     /// `local + offset` in every column of `filters`, carry the expected
-    /// dictionary id and are not null. One tight pass over the first
-    /// column's raw ids; the other columns are only read for its matches.
+    /// dictionary id and are not null. Compare the leading column in small
+    /// blocks; read the other columns only for its matches.
     /// None when a filter column is not a dictionary column.
     pub fn dict_matching_offsets(
         filters: &[DictFilter<'_>],
@@ -559,25 +559,55 @@ impl ColumnData {
             smallvec::SmallVec::with_capacity(filters.len());
         for &(col, local, expected) in filters {
             let (ids, nulls) = col.dict_ids()?;
-            if local + count > ids.len() {
-                return None;
-            }
-            slices.push((ids, nulls, local, expected));
+            let end = local.checked_add(count)?;
+            slices.push((ids.get(local..end)?, nulls.get(local..end)?, expected));
         }
-        let Some(&(first_ids, first_nulls, first_local, first_expected)) = slices.first() else {
+        let Some(&(ids, nulls, expected)) = slices.first() else {
             out.extend(0..count);
             return Some(());
         };
-        let window = &first_ids[first_local..first_local + count];
-        for (offset, &id) in window.iter().enumerate() {
-            if id != first_expected || first_nulls[first_local + offset] {
+        let others = &slices[1..];
+        // Compare eight leading IDs together. Sparse masks avoid entering the
+        // remaining-predicate loop for rejected rows; dense masks use a straight
+        // scan instead of extracting individual bits. Offsets stay in input order.
+        let mut base = 0;
+        for chunk in ids.as_chunks::<8>().0 {
+            let flags = &nulls[base..base + 8];
+            let mut mask = 0u8;
+            for lane in 0..8 {
+                mask |= u8::from((chunk[lane] == expected) & !flags[lane]) << lane;
+            }
+            if mask == u8::MAX {
+                for offset in base..base + 8 {
+                    if others
+                        .iter()
+                        .all(|&(ids, nulls, expected)| ids[offset] == expected && !nulls[offset])
+                    {
+                        out.push(offset);
+                    }
+                }
+                base += 8;
                 continue;
             }
-            let others = slices[1..].iter().all(|&(ids, nulls, local, expected)| {
-                let at = local + offset;
-                ids[at] == expected && !nulls[at]
-            });
-            if others {
+            while mask != 0 {
+                let offset = base + mask.trailing_zeros() as usize;
+                mask &= mask - 1;
+                if others
+                    .iter()
+                    .all(|&(ids, nulls, expected)| ids[offset] == expected && !nulls[offset])
+                {
+                    out.push(offset);
+                }
+            }
+            base += 8;
+        }
+        for offset in base..count {
+            if ids[offset] == expected
+                && !nulls[offset]
+                && others
+                    .iter()
+                    .all(|&(ids, nulls, expected)| ids[offset] == expected && !nulls[offset])
+            {
                 out.push(offset);
             }
         }
@@ -1025,5 +1055,88 @@ mod tests {
         assert!(zm.may_contain_eq(&Value::Integer(50)));
         assert!(!zm.may_contain_eq(&Value::Integer(5)));
         assert!(!zm.may_contain_eq(&Value::Integer(101)));
+    }
+    #[test]
+    fn dict_block_masks_match_scalar_with_nulls_offsets_and_partial_blocks() {
+        // Every mask shape, including zero/full masks, at each block boundary.
+        for mask in 0..=u8::MAX {
+            let columns: Vec<_> = (0..6)
+                .map(|column| {
+                    let ids = (0..40)
+                        .map(|i| {
+                            if column == 0 {
+                                u32::from(mask & (1 << (i % 8)) == 0)
+                            } else {
+                                u32::from((i * (column + 1) + column) % 5 == 0)
+                            }
+                        })
+                        .collect();
+                    let nulls = (0..40).map(|i| (i + column * 3) % 11 == 0).collect();
+                    ColumnData::Dictionary {
+                        dictionary: vec!["yes".into(), "no".into()].into(),
+                        ids,
+                        nulls,
+                    }
+                })
+                .collect();
+            for filter_count in 0..=6 {
+                let filters: Vec<_> = columns
+                    .iter()
+                    .take(filter_count)
+                    .enumerate()
+                    .map(|(i, col)| (col, i, 0))
+                    .collect();
+                for count in 0..=33 {
+                    let mut expected = vec![usize::MAX];
+                    expected.extend((0..count).filter(|&offset| {
+                        filters.iter().all(|&(col, local, id)| {
+                            let (ids, nulls) = col.dict_ids().unwrap();
+                            ids[local + offset] == id && !nulls[local + offset]
+                        })
+                    }));
+                    let mut actual = vec![usize::MAX];
+                    assert_eq!(
+                        ColumnData::dict_matching_offsets(&filters, count, &mut actual),
+                        Some(())
+                    );
+                    assert_eq!(
+                        actual, expected,
+                        "mask={mask} filters={filter_count} count={count}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn dict_block_invalid_windows_leave_output_unchanged() {
+        let valid = ColumnData::Dictionary {
+            dictionary: vec!["yes".into()].into(),
+            ids: vec![0; 16],
+            nulls: vec![false; 16],
+        };
+        let short_nulls = ColumnData::Dictionary {
+            dictionary: vec!["yes".into()].into(),
+            ids: vec![0; 16],
+            nulls: vec![false; 7],
+        };
+        let not_dict = ColumnData::Int64 {
+            values: vec![0; 16],
+            nulls: vec![false; 16],
+        };
+        for (filters, count) in [
+            (vec![(&valid, usize::MAX, 0)], 2),
+            (vec![(&valid, 17, 0)], 0),
+            (vec![(&valid, 8, 0)], 9),
+            (vec![(&valid, 0, 0), (&short_nulls, 0, 0)], 8),
+            (vec![(&valid, 0, 0), (&not_dict, 0, 0)], 8),
+        ] {
+            let mut actual = vec![42];
+            assert_eq!(
+                ColumnData::dict_matching_offsets(&filters, count, &mut actual),
+                None
+            );
+            assert_eq!(actual, [42]);
+        }
     }
 }

--- a/src/storage/volume/format.rs
+++ b/src/storage/volume/format.rs
@@ -65,6 +65,68 @@ pub(crate) const FLAG_SORTED: u8 = 0x01;
 // Helpers
 // =============================================================================
 
+#[cold]
+fn invalid(message: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+fn checked_end(data: &[u8], pos: usize, count: usize, width: usize) -> io::Result<usize> {
+    count
+        .checked_mul(width)
+        .and_then(|len| pos.checked_add(len))
+        .filter(|&end| end <= data.len())
+        .ok_or_else(|| invalid("truncated or overflowing volume range"))
+}
+
+fn read_usize(data: &[u8], pos: &mut usize) -> io::Result<usize> {
+    usize::try_from(read_u64(data, pos)?)
+        .map_err(|_| invalid("volume length exceeds address space"))
+}
+
+fn check_flags(bytes: &[u8]) -> io::Result<()> {
+    // OR reduction is vectorizable and rejects every representation except 0/1.
+    if bytes.iter().fold(0u8, |flags, &byte| flags | byte) > 1 {
+        return Err(invalid("invalid boolean/null flag"));
+    }
+    Ok(())
+}
+
+/// Validate untrusted flags before exposing them as Rust booleans. The copy
+/// uses the already-validated representation instead of pushing each flag.
+fn append_flags(bytes: &[u8], out: &mut Vec<bool>) -> io::Result<()> {
+    check_flags(bytes)?;
+    // SAFETY: bool has size/alignment one, and check_flags proved every byte
+    // is a valid bool representation. The source slice remains borrowed only
+    // for this copy; no reference to unvalidated disk bytes escapes.
+    let flags = unsafe { std::slice::from_raw_parts(bytes.as_ptr().cast::<bool>(), bytes.len()) };
+    out.extend_from_slice(flags);
+    Ok(())
+}
+
+/// Validate layout lengths before allocations; row counts come from disk.
+fn check_block_layout(data: &[u8], tag: u8, rows: usize) -> io::Result<()> {
+    let end = match tag {
+        COL_INT64 | COL_FLOAT64 | COL_TIMESTAMP => checked_end(data, 0, rows, 9)?,
+        COL_BOOLEAN => checked_end(data, 0, rows, 2)?,
+        COL_DICTIONARY => checked_end(data, 0, rows, 5)?,
+        COL_BYTES => {
+            let mut pos = checked_end(data, 0, rows, 1)?;
+            let count = read_usize(data, &mut pos)?;
+            if count != rows {
+                return Err(invalid("bytes offset count differs from row count"));
+            }
+            pos = checked_end(data, pos, count, 16)?;
+            let len = read_usize(data, &mut pos)?;
+            checked_end(data, pos, len, 1)?
+        }
+        _ => return Err(invalid("unknown column type tag")),
+    };
+    if end != data.len() {
+        return Err(invalid("trailing column block bytes"));
+    }
+    Ok(())
+}
+
 fn write_nulls(buf: &mut Vec<u8>, nulls: &[bool]) -> io::Result<()> {
     for &n in nulls {
         buf.push(if n { 1 } else { 0 });
@@ -73,24 +135,22 @@ fn write_nulls(buf: &mut Vec<u8>, nulls: &[bool]) -> io::Result<()> {
 }
 
 fn read_nulls(data: &[u8], pos: &mut usize, count: usize) -> io::Result<Vec<bool>> {
-    let end = *pos + count;
+    let end = checked_end(data, *pos, count, 1)?;
     if end > data.len() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "truncated volume: null bitmap extends past end of data",
         ));
     }
-    let mut nulls = Vec::with_capacity(count);
-    for i in 0..count {
-        nulls.push(data[*pos + i] != 0);
-    }
+    let mut nulls = Vec::new();
+    append_flags(&data[*pos..end], &mut nulls)?;
     *pos = end;
     Ok(nulls)
 }
 
 #[inline]
 fn read_u32(data: &[u8], pos: &mut usize) -> io::Result<u32> {
-    let end = *pos + 4;
+    let end = checked_end(data, *pos, 1, 4)?;
     let bytes: [u8; 4] = data
         .get(*pos..end)
         .and_then(|s| s.try_into().ok())
@@ -103,7 +163,7 @@ fn read_u32(data: &[u8], pos: &mut usize) -> io::Result<u32> {
 
 #[inline]
 fn read_u64(data: &[u8], pos: &mut usize) -> io::Result<u64> {
-    let end = *pos + 8;
+    let end = checked_end(data, *pos, 1, 8)?;
     let bytes: [u8; 8] = data
         .get(*pos..end)
         .and_then(|s| s.try_into().ok())
@@ -116,7 +176,7 @@ fn read_u64(data: &[u8], pos: &mut usize) -> io::Result<u64> {
 
 #[inline]
 fn read_i64(data: &[u8], pos: &mut usize) -> io::Result<i64> {
-    let end = *pos + 8;
+    let end = checked_end(data, *pos, 1, 8)?;
     let bytes: [u8; 8] = data
         .get(*pos..end)
         .and_then(|s| s.try_into().ok())
@@ -129,7 +189,7 @@ fn read_i64(data: &[u8], pos: &mut usize) -> io::Result<i64> {
 
 #[inline]
 fn read_f64(data: &[u8], pos: &mut usize) -> io::Result<f64> {
-    let end = *pos + 8;
+    let end = checked_end(data, *pos, 1, 8)?;
     let bytes: [u8; 8] = data
         .get(*pos..end)
         .and_then(|s| s.try_into().ok())
@@ -142,7 +202,7 @@ fn read_f64(data: &[u8], pos: &mut usize) -> io::Result<f64> {
 
 #[inline]
 fn read_i128(data: &[u8], pos: &mut usize) -> io::Result<i128> {
-    let end = *pos + 16;
+    let end = checked_end(data, *pos, 1, 16)?;
     let bytes: [u8; 16] = data
         .get(*pos..end)
         .and_then(|s| s.try_into().ok())
@@ -232,8 +292,10 @@ fn write_bool_bulk(buf: &mut Vec<u8>, values: &[bool]) {
 
 /// Read `count` i64 values from little-endian bytes in bulk.
 fn read_i64_bulk(data: &[u8], pos: &mut usize, count: usize) -> io::Result<Vec<i64>> {
-    let byte_len = count * 8;
-    let end = *pos + byte_len;
+    let byte_len = count
+        .checked_mul(8)
+        .ok_or_else(|| invalid("column size overflow"))?;
+    let end = checked_end(data, *pos, byte_len, 1)?;
     if end > data.len() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -271,8 +333,10 @@ fn read_i64_bulk(data: &[u8], pos: &mut usize, count: usize) -> io::Result<Vec<i
 
 /// Read `count` f64 values from little-endian bytes in bulk.
 fn read_f64_bulk(data: &[u8], pos: &mut usize, count: usize) -> io::Result<Vec<f64>> {
-    let byte_len = count * 8;
-    let end = *pos + byte_len;
+    let byte_len = count
+        .checked_mul(8)
+        .ok_or_else(|| invalid("column size overflow"))?;
+    let end = checked_end(data, *pos, byte_len, 1)?;
     if end > data.len() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -307,8 +371,10 @@ fn read_f64_bulk(data: &[u8], pos: &mut usize, count: usize) -> io::Result<Vec<f
 
 /// Read `count` u32 values from little-endian bytes in bulk.
 fn read_u32_bulk(data: &[u8], pos: &mut usize, count: usize) -> io::Result<Vec<u32>> {
-    let byte_len = count * 4;
-    let end = *pos + byte_len;
+    let byte_len = count
+        .checked_mul(4)
+        .ok_or_else(|| invalid("column size overflow"))?;
+    let end = checked_end(data, *pos, byte_len, 1)?;
     if end > data.len() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -343,17 +409,15 @@ fn read_u32_bulk(data: &[u8], pos: &mut usize, count: usize) -> io::Result<Vec<u
 
 /// Read `count` boolean values from bytes in bulk.
 fn read_bool_bulk(data: &[u8], pos: &mut usize, count: usize) -> io::Result<Vec<bool>> {
-    let end = *pos + count;
+    let end = checked_end(data, *pos, count, 1)?;
     if end > data.len() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "truncated volume: boolean column data",
         ));
     }
-    let mut values = Vec::with_capacity(count);
-    for i in 0..count {
-        values.push(data[*pos + i] != 0);
-    }
+    let mut values = Vec::new();
+    append_flags(&data[*pos..end], &mut values)?;
     *pos = end;
     Ok(values)
 }
@@ -419,7 +483,8 @@ fn read_value(data: &[u8], pos: &mut usize) -> io::Result<Value> {
                     "truncated null type",
                 ));
             }
-            let dt = DataType::from_u8(data[*pos]).unwrap_or(DataType::Null);
+            let dt =
+                DataType::from_u8(data[*pos]).ok_or_else(|| invalid("unknown null data type"))?;
             *pos += 1;
             Ok(Value::Null(dt))
         }
@@ -427,7 +492,7 @@ fn read_value(data: &[u8], pos: &mut usize) -> io::Result<Value> {
         2 => Ok(Value::Float(read_f64(data, pos)?)),
         3 => {
             let slen = read_u32(data, pos)? as usize;
-            if *pos + slen > data.len() {
+            if checked_end(data, *pos, slen, 1).is_err() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "truncated volume: text value data",
@@ -445,6 +510,7 @@ fn read_value(data: &[u8], pos: &mut usize) -> io::Result<Value> {
                     "truncated boolean",
                 ));
             }
+            check_flags(&data[*pos..*pos + 1])?;
             let b = data[*pos] != 0;
             *pos += 1;
             Ok(Value::Boolean(b))
@@ -460,7 +526,7 @@ fn read_value(data: &[u8], pos: &mut usize) -> io::Result<Value> {
         }
         6 => {
             let len = read_u32(data, pos)? as usize;
-            if *pos + len > data.len() {
+            if checked_end(data, *pos, len, 1).is_err() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "truncated extension data",
@@ -566,17 +632,14 @@ pub(crate) fn read_nulls_into(
     count: usize,
     out: &mut Vec<bool>,
 ) -> io::Result<()> {
-    let end = *pos + count;
+    let end = checked_end(data, *pos, count, 1)?;
     if end > data.len() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "truncated volume: null bitmap extends past end of data",
         ));
     }
-    out.reserve(count);
-    for i in 0..count {
-        out.push(data[*pos + i] != 0);
-    }
+    append_flags(&data[*pos..end], out)?;
     *pos = end;
     Ok(())
 }
@@ -589,8 +652,10 @@ pub(crate) fn read_i64_bulk_into(
     count: usize,
     out: &mut Vec<i64>,
 ) -> io::Result<()> {
-    let byte_len = count * 8;
-    let end = *pos + byte_len;
+    let byte_len = count
+        .checked_mul(8)
+        .ok_or_else(|| invalid("column size overflow"))?;
+    let end = checked_end(data, *pos, byte_len, 1)?;
     if end > data.len() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -631,8 +696,10 @@ pub(crate) fn read_f64_bulk_into(
     count: usize,
     out: &mut Vec<f64>,
 ) -> io::Result<()> {
-    let byte_len = count * 8;
-    let end = *pos + byte_len;
+    let byte_len = count
+        .checked_mul(8)
+        .ok_or_else(|| invalid("column size overflow"))?;
+    let end = checked_end(data, *pos, byte_len, 1)?;
     if end > data.len() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -672,8 +739,10 @@ pub(crate) fn read_u32_bulk_into(
     count: usize,
     out: &mut Vec<u32>,
 ) -> io::Result<()> {
-    let byte_len = count * 4;
-    let end = *pos + byte_len;
+    let byte_len = count
+        .checked_mul(4)
+        .ok_or_else(|| invalid("column size overflow"))?;
+    let end = checked_end(data, *pos, byte_len, 1)?;
     if end > data.len() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -713,17 +782,14 @@ pub(crate) fn read_bool_bulk_into(
     count: usize,
     out: &mut Vec<bool>,
 ) -> io::Result<()> {
-    let end = *pos + count;
+    let end = checked_end(data, *pos, count, 1)?;
     if end > data.len() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "truncated volume: boolean column data",
         ));
     }
-    out.reserve(count);
-    for i in 0..count {
-        out.push(data[*pos + i] != 0);
-    }
+    append_flags(&data[*pos..end], out)?;
     *pos = end;
     Ok(())
 }
@@ -754,6 +820,7 @@ pub(crate) fn deserialize_column_block_into(
     bytes_data_out: Option<&mut Vec<u8>>,
     bytes_offsets_out: Option<&mut Vec<(u64, u64)>>,
 ) -> io::Result<()> {
+    check_block_layout(data, col_type_tag, row_count)?;
     let mut pos = 0;
     match col_type_tag {
         COL_INT64 | COL_TIMESTAMP => {
@@ -802,7 +869,7 @@ pub(crate) fn deserialize_column_block_into(
         }
         COL_BYTES => {
             read_nulls_into(data, &mut pos, row_count, nulls_out)?;
-            let offset_count = read_u64(data, &mut pos)? as usize;
+            let offset_count = read_usize(data, &mut pos)?;
             let bytes_data = bytes_data_out.ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidData, "missing bytes_data_out buffer")
             })?;
@@ -831,14 +898,15 @@ pub(crate) fn deserialize_column_block_into(
                 })?;
                 bytes_offsets.push((adjusted, len));
             }
-            let data_len = read_u64(data, &mut pos)? as usize;
-            if pos + data_len > data.len() {
+            let data_len = read_usize(data, &mut pos)?;
+            if checked_end(data, pos, data_len, 1).is_err() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "truncated column block: bytes data",
                 ));
             }
             bytes_data.extend_from_slice(&data[pos..pos + data_len]);
+            pos += data_len;
             // Validate offsets against the data blob
             for (i, &(off, len)) in bytes_offsets
                 .iter()
@@ -851,7 +919,7 @@ pub(crate) fn deserialize_column_block_into(
                         format!("bytes offset overflow at row {}", i),
                     )
                 })?;
-                if (end as usize) > bytes_data.len() {
+                if end > bytes_data.len() as u64 {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!(
@@ -872,6 +940,9 @@ pub(crate) fn deserialize_column_block_into(
             ));
         }
     }
+    if pos != data.len() {
+        return Err(invalid("trailing column block bytes"));
+    }
     Ok(())
 }
 
@@ -884,8 +955,9 @@ pub(crate) fn deserialize_column_block(
     dictionary: Option<Arc<[SmartString]>>,
     ext_type: DataType,
 ) -> io::Result<ColumnData> {
+    check_block_layout(data, col_type_tag, row_count)?;
     let mut pos = 0;
-    match col_type_tag {
+    let column = match col_type_tag {
         COL_INT64 => {
             let nulls = read_nulls(data, &mut pos, row_count)?;
             let values = read_i64_bulk(data, &mut pos, row_count)?;
@@ -932,31 +1004,32 @@ pub(crate) fn deserialize_column_block(
         }
         COL_BYTES => {
             let nulls = read_nulls(data, &mut pos, row_count)?;
-            let offset_count = read_u64(data, &mut pos)? as usize;
+            let offset_count = read_usize(data, &mut pos)?;
             let mut offsets = Vec::with_capacity(offset_count);
             for _ in 0..offset_count {
                 let off = read_u64(data, &mut pos)?;
                 let len = read_u64(data, &mut pos)?;
                 offsets.push((off, len));
             }
-            let data_len = read_u64(data, &mut pos)? as usize;
-            if pos + data_len > data.len() {
+            let data_len = read_usize(data, &mut pos)?;
+            if checked_end(data, pos, data_len, 1).is_err() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "truncated column block: bytes data",
                 ));
             }
             let blob = data[pos..pos + data_len].to_vec();
+            pos += data_len;
             // Validate offsets to prevent panics on corrupted volumes
             for (i, &(off, len)) in offsets.iter().enumerate() {
-                if !nulls[i] {
+                {
                     let end = off.checked_add(len).ok_or_else(|| {
                         io::Error::new(
                             io::ErrorKind::InvalidData,
                             format!("bytes offset overflow at row {}", i),
                         )
                     })?;
-                    if (end as usize) > blob.len() {
+                    if end > blob.len() as u64 {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
                             format!(
@@ -981,7 +1054,11 @@ pub(crate) fn deserialize_column_block(
             io::ErrorKind::InvalidData,
             format!("unknown column type tag {}", col_type_tag),
         )),
+    }?;
+    if pos != data.len() {
+        return Err(invalid("trailing column block bytes"));
     }
+    Ok(column)
 }
 
 /// Metadata parsed from a V4 volume file (everything except column data).
@@ -1019,7 +1096,7 @@ pub(crate) fn serialize_volume_metadata(vol: &FrozenVolume) -> io::Result<Vec<u8
     let mut shared_dict: Vec<SmartString> = Vec::new();
     let mut dict_counts: Vec<u32> = Vec::new();
     for i in 0..col_count {
-        if let ColumnData::Dictionary { dictionary, .. } = &vol.columns[i] {
+        if let ColumnData::Dictionary { dictionary, .. } = vol.columns.get(i)? {
             dict_counts.push(dictionary.len() as u32);
             shared_dict.extend(dictionary.iter().cloned());
         }
@@ -1028,7 +1105,7 @@ pub(crate) fn serialize_volume_metadata(vol: &FrozenVolume) -> io::Result<Vec<u8
     // Column directory: type(1) + flags(1) + extra(4) per column
     let mut dict_col_idx = 0usize;
     for i in 0..col_count {
-        let col = &vol.columns[i];
+        let col = vol.columns.get(i)?;
         let type_tag = match col {
             ColumnData::Int64 { .. } => COL_INT64,
             ColumnData::Float64 { .. } => COL_FLOAT64,
@@ -1131,9 +1208,10 @@ pub(crate) fn serialize_volume_metadata(vol: &FrozenVolume) -> io::Result<Vec<u8
 pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetadata> {
     let mut pos = 0;
 
-    let row_count = read_u64(data, &mut pos)? as usize;
+    let row_count = read_usize(data, &mut pos)?;
     let col_count = read_u32(data, &mut pos)? as usize;
 
+    checked_end(data, pos, col_count, 6)?;
     // Column directory
     let mut col_type_tags = Vec::with_capacity(col_count);
     let mut col_ext_types = Vec::with_capacity(col_count);
@@ -1151,6 +1229,14 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
         let flags = data[pos];
         pos += 1;
         let extra = read_u32(data, &mut pos)?;
+        if !(COL_INT64..=COL_BYTES).contains(&type_tag) || flags & !FLAG_SORTED != 0 {
+            return Err(invalid("unknown column type or flags"));
+        }
+        if type_tag == COL_BYTES
+            && (extra > u8::MAX as u32 || DataType::from_u8(extra as u8).is_none())
+        {
+            return Err(invalid("invalid extension type"));
+        }
         col_type_tags.push(type_tag);
         col_ext_types.push(if type_tag == COL_BYTES {
             extra as u8
@@ -1163,10 +1249,18 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
 
     // Shared dictionary
     let dict_len = read_u32(data, &mut pos)? as usize;
+    checked_end(data, pos, dict_len, 4)?;
+    if col_dict_counts
+        .iter()
+        .try_fold(0usize, |n, count| n.checked_add(*count as usize))
+        != Some(dict_len)
+    {
+        return Err(invalid("dictionary counts mismatch"));
+    }
     let mut shared_dict = Vec::with_capacity(dict_len);
     for _ in 0..dict_len {
         let slen = read_u32(data, &mut pos)? as usize;
-        if pos + slen > data.len() {
+        if checked_end(data, pos, slen, 1).is_err() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "truncated V4 metadata: dictionary string",
@@ -1180,6 +1274,9 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
 
     // Row IDs (bulk read — single memcpy on LE platforms)
     let row_ids = read_i64_bulk(data, &mut pos, row_count)?;
+    if row_ids.windows(2).any(|w| w[0] >= w[1]) {
+        return Err(invalid("V4 row IDs are not strictly ascending"));
+    }
 
     // Zone maps
     let mut zone_maps = Vec::with_capacity(col_count);
@@ -1188,6 +1285,9 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
         let max = read_value(data, &mut pos)?;
         let null_count = read_u32(data, &mut pos)?;
         let row_count_zm = read_u32(data, &mut pos)?;
+        if null_count > row_count_zm || row_count_zm as usize != row_count {
+            return Err(invalid("invalid volume zone-map counts"));
+        }
         zone_maps.push(ZoneMap {
             min,
             max,
@@ -1198,15 +1298,25 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
 
     // Bloom filters
     let num_blooms = read_u32(data, &mut pos)? as usize;
+    if num_blooms != 0 && num_blooms != col_count {
+        return Err(invalid("bloom count mismatch"));
+    }
+    checked_end(data, pos, num_blooms, 12)?;
     let mut bloom_filters = Vec::with_capacity(num_blooms);
     for _ in 0..num_blooms {
-        let num_bits = read_u64(data, &mut pos)? as usize;
+        let num_bits = read_usize(data, &mut pos)?;
         let data_len = read_u32(data, &mut pos)? as usize;
-        if pos + data_len > data.len() {
+        if checked_end(data, pos, data_len, 1).is_err() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "truncated V4 metadata: bloom filter",
             ));
+        }
+        if num_bits == 0
+            || !data_len.is_multiple_of(8)
+            || num_bits.div_ceil(64).checked_mul(8) != Some(data_len)
+        {
+            return Err(invalid("invalid bloom filter size"));
         }
         let bits_bytes = &data[pos..pos + data_len];
         pos += data_len;
@@ -1219,6 +1329,10 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
     let total_rows = read_u64(data, &mut pos)?;
     let live_rows = read_u64(data, &mut pos)?;
     let stats_col_count = read_u32(data, &mut pos)? as usize;
+    if stats_col_count != col_count || total_rows != row_count as u64 || live_rows > total_rows {
+        return Err(invalid("aggregate counts mismatch"));
+    }
+    checked_end(data, pos, stats_col_count, 44)?;
     let mut stat_columns = Vec::with_capacity(stats_col_count);
     for _ in 0..stats_col_count {
         let sum_int = read_i128(data, &mut pos)?;
@@ -1227,6 +1341,9 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
         let non_null_count = read_u64(data, &mut pos)?;
         let min = read_value(data, &mut pos)?;
         let max = read_value(data, &mut pos)?;
+        if numeric_count > non_null_count || non_null_count > total_rows {
+            return Err(invalid("invalid column aggregate counts"));
+        }
         stat_columns.push(ColumnAggregateStats {
             sum_int,
             sum_float,
@@ -1241,7 +1358,7 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
     let mut column_names = Vec::with_capacity(col_count);
     for _ in 0..col_count {
         let slen = read_u32(data, &mut pos)? as usize;
-        if pos + slen > data.len() {
+        if checked_end(data, pos, slen, 1).is_err() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "truncated V4 metadata: column name",
@@ -1262,22 +1379,51 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
                 "truncated V4 metadata: column type",
             ));
         }
-        column_types.push(DataType::from_u8(data[pos]).unwrap_or(DataType::Null));
+        column_types
+            .push(DataType::from_u8(data[pos]).ok_or_else(|| invalid("unknown column data type"))?);
         pos += 1;
+    }
+    for (ci, dt) in column_types.iter().enumerate() {
+        let expected = match dt {
+            DataType::Integer => COL_INT64,
+            DataType::Float => COL_FLOAT64,
+            DataType::Timestamp => COL_TIMESTAMP,
+            DataType::Boolean => COL_BOOLEAN,
+            DataType::Text => COL_DICTIONARY,
+            _ => COL_BYTES,
+        };
+        if col_type_tags[ci] != expected
+            || (expected == COL_BYTES && col_ext_types[ci] != *dt as u8)
+        {
+            return Err(invalid("column physical/logical type mismatch"));
+        }
     }
 
     // Row groups
     let num_groups = read_u32(data, &mut pos)? as usize;
+    if num_groups != 0 && num_groups != row_count.div_ceil(super::column::ROW_GROUP_SIZE) {
+        return Err(invalid("row group count mismatch"));
+    }
+    checked_end(data, pos, num_groups, 8)?;
     let mut row_groups = Vec::with_capacity(num_groups);
+    let mut next_start = 0;
     for _ in 0..num_groups {
         let start_idx = read_u32(data, &mut pos)?;
         let end_idx = read_u32(data, &mut pos)?;
+        let expected_end = (next_start + super::column::ROW_GROUP_SIZE).min(row_count);
+        if start_idx as usize != next_start || end_idx as usize != expected_end {
+            return Err(invalid("invalid row group range"));
+        }
+        next_start = expected_end;
         let mut group_zone_maps = Vec::with_capacity(col_count);
         for _ in 0..col_count {
             let min = read_value(data, &mut pos)?;
             let max = read_value(data, &mut pos)?;
             let nc = read_u32(data, &mut pos)?;
             let rc = read_u32(data, &mut pos)?;
+            if nc > rc || rc != end_idx - start_idx {
+                return Err(invalid("invalid group zone-map counts"));
+            }
             group_zone_maps.push(ZoneMap {
                 min,
                 max,
@@ -1292,6 +1438,9 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
         });
     }
 
+    if pos != data.len() {
+        return Err(invalid("trailing volume metadata bytes"));
+    }
     let column_name_map = column_names
         .iter()
         .enumerate()
@@ -1327,4 +1476,204 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
         row_groups,
         column_name_map,
     })
+}
+
+#[cfg(test)]
+mod corruption_tests {
+    use super::*;
+    use crate::core::{Row, SchemaBuilder};
+    use crate::storage::volume::writer::VolumeBuilder;
+
+    fn decode(data: &[u8], tag: u8, rows: usize) -> io::Result<ColumnData> {
+        deserialize_column_block(
+            data,
+            tag,
+            rows,
+            Some(Arc::from(vec![SmartString::from("a")])),
+            DataType::Json,
+        )
+    }
+
+    #[test]
+    fn truncated_and_trailing_column_blocks_fail_for_every_type() {
+        let columns = [
+            (
+                COL_INT64,
+                ColumnData::Int64 {
+                    values: vec![17],
+                    nulls: vec![false],
+                },
+            ),
+            (
+                COL_FLOAT64,
+                ColumnData::Float64 {
+                    values: vec![1.25],
+                    nulls: vec![false],
+                },
+            ),
+            (
+                COL_TIMESTAMP,
+                ColumnData::TimestampNanos {
+                    values: vec![17],
+                    nulls: vec![false],
+                },
+            ),
+            (
+                COL_BOOLEAN,
+                ColumnData::Boolean {
+                    values: vec![true],
+                    nulls: vec![false],
+                },
+            ),
+            (
+                COL_DICTIONARY,
+                ColumnData::Dictionary {
+                    ids: vec![0],
+                    nulls: vec![false],
+                    dictionary: Arc::from(vec![SmartString::from("a")]),
+                },
+            ),
+            (
+                COL_BYTES,
+                ColumnData::Bytes {
+                    data: vec![1, 2],
+                    offsets: vec![(0, 2)],
+                    nulls: vec![false],
+                    ext_type: DataType::Json,
+                },
+            ),
+        ];
+        for (tag, column) in columns {
+            let mut raw = serialize_column_block(&column, 0, 1);
+            assert!(decode(&raw, tag, 1).is_ok());
+            for end in 0..raw.len() {
+                assert!(decode(&raw[..end], tag, 1).is_err(), "tag={tag}, end={end}");
+            }
+            raw.push(0);
+            assert!(decode(&raw, tag, 1).is_err(), "tag={tag}: trailing bytes");
+        }
+    }
+
+    #[test]
+    fn bulk_flags_validate_every_byte_before_exposing_booleans() {
+        for len in [0, 1, 31, 32, 33, 64, 65, 257] {
+            let bytes: Vec<u8> = (0..len).map(|i| (i % 2) as u8).collect();
+            let mut out = vec![true];
+            append_flags(&bytes, &mut out).unwrap();
+            assert_eq!(out.len(), len + 1);
+            assert!(out[0]);
+            assert!(out[1..]
+                .iter()
+                .zip(&bytes)
+                .all(|(&flag, &byte)| flag == (byte == 1)));
+            if len == 0 {
+                continue;
+            }
+            for offset in [0, len / 2, len - 1] {
+                for invalid in 2..=u8::MAX {
+                    let mut damaged = bytes.clone();
+                    damaged[offset] = invalid;
+                    let before = out.clone();
+                    let capacity = out.capacity();
+                    assert!(append_flags(&damaged, &mut out).is_err());
+                    assert_eq!(out, before);
+                    assert_eq!(out.capacity(), capacity);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_overflowing_counts_offsets_and_invalid_flags() {
+        assert!(decode(&[], COL_INT64, usize::MAX).is_err());
+        let mut raw = serialize_column_block(
+            &ColumnData::Bytes {
+                data: vec![7],
+                offsets: vec![(0, 1)],
+                nulls: vec![false],
+                ext_type: DataType::Json,
+            },
+            0,
+            1,
+        );
+        raw[1..9].copy_from_slice(&u64::MAX.to_le_bytes());
+        assert!(decode(&raw, COL_BYTES, 1).is_err());
+        raw[1..9].copy_from_slice(&1u64.to_le_bytes());
+        raw[9..17].copy_from_slice(&u64::MAX.to_le_bytes());
+        assert!(decode(&raw, COL_BYTES, 1).is_err());
+        let mut null_flag = vec![0u8; 9];
+        null_flag[0] = 2;
+        assert!(decode(&null_flag, COL_INT64, 1).is_err());
+        assert!(decode(&[0, 2], COL_BOOLEAN, 1).is_err());
+        assert!(decode(&[0, 1, 0, 0, 0], COL_DICTIONARY, 1).is_err());
+        assert!(decode(&[], 255, 0).is_err());
+    }
+
+    #[test]
+    fn append_decoder_rejects_malformed_layout_without_new_group_allocation() {
+        let mut nulls = vec![];
+        let mut values = vec![];
+        assert!(deserialize_column_block_into(
+            &[0, 2],
+            COL_BOOLEAN,
+            1,
+            &mut nulls,
+            None,
+            None,
+            None,
+            Some(&mut values),
+            None,
+            None
+        )
+        .is_err());
+        let mut bytes = vec![];
+        let mut offsets = vec![];
+        let mut raw = vec![0u8; 33];
+        raw[1..9].copy_from_slice(&2u64.to_le_bytes());
+        assert!(deserialize_column_block_into(
+            &raw,
+            COL_BYTES,
+            1,
+            &mut nulls,
+            None,
+            None,
+            None,
+            None,
+            Some(&mut bytes),
+            Some(&mut offsets)
+        )
+        .is_err());
+        assert!(bytes.is_empty() && offsets.is_empty());
+    }
+
+    #[test]
+    fn metadata_rejects_unbounded_counts_bad_identity_and_trailing_bytes() {
+        let schema = SchemaBuilder::new("t")
+            .column("id", DataType::Integer, false, true)
+            .column("s", DataType::Text, false, false)
+            .build();
+        let mut builder = VolumeBuilder::new(&schema);
+        builder.add_row(
+            1,
+            &Row::from_values(vec![Value::Integer(1), Value::text("a")]),
+        );
+        builder.add_row(
+            2,
+            &Row::from_values(vec![Value::Integer(2), Value::text("b")]),
+        );
+        let mut volume = builder.finish();
+        let raw = serialize_volume_metadata(&volume).unwrap();
+        assert!(deserialize_volume_metadata(&raw).is_ok());
+        let mut bad = raw.clone();
+        bad[8..12].copy_from_slice(&u32::MAX.to_le_bytes());
+        assert!(deserialize_volume_metadata(&bad).is_err());
+        let mut bad = raw.clone();
+        bad[24..28].copy_from_slice(&u32::MAX.to_le_bytes());
+        assert!(deserialize_volume_metadata(&bad).is_err());
+        let mut bad = raw;
+        bad.push(0);
+        assert!(deserialize_volume_metadata(&bad).is_err());
+        Arc::make_mut(&mut volume.meta).row_ids.swap(0, 1);
+        assert!(deserialize_volume_metadata(&serialize_volume_metadata(&volume).unwrap()).is_err());
+    }
 }

--- a/src/storage/volume/group_cache.rs
+++ b/src/storage/volume/group_cache.rs
@@ -35,7 +35,7 @@ pub const DEFAULT_BUDGET_BYTES: usize = 64 * 1024 * 1024;
 pub type GroupKey = (usize, u32, u32);
 
 struct Slot {
-    cell: OnceLock<Result<Arc<ColumnData>, String>>,
+    cell: OnceLock<Result<Arc<ColumnData>, (std::io::ErrorKind, String)>>,
     /// The decoder charges the entry's bytes once
     charged: AtomicBool,
 }
@@ -116,9 +116,11 @@ impl DecodedGroupCache {
                 }
             }
         };
-        let outcome = slot
-            .cell
-            .get_or_init(|| decode().map(Arc::new).map_err(|e| e.to_string()));
+        let outcome = slot.cell.get_or_init(|| {
+            decode()
+                .map(Arc::new)
+                .map_err(|e| (e.kind(), e.to_string()))
+        });
         match outcome {
             Ok(column) => {
                 if !slot.charged.swap(true, Ordering::AcqRel) {
@@ -126,10 +128,19 @@ impl DecodedGroupCache {
                 }
                 Ok(Arc::clone(column))
             }
-            Err(message) => {
+            Err((kind, message)) => {
                 // A block that does not decode is not kept; the next reader tries again
-                self.lock().entries.remove(&key);
-                Err(std::io::Error::other(message.clone()))
+                let mut inner = self.lock();
+                if inner
+                    .entries
+                    .get(&key)
+                    .is_some_and(|entry| Arc::ptr_eq(&entry.slot, &slot))
+                {
+                    if let Some(entry) = inner.entries.remove(&key) {
+                        inner.bytes -= entry.bytes;
+                    }
+                }
+                Err(std::io::Error::new(*kind, message.clone()))
             }
         }
     }

--- a/src/storage/volume/io.rs
+++ b/src/storage/volume/io.rs
@@ -145,7 +145,7 @@ fn serialize_v4_opts(
         &vol.meta.column_types,
         vol.meta.row_count,
         compress,
-    );
+    )?;
 
     // 3. Compute total size for pre-allocation
     let all_blocks = store.raw_blocks();
@@ -203,10 +203,12 @@ fn read_volume_v4(path: &Path) -> Result<FrozenVolume> {
 
     let file = std::fs::File::open(path)
         .map_err(|e| crate::core::Error::internal(format!("V4 open {:?}: {}", path, e)))?;
-    let file_len = file
-        .metadata()
-        .map_err(|e| crate::core::Error::internal(format!("V4 stat {:?}: {}", path, e)))?
-        .len() as usize;
+    let file_len = usize::try_from(
+        file.metadata()
+            .map_err(|e| crate::core::Error::internal(format!("V4 stat {:?}: {}", path, e)))?
+            .len(),
+    )
+    .map_err(|_| inv("file length exceeds address space"))?;
     if file_len < 24 {
         return Err(inv("file too small"));
     }
@@ -239,6 +241,21 @@ fn read_volume_v4(path: &Path) -> Result<FrozenVolume> {
     let num_groups = u32::from_le_bytes(header[12..16].try_into().unwrap()) as usize;
     let meta_len = u32::from_le_bytes(header[16..20].try_into().unwrap()) as usize;
 
+    let total_blocks = col_count
+        .checked_mul(num_groups)
+        .ok_or_else(|| inv("block count overflow"))?;
+    let index_bytes = total_blocks
+        .checked_mul(16)
+        .ok_or_else(|| inv("block index overflow"))?;
+    let data_start = 20usize
+        .checked_add(meta_len)
+        .and_then(|n| n.checked_add(index_bytes))
+        .filter(|&n| n <= file_len - 4)
+        .ok_or_else(|| inv("metadata/index exceeds file bounds"))?;
+    if meta_len < 4 {
+        return Err(inv("metadata too short for LZ4 size prefix"));
+    }
+
     // 2. Compressed metadata (read into temp buffer, decompress, drop)
     let mut meta_compressed = vec![0u8; meta_len];
     crc_read!(&mut meta_compressed);
@@ -247,9 +264,24 @@ fn read_volume_v4(path: &Path) -> Result<FrozenVolume> {
     // to avoid lz4_flex::decompress_size_prepended allocating a fresh Vec.
     let meta_raw = if meta_compressed.len() >= 4 {
         let uncomp_size = u32::from_le_bytes(meta_compressed[..4].try_into().unwrap()) as usize;
-        let mut buf = vec![0u8; uncomp_size];
-        lz4_flex::decompress_into(&meta_compressed[4..], &mut buf)
+        if uncomp_size
+            > meta_compressed
+                .len()
+                .saturating_sub(4)
+                .saturating_mul(255)
+                .saturating_add(16)
+        {
+            return Err(inv("impossible metadata LZ4 decoded size"));
+        }
+        let mut buf = Vec::new();
+        buf.try_reserve_exact(uncomp_size)
+            .map_err(|_| inv("metadata allocation failed"))?;
+        buf.resize(uncomp_size, 0);
+        let written = lz4_flex::decompress_into(&meta_compressed[4..], &mut buf)
             .map_err(|e| inv(&format!("metadata LZ4: {}", e)))?;
+        if written != uncomp_size {
+            return Err(inv("metadata LZ4 decoded length mismatch"));
+        }
         drop(meta_compressed);
         buf
     } else {
@@ -268,19 +300,52 @@ fn read_volume_v4(path: &Path) -> Result<FrozenVolume> {
         )));
     }
 
+    if meta.row_count.div_ceil(ROW_GROUP_SIZE) != num_groups {
+        return Err(inv("header row group count mismatch"));
+    }
     // 3. Block index: (compressed_len: u64, decompressed_len: u64) pairs
-    let total_blocks = col_count * num_groups;
-    let mut index_buf = vec![0u8; total_blocks * 16];
+    let mut index_buf = vec![0u8; index_bytes];
     crc_read!(&mut index_buf);
 
     let mut compressed_lens = Vec::with_capacity(total_blocks);
     let mut decompressed_lens_flat = Vec::with_capacity(total_blocks);
+    let mut block_end = data_start;
     for i in 0..total_blocks {
         let off = i * 16;
-        compressed_lens
-            .push(u64::from_le_bytes(index_buf[off..off + 8].try_into().unwrap()) as usize);
-        decompressed_lens_flat
-            .push(u64::from_le_bytes(index_buf[off + 8..off + 16].try_into().unwrap()) as usize);
+        let stored = usize::try_from(u64::from_le_bytes(
+            index_buf[off..off + 8].try_into().unwrap(),
+        ))
+        .map_err(|_| inv("stored block length exceeds address space"))?;
+        let decoded = usize::try_from(u64::from_le_bytes(
+            index_buf[off + 8..off + 16].try_into().unwrap(),
+        ))
+        .map_err(|_| inv("decoded block length exceeds address space"))?;
+        block_end = block_end
+            .checked_add(stored)
+            .filter(|&n| n <= file_len - 4)
+            .ok_or_else(|| inv("column block exceeds file bounds"))?;
+        if decoded == 0 || stored == 0 || decoded > stored.saturating_mul(255).saturating_add(16) {
+            return Err(inv("impossible column block decoded size"));
+        }
+        let ci = i / num_groups;
+        let gi = i % num_groups;
+        let rows = (meta.row_count - gi * ROW_GROUP_SIZE).min(ROW_GROUP_SIZE);
+        let width = match meta.col_type_tags[ci] {
+            super::format::COL_INT64
+            | super::format::COL_FLOAT64
+            | super::format::COL_TIMESTAMP => Some(9usize),
+            super::format::COL_BOOLEAN => Some(2),
+            super::format::COL_DICTIONARY => Some(5),
+            _ => None,
+        };
+        if width.is_some_and(|w| rows.checked_mul(w) != Some(decoded)) {
+            return Err(inv("fixed-width column block size mismatch"));
+        }
+        compressed_lens.push(stored);
+        decompressed_lens_flat.push(decoded);
+    }
+    if block_end != file_len - 4 {
+        return Err(inv("trailing or missing volume bytes"));
     }
     drop(index_buf);
 
@@ -347,7 +412,7 @@ fn read_volume_v4(path: &Path) -> Result<FrozenVolume> {
         dict_ranges,
         group_size,
         meta.row_count,
-    );
+    )?;
     let columns = LazyColumns::deferred(store, col_data_types);
 
     Ok(FrozenVolume {
@@ -738,6 +803,61 @@ mod tests {
     use crate::core::{DataType, Row, SchemaBuilder, Value};
 
     #[test]
+    fn malformed_v4_lengths_fail_before_allocating_or_decoding() {
+        let schema = SchemaBuilder::new("t")
+            .column("id", DataType::Integer, false, true)
+            .build();
+        let mut builder = VolumeBuilder::new(&schema);
+        builder.add_row(1, &Row::from_values(vec![Value::Integer(1)]));
+        let volume = builder.finish();
+        let (original, _) = serialize_v4_public(&volume).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.vol");
+        let meta_len = u32::from_le_bytes(original[16..20].try_into().unwrap()) as usize;
+        let index = 20 + meta_len;
+        let mut cases = Vec::new();
+        let mut bad = original.clone();
+        bad[16..20].copy_from_slice(&u32::MAX.to_le_bytes());
+        cases.push(bad);
+        let mut bad = original.clone();
+        bad[index..index + 8].copy_from_slice(&u64::MAX.to_le_bytes());
+        cases.push(bad);
+        let mut bad = original.clone();
+        bad[index + 8..index + 16].copy_from_slice(&u64::MAX.to_le_bytes());
+        cases.push(bad);
+        let mut bad = original.clone();
+        bad[20..24].copy_from_slice(&u32::MAX.to_le_bytes());
+        cases.push(bad);
+        let mut bad = original;
+        bad.push(0);
+        cases.push(bad);
+        for bad in cases {
+            std::fs::write(&path, bad).unwrap();
+            assert!(read_volume_from_disk(&path).is_err());
+        }
+    }
+
+    #[test]
+    fn v4_metadata_requires_exact_lz4_output_length() {
+        let schema = SchemaBuilder::new("t")
+            .column("id", DataType::Integer, false, true)
+            .build();
+        let mut builder = VolumeBuilder::new(&schema);
+        builder.add_row(1, &Row::from_values(vec![Value::Integer(1)]));
+        let (mut bytes, _) = serialize_v4_public(&builder.finish()).unwrap();
+        let length = u32::from_le_bytes(bytes[20..24].try_into().unwrap());
+        bytes[20..24].copy_from_slice(&(length + 1).to_le_bytes());
+        let payload_end = bytes.len() - 4;
+        let checksum = crc32fast::hash(&bytes[..payload_end]);
+        bytes[payload_end..].copy_from_slice(&checksum.to_le_bytes());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.vol");
+        std::fs::write(&path, bytes).unwrap();
+        let error = read_volume_from_disk(&path).err().unwrap().to_string();
+        assert!(error.contains("decoded length mismatch"), "{error}");
+    }
+
+    #[test]
     fn test_write_and_read_volume() {
         let dir = tempfile::tempdir().unwrap();
         let schema = SchemaBuilder::new("test")
@@ -1077,7 +1197,7 @@ mod tests {
         let path = write_volume_to_disk(dir.path(), "t", 1, &vol).unwrap();
         let loaded = read_volume_from_disk(&path).unwrap();
 
-        let row = loaded.get_row(0);
+        let row = loaded.get_row(0).unwrap();
         assert_eq!(row.get(0), Some(&Value::Integer(42)));
         assert_eq!(row.get(1), Some(&Value::text("test")));
     }

--- a/src/storage/volume/manifest.rs
+++ b/src/storage/volume/manifest.rs
@@ -575,6 +575,9 @@ fn compute_visibility_bitmaps(
     }
 }
 
+type PendingTombstoneUndo = FxHashMap<i64, Vec<(i64, Option<i64>)>>;
+type PublishedTombstoneUndo = FxHashMap<i64, (u64, Vec<(i64, Option<u64>)>)>;
+
 /// Per-table segment manager.
 ///
 /// Owns the manifest, loaded segments, and tombstone set for one table.
@@ -641,6 +644,8 @@ pub struct SegmentManager {
     /// Each row_id carries the timestamp it was tombstoned at, so a savepoint
     /// rollback can discard the tombstones made after the savepoint.
     pending_txn_tombstones: RwLock<FxHashMap<i64, FxHashMap<i64, i64>>>,
+    pending_tombstone_undo: RwLock<PendingTombstoneUndo>,
+    published_tombstone_undo: RwLock<PublishedTombstoneUndo>,
     // Unique constraint checks use per-volume hash indices (on FrozenVolume).
     // No global cache needed. Each volume builds its index lazily on first
     // unique check and never invalidates (volumes are immutable).
@@ -684,6 +689,8 @@ impl SegmentManager {
             reloading: parking_lot::Mutex::new(()),
             tombstones: RwLock::new(Arc::new(FxHashMap::default())),
             pending_txn_tombstones: RwLock::new(FxHashMap::default()),
+            pending_tombstone_undo: RwLock::new(FxHashMap::default()),
+            published_tombstone_undo: RwLock::new(FxHashMap::default()),
             cached_deduped_count: std::sync::atomic::AtomicU64::new(u64::MAX),
             seal_fence: RwLock::new(()),
             visibility_seen: parking_lot::Mutex::new(rustc_hash::FxHashSet::default()),
@@ -708,6 +715,8 @@ impl SegmentManager {
             reloading: parking_lot::Mutex::new(()),
             tombstones: RwLock::new(Arc::new(tombstone_map)),
             pending_txn_tombstones: RwLock::new(FxHashMap::default()),
+            pending_tombstone_undo: RwLock::new(FxHashMap::default()),
+            published_tombstone_undo: RwLock::new(FxHashMap::default()),
             cached_deduped_count: std::sync::atomic::AtomicU64::new(u64::MAX),
             seal_fence: RwLock::new(()),
             visibility_seen: parking_lot::Mutex::new(rustc_hash::FxHashSet::default()),
@@ -974,7 +983,7 @@ impl SegmentManager {
     ) -> crate::core::Result<Option<crate::core::Value>> {
         for seg_id in seg_ids {
             if let Some(cold) = segments.get(seg_id) {
-                if let Ok(idx) = cold.volume.meta.row_ids.binary_search(&row_id) {
+                if let Some(idx) = cold.volume.find_row_id(row_id)? {
                     let pi = if cold.mapping.is_identity {
                         col_idx
                     } else if col_idx < cold.mapping.sources.len() {
@@ -987,12 +996,12 @@ impl SegmentManager {
                     };
                     if cold.volume.is_cold() {
                         if let Some(vol) = self.ensure_volume(*seg_id)? {
-                            return Ok(Some(vol.columns[pi].get_value(idx)));
+                            return Ok(Some(vol.columns.get(pi)?.get_value(idx)));
                         }
                         return Ok(None);
                     }
                     cold.volume.mark_accessed();
-                    return Ok(Some(cold.volume.columns[pi].get_value(idx)));
+                    return Ok(Some(cold.volume.columns.get(pi)?.get_value(idx)));
                 }
             }
         }
@@ -1056,9 +1065,9 @@ impl SegmentManager {
             };
             if let Some(target) = target {
                 if vol.is_sorted(pi) {
-                    let start = vol.columns[pi].binary_search_ge(target);
+                    let start = vol.columns.get(pi)?.binary_search_ge(target);
                     let mut i = start;
-                    while i < vol.meta.row_count && vol.columns[pi].get_i64(i) == target {
+                    while i < vol.meta.row_count && vol.columns.get(pi)?.get_i64(i) == target {
                         let rid = vol.meta.row_ids[i];
                         if seen.insert(rid) && !ts.contains_key(&rid) {
                             if seg_ids.len() > 1 {
@@ -1081,8 +1090,8 @@ impl SegmentManager {
                         if !seen.insert(rid) {
                             continue;
                         }
-                        if !vol.columns[pi].is_null(i)
-                            && vol.columns[pi].get_i64(i) == target
+                        if !vol.columns.get(pi)?.is_null(i)
+                            && vol.columns.get(pi)?.get_i64(i) == target
                             && !ts.contains_key(&rid)
                         {
                             if seg_ids.len() > 1 {
@@ -1268,7 +1277,7 @@ impl SegmentManager {
                     } else {
                         false
                     }
-                });
+                })?;
             } else {
                 // Schema-evolved volume: some columns missing (default matches).
                 // Check only the columns that exist in the volume.
@@ -1283,10 +1292,14 @@ impl SegmentManager {
                     if ts.contains_key(&rid) || !seen.insert(rid) {
                         continue;
                     }
-                    let matches = present_cols.iter().all(|&(val_idx, ci)| {
-                        let v = vol.columns[ci].get_value(i);
-                        !v.is_null() && v == *values[val_idx]
-                    });
+                    let mut matches = true;
+                    for &(val_idx, ci) in &present_cols {
+                        let v = vol.columns.get(ci)?.get_value(i);
+                        if v.is_null() || v != *values[val_idx] {
+                            matches = false;
+                            break;
+                        }
+                    }
                     if matches {
                         vol_result = Some(rid);
                         break;
@@ -1795,11 +1808,95 @@ impl SegmentManager {
     /// Track a cold row_id as pending tombstone for a transaction.
     /// Called during DML (UPDATE/DELETE of cold rows).
     pub fn add_pending_tombstone(&self, txn_id: i64, row_id: i64) {
-        self.pending_txn_tombstones
-            .write()
+        let mut pending = self.pending_txn_tombstones.write();
+        let previous = pending
             .entry(txn_id)
             .or_default()
             .insert(row_id, get_fast_timestamp());
+        self.pending_tombstone_undo
+            .write()
+            .entry(txn_id)
+            .or_default()
+            .push((row_id, previous));
+    }
+
+    pub fn pending_statement_checkpoint(&self, txn_id: i64) -> usize {
+        self.pending_tombstone_undo
+            .read()
+            .get(&txn_id)
+            .map_or(0, Vec::len)
+    }
+
+    pub fn finish_pending_statement(&self, txn_id: i64, checkpoint: usize, success: bool) {
+        let mut pending = self.pending_txn_tombstones.write();
+        if let Some(journal) = self.pending_tombstone_undo.write().remove(&txn_id) {
+            if !success {
+                let rows = pending.entry(txn_id).or_default();
+                for (row_id, previous) in journal.into_iter().skip(checkpoint).rev() {
+                    match previous {
+                        Some(timestamp) => {
+                            rows.insert(row_id, timestamp);
+                        }
+                        None => {
+                            rows.remove(&row_id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Capture only this transaction's tombstones before any table publishes.
+    pub fn prepare_tombstone_publication(&self, txn_id: i64, commit_seq: u64) {
+        let pending = self.pending_txn_tombstones.read();
+        let Some(rows) = pending.get(&txn_id) else {
+            return;
+        };
+        let committed = self.tombstones.read();
+        let undo = rows
+            .keys()
+            .map(|&row_id| (row_id, committed.get(&row_id).copied()))
+            .collect();
+        self.published_tombstone_undo
+            .write()
+            .insert(txn_id, (commit_seq, undo));
+    }
+
+    /// Sequence matching preserves unrelated concurrent tombstone updates.
+    pub fn finish_tombstone_publication(&self, txn_id: i64, success: bool) {
+        if !success {
+            self.rollback_pending_tombstones(txn_id);
+        }
+        let Some((sequence, undo)) = self.published_tombstone_undo.write().remove(&txn_id) else {
+            return;
+        };
+        if success {
+            return;
+        }
+        let mut manifest = self.manifest.write();
+        let mut guard = self.tombstones.write();
+        let tombstones = Arc::make_mut(&mut *guard);
+        for (row_id, previous) in undo {
+            if tombstones.get(&row_id) != Some(&sequence) {
+                continue;
+            }
+            match previous {
+                Some(old) => {
+                    tombstones.insert(row_id, old);
+                    if let Some(entry) =
+                        manifest.tombstones.iter_mut().find(|(id, _)| *id == row_id)
+                    {
+                        entry.1 = old;
+                    }
+                }
+                None => {
+                    tombstones.remove(&row_id);
+                    manifest.tombstones.retain(|(id, _)| *id != row_id);
+                }
+            }
+        }
+        self.cached_deduped_count
+            .store(u64::MAX, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Get pending tombstone row_ids for a transaction (for WAL recording).
@@ -1846,6 +1943,7 @@ impl SegmentManager {
     /// isolation: older snapshots won't see these tombstones.
     pub fn commit_pending_tombstones(&self, txn_id: i64, commit_seq: u64) {
         let pending = self.pending_txn_tombstones.write().remove(&txn_id);
+        self.pending_tombstone_undo.write().remove(&txn_id);
         if let Some(ids) = pending {
             if !ids.is_empty() {
                 let id_vec: Vec<i64> = ids.into_keys().collect();
@@ -1857,6 +1955,7 @@ impl SegmentManager {
     /// Rollback pending tombstones: discard without applying.
     pub fn rollback_pending_tombstones(&self, txn_id: i64) {
         self.pending_txn_tombstones.write().remove(&txn_id);
+        self.pending_tombstone_undo.write().remove(&txn_id);
     }
 
     /// Discard the pending tombstones made after a timestamp (savepoint rollback)
@@ -1891,10 +1990,10 @@ impl SegmentManager {
     /// Check if a row_id exists in any segment (not tombstoned).
     ///
     /// Used for constraint checking (PK/UNIQUE).
-    pub fn row_exists(&self, row_id: i64) -> bool {
+    pub fn row_exists(&self, row_id: i64) -> crate::core::Result<bool> {
         let ts = Arc::clone(&*self.tombstones.read());
         if ts.contains_key(&row_id) {
-            return false;
+            return Ok(false);
         }
         // Metadata-only check (binary search on row_ids). Does not access
         // column data, so no mark_accessed — should not pin volumes.
@@ -1913,12 +2012,12 @@ impl SegmentManager {
                 continue;
             }
             if let Some(cold) = segments.get(seg_id) {
-                if cold.volume.meta.row_ids.binary_search(&row_id).is_ok() {
-                    return true;
+                if cold.volume.find_row_id(row_id)?.is_some() {
+                    return Ok(true);
                 }
             }
         }
-        false
+        Ok(false)
     }
 
     /// Get a cold row by row_id. Returns the Row if found and not tombstoned.
@@ -1945,16 +2044,16 @@ impl SegmentManager {
                 continue;
             }
             if let Some(cold) = segments.get(seg_id) {
-                if let Ok(idx) = cold.volume.meta.row_ids.binary_search(&row_id) {
+                if let Some(idx) = cold.volume.find_row_id(row_id)? {
                     if cold.volume.is_cold() {
                         if let Some(vol) = self.ensure_volume(*seg_id)? {
-                            return Ok(Some(vol.get_row(idx)));
+                            return Ok(Some(vol.get_row(idx)?));
                         }
                         // Segment removed by compaction — retry with fresh state.
                         return self.get_cold_row_retry(row_id);
                     }
                     cold.volume.mark_accessed();
-                    return Ok(Some(cold.volume.get_row(idx)));
+                    return Ok(Some(cold.volume.get_row(idx)?));
                 }
             }
         }
@@ -1977,7 +2076,7 @@ impl SegmentManager {
         };
         for seg_id in &seg_ids {
             if let Some(cold) = segments.get(seg_id) {
-                if let Ok(idx) = cold.volume.meta.row_ids.binary_search(&row_id) {
+                if let Some(idx) = cold.volume.find_row_id(row_id)? {
                     if cold.volume.is_cold() {
                         return Err(crate::core::Error::Internal {
                             message: format!(
@@ -1988,7 +2087,7 @@ impl SegmentManager {
                         });
                     }
                     cold.volume.mark_accessed();
-                    return Ok(Some(cold.volume.get_row(idx)));
+                    return Ok(Some(cold.volume.get_row(idx)?));
                 }
             }
         }
@@ -2025,7 +2124,7 @@ impl SegmentManager {
                 continue;
             }
             if let Some(cold) = segments.get(seg_id) {
-                if let Ok(idx) = cold.volume.meta.row_ids.binary_search(&row_id) {
+                if let Some(idx) = cold.volume.find_row_id(row_id)? {
                     let vol = if cold.volume.is_cold() {
                         match self.ensure_volume(*seg_id)? {
                             Some(v) => v,
@@ -2040,9 +2139,9 @@ impl SegmentManager {
                     };
                     let mapping = self.get_volume_mapping(*seg_id, schema);
                     if mapping.is_identity {
-                        return Ok(Some(vol.get_row(idx)));
+                        return Ok(Some(vol.get_row(idx)?));
                     }
-                    return Ok(Some(vol.get_row_mapped(idx, &mapping)));
+                    return Ok(Some(vol.get_row_mapped(idx, &mapping)?));
                 }
             }
         }
@@ -2069,7 +2168,7 @@ impl SegmentManager {
         };
         for seg_id in &seg_ids {
             if let Some(cold) = segments.get(seg_id) {
-                if let Ok(idx) = cold.volume.meta.row_ids.binary_search(&row_id) {
+                if let Some(idx) = cold.volume.find_row_id(row_id)? {
                     if cold.volume.is_cold() {
                         return Err(crate::core::Error::Internal {
                             message: format!(
@@ -2082,9 +2181,9 @@ impl SegmentManager {
                     cold.volume.mark_accessed();
                     let mapping = self.get_volume_mapping(*seg_id, schema);
                     if mapping.is_identity {
-                        return Ok(Some(cold.volume.get_row(idx)));
+                        return Ok(Some(cold.volume.get_row(idx)?));
                     }
-                    return Ok(Some(cold.volume.get_row_mapped(idx, &mapping)));
+                    return Ok(Some(cold.volume.get_row_mapped(idx, &mapping)?));
                 }
             }
         }
@@ -2094,7 +2193,7 @@ impl SegmentManager {
     /// Check if a row_id actually exists in any loaded volume.
     /// Does NOT check tombstones. Used for idempotent WAL replay.
     /// Uses binary search on the volume's row_ids for O(log n) per segment.
-    pub fn is_row_id_in_volume(&self, row_id: i64) -> bool {
+    pub fn is_row_id_in_volume(&self, row_id: i64) -> crate::core::Result<bool> {
         let (seg_ids, segments) = {
             let manifest = self.manifest.read();
             let seg_ids: Vec<(u64, i64, i64)> = manifest
@@ -2110,12 +2209,12 @@ impl SegmentManager {
                 continue;
             }
             if let Some(cold) = segments.get(seg_id) {
-                if cold.volume.meta.row_ids.binary_search(&row_id).is_ok() {
-                    return true;
+                if cold.volume.find_row_id(row_id)?.is_some() {
+                    return Ok(true);
                 }
             }
         }
-        false
+        Ok(false)
     }
 
     /// Get the total live row count across all segments (minus tombstones).
@@ -2977,8 +3076,8 @@ mod tests {
 
         assert_eq!(mgr.segment_count(), 1);
         assert_eq!(mgr.total_row_count(), 10);
-        assert!(mgr.row_exists(5));
-        assert!(!mgr.row_exists(11));
+        assert!(mgr.row_exists(5).unwrap());
+        assert!(!mgr.row_exists(11).unwrap());
     }
 
     #[test]
@@ -3014,16 +3113,16 @@ mod tests {
 
         // Tombstone row_id=5 (commit_seq=1)
         mgr.add_tombstones(&[5], 1);
-        assert!(!mgr.row_exists(5));
-        assert!(mgr.row_exists(4));
-        assert!(mgr.row_exists(6));
+        assert!(!mgr.row_exists(5).unwrap());
+        assert!(mgr.row_exists(4).unwrap());
+        assert!(mgr.row_exists(6).unwrap());
         assert_eq!(mgr.total_row_count(), 9);
         assert!(mgr.is_tombstoned(5));
         assert!(!mgr.is_tombstoned(4));
 
         // Clear tombstones
         mgr.clear_tombstones();
-        assert!(mgr.row_exists(5));
+        assert!(mgr.row_exists(5).unwrap());
         assert_eq!(mgr.total_row_count(), 10);
     }
 
@@ -3151,7 +3250,7 @@ mod tests {
         {
             let vols = mgr.get_volumes_newest_first().unwrap();
             let (_, cs) = &vols[0];
-            let row = cs.volume.get_row(0);
+            let row = cs.volume.get_row(0).unwrap();
             assert_eq!(row[0], Value::Integer(1));
         }
 
@@ -3207,7 +3306,7 @@ mod tests {
         {
             let vols = mgr.get_volumes_newest_first().unwrap();
             let (_, cs) = &vols[0];
-            let row = cs.volume.get_row(49);
+            let row = cs.volume.get_row(49).unwrap();
             assert_eq!(row[0], Value::Integer(50));
         }
 
@@ -3257,7 +3356,10 @@ mod tests {
         }
 
         // Metadata still accessible on cold volumes.
-        assert!(mgr.row_exists(50), "metadata (row_ids) should work on cold");
+        assert!(
+            mgr.row_exists(50).unwrap(),
+            "metadata (row_ids) should work on cold"
+        );
         assert_eq!(mgr.total_row_count(), 100);
 
         // Volume is still in the map (not removed).
@@ -3392,7 +3494,7 @@ mod tests {
         let vols = snap.volumes_newest_first();
         assert_eq!(vols.len(), 1, "snapshot must not lose its segment");
         assert_eq!(vols[0].0, 1);
-        assert_eq!(vols[0].1.volume.get_row(0)[0], Value::Integer(1));
+        assert_eq!(vols[0].1.volume.get_row(0).unwrap()[0], Value::Integer(1));
     }
     #[test]
     fn test_unique_lookup_uses_statement_snapshot_not_live_state() {
@@ -3464,5 +3566,45 @@ mod tests {
             )
             .unwrap();
         assert_eq!(found, Some(5), "snapshot lookup must succeed");
+    }
+}
+
+#[cfg(test)]
+mod publication_undo_tests {
+    use super::*;
+
+    #[test]
+    fn failed_prepare_discards_pending_tombstones_without_an_undo_receipt() {
+        let manager = SegmentManager::new("pending_undo", None);
+        manager.add_pending_tombstone(7, 1);
+        let checkpoint = manager.pending_statement_checkpoint(7);
+        let original = manager.pending_txn_tombstones.read()[&7][&1];
+        manager.add_pending_tombstone(7, 1);
+        manager.add_pending_tombstone(7, 2);
+        manager.finish_pending_statement(7, checkpoint, false);
+        assert_eq!(manager.pending_txn_tombstones.read()[&7][&1], original);
+        assert!(!manager.is_pending_tombstone(7, 2));
+        // Failure before prepare_tombstone_publication creates any receipt.
+        manager.finish_tombstone_publication(7, false);
+        assert_eq!(manager.pending_tombstone_count(7), 0);
+        assert!(!manager.pending_txn_tombstones.read().contains_key(&7));
+        assert!(!manager.pending_tombstone_undo.read().contains_key(&7));
+    }
+
+    #[test]
+    fn tombstone_undo_restores_prior_sequences_and_preserves_unrelated_writes() {
+        let manager = SegmentManager::new("committed_undo", None);
+        manager.add_tombstones(&[1], 5);
+        manager.add_pending_tombstone(7, 1);
+        manager.add_pending_tombstone(7, 2);
+        manager.prepare_tombstone_publication(7, 10);
+        manager.commit_pending_tombstones(7, 10);
+        manager.add_tombstones(&[3], 11);
+        manager.finish_tombstone_publication(7, false);
+        let tombstones = manager.tombstone_set_arc();
+        assert_eq!(tombstones.get(&1), Some(&5));
+        assert!(!tombstones.contains_key(&2));
+        assert_eq!(tombstones.get(&3), Some(&11));
+        assert!(manager.published_tombstone_undo.read().is_empty());
     }
 }

--- a/src/storage/volume/scanner.rs
+++ b/src/storage/volume/scanner.rs
@@ -195,46 +195,48 @@ impl VolumeScanner {
     }
 
     /// True when the row at `idx` lies past the stop key
-    fn past_stop_key(&self, idx: usize) -> bool {
+    fn past_stop_key(&self, idx: usize) -> Result<bool> {
         let Some((col_idx, target, ascending)) = self.stop_key else {
-            return false;
+            return Ok(false);
         };
-        let (col, local) = self.col_and_idx(col_idx, idx);
+        let (col, local) = self.col_and_idx(col_idx, idx)?;
         if col.is_null(local) {
-            return false;
+            return Ok(false);
         }
         let key = col.get_i64(local);
-        if ascending {
+        Ok(if ascending {
             key > target
         } else {
             key < target
-        }
+        })
     }
 
     /// The rows in `[lo, hi)` that pass every dictionary filter, in one pass
     /// over the raw ids of the group; None when a filter column is not a
     /// dictionary column here and the rows must be tested one by one
-    fn dictionary_candidates(&self, lo: usize, hi: usize) -> Option<Vec<usize>> {
-        let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = self
-            .dict_filters
-            .iter()
-            .map(|&(col_idx, expected)| {
-                let (col, local_lo) = self.col_and_idx(col_idx, lo);
-                (col, local_lo, expected)
-            })
-            .collect();
+    fn dictionary_candidates(&self, lo: usize, hi: usize) -> Result<Option<Vec<usize>>> {
+        let mut filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> =
+            smallvec::SmallVec::with_capacity(self.dict_filters.len());
+        for &(col_idx, expected) in &self.dict_filters {
+            let (col, local_lo) = self.col_and_idx(col_idx, lo)?;
+            filters.push((col, local_lo, expected));
+        }
         let mut candidates = Vec::new();
-        super::column::ColumnData::dict_matching_offsets(&filters, hi - lo, &mut candidates)?;
+        if super::column::ColumnData::dict_matching_offsets(&filters, hi - lo, &mut candidates)
+            .is_none()
+        {
+            return Ok(None);
+        }
         for idx in &mut candidates {
             *idx += lo;
         }
-        Some(candidates)
+        Ok(Some(candidates))
     }
 
     /// The reverse walk: the newest row of the range first. Row groups are
     /// entered from their end; a pruned group is skipped whole; with
     /// dictionary filters the group's candidates are found in one pass.
-    fn next_reverse(&mut self) -> bool {
+    fn next_reverse(&mut self) -> Result<bool> {
         let use_group_cache = self.volume.columns.should_use_group_cache();
         while self.current_idx < self.end_idx {
             let idx = self.end_idx - 1;
@@ -252,13 +254,13 @@ impl VolumeScanner {
                     self.load_group_cache(group_idx);
                     if self.error.is_some() {
                         self.has_current = false;
-                        return false;
+                        return Ok(false);
                     }
                 }
             }
             if !self.dict_filters.is_empty() && self.candidates_group != Some(group_idx) {
                 let lo = group_start.max(self.current_idx);
-                match self.dictionary_candidates(lo, self.end_idx) {
+                match self.dictionary_candidates(lo, self.end_idx)? {
                     Some(candidates) => {
                         self.group_candidates = candidates;
                         self.candidates_group = Some(group_idx);
@@ -281,10 +283,10 @@ impl VolumeScanner {
             } else {
                 idx
             };
-            if self.past_stop_key(idx) {
+            if self.past_stop_key(idx)? {
                 self.end_idx = self.current_idx;
                 self.has_current = false;
-                return false;
+                return Ok(false);
             }
             self.end_idx = idx;
             if self.should_skip_row(idx) {
@@ -292,22 +294,22 @@ impl VolumeScanner {
             }
             if self.candidates_group != Some(group_idx)
                 && !self.dict_filters.is_empty()
-                && self.dict_filters_reject(idx)
+                && self.dict_filters_reject(idx)?
             {
                 continue;
             }
-            if !self.typed_predicates.is_empty() && !self.evaluate_typed_predicates(idx) {
+            if !self.typed_predicates.is_empty() && !self.evaluate_typed_predicates(idx)? {
                 continue;
             }
-            if !self.materialize_row(idx) {
+            if !self.materialize_row(idx)? {
                 continue;
             }
             self.current_rid = self.volume.meta.row_ids[idx];
             self.has_current = true;
-            return true;
+            return Ok(true);
         }
         self.has_current = false;
-        false
+        Ok(false)
     }
     /// Compute whether `project_cols` is an identity mapping over all volume columns.
     /// Extracted as a helper so both constructors share the same logic.
@@ -511,6 +513,16 @@ impl VolumeScanner {
     /// Set a predicate filter on this scanner.
     /// Automatically extracts dictionary-based fast filters for text equality predicates.
     pub fn set_filter(&mut self, filter: Box<dyn crate::storage::expression::Expression>) {
+        if let Err(error) = self.try_set_filter(filter) {
+            self.error = Some(error);
+            self.has_current = false;
+        }
+    }
+
+    fn try_set_filter(
+        &mut self,
+        filter: Box<dyn crate::storage::expression::Expression>,
+    ) -> Result<()> {
         // Extract dictionary filters for fast pre-filtering.
         // Uses CompressedBlockStore's shared dict when available (no column decompression).
         let comparisons = filter.collect_comparisons();
@@ -532,14 +544,14 @@ impl VolumeScanner {
                     let dict_id = if let Some(st) = store {
                         st.dict_lookup(col_idx, s.as_str())
                     } else {
-                        self.volume.columns[col_idx].dict_lookup(s.as_str())
+                        self.volume.columns.get(col_idx)?.dict_lookup(s.as_str())
                     };
                     if let Some(id) = dict_id {
                         self.dict_filters.push((col_idx, id));
                     } else {
                         self.current_idx = self.end_idx;
                         self.filter = Some(filter);
-                        return;
+                        return Ok(());
                     }
                 }
             }
@@ -564,22 +576,8 @@ impl VolumeScanner {
                         continue;
                     }
                     let mut group_cols = Vec::with_capacity(self.dict_filters.len());
-                    let mut corrupt = false;
                     for &(ci, _) in &self.dict_filters {
-                        match st.group_column(ci, gi) {
-                            Ok(col) => group_cols.push(col),
-                            Err(_) => {
-                                corrupt = true;
-                                break;
-                            }
-                        }
-                    }
-                    if corrupt {
-                        self.current_idx = self.end_idx;
-                        self.error =
-                            Some(Error::internal("corrupt V4 block during dictionary filter"));
-                        self.filter = Some(filter);
-                        return;
+                        group_cols.push(st.group_column(ci, gi)?);
                     }
                     let lo = gs.max(self.current_idx);
                     let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = self
@@ -630,8 +628,8 @@ impl VolumeScanner {
                     let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = self
                         .dict_filters
                         .iter()
-                        .map(|&(ci, eid)| (&self.volume.columns[ci], lo, eid))
-                        .collect();
+                        .map(|&(ci, eid)| Ok((self.volume.columns.get(ci)?, lo, eid)))
+                        .collect::<Result<_>>()?;
                     let first = m.len();
                     if super::column::ColumnData::dict_matching_offsets(&filters, hi - lo, &mut m)
                         .is_none()
@@ -648,10 +646,14 @@ impl VolumeScanner {
                 if !vectorized {
                     m.clear();
                     for i in self.current_idx..self.end_idx {
-                        let ok = self.dict_filters.iter().all(|&(ci, eid)| {
-                            !self.volume.columns[ci].is_null(i)
-                                && self.volume.columns[ci].get_dict_id(i) == eid
-                        });
+                        let mut ok = true;
+                        for &(ci, eid) in &self.dict_filters {
+                            let col = self.volume.columns.get(ci)?;
+                            if col.is_null(i) || col.get_dict_id(i) != eid {
+                                ok = false;
+                                break;
+                            }
+                        }
                         if ok {
                             m.push(i);
                         }
@@ -788,15 +790,16 @@ impl VolumeScanner {
         }
 
         self.filter = Some(filter);
+        Ok(())
     }
 
     /// Evaluate typed pre-filter predicates directly on column data.
     /// Returns false only if the row definitely does not match (safe rejection).
     /// NULL columns conservatively pass through (the full filter handles NULL logic).
     #[inline]
-    fn evaluate_typed_predicates(&self, idx: usize) -> bool {
+    fn evaluate_typed_predicates(&self, idx: usize) -> Result<bool> {
         for pred in &self.typed_predicates {
-            let (col, local) = self.col_and_idx(pred.col_idx, idx);
+            let (col, local) = self.col_and_idx(pred.col_idx, idx)?;
             if col.is_null(local) {
                 // NULL: conservatively pass through (might match under SQL NULL semantics).
                 // The full filter will handle it correctly.
@@ -837,10 +840,10 @@ impl VolumeScanner {
                 }
             };
             if !matches {
-                return false;
+                return Ok(false);
             }
         }
-        true
+        Ok(true)
     }
 
     /// Set a precomputed column mapping for schema-evolved volumes.
@@ -859,13 +862,13 @@ impl VolumeScanner {
         &self,
         col_idx: usize,
         global_idx: usize,
-    ) -> (&super::column::ColumnData, usize) {
+    ) -> Result<(&super::column::ColumnData, usize)> {
         if let Some(ref cache) = self.group_cache {
             if let Some(pair) = cache.col_and_local(col_idx, global_idx) {
-                return pair;
+                return Ok(pair);
             }
         }
-        (&self.volume.columns[col_idx], global_idx)
+        Ok((self.volume.columns.get(col_idx)?, global_idx))
     }
 
     /// Load group cache for a new row group. Decompresses only the columns
@@ -891,7 +894,7 @@ impl VolumeScanner {
                     match store.group_column(ci, group_idx) {
                         Ok(col) => columns[ci] = Some(col),
                         Err(e) => {
-                            self.error = Some(Error::internal(format!("corrupt V4 block: {}", e)));
+                            self.error = Some(e.into());
                             return;
                         }
                     }
@@ -903,7 +906,7 @@ impl VolumeScanner {
                     match store.group_column(ci, group_idx) {
                         Ok(col) => *slot = Some(col),
                         Err(e) => {
-                            self.error = Some(Error::internal(format!("corrupt V4 block: {}", e)));
+                            self.error = Some(e.into());
                             return;
                         }
                     }
@@ -956,21 +959,21 @@ impl VolumeScanner {
     /// does NOT match (should be skipped). Only called when dict_filters is
     /// non-empty.
     #[inline(always)]
-    fn dict_filters_reject(&self, idx: usize) -> bool {
+    fn dict_filters_reject(&self, idx: usize) -> Result<bool> {
         for &(col_idx, expected_id) in &self.dict_filters {
-            let (col, local) = self.col_and_idx(col_idx, idx);
+            let (col, local) = self.col_and_idx(col_idx, idx)?;
             if col.is_null(local) || col.get_dict_id(local) != expected_id {
-                return true;
+                return Ok(true);
             }
         }
-        false
+        Ok(false)
     }
 
     /// Materialize a row at `idx`, evaluate the filter (if any), and write
     /// the result into `self.current_row`. Returns false if the filter
     /// rejects the row.
     #[inline(always)]
-    fn materialize_row(&mut self, idx: usize) -> bool {
+    fn materialize_row(&mut self, idx: usize) -> Result<bool> {
         // Per-group cache path: only when no schema mapping is needed.
         // Schema-evolved volumes require column_mapping which remaps positions.
         if self.group_cache.is_some() && self.column_mapping.is_none() {
@@ -980,14 +983,14 @@ impl VolumeScanner {
         if let Some(ref filter) = self.filter {
             let full_row = match (&self.needed_cols, &self.column_mapping) {
                 (Some(mask), Some(mapping)) => {
-                    self.volume.get_row_mapped_needed(idx, mapping, mask)
+                    self.volume.get_row_mapped_needed(idx, mapping, mask)?
                 }
-                (Some(mask), None) => self.volume.get_row_needed(idx, mask),
-                (None, Some(mapping)) => self.volume.get_row_mapped(idx, mapping),
-                (None, None) => self.volume.get_row(idx),
+                (Some(mask), None) => self.volume.get_row_needed(idx, mask)?,
+                (None, Some(mapping)) => self.volume.get_row_mapped(idx, mapping)?,
+                (None, None) => self.volume.get_row(idx)?,
             };
             if !filter.evaluate_fast(&full_row) {
-                return false;
+                return Ok(false);
             }
             if self.is_full_projection {
                 self.current_row = full_row;
@@ -1006,55 +1009,44 @@ impl VolumeScanner {
             }
         } else if let Some(ref mapping) = self.column_mapping {
             if self.is_full_projection {
-                self.current_row = self.volume.get_row_mapped(idx, mapping);
+                self.current_row = self.volume.get_row_mapped(idx, mapping)?;
             } else {
                 self.current_row =
                     self.volume
-                        .get_row_mapped_projected(idx, mapping, &self.project_cols);
+                        .get_row_mapped_projected(idx, mapping, &self.project_cols)?;
             }
         } else if self.is_full_projection {
-            self.current_row = self.volume.get_row(idx);
+            self.current_row = self.volume.get_row(idx)?;
         } else {
-            self.current_row = self.volume.get_row_projected(idx, &self.project_cols);
+            self.current_row = self.volume.get_row_projected(idx, &self.project_cols)?;
         }
-        true
+        Ok(true)
     }
 
     /// Build a row from the per-group column cache (avoids full-column decompression).
-    fn materialize_row_from_cache(&mut self, idx: usize) -> bool {
+    fn materialize_row_from_cache(&mut self, idx: usize) -> Result<bool> {
         let col_count = self.volume.columns.len();
-
-        // Build full-width row from cache
-        let full_row = if let Some(ref needed) = self.needed_cols {
-            let values: Vec<Value> = (0..col_count)
-                .map(|ci| {
-                    if ci < needed.len() && needed[ci] {
-                        let (col, local) = self.col_and_idx(ci, idx);
-                        col.get_value(local)
-                    } else {
-                        Value::Null(self.volume.columns.data_type(ci))
-                    }
-                })
-                .collect();
-            Row::from_values(values)
-        } else {
-            let values: Vec<Value> = (0..col_count)
-                .map(|ci| {
-                    let (col, local) = self.col_and_idx(ci, idx);
-                    col.get_value(local)
-                })
-                .collect();
-            Row::from_values(values)
-        };
-
-        // Apply filter if present
-        if let Some(ref filter) = self.filter {
-            if !filter.evaluate_fast(&full_row) {
-                return false;
+        let mut values = Vec::with_capacity(col_count);
+        for ci in 0..col_count {
+            if self
+                .needed_cols
+                .as_ref()
+                .is_none_or(|needed| ci < needed.len() && needed[ci])
+            {
+                let (col, local) = self.col_and_idx(ci, idx)?;
+                values.push(col.get_value(local));
+            } else {
+                values.push(Value::Null(self.volume.columns.data_type(ci)));
             }
         }
-
-        // Project
+        let full_row = Row::from_values(values);
+        if self
+            .filter
+            .as_ref()
+            .is_some_and(|filter| !filter.evaluate_fast(&full_row))
+        {
+            return Ok(false);
+        }
         if self.is_full_projection {
             self.current_row = full_row;
         } else {
@@ -1070,15 +1062,15 @@ impl VolumeScanner {
                     .collect(),
             );
         }
-        true
+        Ok(true)
     }
 }
 
-impl Scanner for VolumeScanner {
-    fn next(&mut self) -> bool {
+impl VolumeScanner {
+    fn try_next(&mut self) -> Result<bool> {
         if self.error.is_some() {
             self.has_current = false;
-            return false;
+            return Ok(false);
         }
         if self.reverse {
             return self.next_reverse();
@@ -1096,7 +1088,7 @@ impl Scanner for VolumeScanner {
                     }
                     _ => {
                         self.has_current = false;
-                        return false;
+                        return Ok(false);
                     }
                 };
 
@@ -1112,21 +1104,21 @@ impl Scanner for VolumeScanner {
                         self.load_group_cache(gi);
                         if self.error.is_some() {
                             self.has_current = false;
-                            return false;
+                            return Ok(false);
                         }
                     }
                 }
 
-                if !self.typed_predicates.is_empty() && !self.evaluate_typed_predicates(idx) {
+                if !self.typed_predicates.is_empty() && !self.evaluate_typed_predicates(idx)? {
                     continue;
                 }
-                if !self.materialize_row(idx) {
+                if !self.materialize_row(idx)? {
                     continue;
                 }
 
                 self.current_rid = self.volume.meta.row_ids[idx];
                 self.has_current = true;
-                return true;
+                return Ok(true);
             }
         }
 
@@ -1152,15 +1144,15 @@ impl Scanner for VolumeScanner {
                     self.load_group_cache(group_idx);
                     if self.error.is_some() {
                         self.has_current = false;
-                        return false;
+                        return Ok(false);
                     }
                 }
             }
 
-            if self.stop_key.is_some() && self.past_stop_key(self.current_idx) {
+            if self.stop_key.is_some() && self.past_stop_key(self.current_idx)? {
                 self.current_idx = self.end_idx;
                 self.has_current = false;
-                return false;
+                return Ok(false);
             }
 
             if self.should_skip_row(self.current_idx) {
@@ -1170,15 +1162,15 @@ impl Scanner for VolumeScanner {
 
             let idx = self.current_idx;
 
-            if !self.dict_filters.is_empty() && self.dict_filters_reject(idx) {
+            if !self.dict_filters.is_empty() && self.dict_filters_reject(idx)? {
                 self.current_idx += 1;
                 continue;
             }
-            if !self.typed_predicates.is_empty() && !self.evaluate_typed_predicates(idx) {
+            if !self.typed_predicates.is_empty() && !self.evaluate_typed_predicates(idx)? {
                 self.current_idx += 1;
                 continue;
             }
-            if !self.materialize_row(idx) {
+            if !self.materialize_row(idx)? {
                 self.current_idx += 1;
                 continue;
             }
@@ -1186,11 +1178,24 @@ impl Scanner for VolumeScanner {
             self.current_rid = self.volume.meta.row_ids[idx];
             self.has_current = true;
             self.current_idx += 1;
-            return true;
+            return Ok(true);
         }
 
         self.has_current = false;
-        false
+        Ok(false)
+    }
+}
+
+impl Scanner for VolumeScanner {
+    fn next(&mut self) -> bool {
+        match self.try_next() {
+            Ok(value) => value,
+            Err(error) => {
+                self.error = Some(error);
+                self.has_current = false;
+                false
+            }
+        }
     }
 
     fn row(&self) -> &Row {

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -274,7 +274,8 @@ impl SegmentedTable {
 
     /// Validate that cold segment data has no duplicate values for a unique index.
     /// Called before CREATE UNIQUE INDEX to prevent certifying already-invalid data.
-    fn validate_cold_unique(&self, index_name: &str, columns: &[&str]) -> Result<()> {
+    fn validate_cold_unique(&self, index: &Arc<dyn Index>, columns: &[&str]) -> Result<()> {
+        let index_name = index.name();
         let schema = self.hot.schema();
         let col_indices: Vec<usize> = columns
             .iter()
@@ -293,12 +294,13 @@ impl SegmentedTable {
         let ts = self.segment_mgr.tombstone_set_arc();
         let mut seen_values: ahash::AHashMap<Vec<Value>, i64> = ahash::AHashMap::new();
 
+        let mut matching_hot = Vec::new();
+
         // Build skip set: hot row_ids + pending tombstones for this transaction.
         // Inside an explicit transaction, uncommitted UPDATEs create pending
         // local versions that shadow cold rows. has_row_id only sees committed
         // rows, so we also need pending tombstones to skip rows being modified.
-        let mut hot_skip: FxHashSet<i64> =
-            FxHashSet::with_capacity_and_hasher(10_000, Default::default());
+        let mut hot_skip = FxHashSet::default();
         self.hot.collect_hot_row_ids_into(&mut hot_skip);
         self.segment_mgr
             .insert_pending_tombstones_into(self.txn_id(), &mut hot_skip);
@@ -322,22 +324,29 @@ impl SegmentedTable {
                 }
                 let values: Vec<Value> = col_indices
                     .iter()
-                    .map(|&ci| {
+                    .map(|&ci| -> Result<Value> {
                         use super::writer::ColSource;
-                        if ci < mapping.sources.len() {
+                        Ok(if ci < mapping.sources.len() {
                             match &mapping.sources[ci] {
-                                ColSource::Volume(phys) => vol.columns[*phys].get_value(i),
+                                ColSource::Volume(phys) => vol.columns.get(*phys)?.get_value(i),
                                 ColSource::Default(v) => v.clone(),
                             }
                         } else {
                             self.column_default(ci)
-                        }
+                        })
                     })
-                    .collect();
+                    .collect::<Result<Vec<_>>>()?;
                 if values.iter().any(|v| v.is_null()) {
                     continue;
                 }
-                if let Some(&existing_rid) = seen_values.get(&values) {
+                matching_hot.clear();
+                index.get_row_ids_equal_into(&values, &mut matching_hot);
+                let conflict = matching_hot
+                    .iter()
+                    .copied()
+                    .find(|&id| id != rid)
+                    .or_else(|| seen_values.get(&values).copied());
+                if let Some(existing_rid) = conflict {
                     return Err(crate::core::Error::UniqueConstraint {
                         index: index_name.to_string(),
                         column: columns.join(", "),
@@ -356,13 +365,8 @@ impl SegmentedTable {
     }
 
     /// Populate an index from cold segment data.
-    /// Called after index creation on the hot store.
-    /// Propagates errors so unique-constraint violations are not swallowed.
-    fn populate_index_from_cold(&self, name: &str, columns: &[&str]) -> Result<()> {
-        let index = match self.hot.get_index(name) {
-            Some(idx) => idx,
-            None => return Ok(()),
-        };
+    /// The detached index stays invisible until every required cold read succeeds.
+    fn populate_index_from_cold(&self, index: &Arc<dyn Index>, columns: &[&str]) -> Result<()> {
         let schema = self.hot.schema();
         let col_indices: Vec<usize> = columns
             .iter()
@@ -378,6 +382,10 @@ impl SegmentedTable {
         }
         let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let ts = self.segment_mgr.tombstone_set_arc();
+        let mut hot_skip = FxHashSet::default();
+        self.hot.collect_hot_row_ids_into(&mut hot_skip);
+        self.segment_mgr
+            .insert_pending_tombstones_into(self.txn_id(), &mut hot_skip);
         for (seg_id, cs) in volumes.iter() {
             let vol = &cs.volume;
             // Use column mapping to translate schema indices to physical volume indices.
@@ -387,29 +395,56 @@ impl SegmentedTable {
                     continue;
                 }
                 let rid = vol.meta.row_ids[i];
-                if self.is_row_tombstoned(&ts, rid) {
+                if self.is_row_tombstoned(&ts, rid) || hot_skip.contains(&rid) {
                     continue;
                 }
                 let values: Vec<Value> = col_indices
                     .iter()
-                    .map(|&ci| {
+                    .map(|&ci| -> Result<Value> {
                         use super::writer::ColSource;
-                        if ci < mapping.sources.len() {
+                        Ok(if ci < mapping.sources.len() {
                             match &mapping.sources[ci] {
-                                ColSource::Volume(phys) => vol.columns[*phys].get_value(i),
+                                ColSource::Volume(phys) => vol.columns.get(*phys)?.get_value(i),
                                 ColSource::Default(v) => v.clone(),
                             }
                         } else {
                             self.column_default(ci)
-                        }
+                        })
                     })
-                    .collect();
+                    .collect::<Result<Vec<_>>>()?;
                 if !values.iter().any(|v| v.is_null()) {
                     index.add(&values, rid, rid)?;
                 }
             }
         }
         Ok(())
+    }
+
+    fn finish_index_build(
+        &self,
+        index: &Arc<dyn Index>,
+        columns: &[&str],
+        is_unique: bool,
+        generation: u64,
+        install: &mut dyn FnMut() -> Result<()>,
+    ) -> Result<()> {
+        if self.segment_mgr.has_segments() {
+            if index.index_type() == IndexType::Hnsw {
+                self.populate_index_from_cold(index, columns)?;
+            } else if is_unique {
+                self.validate_cold_unique(index, columns)?;
+            }
+        }
+        // The dedicated catalog build lease excludes writers throughout the build.
+        // Cold I/O finishes before this short transfer fence; a concurrent seal
+        // invalidates the build instead of allowing an inconsistent hot/cold index.
+        let _fence = self.segment_mgr.acquire_seal_read();
+        if generation != self.segment_mgr.seal_generation() {
+            return Err(crate::core::Error::internal(
+                "write conflict: cold generation changed during index build",
+            ));
+        }
+        install()
     }
 
     /// Get a fast approximate row count across all segments.
@@ -660,7 +695,7 @@ impl SegmentedTable {
         vol: &FrozenVolume,
         comparisons: &[(&str, crate::core::Operator, &Value)],
         bloom_hashes: &[Option<u64>],
-    ) -> (bool, usize, usize) {
+    ) -> Result<(bool, usize, usize)> {
         let mut start = 0usize;
         let mut end = vol.meta.row_count;
 
@@ -685,7 +720,7 @@ impl SegmentedTable {
                         _ => false,
                     };
                 if dominated {
-                    return (true, 0, 0);
+                    return Ok((true, 0, 0));
                 }
 
                 // Binary search on sorted columns.
@@ -711,14 +746,13 @@ impl SegmentedTable {
                             None
                         };
                         match op {
-                            // A search that hits a block it cannot decode
-                            // leaves the range as it is: the scan then reaches
-                            // the block and reports the error
+                            // Unsupported searches leave the range unchanged;
+                            // a block read or decode failure aborts the query.
                             crate::core::Operator::Gte => {
                                 let idx = if let Some(st) = store {
-                                    st.binary_search_ge(col_idx, target, &vol.meta.row_groups)
+                                    st.binary_search_ge(col_idx, target, &vol.meta.row_groups)?
                                 } else {
-                                    Some(vol.columns[col_idx].binary_search_ge(target))
+                                    Some(vol.columns.get(col_idx)?.binary_search_ge(target))
                                 };
                                 if let Some(idx) = idx {
                                     if idx > start {
@@ -728,9 +762,9 @@ impl SegmentedTable {
                             }
                             crate::core::Operator::Gt => {
                                 let idx = if let Some(st) = store {
-                                    st.binary_search_gt(col_idx, target, &vol.meta.row_groups)
+                                    st.binary_search_gt(col_idx, target, &vol.meta.row_groups)?
                                 } else {
-                                    Some(vol.columns[col_idx].binary_search_gt(target))
+                                    Some(vol.columns.get(col_idx)?.binary_search_gt(target))
                                 };
                                 if let Some(idx) = idx {
                                     if idx > start {
@@ -740,9 +774,9 @@ impl SegmentedTable {
                             }
                             crate::core::Operator::Lte => {
                                 let idx = if let Some(st) = store {
-                                    st.binary_search_gt(col_idx, target, &vol.meta.row_groups)
+                                    st.binary_search_gt(col_idx, target, &vol.meta.row_groups)?
                                 } else {
-                                    Some(vol.columns[col_idx].binary_search_gt(target))
+                                    Some(vol.columns.get(col_idx)?.binary_search_gt(target))
                                 };
                                 if let Some(idx) = idx {
                                     if idx < end {
@@ -752,9 +786,9 @@ impl SegmentedTable {
                             }
                             crate::core::Operator::Lt => {
                                 let idx = if let Some(st) = store {
-                                    st.binary_search_ge(col_idx, target, &vol.meta.row_groups)
+                                    st.binary_search_ge(col_idx, target, &vol.meta.row_groups)?
                                 } else {
-                                    Some(vol.columns[col_idx].binary_search_ge(target))
+                                    Some(vol.columns.get(col_idx)?.binary_search_ge(target))
                                 };
                                 if let Some(idx) = idx {
                                     if idx < end {
@@ -769,7 +803,7 @@ impl SegmentedTable {
             }
         }
 
-        (start >= end, start, end)
+        Ok((start >= end, start, end))
     }
 
     /// Create lazy segment scanners for a read query, applying zone map pruning
@@ -812,7 +846,7 @@ impl SegmentedTable {
 
         for (seg_id, cs) in volumes.iter() {
             let vol = &cs.volume;
-            let (should_skip, start, end) = Self::prune_volume(vol, &comparisons, &bloom_hashes);
+            let (should_skip, start, end) = Self::prune_volume(vol, &comparisons, &bloom_hashes)?;
             if should_skip {
                 continue;
             }
@@ -824,7 +858,7 @@ impl SegmentedTable {
                     Some(v) => v,
                     None => continue,
                 };
-                let (_, s, e) = Self::prune_volume(&loaded, &comparisons, &bloom_hashes);
+                let (_, s, e) = Self::prune_volume(&loaded, &comparisons, &bloom_hashes)?;
                 (&loaded, s, e)
             } else {
                 (vol, start, end)
@@ -895,42 +929,35 @@ impl SegmentedTable {
         // Pre-filter volumes using zone-map metadata BEFORE parallel dispatch.
         // This avoids rayon scheduling overhead for volumes that would be pruned.
         let bloom_hashes = Self::precompute_bloom_hashes(&comparisons);
-        let pruned_volumes: Vec<&(u64, super::manifest::ColdSegment)> = if comparisons.is_empty() {
-            volumes.iter().collect()
-        } else {
-            volumes
-                .iter()
-                .filter(|(_, cs)| {
-                    let (skip, _, _) = Self::prune_volume(&cs.volume, &comparisons, &bloom_hashes);
-                    !skip
-                })
-                .collect()
-        };
+        let mut pruned_volumes = Vec::with_capacity(volumes.len());
+        for entry @ (_, cs) in volumes.iter() {
+            if comparisons.is_empty()
+                || !Self::prune_volume(&cs.volume, &comparisons, &bloom_hashes)?.0
+            {
+                pruned_volumes.push(entry);
+            }
+        }
         let hot_skip_ref = &hot_skip;
         let tombstones_ref = &tombstones_arc;
-        let reload_failed = std::sync::atomic::AtomicBool::new(false);
 
         // Per-volume row collection closure. Returns Some(vol_rows) or None if pruned.
         let process_volume =
-            |(seg_id, cs): &(u64, super::manifest::ColdSegment)| -> Option<RowVec> {
+            |(seg_id, cs): &(u64, super::manifest::ColdSegment)| -> Result<Option<RowVec>> {
                 let vol = &cs.volume;
                 let (should_skip, start, end) =
-                    Self::prune_volume(vol, &comparisons, &bloom_hashes);
+                    Self::prune_volume(vol, &comparisons, &bloom_hashes)?;
                 if should_skip {
-                    return None;
+                    return Ok(None);
                 }
                 // Load cold volume on demand after zone-map/bloom pruning.
                 let loaded;
                 let (vol, start, end) = if vol.is_cold() {
                     loaded = match self.segment_mgr.ensure_volume(*seg_id) {
                         Ok(Some(v)) => v,
-                        Ok(None) => return None,
-                        Err(_) => {
-                            reload_failed.store(true, std::sync::atomic::Ordering::Relaxed);
-                            return None;
-                        }
+                        Ok(None) => return Ok(None),
+                        Err(e) => return Err(e),
                     };
-                    let (_, s, e) = Self::prune_volume(&loaded, &comparisons, &bloom_hashes);
+                    let (_, s, e) = Self::prune_volume(&loaded, &comparisons, &bloom_hashes)?;
                     (&loaded, s, e)
                 } else {
                     vol.mark_accessed();
@@ -950,7 +977,7 @@ impl SegmentedTable {
                             let dict_id = if let Some(st) = store {
                                 st.dict_lookup(col_idx, s.as_str())
                             } else {
-                                vol.columns[col_idx].dict_lookup(s.as_str())
+                                vol.columns.get(col_idx)?.dict_lookup(s.as_str())
                             };
                             if let Some(id) = dict_id {
                                 dict_filters.push((col_idx, id));
@@ -963,7 +990,7 @@ impl SegmentedTable {
                 }
 
                 if start >= end {
-                    return None;
+                    return Ok(None);
                 }
 
                 let current_schema = self.hot.schema();
@@ -974,8 +1001,8 @@ impl SegmentedTable {
                 let mut candidates: Vec<usize> = Vec::new();
                 let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = dict_filters
                     .iter()
-                    .map(|&(col_idx, expected)| (&vol.columns[col_idx], start, expected))
-                    .collect();
+                    .map(|&(col_idx, expected)| Ok((vol.columns.get(col_idx)?, start, expected)))
+                    .collect::<Result<_>>()?;
                 let prefiltered = !filters.is_empty()
                     && super::column::ColumnData::dict_matching_offsets(
                         &filters,
@@ -1015,8 +1042,8 @@ impl SegmentedTable {
                     if !prefiltered && !dict_filters.is_empty() {
                         let mut matches = true;
                         for &(col_idx, expected_id) in &dict_filters {
-                            if vol.columns[col_idx].is_null(i)
-                                || vol.columns[col_idx].get_dict_id(i) != expected_id
+                            if vol.columns.get(col_idx)?.is_null(i)
+                                || vol.columns.get(col_idx)?.get_dict_id(i) != expected_id
                             {
                                 matches = false;
                                 break;
@@ -1028,9 +1055,9 @@ impl SegmentedTable {
                     }
 
                     let row = if mapping.is_identity {
-                        vol.get_row(i)
+                        vol.get_row(i)?
                     } else {
-                        vol.get_row_mapped(i, &mapping)
+                        vol.get_row_mapped(i, &mapping)?
                     };
                     if let Some(expr) = where_expr {
                         if !expr.evaluate_fast(&row) {
@@ -1039,7 +1066,7 @@ impl SegmentedTable {
                     }
                     vol_rows.push((row_id, row));
                 }
-                Some(vol_rows)
+                Ok(Some(vol_rows))
             };
 
         // Parallel or sequential volume processing.
@@ -1054,28 +1081,20 @@ impl SegmentedTable {
                 use rayon::prelude::*;
                 pruned_volumes
                     .par_iter()
-                    .filter_map(|v| process_volume(v))
-                    .collect()
+                    .filter_map(|v| process_volume(v).transpose())
+                    .collect::<Result<Vec<_>>>()?
             } else {
                 pruned_volumes
                     .iter()
-                    .filter_map(|v| process_volume(v))
-                    .collect()
+                    .filter_map(|v| process_volume(v).transpose())
+                    .collect::<Result<Vec<_>>>()?
             };
         #[cfg(not(feature = "parallel"))]
         let per_volume_rows: Vec<RowVec> = pruned_volumes
             .iter()
-            .filter_map(|v| process_volume(v))
-            .collect();
+            .filter_map(|v| process_volume(v).transpose())
+            .collect::<Result<Vec<_>>>()?;
 
-        if reload_failed.load(std::sync::atomic::Ordering::Relaxed) {
-            return Err(crate::core::Error::Internal {
-                message: format!(
-                    "table '{}': cold volume reload failed; refusing to serve partial data",
-                    self.segment_mgr.table_name()
-                ),
-            });
-        }
         for vol_rows in per_volume_rows.into_iter().rev() {
             for entry in vol_rows {
                 rows.push(entry);
@@ -1084,30 +1103,23 @@ impl SegmentedTable {
         Ok(rows)
     }
 
-    /// Find a row in segments by row_id. Returns (volume, local_offset) if found
-    /// and not tombstoned or hot-shadowed. Uses manifest min/max for fast segment
-    /// identification, then binary search within the segment.
-    /// Statement-scoped variant of find_segment_row over a pre-verified
-    /// warm snapshot (see segments_snapshot): never needs a reload, so a
-    /// DML statement that already mutated the hot buffer cannot fail
-    /// mid-statement on cold-volume access. Segments compacted away after
-    /// the snapshot are simply found in the snapshot's older volumes,
-    /// which is exactly the statement's view of the data.
+    /// Find a non-tombstoned, non-hot-shadowed row in the retained volume snapshot.
+    /// Use segment bounds and binary search; propagate identity or column read errors.
     fn find_segment_row_in(
         &self,
         snap: &super::manifest::StatementSnapshot,
         row_id: i64,
-    ) -> Option<(u64, super::manifest::ColdSegment, usize)> {
-        if self.hot.has_row_id(row_id) {
-            return None;
+    ) -> Result<Option<(u64, super::manifest::ColdSegment, usize)>> {
+        if self.hot.has_row_id(row_id)? {
+            return Ok(None);
         }
         // Tombstone view from the SAME snapshot; only the pending set is
         // read live because it is this transaction's own state.
         if self.is_row_tombstoned(&snap.tombstones, row_id) {
-            return None;
+            return Ok(None);
         }
         if self.segment_mgr.is_pending_tombstone(self.txn_id(), row_id) {
-            return None;
+            return Ok(None);
         }
         for &seg_id in &snap.seg_ids_newest_first {
             let Some(cold) = snap.segs.get(&seg_id) else {
@@ -1122,17 +1134,17 @@ impl SegmentedTable {
             if row_id < min_id || row_id > max_id {
                 continue;
             }
-            if let Ok(idx) = vol.meta.row_ids.binary_search(&row_id) {
+            if let Some(idx) = vol.find_row_id(row_id)? {
                 vol.mark_accessed();
-                return Some((seg_id, cold.clone(), idx));
+                return Ok(Some((seg_id, cold.clone(), idx)));
             }
         }
-        None
+        Ok(None)
     }
 
     fn find_segment_row(&self, row_id: i64) -> Result<Option<(u64, Arc<FrozenVolume>, usize)>> {
         // Hot buffer shadows cold: if the row exists in hot, the cold copy is stale
-        if self.hot.has_row_id(row_id) {
+        if self.hot.has_row_id(row_id)? {
             return Ok(None);
         }
         // Check committed tombstones (snapshot-aware: newer tombstones are invisible)
@@ -1175,7 +1187,7 @@ impl SegmentedTable {
             if row_id < min_id || row_id > max_id {
                 continue;
             }
-            if let Ok(idx) = vol.meta.row_ids.binary_search(&row_id) {
+            if let Some(idx) = vol.find_row_id(row_id)? {
                 if vol.is_cold() {
                     drop(segs);
                     if let Some(loaded) = self.segment_mgr.ensure_volume(seg_id)? {
@@ -1216,7 +1228,7 @@ impl SegmentedTable {
                 continue;
             };
             let vol = &cold.volume;
-            if let Ok(idx) = vol.meta.row_ids.binary_search(&row_id) {
+            if let Some(idx) = vol.find_row_id(row_id)? {
                 // segments_snapshot fails closed, so vol is never cold here.
                 vol.mark_accessed();
                 return Ok(Some((seg_id, Arc::clone(vol), idx)));
@@ -1238,9 +1250,9 @@ impl SegmentedTable {
         tombstones: &FxHashMap<i64, u64>,
         hot_skip: &FxHashSet<i64>,
         no_tombstones: bool,
-    ) {
+    ) -> Result<()> {
         for i in 0..vol.meta.row_count {
-            if vol.columns[pi].is_null(i) || !cs.is_visible(i) {
+            if vol.columns.get(pi)?.is_null(i) || !cs.is_visible(i) {
                 continue;
             }
             let rid = vol.meta.row_ids[i];
@@ -1250,7 +1262,7 @@ impl SegmentedTable {
             if !no_tombstones && self.is_row_tombstoned(tombstones, rid) {
                 continue;
             }
-            let val = vol.columns[pi].get_value(i);
+            let val = vol.columns.get(pi)?.get_value(i);
             match overall_min {
                 None => *overall_min = Some(val),
                 Some(ref current) => {
@@ -1260,6 +1272,7 @@ impl SegmentedTable {
                 }
             }
         }
+        Ok(())
     }
 
     /// Generic fallback for max_column scan on non-numeric column types.
@@ -1273,9 +1286,9 @@ impl SegmentedTable {
         tombstones: &FxHashMap<i64, u64>,
         hot_skip: &FxHashSet<i64>,
         no_tombstones: bool,
-    ) {
+    ) -> Result<()> {
         for i in 0..vol.meta.row_count {
-            if vol.columns[pi].is_null(i) || !cs.is_visible(i) {
+            if vol.columns.get(pi)?.is_null(i) || !cs.is_visible(i) {
                 continue;
             }
             let rid = vol.meta.row_ids[i];
@@ -1285,7 +1298,7 @@ impl SegmentedTable {
             if !no_tombstones && self.is_row_tombstoned(tombstones, rid) {
                 continue;
             }
-            let val = vol.columns[pi].get_value(i);
+            let val = vol.columns.get(pi)?.get_value(i);
             match overall_max {
                 None => *overall_max = Some(val),
                 Some(ref current) => {
@@ -1295,6 +1308,7 @@ impl SegmentedTable {
                 }
             }
         }
+        Ok(())
     }
 }
 
@@ -1365,9 +1379,8 @@ impl Table for SegmentedTable {
             self.check_segment_constraints(&row)?;
         }
         let result = self.hot.insert(row)?;
-        if self.segment_mgr.has_segments() {
-            self.segment_mgr.record_txn_seal_generation(self.txn_id());
-        }
+        // Generation zero matters too: a first seal must revalidate earlier hot writes.
+        self.segment_mgr.record_txn_seal_generation(self.txn_id());
         Ok(result)
     }
 
@@ -1377,9 +1390,8 @@ impl Table for SegmentedTable {
             self.check_segment_constraints(&row)?;
         }
         self.hot.insert_discard(row)?;
-        if self.segment_mgr.has_segments() {
-            self.segment_mgr.record_txn_seal_generation(self.txn_id());
-        }
+        // Generation zero matters too: a first seal must revalidate earlier hot writes.
+        self.segment_mgr.record_txn_seal_generation(self.txn_id());
         Ok(())
     }
 
@@ -1393,9 +1405,8 @@ impl Table for SegmentedTable {
             }
         }
         self.hot.insert_batch(rows)?;
-        if self.segment_mgr.has_segments() {
-            self.segment_mgr.record_txn_seal_generation(self.txn_id());
-        }
+        // Generation zero matters too: a first seal must revalidate earlier hot writes.
+        self.segment_mgr.record_txn_seal_generation(self.txn_id());
         Ok(())
     }
 
@@ -1450,7 +1461,7 @@ impl Table for SegmentedTable {
             let vol = &cs.volume;
 
             // Prune volume by zone maps and bloom filters.
-            let (should_skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes);
+            let (should_skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes)?;
             if should_skip {
                 continue;
             }
@@ -1479,9 +1490,9 @@ impl Table for SegmentedTable {
                     continue;
                 }
                 let row = if mapping.is_identity {
-                    vol.get_row(i)
+                    vol.get_row(i)?
                 } else {
-                    vol.get_row_mapped(i, &mapping)
+                    vol.get_row_mapped(i, &mapping)?
                 };
                 if let Some(expr) = where_expr {
                     if !expr.evaluate_fast(&row) {
@@ -1570,7 +1581,7 @@ impl Table for SegmentedTable {
         )> = None;
         for &row_id in row_ids {
             let found = match &cold_snapshot {
-                Some(snap) => self.find_segment_row_in(snap, row_id),
+                Some(snap) => self.find_segment_row_in(snap, row_id)?,
                 None => None,
             };
             if let Some((_seg_id, cs, idx)) = found {
@@ -1585,9 +1596,9 @@ impl Table for SegmentedTable {
                     }
                 };
                 let row = if mapping.is_identity {
-                    vol.get_row(idx)
+                    vol.get_row(idx)?
                 } else {
-                    vol.get_row_mapped(idx, mapping)
+                    vol.get_row_mapped(idx, mapping)?
                 };
                 let old_row = row.clone();
                 let (new_row, changed) = setter(row)?;
@@ -1666,7 +1677,7 @@ impl Table for SegmentedTable {
 
         for &row_id in row_ids {
             let found = match &cold_snapshot {
-                Some(snap) => self.find_segment_row_in(snap, row_id),
+                Some(snap) => self.find_segment_row_in(snap, row_id)?,
                 None => None,
             };
             if let Some((_seg_id, _cs, _idx)) = found {
@@ -1804,7 +1815,7 @@ impl Table for SegmentedTable {
             let vol = &cs.volume;
 
             // Prune volume by zone maps and bloom filters.
-            let (should_skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes);
+            let (should_skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes)?;
             if should_skip {
                 continue;
             }
@@ -1840,7 +1851,7 @@ impl Table for SegmentedTable {
                         (Some(mask), true) => {
                             for ci in 0..vol.columns.len() {
                                 if ci < mask.len() && mask[ci] {
-                                    reusable_row.push(vol.columns[ci].get_value(i));
+                                    reusable_row.push(vol.columns.get(ci)?.get_value(i));
                                 } else {
                                     reusable_row.push(Value::Null(vol.columns.data_type(ci)));
                                 }
@@ -1851,7 +1862,7 @@ impl Table for SegmentedTable {
                                 if ci < mask.len() && mask[ci] {
                                     match src {
                                         super::writer::ColSource::Volume(vi) => {
-                                            reusable_row.push(vol.columns[*vi].get_value(i));
+                                            reusable_row.push(vol.columns.get(*vi)?.get_value(i));
                                         }
                                         super::writer::ColSource::Default(val) => {
                                             reusable_row.push(val.clone());
@@ -1872,14 +1883,14 @@ impl Table for SegmentedTable {
                         }
                         (None, true) => {
                             for ci in 0..vol.columns.len() {
-                                reusable_row.push(vol.columns[ci].get_value(i));
+                                reusable_row.push(vol.columns.get(ci)?.get_value(i));
                             }
                         }
                         (None, false) => {
                             for src in &mapping.sources {
                                 match src {
                                     super::writer::ColSource::Volume(vi) => {
-                                        reusable_row.push(vol.columns[*vi].get_value(i));
+                                        reusable_row.push(vol.columns.get(*vi)?.get_value(i));
                                     }
                                     super::writer::ColSource::Default(val) => {
                                         reusable_row.push(val.clone());
@@ -2035,9 +2046,9 @@ impl Table for SegmentedTable {
                     }
                 };
                 let row = if mapping.is_identity {
-                    vol.get_row(idx)
+                    vol.get_row(idx)?
                 } else {
-                    vol.get_row_mapped(idx, mapping)
+                    vol.get_row_mapped(idx, mapping)?
                 };
                 result.push((row_id, row));
             } else {
@@ -2092,9 +2103,9 @@ impl Table for SegmentedTable {
                     }
                 };
                 let row = if mapping.is_identity {
-                    vol.get_row(idx)
+                    vol.get_row(idx)?
                 } else {
-                    vol.get_row_mapped(idx, mapping)
+                    vol.get_row_mapped(idx, mapping)?
                 };
                 if filter.evaluate_fast(&row) {
                     buffer.push((row_id, row));
@@ -2173,7 +2184,7 @@ impl Table for SegmentedTable {
         'done: for (nf_idx, (seg_id, cs)) in volumes.iter().enumerate().rev() {
             let vol = &cs.volume;
             if !comparisons.is_empty() {
-                let (skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes);
+                let (skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes)?;
                 if skip {
                     continue;
                 }
@@ -2200,9 +2211,9 @@ impl Table for SegmentedTable {
                     continue;
                 }
                 let row = if mapping.is_identity {
-                    vol.get_row(i)
+                    vol.get_row(i)?
                 } else {
-                    vol.get_row_mapped(i, &mapping)
+                    vol.get_row_mapped(i, &mapping)?
                 };
                 if let Some(expr) = where_expr {
                     if !expr.evaluate_fast(&row) {
@@ -2286,7 +2297,7 @@ impl Table for SegmentedTable {
             let vol = &cs.volume;
             // Zone-map pruning: skip entire volume if no rows can match.
             let pruned = if !comparisons.is_empty() {
-                let (skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes);
+                let (skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes)?;
                 skip
             } else {
                 false
@@ -2323,9 +2334,9 @@ impl Table for SegmentedTable {
                 // even during the skip phase to get correct offset counting.
                 if where_expr.is_some() {
                     let row = if mapping.is_identity {
-                        vol.get_row(i)
+                        vol.get_row(i)?
                     } else {
-                        vol.get_row_mapped(i, &mapping)
+                        vol.get_row_mapped(i, &mapping)?
                     };
                     if let Some(expr) = where_expr {
                         if !expr.evaluate_fast(&row) {
@@ -2344,9 +2355,9 @@ impl Table for SegmentedTable {
                         cold_skipped += 1;
                     } else {
                         let row = if mapping.is_identity {
-                            vol.get_row(i)
+                            vol.get_row(i)?
                         } else {
-                            vol.get_row_mapped(i, &mapping)
+                            vol.get_row_mapped(i, &mapping)?
                         };
                         result.push((row_id, row));
                     }
@@ -2398,19 +2409,19 @@ impl Table for SegmentedTable {
             .collect())
     }
 
-    fn has_row_id(&self, row_id: i64) -> bool {
-        if self.hot.has_row_id(row_id) {
-            return true;
+    fn has_row_id(&self, row_id: i64) -> Result<bool> {
+        if self.hot.has_row_id(row_id)? {
+            return Ok(true);
         }
         if !self.segment_mgr.has_segments() {
-            return false;
+            return Ok(false);
         }
         // Snapshot-aware: row_exists() checks all tombstones unconditionally,
         // but a snapshot txn should still see rows tombstoned after its begin_seq.
         if self.snapshot_seq.is_some() {
             let ts = self.segment_mgr.tombstone_set_arc();
             if self.is_row_tombstoned(&ts, row_id) {
-                return false;
+                return Ok(false);
             }
             return self.segment_mgr.is_row_id_in_volume(row_id);
         }
@@ -2425,11 +2436,11 @@ impl Table for SegmentedTable {
     // Row count
     // =========================================================================
 
-    fn row_count(&self) -> usize {
+    fn row_count(&self) -> Result<usize> {
         // Snapshot isolation: deduped_row_count and the fast path subtract ALL
         // tombstones, but a snapshot may not see newer ones. Use full scan.
         if self.snapshot_seq.is_some() {
-            return self.collect_all_rows(None).map_or(0, |r| r.len());
+            return self.collect_all_rows(None).map(|r| r.len());
         }
         // During seal, rows temporarily exist in both hot and cold.
         // Use the same O(1) formula with overlap correction. The count
@@ -2440,7 +2451,7 @@ impl Table for SegmentedTable {
         let seg = self.segment_mgr.deduped_row_count();
         let pending = self.segment_mgr.pending_tombstone_count(self.txn_id());
         let overlap = self.segment_mgr.seal_overlap();
-        seg.saturating_sub(pending) + self.hot.row_count().saturating_sub(overlap)
+        Ok(seg.saturating_sub(pending) + self.hot.row_count()?.saturating_sub(overlap))
     }
 
     fn row_count_hint(&self) -> usize {
@@ -2450,33 +2461,37 @@ impl Table for SegmentedTable {
         seg.saturating_sub(pending) + self.hot.row_count_hint().saturating_sub(overlap)
     }
 
-    fn fast_row_count(&self) -> Option<usize> {
+    fn fast_row_count(&self) -> Result<Option<usize>> {
         // Snapshot isolation: deduped_row_count subtracts ALL tombstones, but
         // this snapshot may not see newer tombstones. Fall back to scan which
         // correctly filters by snapshot_seq.
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
-        let hot_count = self.hot.fast_row_count()?;
+        let Some(hot_count) = self.hot.fast_row_count()? else {
+            return Ok(None);
+        };
         let seg = self.segment_mgr.deduped_row_count();
         let pending = self.segment_mgr.pending_tombstone_count(self.txn_id());
         let overlap = self.segment_mgr.seal_overlap();
         // During seal, rows temporarily exist in both hot and cold.
         // Subtract overlap to avoid double-counting. May drift by a few rows
         // during the brief window, but O(1) vs O(N) is worth it.
-        Some(seg.saturating_sub(pending) + hot_count.saturating_sub(overlap))
+        Ok(Some(
+            seg.saturating_sub(pending) + hot_count.saturating_sub(overlap),
+        ))
     }
 
     // =========================================================================
     // Aggregation pushdown
     // =========================================================================
 
-    fn sum_column(&self, col_idx: usize) -> Option<(f64, usize)> {
+    fn sum_column(&self, col_idx: usize) -> Result<Option<(f64, usize)>> {
         // Snapshot isolation: cold aggregation uses tombstones without snapshot
         // filtering. Bail so the executor falls back to full scan.
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         let hot_result = self.hot.sum_column(col_idx);
@@ -2487,10 +2502,12 @@ impl Table for SegmentedTable {
 
         // During seal, hot+cold overlap — can't reliably sum
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
-        let (hot_sum, hot_count) = hot_result?;
+        let Some((hot_sum, hot_count)) = hot_result? else {
+            return Ok(None);
+        };
 
         // Pre-compute default contribution for schema-evolved volumes
         // that are missing this column (added via ALTER TABLE ADD COLUMN).
@@ -2556,11 +2573,11 @@ impl Table for SegmentedTable {
                 }
             }
             let total_sum = hot_sum + cold_sum_int as f64 + cold_sum_float;
-            return Some((total_sum, total_count));
+            return Ok(Some((total_sum, total_count)));
         }
 
         // Tombstones exist: scan columnar data with dedup (avoids full Row materialization)
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -2591,10 +2608,10 @@ impl Table for SegmentedTable {
                     continue;
                 }
                 if let Some(pi) = phys {
-                    if vol.columns[pi].is_null(i) {
+                    if vol.columns.get(pi)?.is_null(i) {
                         continue;
                     }
-                    match &vol.columns[pi] {
+                    match vol.columns.get(pi)? {
                         crate::storage::volume::column::ColumnData::Int64 { values, .. } => {
                             total_sum += values[i] as f64;
                             total_count += 1;
@@ -2615,12 +2632,12 @@ impl Table for SegmentedTable {
                 }
             }
         }
-        Some((total_sum, total_count))
+        Ok(Some((total_sum, total_count)))
     }
 
-    fn min_column(&self, col_idx: usize) -> Option<Option<Value>> {
+    fn min_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         let hot_result = self.hot.min_column(col_idx);
@@ -2630,10 +2647,12 @@ impl Table for SegmentedTable {
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
-        let hot_min = hot_result?;
+        let Some(hot_min) = hot_result? else {
+            return Ok(None);
+        };
 
         let schema = self.hot.schema();
         // Column resolution uses mapping (handles renames/drops) not col_name.
@@ -2686,7 +2705,7 @@ impl Table for SegmentedTable {
                     }
                 }
             }
-            return Some(overall_min);
+            return Ok(Some(overall_min));
         }
 
         // Zone-map fast path: when there are no tombstones/pending tombstones
@@ -2699,7 +2718,7 @@ impl Table for SegmentedTable {
             && !self.segment_mgr.has_pending_tombstones(self.txn_id());
 
         // Scan columnar data with dedup (typed direct access, no Value alloc)
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = if no_tombstones {
             None
         } else {
@@ -2750,7 +2769,7 @@ impl Table for SegmentedTable {
 
             // Typed direct scan: compare on primitive types to avoid Value alloc
             if let Some(pi) = phys {
-                match &vol.columns[pi] {
+                match vol.columns.get(pi)? {
                     crate::storage::volume::column::ColumnData::Int64 { values, nulls } => {
                         let mut best_i64 = match &overall_min {
                             Some(Value::Integer(v)) => Some(*v),
@@ -2765,7 +2784,7 @@ impl Table for SegmentedTable {
                                     tombstones_ref,
                                     &hot_skip,
                                     no_tombstones,
-                                );
+                                )?;
                                 continue;
                             }
                         };
@@ -2802,7 +2821,7 @@ impl Table for SegmentedTable {
                                     tombstones_ref,
                                     &hot_skip,
                                     no_tombstones,
-                                );
+                                )?;
                                 continue;
                             }
                         };
@@ -2848,7 +2867,7 @@ impl Table for SegmentedTable {
                                     tombstones_ref,
                                     &hot_skip,
                                     no_tombstones,
-                                );
+                                )?;
                                 continue;
                             }
                         };
@@ -2888,7 +2907,7 @@ impl Table for SegmentedTable {
                             tombstones_ref,
                             &hot_skip,
                             no_tombstones,
-                        );
+                        )?;
                     }
                 }
             } else if has_non_null_default {
@@ -2919,12 +2938,12 @@ impl Table for SegmentedTable {
                 }
             }
         }
-        Some(overall_min)
+        Ok(Some(overall_min))
     }
 
-    fn max_column(&self, col_idx: usize) -> Option<Option<Value>> {
+    fn max_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         let hot_result = self.hot.max_column(col_idx);
@@ -2934,10 +2953,12 @@ impl Table for SegmentedTable {
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
-        let hot_max = hot_result?;
+        let Some(hot_max) = hot_result? else {
+            return Ok(None);
+        };
 
         let schema = self.hot.schema();
         // Column resolution uses mapping (handles renames/drops) not col_name.
@@ -2991,14 +3012,14 @@ impl Table for SegmentedTable {
                     }
                 }
             }
-            return Some(overall_max);
+            return Ok(Some(overall_max));
         }
 
         // See min_column: same zone-map + typed scan strategy for MAX.
         let no_tombstones = self.segment_mgr.is_tombstone_set_empty()
             && !self.segment_mgr.has_pending_tombstones(self.txn_id());
 
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = if no_tombstones {
             None
         } else {
@@ -3047,7 +3068,7 @@ impl Table for SegmentedTable {
 
             // Typed direct scan: compare on primitive types to avoid Value alloc
             if let Some(pi) = phys {
-                match &vol.columns[pi] {
+                match vol.columns.get(pi)? {
                     crate::storage::volume::column::ColumnData::Int64 { values, nulls } => {
                         let mut best_i64 = match &overall_max {
                             Some(Value::Integer(v)) => Some(*v),
@@ -3061,7 +3082,7 @@ impl Table for SegmentedTable {
                                     tombstones_ref,
                                     &hot_skip,
                                     no_tombstones,
-                                );
+                                )?;
                                 continue;
                             }
                         };
@@ -3098,7 +3119,7 @@ impl Table for SegmentedTable {
                                     tombstones_ref,
                                     &hot_skip,
                                     no_tombstones,
-                                );
+                                )?;
                                 continue;
                             }
                         };
@@ -3144,7 +3165,7 @@ impl Table for SegmentedTable {
                                     tombstones_ref,
                                     &hot_skip,
                                     no_tombstones,
-                                );
+                                )?;
                                 continue;
                             }
                         };
@@ -3184,7 +3205,7 @@ impl Table for SegmentedTable {
                             tombstones_ref,
                             &hot_skip,
                             no_tombstones,
-                        );
+                        )?;
                     }
                 }
             } else if has_non_null_default {
@@ -3213,16 +3234,16 @@ impl Table for SegmentedTable {
                 }
             }
         }
-        Some(overall_max)
+        Ok(Some(overall_max))
     }
 
     // =========================================================================
     // Partition and index-based pushdowns
     // =========================================================================
 
-    fn get_partition_count(&self, column_name: &str) -> Option<usize> {
+    fn get_partition_count(&self, column_name: &str) -> Result<Option<usize>> {
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         if !self.segment_mgr.has_segments() {
@@ -3231,22 +3252,26 @@ impl Table for SegmentedTable {
 
         // During seal, hot+cold overlap — can't reliably count
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
         let schema = self.hot.schema();
-        let col_idx = *schema.column_index_map().get(&column_name.to_lowercase())?;
+        let Some(&col_idx) = schema.column_index_map().get(&column_name.to_lowercase()) else {
+            return Ok(None);
+        };
 
         // Collect hot distinct values from index. If no index exists on this
         // column, bail — we can't enumerate hot values without a full scan.
         let mut distinct: ValueSet = ValueSet::default();
-        let hot_values = self.hot.get_partition_values(column_name)?;
+        let Some(hot_values) = self.hot.get_partition_values(column_name)? else {
+            return Ok(None);
+        };
         for v in hot_values {
             distinct.insert(v);
         }
 
         // Build skip set: hot row_ids + tombstones + pending tombstones
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -3278,8 +3303,8 @@ impl Table for SegmentedTable {
                     continue;
                 }
                 if let Some(pi) = phys {
-                    if !vol.columns[pi].is_null(i) {
-                        distinct.insert(vol.columns[pi].get_value(i));
+                    if !vol.columns.get(pi)?.is_null(i) {
+                        distinct.insert(vol.columns.get(pi)?.get_value(i));
                     }
                 } else if has_non_null_default {
                     distinct.insert(default_val.clone());
@@ -3287,33 +3312,37 @@ impl Table for SegmentedTable {
             }
         }
 
-        Some(distinct.len())
+        Ok(Some(distinct.len()))
     }
 
-    fn get_partition_values(&self, column_name: &str) -> Option<Vec<Value>> {
+    fn get_partition_values(&self, column_name: &str) -> Result<Option<Vec<Value>>> {
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         if let Some(result) = self.unsealed(|hot| hot.get_partition_values(column_name)) {
             return result;
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
         let schema = self.hot.schema();
-        let col_idx = *schema.column_index_map().get(&column_name.to_lowercase())?;
+        let Some(&col_idx) = schema.column_index_map().get(&column_name.to_lowercase()) else {
+            return Ok(None);
+        };
 
         // Bail if hot has no index on this column — can't enumerate hot values
         // without a full scan. Returning Some with only cold values would be wrong.
         let mut distinct: ValueSet = ValueSet::default();
-        let hot_values = self.hot.get_partition_values(column_name)?;
+        let Some(hot_values) = self.hot.get_partition_values(column_name)? else {
+            return Ok(None);
+        };
         for v in hot_values {
             distinct.insert(v);
         }
 
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -3344,8 +3373,8 @@ impl Table for SegmentedTable {
                     continue;
                 }
                 if let Some(pi) = phys {
-                    if !vol.columns[pi].is_null(i) {
-                        distinct.insert(vol.columns[pi].get_value(i));
+                    if !vol.columns.get(pi)?.is_null(i) {
+                        distinct.insert(vol.columns.get(pi)?.get_value(i));
                     }
                 } else if has_non_null_default {
                     distinct.insert(default_val.clone());
@@ -3353,44 +3382,44 @@ impl Table for SegmentedTable {
             }
         }
 
-        Some(distinct.into_iter().collect())
+        Ok(Some(distinct.into_iter().collect()))
     }
 
-    fn compute_distinct_values(&self, col_idx: usize) -> Option<Vec<Value>> {
+    fn compute_distinct_values(&self, col_idx: usize) -> Result<Option<Vec<Value>>> {
         // Bail for snapshot isolation — tombstone visibility is snapshot-dependent
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         // Bail during seal overlap — hot and cold may have duplicates
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
         let schema = self.hot.schema();
         if col_idx >= schema.columns.len() {
-            return None;
+            return Ok(None);
         }
         let col_name = &schema.columns[col_idx].name;
 
         // Collect hot distinct values via index (same requirement as get_partition_values)
         let mut distinct: ValueSet = ValueSet::default();
-        if let Some(hot_values) = self.hot.get_partition_values(col_name) {
+        if let Some(hot_values) = self.hot.get_partition_values(col_name)? {
             for v in hot_values {
                 distinct.insert(v);
             }
-        } else if self.hot.row_count() > 0 {
+        } else if self.hot.row_count()? > 0 {
             // Hot has rows but no index on this column — cannot enumerate without full scan
-            return None;
+            return Ok(None);
         }
 
         if !self.segment_mgr.has_segments() {
-            return Some(distinct.into_iter().collect());
+            return Ok(Some(distinct.into_iter().collect()));
         }
 
         let no_tombstones = self.segment_mgr.is_tombstone_set_empty()
             && !self.segment_mgr.has_pending_tombstones(self.txn_id());
 
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = if no_tombstones {
             // Avoid cloning the Arc when we know the set is empty
             Arc::new(FxHashMap::default())
@@ -3449,8 +3478,8 @@ impl Table for SegmentedTable {
                     if !no_tombstones && self.is_row_tombstoned(&tombstones_arc, rid) {
                         continue;
                     }
-                    if !vol.columns[pi].is_null(i) {
-                        distinct.insert(vol.columns[pi].get_value(i));
+                    if !vol.columns.get(pi)?.is_null(i) {
+                        distinct.insert(vol.columns.get(pi)?.get_value(i));
                     }
                 }
             } else if has_non_null_default {
@@ -3474,12 +3503,15 @@ impl Table for SegmentedTable {
             }
         }
 
-        Some(distinct.into_iter().collect())
+        Ok(Some(distinct.into_iter().collect()))
     }
 
-    fn collect_rows_grouped_by_partition(&self, column_name: &str) -> Option<Vec<(Value, RowVec)>> {
+    fn collect_rows_grouped_by_partition(
+        &self,
+        column_name: &str,
+    ) -> Result<Option<Vec<(Value, RowVec)>>> {
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         if !self.segment_mgr.has_segments() {
@@ -3487,22 +3519,24 @@ impl Table for SegmentedTable {
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
         let schema = self.hot.schema();
-        let col_idx = *schema.column_index_map().get(&column_name.to_lowercase())?;
+        let Some(&col_idx) = schema.column_index_map().get(&column_name.to_lowercase()) else {
+            return Ok(None);
+        };
 
         // Start from hot grouped data
         let mut groups: ValueMap<RowVec> = ValueMap::default();
-        if let Some(hot_groups) = self.hot.collect_rows_grouped_by_partition(column_name) {
+        if let Some(hot_groups) = self.hot.collect_rows_grouped_by_partition(column_name)? {
             for (val, rows) in hot_groups {
                 groups.insert(val, rows);
             }
         }
 
         // Build hot_skip: hot row_ids + tombstones + pending tombstones
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -3534,25 +3568,25 @@ impl Table for SegmentedTable {
                     continue;
                 }
                 let val = if let Some(pc) = phys_col {
-                    if vol.columns[pc].is_null(i) {
+                    if vol.columns.get(pc)?.is_null(i) {
                         continue;
                     }
-                    vol.columns[pc].get_value(i)
+                    vol.columns.get(pc)?.get_value(i)
                 } else if has_non_null_default {
                     default_val.clone()
                 } else {
                     continue;
                 };
                 let row = if mapping.is_identity {
-                    vol.get_row(i)
+                    vol.get_row(i)?
                 } else {
-                    vol.get_row_mapped(i, mapping)
+                    vol.get_row_mapped(i, mapping)?
                 };
                 groups.entry(val).or_default().push((rid, row));
             }
         }
 
-        Some(groups.into_iter().collect())
+        Ok(Some(groups.into_iter().collect()))
     }
 
     fn get_rows_for_partition_value(
@@ -3644,10 +3678,10 @@ impl Table for SegmentedTable {
                     continue;
                 }
                 let matches = if let Some(pc) = phys_col {
-                    if vol.columns[pc].is_null(i) {
+                    if vol.columns.get(pc)?.is_null(i) {
                         false
                     } else {
-                        &vol.columns[pc].get_value(i) == partition_value
+                        &vol.columns.get(pc)?.get_value(i) == partition_value
                     }
                 } else {
                     // Missing column → all rows have default, already checked match above
@@ -3655,9 +3689,9 @@ impl Table for SegmentedTable {
                 };
                 if matches {
                     let row = if mapping.is_identity {
-                        vol.get_row(i)
+                        vol.get_row(i)?
                     } else {
-                        vol.get_row_mapped(i, mapping)
+                        vol.get_row_mapped(i, mapping)?
                     };
                     result.push((rid, row));
                 }
@@ -3673,7 +3707,7 @@ impl Table for SegmentedTable {
         ascending: bool,
         limit: usize,
         offset: usize,
-    ) -> Option<RowVec> {
+    ) -> Result<Option<RowVec>> {
         if let Some(result) = self.unsealed(|hot| {
             hot.collect_rows_ordered_by_index(column_name, ascending, limit, offset)
         }) {
@@ -3683,21 +3717,23 @@ impl Table for SegmentedTable {
         // Snapshot isolation: the merge path doesn't filter by snapshot_seq.
         // Fall back to the full scan + sort path which handles MVCC correctly.
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
 
         // Only optimize when ORDER BY column is the INTEGER PRIMARY KEY.
         // For PK, row_id order == value order, so we can merge sorted sources.
         let schema = self.hot.schema().clone();
-        let pk_idx = schema.pk_column_index()?;
+        let Some(pk_idx) = schema.pk_column_index() else {
+            return Ok(None);
+        };
         let pk_col = &schema.columns[pk_idx];
         if pk_col.name_lower != column_name.to_lowercase() {
-            return None;
+            return Ok(None);
         }
 
         let needed = limit.saturating_add(offset);
         if needed == 0 {
-            return Some(RowVec::new());
+            return Ok(Some(RowVec::new()));
         }
 
         // 1. Collect hot rows in PK order. Only materialize `needed` rows
@@ -3705,15 +3741,12 @@ impl Table for SegmentedTable {
         let hot_rows =
             match self
                 .hot
-                .collect_rows_ordered_by_index(column_name, ascending, needed, 0)
+                .collect_rows_ordered_by_index(column_name, ascending, needed, 0)?
             {
                 Some(rows) => rows,
                 None => {
                     // Local changes prevent ordered iteration — fall back to collect + sort.
-                    let mut rows = match self.hot.collect_all_rows(None) {
-                        Ok(r) => r,
-                        Err(_) => return None,
-                    };
+                    let mut rows = self.hot.collect_all_rows(None)?;
                     if ascending {
                         rows.sort_unstable_by_key(|&(id, _)| id);
                     } else {
@@ -3735,7 +3768,7 @@ impl Table for SegmentedTable {
 
         // 3. Get volumes (oldest first — segment_id ascending order).
         //    We need column data for materialization, so use ensure_columns path.
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         // volumes is oldest-first after the reverse inside get_volumes_newest_first.
 
         // 4. K-way merge using per-source cursors.
@@ -3866,9 +3899,9 @@ impl Table for SegmentedTable {
 
                 // Materialize the row
                 let row = if vs.mapping.is_identity {
-                    vs.volume.get_row(idx)
+                    vs.volume.get_row(idx)?
                 } else {
-                    vs.volume.get_row_mapped(idx, &vs.mapping)
+                    vs.volume.get_row_mapped(idx, &vs.mapping)?
                 };
 
                 if skipped < offset {
@@ -3879,7 +3912,7 @@ impl Table for SegmentedTable {
             }
         }
 
-        Some(result)
+        Ok(Some(result))
     }
 
     fn collect_rows_pk_keyset(
@@ -4059,7 +4092,7 @@ impl Table for SegmentedTable {
             }
             let (seg_id, cs) = &volumes[i];
             let (should_skip, mut narrow_start, mut narrow_end) =
-                Self::prune_volume(&cs.volume, &comparisons, &bloom_hashes);
+                Self::prune_volume(&cs.volume, &comparisons, &bloom_hashes)?;
             if should_skip {
                 continue;
             }
@@ -4072,7 +4105,7 @@ impl Table for SegmentedTable {
                 // Only a loaded volume can narrow the range through the sorted
                 // columns' binary search; a warm one already did above
                 (_, narrow_start, narrow_end) =
-                    Self::prune_volume(&loaded, &comparisons, &bloom_hashes);
+                    Self::prune_volume(&loaded, &comparisons, &bloom_hashes)?;
                 &loaded
             } else {
                 &cs.volume
@@ -4142,7 +4175,7 @@ impl Table for SegmentedTable {
                 }
                 while scanner.next() {
                     let (row_id, row) = scanner.take_row_with_id();
-                    if sealed_copies_checked && self.hot.has_row_id(row_id) {
+                    if sealed_copies_checked && self.hot.has_row_id(row_id)? {
                         continue;
                     }
                     keep.offer(row_id, row);
@@ -4165,11 +4198,7 @@ impl Table for SegmentedTable {
     // =========================================================================
 
     fn create_index(&self, name: &str, columns: &[&str], is_unique: bool) -> Result<()> {
-        // For unique indexes, validate cold data has no duplicates first.
-        if is_unique && self.segment_mgr.has_segments() {
-            self.validate_cold_unique(name, columns)?;
-        }
-        self.hot.create_index(name, columns, is_unique)
+        self.create_index_with_type(name, columns, is_unique, None)
     }
 
     fn create_index_with_type(
@@ -4179,25 +4208,16 @@ impl Table for SegmentedTable {
         is_unique: bool,
         index_type: Option<IndexType>,
     ) -> Result<()> {
-        // For unique indexes (non-HNSW), validate cold data has no duplicates first.
-        // HNSW unique validation happens during populate_index_from_cold via index.add().
-        if is_unique && index_type != Some(IndexType::Hnsw) && self.segment_mgr.has_segments() {
-            self.validate_cold_unique(name, columns)?;
-        }
-
-        self.hot
-            .create_index_with_type(name, columns, is_unique, index_type)?;
-
-        // HNSW indexes store all data (hot + cold). After creating the index
-        // on the hot store, populate it from cold segments.
-        if index_type == Some(IndexType::Hnsw) && self.segment_mgr.has_segments() {
-            if let Err(e) = self.populate_index_from_cold(name, columns) {
-                // Roll back the hot index on cold population failure
-                let _ = self.hot.drop_index(name);
-                return Err(e);
-            }
-        }
-        Ok(())
+        let generation = self.segment_mgr.seal_generation();
+        self.hot.create_index_with_type_and_finalizer(
+            name,
+            columns,
+            is_unique,
+            index_type,
+            &mut |index, install| {
+                self.finish_index_build(index, columns, is_unique, generation, install)
+            },
+        )
     }
 
     fn create_hnsw_index(
@@ -4210,8 +4230,8 @@ impl Table for SegmentedTable {
         ef_search: usize,
         metric: crate::storage::index::HnswDistanceMetric,
     ) -> Result<()> {
-        // Delegate to hot store which creates the HNSW with custom params
-        self.hot.create_hnsw_index(
+        let generation = self.segment_mgr.seal_generation();
+        self.hot.create_hnsw_index_with_finalizer(
             name,
             column,
             is_unique,
@@ -4219,16 +4239,10 @@ impl Table for SegmentedTable {
             ef_construction,
             ef_search,
             metric,
-        )?;
-
-        // Populate from cold segments (HNSW must include all data)
-        if self.segment_mgr.has_segments() {
-            if let Err(e) = self.populate_index_from_cold(name, &[column]) {
-                let _ = self.hot.drop_index(name);
-                return Err(e);
-            }
-        }
-        Ok(())
+            &mut |index, install| {
+                self.finish_index_build(index, &[column], is_unique, generation, install)
+            },
+        )
     }
 
     fn drop_index(&self, name: &str) -> Result<()> {
@@ -4241,11 +4255,15 @@ impl Table for SegmentedTable {
         is_unique: bool,
         custom_name: Option<&str>,
     ) -> Result<()> {
-        if is_unique && self.segment_mgr.has_segments() {
-            self.validate_cold_unique(custom_name.unwrap_or(column_name), &[column_name])?;
-        }
-        self.hot
-            .create_btree_index(column_name, is_unique, custom_name)
+        let generation = self.segment_mgr.seal_generation();
+        self.hot.create_btree_index_with_finalizer(
+            column_name,
+            is_unique,
+            custom_name,
+            &mut |index, install| {
+                self.finish_index_build(index, &[column_name], is_unique, generation, install)
+            },
+        )
     }
 
     fn drop_btree_index(&self, column_name: &str) -> Result<()> {
@@ -4258,10 +4276,15 @@ impl Table for SegmentedTable {
         columns: &[&str],
         is_unique: bool,
     ) -> Result<()> {
-        if is_unique && self.segment_mgr.has_segments() {
-            self.validate_cold_unique(name, columns)?;
-        }
-        self.hot.create_multi_column_index(name, columns, is_unique)
+        let generation = self.segment_mgr.seal_generation();
+        self.hot.create_multi_column_index_with_finalizer(
+            name,
+            columns,
+            is_unique,
+            &mut |index, install| {
+                self.finish_index_build(index, columns, is_unique, generation, install)
+            },
+        )
     }
 
     fn has_index_on_column(&self, column_name: &str) -> bool {
@@ -4554,9 +4577,9 @@ impl Table for SegmentedTable {
                                     DataType::Integer | DataType::Timestamp
                                 )
                                 && pi < vol.columns.len()
-                                && !vol.columns[pi].is_null(i)
+                                && !vol.columns.get(pi)?.is_null(i)
                             {
-                                let pk_val = vol.columns[pi].get_i64(i);
+                                let pk_val = vol.columns.get(pi)?.get_i64(i);
                                 if hot_pks.contains(&pk_val) {
                                     continue;
                                 }
@@ -4564,9 +4587,9 @@ impl Table for SegmentedTable {
                         }
                     }
                     let row = if mapping.is_identity {
-                        vol.get_row(i)
+                        vol.get_row(i)?
                     } else {
-                        vol.get_row_mapped(i, &mapping)
+                        vol.get_row_mapped(i, &mapping)?
                     };
                     if let Some(e) = expr {
                         if !e.evaluate_fast(&row) {
@@ -4611,27 +4634,27 @@ impl Table for SegmentedTable {
         &self,
         aggregates: &[(AggregateOp, usize)],
         where_expr: &dyn Expression,
-    ) -> Option<Vec<Value>> {
+    ) -> Result<Option<Vec<Value>>> {
         // Bail out: snapshot isolation requires tombstone filtering by snapshot_seq
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         // Bail out: during seal, hot+cold overlap makes aggregation unreliable
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
         // Bail out: no cold volumes — let the regular path handle hot-only data
         if !self.segment_mgr.has_segments() {
-            return None;
+            return Ok(None);
         }
         // Bail out: only conjunctive-simple filters can be evaluated on raw arrays
         if !where_expr.is_conjunctive_simple() {
-            return None;
+            return Ok(None);
         }
         let comparisons = where_expr.collect_comparisons();
         if comparisons.is_empty() {
-            return None;
+            return Ok(None);
         }
 
         let schema = self.hot.schema().clone();
@@ -4653,10 +4676,9 @@ impl Table for SegmentedTable {
 
         let mut preds: Vec<ResolvedPred> = Vec::with_capacity(comparisons.len());
         for (col_name, op, value) in &comparisons {
-            let col_idx = schema
-                .column_index_map()
-                .get(&col_name.to_lowercase())
-                .copied()?;
+            let Some(&col_idx) = schema.column_index_map().get(&col_name.to_lowercase()) else {
+                return Ok(None);
+            };
             let col_type = schema.columns[col_idx].data_type;
             let target = match (col_type, value) {
                 (DataType::Integer, Value::Integer(i)) => TypedTarget::Int64(*i),
@@ -4675,7 +4697,7 @@ impl Table for SegmentedTable {
                 (DataType::Text, Value::Text(s)) if *op == crate::core::Operator::Eq => {
                     TypedTarget::DictEq(crate::common::SmartString::from(s.as_str()))
                 }
-                _ => return None, // unsupported type combination
+                _ => return Ok(None), // unsupported type combination
             };
             preds.push(ResolvedPred {
                 schema_col_idx: col_idx,
@@ -4750,7 +4772,7 @@ impl Table for SegmentedTable {
         let mut accums = vec![Accum::default(); aggregates.len()];
 
         // --- Hot buffer rows -------------------------------------------------
-        let hot_rows = self.hot.collect_all_rows(Some(where_expr)).ok()?;
+        let hot_rows = self.hot.collect_all_rows(Some(where_expr))?;
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(hot_rows.len().max(1024), Default::default());
         for (row_id, row) in &hot_rows {
@@ -4854,7 +4876,7 @@ impl Table for SegmentedTable {
         self.hot.collect_hot_row_ids_into(&mut hot_skip);
 
         // --- Cold volumes (THE FAST PATH) ------------------------------------
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         self.segment_mgr
             .insert_pending_tombstones_into(self.txn_id(), &mut hot_skip);
@@ -4867,8 +4889,8 @@ impl Table for SegmentedTable {
             dict_id: Option<u32>, // resolved dict_id for DictEq (per-volume)
             is_timestamp: bool,
         }
-        struct PhysAgg {
-            phys_col: Option<usize>, // None for CountStar or ColSource::Default
+        struct PhysAgg<'a> {
+            column: Option<&'a super::column::ColumnData>, // Bound on the first matching row
             op: AggregateOp,
             default_val: Option<Value>, // For ColSource::Default
         }
@@ -4897,19 +4919,14 @@ impl Table for SegmentedTable {
 
         // Accumulate one row into per-volume accumulators from raw columnar data.
         #[inline(always)]
-        fn accumulate_row(
-            accums: &mut [Accum],
-            phys_aggs: &[PhysAgg],
-            columns: &super::writer::LazyColumns,
-            i: usize,
-        ) {
+        fn accumulate_row(accums: &mut [Accum], phys_aggs: &[PhysAgg<'_>], i: usize) {
             for (agg_idx, pa) in phys_aggs.iter().enumerate() {
                 let acc = &mut accums[agg_idx];
                 match pa.op {
                     AggregateOp::CountStar => acc.count += 1,
                     AggregateOp::Count => {
-                        if let Some(pc) = pa.phys_col {
-                            if !columns[pc].is_null(i) {
+                        if let Some(col) = pa.column {
+                            if !col.is_null(i) {
                                 acc.count += 1;
                             }
                         } else if let Some(ref def) = pa.default_val {
@@ -4919,8 +4936,7 @@ impl Table for SegmentedTable {
                         }
                     }
                     AggregateOp::Sum | AggregateOp::Avg => {
-                        if let Some(pc) = pa.phys_col {
-                            let col = &columns[pc];
+                        if let Some(col) = pa.column {
                             if !col.is_null(i) {
                                 match col.data_type() {
                                     DataType::Integer | DataType::Timestamp => {
@@ -4962,8 +4978,7 @@ impl Table for SegmentedTable {
                         }
                     }
                     AggregateOp::Min => {
-                        if let Some(pc) = pa.phys_col {
-                            let col = &columns[pc];
+                        if let Some(col) = pa.column {
                             if !col.is_null(i) {
                                 match col.data_type() {
                                     DataType::Integer | DataType::Timestamp => {
@@ -5008,8 +5023,7 @@ impl Table for SegmentedTable {
                         }
                     }
                     AggregateOp::Max => {
-                        if let Some(pc) = pa.phys_col {
-                            let col = &columns[pc];
+                        if let Some(col) = pa.column {
                             if !col.is_null(i) {
                                 match col.data_type() {
                                     DataType::Integer | DataType::Timestamp => {
@@ -5074,23 +5088,16 @@ impl Table for SegmentedTable {
             })
             .collect();
         let bloom_hashes = Self::precompute_bloom_hashes(&comparisons_for_prune);
-        let volumes: Vec<&(u64, super::manifest::ColdSegment)> = if comparisons_for_prune.is_empty()
-        {
-            volumes.iter().collect()
-        } else {
-            volumes
-                .iter()
-                .filter(|(_, cs)| {
-                    // Only pre-prune identity-mapped volumes (no schema evolution)
-                    if !cs.mapping.is_identity {
-                        return true; // keep — pruned inside closure with mapping
-                    }
-                    let (skip, _, _) =
-                        Self::prune_volume(&cs.volume, &comparisons_for_prune, &bloom_hashes);
-                    !skip
-                })
-                .collect()
-        };
+        let mut selected_volumes = Vec::with_capacity(volumes.len());
+        for entry @ (_, cs) in volumes.iter() {
+            if comparisons_for_prune.is_empty()
+                || !cs.mapping.is_identity
+                || !Self::prune_volume(&cs.volume, &comparisons_for_prune, &bloom_hashes)?.0
+            {
+                selected_volumes.push(entry);
+            }
+        }
+        let volumes = selected_volumes;
 
         // --- Per-volume accumulation closure -----------------------------------
         // Extracted so both sequential and parallel paths share one implementation.
@@ -5102,9 +5109,9 @@ impl Table for SegmentedTable {
         let tombstones_ref = &tombstones_arc;
 
         let process_volume =
-            |(seg_id, cs): &(u64, super::manifest::ColdSegment)| -> Option<Vec<Accum>> {
+            |(seg_id, cs): &(u64, super::manifest::ColdSegment)| -> Result<Option<Vec<Accum>>> {
                 if bail.load(std::sync::atomic::Ordering::Relaxed) {
-                    return None;
+                    return Ok(None);
                 }
                 let vol = &cs.volume;
                 let mapping = self.segment_mgr.get_volume_mapping(*seg_id, &schema);
@@ -5116,7 +5123,7 @@ impl Table for SegmentedTable {
                 for pred in &preds {
                     if pred.schema_col_idx >= mapping.sources.len() {
                         bail.store(true, std::sync::atomic::Ordering::Relaxed);
-                        return None;
+                        return Ok(None);
                     }
                     match &mapping.sources[pred.schema_col_idx] {
                         super::writer::ColSource::Volume(phys_idx) => {
@@ -5136,7 +5143,7 @@ impl Table for SegmentedTable {
                                     }
                                     None => {
                                         bail.store(true, std::sync::atomic::Ordering::Relaxed);
-                                        return None;
+                                        return Ok(None);
                                     }
                                 }
                             } else {
@@ -5182,7 +5189,7 @@ impl Table for SegmentedTable {
                     }
                 }
                 if skip_volume {
-                    return None;
+                    return Ok(None);
                 }
 
                 // Zone-map pruning
@@ -5201,7 +5208,7 @@ impl Table for SegmentedTable {
                             _ => true,
                         };
                         if !can_match {
-                            return None;
+                            return Ok(None);
                         }
                     }
                 }
@@ -5240,11 +5247,11 @@ impl Table for SegmentedTable {
                 };
 
                 // Resolve aggregate physical columns
-                let mut phys_aggs: Vec<PhysAgg> = Vec::with_capacity(agg_count);
+                let mut phys_aggs: Vec<PhysAgg<'_>> = Vec::with_capacity(agg_count);
                 for (op, col_idx) in aggregates {
                     if matches!(op, AggregateOp::CountStar) {
                         phys_aggs.push(PhysAgg {
-                            phys_col: None,
+                            column: None,
                             op: *op,
                             default_val: None,
                         });
@@ -5252,19 +5259,19 @@ impl Table for SegmentedTable {
                     }
                     if *col_idx >= mapping.sources.len() {
                         bail.store(true, std::sync::atomic::Ordering::Relaxed);
-                        return None;
+                        return Ok(None);
                     }
                     match &mapping.sources[*col_idx] {
-                        super::writer::ColSource::Volume(phys_idx) => {
+                        super::writer::ColSource::Volume(_) => {
                             phys_aggs.push(PhysAgg {
-                                phys_col: Some(*phys_idx),
+                                column: None,
                                 op: *op,
                                 default_val: None,
                             });
                         }
                         super::writer::ColSource::Default(val) => {
                             phys_aggs.push(PhysAgg {
-                                phys_col: None,
+                                column: None,
                                 op: *op,
                                 default_val: Some(val.clone()),
                             });
@@ -5274,6 +5281,7 @@ impl Table for SegmentedTable {
 
                 // Inner loop: per-volume accumulators
                 let mut vol_accums = vec![Accum::default(); agg_count];
+                let mut aggregates_bound = false;
                 let mut group_candidates: Vec<usize> = Vec::new();
                 let row_count = vol.meta.row_count;
                 let rg_size = super::column::ROW_GROUP_SIZE;
@@ -5294,13 +5302,13 @@ impl Table for SegmentedTable {
                             .iter()
                             .filter(|pp| matches!(pp.target, TypedTarget::DictEq(_)))
                             .map(|pp| {
-                                (
-                                    &vol.columns[pp.phys_col],
+                                Ok((
+                                    vol.columns.get(pp.phys_col)?,
                                     g_start,
                                     pp.dict_id.unwrap_or(u32::MAX),
-                                )
+                                ))
                             })
-                            .collect();
+                            .collect::<Result<_>>()?;
                     group_candidates.clear();
                     let prefiltered = !dict_preds.is_empty()
                         && super::column::ColumnData::dict_matching_offsets(
@@ -5340,7 +5348,7 @@ impl Table for SegmentedTable {
                             if prefiltered && matches!(pp.target, TypedTarget::DictEq(_)) {
                                 continue;
                             }
-                            let col = &vol.columns[pp.phys_col];
+                            let col = vol.columns.get(pp.phys_col)?;
                             if col.is_null(i) {
                                 all_pass = false;
                                 break;
@@ -5365,11 +5373,25 @@ impl Table for SegmentedTable {
                             continue;
                         }
 
-                        accumulate_row(&mut vol_accums, &phys_aggs, &vol.columns, i);
+                        // Keep lazy I/O outside the accumulation loop. A fully
+                        // pruned volume never needs its aggregate columns.
+                        if !aggregates_bound {
+                            for ((op, col_idx), pa) in aggregates.iter().zip(&mut phys_aggs) {
+                                if !matches!(op, AggregateOp::CountStar) {
+                                    if let super::writer::ColSource::Volume(phys_idx) =
+                                        &mapping.sources[*col_idx]
+                                    {
+                                        pa.column = Some(vol.columns.get(*phys_idx)?);
+                                    }
+                                }
+                            }
+                            aggregates_bound = true;
+                        }
+                        accumulate_row(&mut vol_accums, &phys_aggs, i);
                     }
                 }
 
-                Some(vol_accums)
+                Ok(Some(vol_accums))
             };
 
         // Parallel or sequential volume processing.
@@ -5380,17 +5402,22 @@ impl Table for SegmentedTable {
             use rayon::prelude::*;
             volumes
                 .par_iter()
-                .filter_map(|v| process_volume(v))
-                .collect()
+                .filter_map(|v| process_volume(v).transpose())
+                .collect::<Result<Vec<_>>>()?
         } else {
-            volumes.iter().filter_map(|v| process_volume(v)).collect()
+            volumes
+                .iter()
+                .filter_map(|v| process_volume(v).transpose())
+                .collect::<Result<Vec<_>>>()?
         };
         #[cfg(not(feature = "parallel"))]
-        let volume_accums: Vec<Vec<Accum>> =
-            volumes.iter().filter_map(|v| process_volume(v)).collect();
+        let volume_accums: Vec<Vec<Accum>> = volumes
+            .iter()
+            .filter_map(|v| process_volume(v).transpose())
+            .collect::<Result<Vec<_>>>()?;
 
         if bail.load(std::sync::atomic::Ordering::Relaxed) {
-            return None;
+            return Ok(None);
         }
 
         // Merge per-volume accumulators
@@ -5486,20 +5513,20 @@ impl Table for SegmentedTable {
             })
             .collect();
 
-        Some(results)
+        Ok(Some(results))
     }
 
     fn compute_grouped_aggregates(
         &self,
         group_by_indices: &[usize],
         aggregates: &[(AggregateOp, usize)],
-    ) -> Option<Vec<GroupedAggregateResult>> {
+    ) -> Result<Option<Vec<GroupedAggregateResult>>> {
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         // Multi-column GROUP BY: fall back to the full executor path.
         if group_by_indices.len() != 1 {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         if !self.segment_mgr.has_segments() {
@@ -5510,7 +5537,7 @@ impl Table for SegmentedTable {
 
         // During seal, hot+cold overlap — can't reliably aggregate
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
         let gb_idx = group_by_indices[0];
@@ -5774,7 +5801,7 @@ impl Table for SegmentedTable {
         let mut groups: ValueMap<(Vec<Value>, Vec<Accum>)> = ValueMap::default();
 
         // ---- Process hot rows (small, use Value-based path) ----
-        let hot_rows = self.hot.collect_all_rows(None).ok()?;
+        let hot_rows = self.hot.collect_all_rows(None)?;
         for (_, row) in &hot_rows {
             let key = row
                 .get(gb_idx)
@@ -5788,7 +5815,7 @@ impl Table for SegmentedTable {
         }
 
         // ---- Process cold volumes (columnar fast path) ----
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -5800,7 +5827,7 @@ impl Table for SegmentedTable {
         let gb_data_type = if gb_idx < current_schema.columns.len() {
             current_schema.columns[gb_idx].data_type
         } else {
-            return None;
+            return Ok(None);
         };
 
         // Only support Dictionary (Text), Int64 (Integer), and TimestampNanos (Timestamp).
@@ -5808,7 +5835,7 @@ impl Table for SegmentedTable {
         let gb_is_dict = gb_data_type == DataType::Text;
         let gb_is_i64 = gb_data_type == DataType::Integer || gb_data_type == DataType::Timestamp;
         if !gb_is_dict && !gb_is_i64 {
-            return None;
+            return Ok(None);
         }
 
         // Resolved physical aggregate column for a volume.
@@ -5825,14 +5852,14 @@ impl Table for SegmentedTable {
             phys_aggs: &[PhysAgg],
             vol_columns: &super::writer::LazyColumns,
             i: usize,
-        ) {
+        ) -> Result<()> {
             for (agg_idx, pa) in phys_aggs.iter().enumerate() {
                 let acc = &mut accums[agg_idx];
                 match pa.op {
                     AggregateOp::CountStar => acc.count += 1,
                     AggregateOp::Count => {
                         if let Some(phys_col) = pa.phys_col {
-                            if !vol_columns[phys_col].is_null(i) {
+                            if !vol_columns.get(phys_col)?.is_null(i) {
                                 acc.count += 1;
                             }
                         } else if let Some(ref def) = pa.default_val {
@@ -5843,7 +5870,7 @@ impl Table for SegmentedTable {
                     }
                     AggregateOp::Sum | AggregateOp::Avg => {
                         if let Some(phys_col) = pa.phys_col {
-                            let col = &vol_columns[phys_col];
+                            let col = vol_columns.get(phys_col)?;
                             if !col.is_null(i) {
                                 match col.data_type() {
                                     DataType::Integer | DataType::Timestamp => {
@@ -5886,7 +5913,7 @@ impl Table for SegmentedTable {
                     }
                     AggregateOp::Min => {
                         if let Some(phys_col) = pa.phys_col {
-                            let col = &vol_columns[phys_col];
+                            let col = vol_columns.get(phys_col)?;
                             if !col.is_null(i) {
                                 match col.data_type() {
                                     DataType::Integer | DataType::Timestamp => {
@@ -5942,7 +5969,7 @@ impl Table for SegmentedTable {
                     }
                     AggregateOp::Max => {
                         if let Some(phys_col) = pa.phys_col {
-                            let col = &vol_columns[phys_col];
+                            let col = vol_columns.get(phys_col)?;
                             if !col.is_null(i) {
                                 match col.data_type() {
                                     DataType::Integer | DataType::Timestamp => {
@@ -5998,6 +6025,7 @@ impl Table for SegmentedTable {
                     }
                 }
             }
+            Ok(())
         }
 
         // Per-volume grouped aggregation closure.
@@ -6007,132 +6035,209 @@ impl Table for SegmentedTable {
         let hot_skip_ref = &hot_skip;
         let tombstones_ref = &tombstones_arc;
 
-        let process_volume = |(seg_id, cs): &(u64, super::manifest::ColdSegment)|
-             -> Option<ValueMap<(Vec<Value>, Vec<Accum>)>> {
-            if bail.load(std::sync::atomic::Ordering::Relaxed) { return None; }
-            let vol = &cs.volume;
-            let mapping = self.segment_mgr.get_volume_mapping(*seg_id, current_schema);
-
-            if gb_idx >= mapping.sources.len() {
-                bail.store(true, std::sync::atomic::Ordering::Relaxed);
-                return None;
-            }
-
-            let mut phys_aggs: Vec<PhysAgg> = Vec::with_capacity(agg_count);
-            for (op, col_idx) in aggregates {
-                if matches!(op, AggregateOp::CountStar) {
-                    phys_aggs.push(PhysAgg { phys_col: None, op: *op, default_val: None });
-                    continue;
+        type LocalGroups = ValueMap<(Vec<Value>, Vec<Accum>)>;
+        let process_volume =
+            |(seg_id, cs): &(u64, super::manifest::ColdSegment)| -> Result<Option<LocalGroups>> {
+                if bail.load(std::sync::atomic::Ordering::Relaxed) {
+                    return Ok(None);
                 }
-                if *col_idx >= mapping.sources.len() {
+                let vol = &cs.volume;
+                let mapping = self.segment_mgr.get_volume_mapping(*seg_id, current_schema);
+
+                if gb_idx >= mapping.sources.len() {
                     bail.store(true, std::sync::atomic::Ordering::Relaxed);
-                    return None;
+                    return Ok(None);
                 }
-                match &mapping.sources[*col_idx] {
-                    super::writer::ColSource::Volume(phys_idx) => {
-                        phys_aggs.push(PhysAgg { phys_col: Some(*phys_idx), op: *op, default_val: None });
+
+                let mut phys_aggs: Vec<PhysAgg> = Vec::with_capacity(agg_count);
+                for (op, col_idx) in aggregates {
+                    if matches!(op, AggregateOp::CountStar) {
+                        phys_aggs.push(PhysAgg {
+                            phys_col: None,
+                            op: *op,
+                            default_val: None,
+                        });
+                        continue;
                     }
-                    super::writer::ColSource::Default(val) => {
-                        phys_aggs.push(PhysAgg { phys_col: None, op: *op, default_val: Some(val.clone()) });
+                    if *col_idx >= mapping.sources.len() {
+                        bail.store(true, std::sync::atomic::Ordering::Relaxed);
+                        return Ok(None);
+                    }
+                    match &mapping.sources[*col_idx] {
+                        super::writer::ColSource::Volume(phys_idx) => {
+                            phys_aggs.push(PhysAgg {
+                                phys_col: Some(*phys_idx),
+                                op: *op,
+                                default_val: None,
+                            });
+                        }
+                        super::writer::ColSource::Default(val) => {
+                            phys_aggs.push(PhysAgg {
+                                phys_col: None,
+                                op: *op,
+                                default_val: Some(val.clone()),
+                            });
+                        }
                     }
                 }
-            }
 
-            let mut local_groups: ValueMap<(Vec<Value>, Vec<Accum>)> = ValueMap::default();
+                let mut local_groups: ValueMap<(Vec<Value>, Vec<Accum>)> = ValueMap::default();
 
-            match &mapping.sources[gb_idx] {
-                super::writer::ColSource::Volume(gb_phys_idx) => {
-                    let gb_phys = *gb_phys_idx;
-                    let gb_col = &vol.columns[gb_phys];
+                match &mapping.sources[gb_idx] {
+                    super::writer::ColSource::Volume(gb_phys_idx) => {
+                        let gb_phys = *gb_phys_idx;
+                        let gb_col = vol.columns.get(gb_phys)?;
 
-                    if gb_is_dict {
-                        if let super::column::ColumnData::Dictionary { ids: dict_ids, dictionary, nulls: gb_nulls } = gb_col {
-                            let dict_len = dictionary.len();
-                            let num_local = dict_len + 1;
-                            let mut la: Vec<Vec<Accum>> = (0..num_local).map(|_| vec![Accum::default(); agg_count]).collect();
-                            let mut lc = vec![0u32; num_local];
+                        if gb_is_dict {
+                            if let super::column::ColumnData::Dictionary {
+                                ids: dict_ids,
+                                dictionary,
+                                nulls: gb_nulls,
+                            } = gb_col
+                            {
+                                let dict_len = dictionary.len();
+                                let num_local = dict_len + 1;
+                                let mut la: Vec<Vec<Accum>> = (0..num_local)
+                                    .map(|_| vec![Accum::default(); agg_count])
+                                    .collect();
+                                let mut lc = vec![0u32; num_local];
 
-                            for i in 0..vol.meta.row_count {
-                                if !cs.is_visible(i) { continue; }
-                                let rid = vol.meta.row_ids[i];
-                                if self.is_row_tombstoned(tombstones_ref, rid) || hot_skip_ref.contains(&rid) { continue; }
-                                let g = if gb_nulls[i] { dict_len } else { dict_ids[i] as usize };
-                                lc[g] += 1;
-                                accumulate_columnar(&mut la[g], &phys_aggs, &vol.columns, i);
-                            }
+                                for i in 0..vol.meta.row_count {
+                                    if !cs.is_visible(i) {
+                                        continue;
+                                    }
+                                    let rid = vol.meta.row_ids[i];
+                                    if self.is_row_tombstoned(tombstones_ref, rid)
+                                        || hot_skip_ref.contains(&rid)
+                                    {
+                                        continue;
+                                    }
+                                    let g = if gb_nulls[i] {
+                                        dict_len
+                                    } else {
+                                        dict_ids[i] as usize
+                                    };
+                                    lc[g] += 1;
+                                    accumulate_columnar(&mut la[g], &phys_aggs, &vol.columns, i)?;
+                                }
 
-                            for gid in 0..num_local {
-                                if lc[gid] == 0 { continue; }
-                                let key = if gid == dict_len { Value::Null(DataType::Text) } else { Value::Text(dictionary[gid].clone()) };
-                                let entry = local_groups.entry(key.clone()).or_insert_with(|| (vec![key], vec![Accum::default(); agg_count]));
-                                for (ai, la_acc) in la[gid].iter().enumerate() { merge_accum(&mut entry.1[ai], la_acc); }
+                                for gid in 0..num_local {
+                                    if lc[gid] == 0 {
+                                        continue;
+                                    }
+                                    let key = if gid == dict_len {
+                                        Value::Null(DataType::Text)
+                                    } else {
+                                        Value::Text(dictionary[gid].clone())
+                                    };
+                                    let entry =
+                                        local_groups.entry(key.clone()).or_insert_with(|| {
+                                            (vec![key], vec![Accum::default(); agg_count])
+                                        });
+                                    for (ai, la_acc) in la[gid].iter().enumerate() {
+                                        merge_accum(&mut entry.1[ai], la_acc);
+                                    }
+                                }
+                            } else {
+                                bail.store(true, std::sync::atomic::Ordering::Relaxed);
+                                return Ok(None);
                             }
                         } else {
-                            bail.store(true, std::sync::atomic::Ordering::Relaxed);
-                            return None;
-                        }
-                    } else {
-                        let mut key_to_group: FxHashMap<i64, usize> = FxHashMap::default();
-                        let mut la: Vec<Vec<Accum>> = Vec::new();
-                        let mut null_acc: Vec<Accum> = vec![Accum::default(); agg_count];
-                        let mut null_cnt: u32 = 0;
+                            let mut key_to_group: FxHashMap<i64, usize> = FxHashMap::default();
+                            let mut la: Vec<Vec<Accum>> = Vec::new();
+                            let mut null_acc: Vec<Accum> = vec![Accum::default(); agg_count];
+                            let mut null_cnt: u32 = 0;
 
-                        for i in 0..vol.meta.row_count {
-                            if !cs.is_visible(i) { continue; }
-                            let rid = vol.meta.row_ids[i];
-                            if self.is_row_tombstoned(tombstones_ref, rid) || hot_skip_ref.contains(&rid) { continue; }
-                            if gb_col.is_null(i) {
-                                null_cnt += 1;
-                                accumulate_columnar(&mut null_acc, &phys_aggs, &vol.columns, i);
-                            } else {
-                                let raw_key = gb_col.get_i64(i);
-                                let next_id = la.len();
-                                let gid = *key_to_group.entry(raw_key).or_insert_with(|| { la.push(vec![Accum::default(); agg_count]); next_id });
-                                accumulate_columnar(&mut la[gid], &phys_aggs, &vol.columns, i);
+                            for i in 0..vol.meta.row_count {
+                                if !cs.is_visible(i) {
+                                    continue;
+                                }
+                                let rid = vol.meta.row_ids[i];
+                                if self.is_row_tombstoned(tombstones_ref, rid)
+                                    || hot_skip_ref.contains(&rid)
+                                {
+                                    continue;
+                                }
+                                if gb_col.is_null(i) {
+                                    null_cnt += 1;
+                                    accumulate_columnar(
+                                        &mut null_acc,
+                                        &phys_aggs,
+                                        &vol.columns,
+                                        i,
+                                    )?;
+                                } else {
+                                    let raw_key = gb_col.get_i64(i);
+                                    let next_id = la.len();
+                                    let gid = *key_to_group.entry(raw_key).or_insert_with(|| {
+                                        la.push(vec![Accum::default(); agg_count]);
+                                        next_id
+                                    });
+                                    accumulate_columnar(&mut la[gid], &phys_aggs, &vol.columns, i)?;
+                                }
+                            }
+
+                            if null_cnt > 0 {
+                                let nk = Value::Null(gb_data_type);
+                                let entry = local_groups.entry(nk.clone()).or_insert_with(|| {
+                                    (vec![nk], vec![Accum::default(); agg_count])
+                                });
+                                for (ai, a) in null_acc.iter().enumerate() {
+                                    merge_accum(&mut entry.1[ai], a);
+                                }
+                            }
+                            for (raw_key, gid) in &key_to_group {
+                                let key = if gb_data_type == DataType::Timestamp {
+                                    let secs = raw_key.div_euclid(1_000_000_000);
+                                    let sub = raw_key.rem_euclid(1_000_000_000) as u32;
+                                    match chrono::TimeZone::timestamp_opt(&chrono::Utc, secs, sub) {
+                                        chrono::LocalResult::Single(dt) => Value::Timestamp(dt),
+                                        _ => Value::Null(DataType::Timestamp),
+                                    }
+                                } else {
+                                    Value::Integer(*raw_key)
+                                };
+                                let entry = local_groups.entry(key.clone()).or_insert_with(|| {
+                                    (vec![key], vec![Accum::default(); agg_count])
+                                });
+                                for (ai, a) in la[*gid].iter().enumerate() {
+                                    merge_accum(&mut entry.1[ai], a);
+                                }
                             }
                         }
-
-                        if null_cnt > 0 {
-                            let nk = Value::Null(gb_data_type);
-                            let entry = local_groups.entry(nk.clone()).or_insert_with(|| (vec![nk], vec![Accum::default(); agg_count]));
-                            for (ai, a) in null_acc.iter().enumerate() { merge_accum(&mut entry.1[ai], a); }
+                    }
+                    super::writer::ColSource::Default(default_val) => {
+                        let mut la = vec![Accum::default(); agg_count];
+                        let mut visible = 0usize;
+                        for i in 0..vol.meta.row_count {
+                            if !cs.is_visible(i) {
+                                continue;
+                            }
+                            let rid = vol.meta.row_ids[i];
+                            if self.is_row_tombstoned(tombstones_ref, rid)
+                                || hot_skip_ref.contains(&rid)
+                            {
+                                continue;
+                            }
+                            visible += 1;
+                            accumulate_columnar(&mut la, &phys_aggs, &vol.columns, i)?;
                         }
-                        for (raw_key, gid) in &key_to_group {
-                            let key = if gb_data_type == DataType::Timestamp {
-                                let secs = raw_key.div_euclid(1_000_000_000);
-                                let sub = raw_key.rem_euclid(1_000_000_000) as u32;
-                                match chrono::TimeZone::timestamp_opt(&chrono::Utc, secs, sub) {
-                                    chrono::LocalResult::Single(dt) => Value::Timestamp(dt),
-                                    _ => Value::Null(DataType::Timestamp),
+                        if visible > 0 {
+                            let key = default_val.clone();
+                            local_groups
+                                .entry(key.clone())
+                                .or_insert_with(|| (vec![key], vec![Accum::default(); agg_count]));
+                            if let Some(entry) = local_groups.get_mut(default_val) {
+                                for (ai, a) in la.iter().enumerate() {
+                                    merge_accum(&mut entry.1[ai], a);
                                 }
-                            } else { Value::Integer(*raw_key) };
-                            let entry = local_groups.entry(key.clone()).or_insert_with(|| (vec![key], vec![Accum::default(); agg_count]));
-                            for (ai, a) in la[*gid].iter().enumerate() { merge_accum(&mut entry.1[ai], a); }
+                            }
                         }
                     }
                 }
-                super::writer::ColSource::Default(default_val) => {
-                    let mut la = vec![Accum::default(); agg_count];
-                    let mut visible = 0usize;
-                    for i in 0..vol.meta.row_count {
-                        if !cs.is_visible(i) { continue; }
-                        let rid = vol.meta.row_ids[i];
-                        if self.is_row_tombstoned(tombstones_ref, rid) || hot_skip_ref.contains(&rid) { continue; }
-                        visible += 1;
-                        accumulate_columnar(&mut la, &phys_aggs, &vol.columns, i);
-                    }
-                    if visible > 0 {
-                        let key = default_val.clone();
-                        local_groups.entry(key.clone()).or_insert_with(|| (vec![key], vec![Accum::default(); agg_count]));
-                        if let Some(entry) = local_groups.get_mut(default_val) {
-                            for (ai, a) in la.iter().enumerate() { merge_accum(&mut entry.1[ai], a); }
-                        }
-                    }
-                }
-            }
 
-            Some(local_groups)
-        };
+                Ok(Some(local_groups))
+            };
 
         // Sequential: merge each volume's groups immediately (O(1) extra maps).
         // Parallel: collect per-volume maps then merge (O(volumes) extra maps).
@@ -6146,10 +6251,12 @@ impl Table for SegmentedTable {
             #[cfg(feature = "parallel")]
             {
                 use rayon::prelude::*;
-                let vol_group_maps: Vec<ValueMap<(Vec<Value>, Vec<Accum>)>> =
-                    volumes.par_iter().filter_map(&process_volume).collect();
+                let vol_group_maps: Vec<ValueMap<(Vec<Value>, Vec<Accum>)>> = volumes
+                    .par_iter()
+                    .filter_map(|v| process_volume(v).transpose())
+                    .collect::<Result<Vec<_>>>()?;
                 if bail.load(std::sync::atomic::Ordering::Relaxed) {
-                    return None;
+                    return Ok(None);
                 }
                 for vol_map in vol_group_maps {
                     for (key, (group_values, vol_accums)) in vol_map {
@@ -6165,9 +6272,9 @@ impl Table for SegmentedTable {
         } else {
             for v in volumes.iter() {
                 if bail.load(std::sync::atomic::Ordering::Relaxed) {
-                    return None;
+                    return Ok(None);
                 }
-                if let Some(vol_map) = process_volume(v) {
+                if let Some(vol_map) = process_volume(v)? {
                     for (key, (group_values, vol_accums)) in vol_map {
                         let entry = groups
                             .entry(key)
@@ -6181,7 +6288,7 @@ impl Table for SegmentedTable {
         }
 
         if bail.load(std::sync::atomic::Ordering::Relaxed) {
-            return None;
+            return Ok(None);
         }
 
         // Convert to results
@@ -6194,7 +6301,7 @@ impl Table for SegmentedTable {
             })
             .collect();
 
-        Some(results)
+        Ok(Some(results))
     }
 }
 
@@ -6392,13 +6499,13 @@ mod tests {
         ) -> Result<Box<dyn QueryResult>> {
             Err(crate::core::Error::internal("not implemented"))
         }
-        fn row_count(&self) -> usize {
-            self.rows.len()
+        fn row_count(&self) -> Result<usize> {
+            Ok(self.rows.len())
         }
-        fn fast_row_count(&self) -> Option<usize> {
-            Some(self.rows.len())
+        fn fast_row_count(&self) -> Result<Option<usize>> {
+            Ok(Some(self.rows.len()))
         }
-        fn max_column(&self, col_idx: usize) -> Option<Option<Value>> {
+        fn max_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
             let mut max: Option<Value> = None;
             for (_, row) in &self.rows {
                 if let Some(val) = row.get(col_idx) {
@@ -6414,9 +6521,9 @@ mod tests {
                     }
                 }
             }
-            Some(max)
+            Ok(Some(max))
         }
-        fn sum_column(&self, col_idx: usize) -> Option<(f64, usize)> {
+        fn sum_column(&self, col_idx: usize) -> Result<Option<(f64, usize)>> {
             let mut sum = 0.0;
             let mut count = 0;
             for (_, row) in &self.rows {
@@ -6432,7 +6539,7 @@ mod tests {
                     _ => {}
                 }
             }
-            Some((sum, count))
+            Ok(Some((sum, count)))
         }
     }
 
@@ -6461,7 +6568,7 @@ mod tests {
         );
         let table = SegmentedTable::hot_only(Box::new(hot));
 
-        assert_eq!(table.row_count(), 2);
+        assert_eq!(table.row_count().unwrap(), 2);
         assert_eq!(table.segment_count(), 0);
     }
 
@@ -6501,8 +6608,8 @@ mod tests {
 
         let table = SegmentedTable::new(Box::new(hot), mgr);
 
-        assert_eq!(table.row_count(), 5); // 3 segment + 2 hot
-        assert_eq!(table.fast_row_count(), Some(5));
+        assert_eq!(table.row_count().unwrap(), 5); // 3 segment + 2 hot
+        assert_eq!(table.fast_row_count().unwrap(), Some(5));
     }
 
     #[test]
@@ -6561,7 +6668,7 @@ mod tests {
 
         let table = SegmentedTable::new(Box::new(hot), mgr);
 
-        let max = table.max_column(1);
+        let max = table.max_column(1).unwrap();
         assert_eq!(max, Some(Some(Value::Float(500.0))));
     }
 
@@ -6591,7 +6698,7 @@ mod tests {
 
         let table = SegmentedTable::new(Box::new(hot), mgr);
 
-        let (sum, count) = table.sum_column(1).unwrap();
+        let (sum, count) = table.sum_column(1).unwrap().unwrap();
         assert_eq!(sum, 530.0);
         assert_eq!(count, 3);
     }
@@ -6643,7 +6750,7 @@ mod tests {
         let hot = MockHotTable::new(schema.clone(), vec![]);
 
         let mut table = SegmentedTable::hot_only(Box::new(hot));
-        assert_eq!(table.row_count(), 0);
+        assert_eq!(table.row_count().unwrap(), 0);
 
         table
             .insert(Row::from_values(vec![
@@ -6651,7 +6758,7 @@ mod tests {
                 Value::Float(10.0),
             ]))
             .unwrap();
-        assert_eq!(table.row_count(), 1);
+        assert_eq!(table.row_count().unwrap(), 1);
     }
 
     #[test]
@@ -6690,8 +6797,181 @@ mod tests {
         table.commit().unwrap();
         assert_eq!(mgr.total_row_count(), 2);
         assert!(mgr.is_tombstoned(2));
-        assert!(mgr.row_exists(1));
-        assert!(mgr.row_exists(3));
-        assert!(!mgr.row_exists(2));
+        assert!(mgr.row_exists(1).unwrap());
+        assert!(mgr.row_exists(3).unwrap());
+        assert!(!mgr.row_exists(2).unwrap());
+    }
+
+    #[test]
+    #[cfg(feature = "test-failpoints")]
+    fn filtered_aggregate_rejects_error_after_a_complete_volume() {
+        use crate::storage::expression::ComparisonExpr;
+        use crate::test_failpoints::{check_cold_read, fail_cold_read_on, FailpointGuard};
+
+        let _guard = FailpointGuard::new();
+        let schema = SchemaBuilder::new("test")
+            .column("id", DataType::Integer, false, true)
+            .column("category", DataType::Text, false, false)
+            .column("amount", DataType::Integer, false, false)
+            .build();
+        let first = Row::from_values(vec![
+            Value::Integer(1),
+            Value::text("a"),
+            Value::Integer(10),
+        ]);
+        let mgr = make_segment_mgr(&schema, &[(1, first)]);
+        let table = SegmentedTable::new(
+            Box::new(MockHotTable::new(schema.clone(), Vec::new())),
+            Arc::clone(&mgr),
+        );
+        let filter = ComparisonExpr::new("category", crate::core::Operator::Eq, Value::text("a"));
+        let aggregates = [(AggregateOp::Sum, 2)];
+
+        // Measure this fixture's boundaries: dictionary filter and then SUM
+        // binding. The third read stays armed after a whole volume completes.
+        fail_cold_read_on(3);
+        assert_eq!(
+            table
+                .compute_filtered_aggregates(&aggregates, &filter)
+                .unwrap()
+                .unwrap(),
+            vec![Value::Integer(10)]
+        );
+        assert!(check_cold_read().is_err());
+        fail_cold_read_on(0);
+
+        let mut builder = VolumeBuilder::with_capacity(&schema, 1);
+        builder.add_row(
+            2,
+            &Row::from_values(vec![
+                Value::Integer(2),
+                Value::text("a"),
+                Value::Integer(20),
+            ]),
+        );
+        mgr.register_segment(
+            2,
+            Arc::new(builder.finish()),
+            SegmentMeta {
+                segment_id: 2,
+                file_path: PathBuf::from("second.vol"),
+                row_count: 1,
+                min_row_id: 2,
+                max_row_id: 2,
+                schema_version: 0,
+                creation_lsn: 0,
+                seal_seq: 0,
+            },
+            None,
+        );
+        assert_eq!(table.segment_count(), 2);
+
+        // Two volumes use sequential dispatch. Read four binds SUM in the
+        // second volume, after the first has produced its accumulator.
+        fail_cold_read_on(4);
+        let error = table
+            .compute_filtered_aggregates(&aggregates, &filter)
+            .unwrap_err();
+        assert!(error.to_string().contains("injected cold read failure"));
+        fail_cold_read_on(0);
+        assert_eq!(
+            table
+                .compute_filtered_aggregates(&aggregates, &filter)
+                .unwrap()
+                .unwrap(),
+            vec![Value::Integer(30)]
+        );
+    }
+
+    #[test]
+    #[cfg(all(feature = "parallel", feature = "test-failpoints"))]
+    fn parallel_cold_reads_propagate_worker_errors() {
+        use crate::storage::expression::ComparisonExpr;
+        use crate::test_failpoints::{fail_cold_read_on, FailpointGuard};
+
+        let _guard = FailpointGuard::new();
+        let schema = SchemaBuilder::new("test")
+            .column("id", DataType::Integer, false, true)
+            .column("category", DataType::Integer, false, false)
+            .column("amount", DataType::Integer, false, false)
+            .build();
+        let mgr = Arc::new(SegmentManager::new("test", None));
+        // Four 25K volumes meet all three parallel dispatch thresholds. Build
+        // the immutable inputs directly so checkpoint compaction cannot merge them.
+        for segment in 0..4u64 {
+            let mut builder = VolumeBuilder::with_capacity(&schema, 25_000);
+            let first = segment as i64 * 25_000 + 1;
+            for row_id in first..first + 25_000 {
+                builder.add_row(
+                    row_id,
+                    &Row::from_values(vec![
+                        Value::Integer(row_id),
+                        Value::Integer(row_id % 7),
+                        Value::Integer(row_id),
+                    ]),
+                );
+            }
+            mgr.register_segment(
+                segment + 1,
+                Arc::new(builder.finish()),
+                SegmentMeta {
+                    segment_id: segment + 1,
+                    file_path: PathBuf::from(format!("parallel-{segment}.vol")),
+                    row_count: 25_000,
+                    min_row_id: first,
+                    max_row_id: first + 24_999,
+                    schema_version: 0,
+                    creation_lsn: 0,
+                    seal_seq: 0,
+                },
+                None,
+            );
+        }
+        let table = SegmentedTable::new(Box::new(MockHotTable::new(schema, Vec::new())), mgr);
+        assert_eq!(table.segment_count(), 4);
+        assert_eq!(table.row_count().unwrap(), 100_000);
+        let filter = ComparisonExpr::new("category", crate::core::Operator::Gte, Value::Integer(0));
+        let aggregates = [(AggregateOp::Sum, 2)];
+
+        fn assert_read_error<T>(result: Result<T>) {
+            match result {
+                Err(error) => assert!(error.to_string().contains("injected cold read failure")),
+                Ok(_) => panic!("parallel worker read failure returned partial success"),
+            }
+        }
+
+        // Fail after input metadata preparation, while workers have begun rows.
+        fail_cold_read_on(64);
+        assert_read_error(table.collect_all_rows(None));
+        fail_cold_read_on(0);
+        assert_eq!(table.collect_all_rows(None).unwrap().len(), 100_000);
+
+        fail_cold_read_on(64);
+        assert_read_error(table.compute_filtered_aggregates(&aggregates, &filter));
+        fail_cold_read_on(0);
+        assert_eq!(
+            table
+                .compute_filtered_aggregates(&aggregates, &filter)
+                .unwrap()
+                .unwrap(),
+            vec![Value::Integer(5_000_050_000)]
+        );
+
+        fail_cold_read_on(64);
+        assert_read_error(table.compute_grouped_aggregates(&[1], &aggregates));
+        fail_cold_read_on(0);
+        let groups = table
+            .compute_grouped_aggregates(&[1], &aggregates)
+            .unwrap()
+            .unwrap();
+        assert_eq!(groups.len(), 7);
+        let total: i64 = groups
+            .iter()
+            .map(|group| match group.aggregate_values[0] {
+                Value::Integer(value) => value,
+                ref value => panic!("expected integer SUM, received {value:?}"),
+            })
+            .sum();
+        assert_eq!(total, 5_000_050_000);
     }
 }

--- a/src/storage/volume/writer.rs
+++ b/src/storage/volume/writer.rs
@@ -19,6 +19,7 @@
 //! pre-computed aggregate stats. This is done by a background thread during
 //! the seal operation.
 
+use std::io;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
@@ -39,6 +40,22 @@ use super::format::{
     COL_DICTIONARY,
 };
 use super::stats::VolumeAggregateStats;
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+#[derive(Debug)]
+struct ColumnReadError {
+    kind: io::ErrorKind,
+    message: String,
+}
+impl From<io::Error> for ColumnReadError {
+    fn from(e: io::Error) -> Self {
+        Self {
+            kind: e.kind(),
+            message: e.to_string(),
+        }
+    }
+}
 
 // =============================================================================
 // CompressedBlockStore: per-column per-row-group LZ4 blocks in RAM
@@ -92,10 +109,14 @@ impl CompressedBlockStore {
         col_idx: usize,
         group_idx: usize,
     ) -> std::io::Result<Arc<ColumnData>> {
-        super::group_cache::DECODED_GROUPS
-            .get_or_decode((self.id, col_idx as u32, group_idx as u32), || {
-                self.decompress_single_group(col_idx, group_idx)
-            })
+        #[cfg(any(test, feature = "test-failpoints"))]
+        crate::test_failpoints::check_cold_read()?;
+        let col_key = u32::try_from(col_idx).map_err(|_| invalid_data("column index overflow"))?;
+        let group_key =
+            u32::try_from(group_idx).map_err(|_| invalid_data("group index overflow"))?;
+        super::group_cache::DECODED_GROUPS.get_or_decode((self.id, col_key, group_key), || {
+            self.decompress_single_group(col_idx, group_idx)
+        })
     }
 
     /// Compress existing columns into per-group LZ4 blocks.
@@ -104,7 +125,7 @@ impl CompressedBlockStore {
         columns: &LazyColumns,
         col_data_types: &[DataType],
         row_count: usize,
-    ) -> Self {
+    ) -> io::Result<Self> {
         Self::compress_columns_opts(columns, col_data_types, row_count, true)
     }
 
@@ -116,7 +137,7 @@ impl CompressedBlockStore {
         col_data_types: &[DataType],
         row_count: usize,
         compress: bool,
-    ) -> Self {
+    ) -> io::Result<Self> {
         let group_size = ROW_GROUP_SIZE;
         let col_count = columns.len();
         let num_groups = if row_count == 0 {
@@ -133,7 +154,7 @@ impl CompressedBlockStore {
         let mut col_ext_types = Vec::with_capacity(col_count);
 
         for col_idx in 0..col_count {
-            let col = &columns[col_idx];
+            let col = columns.get(col_idx)?;
             let type_tag = match col {
                 ColumnData::Int64 { .. } => super::format::COL_INT64,
                 ColumnData::Float64 { .. } => super::format::COL_FLOAT64,
@@ -155,7 +176,10 @@ impl CompressedBlockStore {
         }
 
         // Phase 2: Serialize column blocks (optionally LZ4-compressed).
-        let compress_blocks = |col: &ColumnData| -> (Vec<Vec<u8>>, Vec<usize>) {
+        let compress_blocks = |col: &ColumnData| -> io::Result<(Vec<Vec<u8>>, Vec<usize>)> {
+            if col.len() != row_count {
+                return Err(invalid_data("column row count mismatch"));
+            }
             let mut col_blocks = Vec::with_capacity(num_groups);
             let mut col_decomp_lens = Vec::with_capacity(num_groups);
             let mut start = 0;
@@ -175,7 +199,7 @@ impl CompressedBlockStore {
                 }
                 start = end;
             }
-            (col_blocks, col_decomp_lens)
+            Ok((col_blocks, col_decomp_lens))
         };
 
         #[cfg(feature = "parallel")]
@@ -183,8 +207,8 @@ impl CompressedBlockStore {
             use rayon::prelude::*;
             let results: Vec<(Vec<Vec<u8>>, Vec<usize>)> = (0..col_count)
                 .into_par_iter()
-                .map(|col_idx| compress_blocks(&columns[col_idx]))
-                .collect();
+                .map(|col_idx| compress_blocks(columns.get(col_idx)?))
+                .collect::<io::Result<_>>()?;
             let mut all_blocks = Vec::with_capacity(col_count);
             let mut all_decomp_lens = Vec::with_capacity(col_count);
             for (blocks, lens) in results {
@@ -199,7 +223,7 @@ impl CompressedBlockStore {
             let mut all_blocks = Vec::with_capacity(col_count);
             let mut all_decomp_lens = Vec::with_capacity(col_count);
             for col_idx in 0..col_count {
-                let (blocks, lens) = compress_blocks(&columns[col_idx]);
+                let (blocks, lens) = compress_blocks(columns.get(col_idx)?)?;
                 all_blocks.push(blocks);
                 all_decomp_lens.push(lens);
             }
@@ -210,7 +234,7 @@ impl CompressedBlockStore {
             .iter()
             .map(|(ci, start, end)| (*ci, Arc::from(&shared_dict[*start..*end])))
             .collect();
-        Self {
+        Ok(Self {
             blocks: all_blocks,
             decompressed_lens: all_decomp_lens,
             col_type_tags,
@@ -220,7 +244,7 @@ impl CompressedBlockStore {
             group_size,
             row_count,
             id: next_store_id(),
-        }
+        })
     }
 
     /// Build a CompressedBlockStore from pre-compressed blocks (V4 file read).
@@ -236,13 +260,62 @@ impl CompressedBlockStore {
         dict_ranges: Vec<(usize, usize, usize)>,
         group_size: usize,
         row_count: usize,
-    ) -> Self {
+    ) -> io::Result<Self> {
+        let col_count = blocks.len();
+        if group_size == 0
+            || col_type_tags.len() != col_count
+            || col_data_types.len() != col_count
+            || col_ext_types.len() != col_count
+            || decompressed_lens.len() != col_count
+        {
+            return Err(invalid_data("inconsistent block store column metadata"));
+        }
+        let groups = row_count.div_ceil(group_size);
+        for ci in 0..col_count {
+            if blocks[ci].len() != groups || decompressed_lens[ci].len() != groups {
+                return Err(invalid_data("inconsistent block store group count"));
+            }
+            if !(super::format::COL_INT64..=COL_BYTES).contains(&col_type_tags[ci]) {
+                return Err(invalid_data("unknown column type tag"));
+            }
+            if col_type_tags[ci] == COL_BYTES && DataType::from_u8(col_ext_types[ci]).is_none() {
+                return Err(invalid_data("invalid bytes extension type"));
+            }
+            for (gi, (block, &decoded)) in blocks[ci].iter().zip(&decompressed_lens[ci]).enumerate()
+            {
+                let rows = (row_count - gi * group_size).min(group_size);
+                let width = match col_type_tags[ci] {
+                    super::format::COL_INT64
+                    | super::format::COL_FLOAT64
+                    | super::format::COL_TIMESTAMP => Some(9usize),
+                    super::format::COL_BOOLEAN => Some(2),
+                    COL_DICTIONARY => Some(5),
+                    _ => None,
+                };
+                if block.is_empty()
+                    || decoded == 0
+                    || decoded > block.len().saturating_mul(255).saturating_add(16)
+                    || width.is_some_and(|w| rows.checked_mul(w) != Some(decoded))
+                {
+                    return Err(invalid_data("invalid block length"));
+                }
+            }
+        }
+        for &(ci, start, end) in &dict_ranges {
+            if ci >= col_count
+                || col_type_tags[ci] != COL_DICTIONARY
+                || start > end
+                || end > shared_dict.len()
+            {
+                return Err(invalid_data("invalid dictionary range"));
+            }
+        }
         let col_dicts: Vec<(usize, Arc<[SmartString]>)> = dict_ranges
             .iter()
             .map(|(ci, start, end)| (*ci, Arc::from(&shared_dict[*start..*end])))
             .collect();
         // shared_dict and dict_ranges are consumed — only col_dicts kept
-        Self {
+        Ok(Self {
             blocks,
             decompressed_lens,
             col_type_tags,
@@ -252,13 +325,16 @@ impl CompressedBlockStore {
             group_size,
             row_count,
             id: next_store_id(),
-        }
+        })
     }
 
     /// Decompress a single column from RAM. Concatenates all row-group blocks.
     /// Runs at ~4 GB/s (LZ4 from RAM), typically <1ms per column.
-    pub fn decompress_column(&self, col_idx: usize) -> ColumnData {
-        let col_blocks = &self.blocks[col_idx];
+    pub fn decompress_column(&self, col_idx: usize) -> io::Result<ColumnData> {
+        let col_blocks = self
+            .blocks
+            .get(col_idx)
+            .ok_or_else(|| invalid_data("column index out of bounds"))?;
         let type_tag = self.col_type_tags[col_idx];
         let ext_type = DataType::from_u8(self.col_ext_types[col_idx]).unwrap_or(DataType::Null);
 
@@ -273,39 +349,7 @@ impl CompressedBlockStore {
         };
 
         if col_blocks.len() == 1 {
-            let decomp_len = self.decompressed_lens[col_idx][0];
-            let group_rows = self.row_count.min(self.group_size);
-            if col_blocks[0].len() == decomp_len {
-                return deserialize_column_block(
-                    &col_blocks[0],
-                    type_tag,
-                    group_rows,
-                    dict,
-                    ext_type,
-                )
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "corrupt V4 block: col={}, raw, {} rows: {}",
-                        col_idx, group_rows, e
-                    )
-                });
-            }
-            let mut raw = vec![0u8; decomp_len];
-            lz4_flex::decompress_into(&col_blocks[0], &mut raw).unwrap_or_else(|e| {
-                panic!(
-                    "corrupt V4 block: col={}, {} bytes: {}",
-                    col_idx,
-                    col_blocks[0].len(),
-                    e
-                )
-            });
-            return deserialize_column_block(&raw, type_tag, group_rows, dict, ext_type)
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "corrupt V4 block: col={}, {} rows: {}",
-                        col_idx, group_rows, e
-                    )
-                });
+            return self.decompress_single_group(col_idx, 0);
         }
 
         // Multiple groups — decompress each block directly into pre-allocated
@@ -318,7 +362,7 @@ impl CompressedBlockStore {
             .unwrap_or(0);
         let mut lz4_buf = Vec::with_capacity(max_decomp);
         let num_groups = col_blocks.len();
-        match type_tag {
+        let column = match type_tag {
             super::format::COL_INT64 => {
                 let mut all_values = Vec::with_capacity(self.row_count);
                 let mut all_nulls = Vec::with_capacity(self.row_count);
@@ -337,8 +381,7 @@ impl CompressedBlockStore {
                         None,
                         None,
                         None,
-                    )
-                    .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}, group={gi}: {e}"));
+                    )?;
                 }
                 ColumnData::Int64 {
                     values: all_values,
@@ -363,8 +406,7 @@ impl CompressedBlockStore {
                         None,
                         None,
                         None,
-                    )
-                    .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}, group={gi}: {e}"));
+                    )?;
                 }
                 ColumnData::Float64 {
                     values: all_values,
@@ -389,8 +431,7 @@ impl CompressedBlockStore {
                         None,
                         None,
                         None,
-                    )
-                    .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}, group={gi}: {e}"));
+                    )?;
                 }
                 ColumnData::TimestampNanos {
                     values: all_values,
@@ -415,8 +456,7 @@ impl CompressedBlockStore {
                         Some(&mut all_values),
                         None,
                         None,
-                    )
-                    .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}, group={gi}: {e}"));
+                    )?;
                 }
                 ColumnData::Boolean {
                     values: all_values,
@@ -441,8 +481,7 @@ impl CompressedBlockStore {
                         None,
                         None,
                         None,
-                    )
-                    .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}, group={gi}: {e}"));
+                    )?;
                 }
                 ColumnData::Dictionary {
                     ids: all_ids,
@@ -469,8 +508,7 @@ impl CompressedBlockStore {
                         None,
                         Some(&mut all_data),
                         Some(&mut all_offsets),
-                    )
-                    .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}, group={gi}: {e}"));
+                    )?;
                 }
                 ColumnData::Bytes {
                     data: all_data,
@@ -479,18 +517,21 @@ impl CompressedBlockStore {
                     nulls: all_nulls,
                 }
             }
-            _ => self
-                .decompress_block(
-                    col_idx,
-                    0,
-                    &col_blocks[0],
-                    type_tag,
-                    num_groups,
-                    dict,
-                    ext_type,
-                )
-                .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}: {e}")),
+            _ => return Err(invalid_data("unknown column type tag")),
+        };
+        if let ColumnData::Dictionary {
+            ids,
+            nulls,
+            dictionary,
+        } = &column
+        {
+            for (id, is_null) in ids.iter().zip(nulls) {
+                if !is_null && (*id as usize) >= dictionary.len() {
+                    return Err(invalid_data("dictionary ID exceeds dictionary length"));
+                }
+            }
         }
+        Ok(column)
     }
 
     /// Decompress and deserialize a single block with context in error messages.
@@ -520,6 +561,9 @@ impl CompressedBlockStore {
                 )
             })?
         };
+        if raw_bytes.len() != decomp_len {
+            return Err(invalid_data("LZ4 decoded length mismatch"));
+        }
         deserialize_column_block(&raw_bytes, type_tag, group_rows, dict, ext_type)
     }
 
@@ -564,15 +608,19 @@ impl CompressedBlockStore {
         if lz4_buf.len() < decomp_len {
             lz4_buf.resize(decomp_len, 0);
         }
-        lz4_flex::decompress_into(block, &mut lz4_buf[..decomp_len]).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "corrupt V4 block: col={}, group={}/{}: {}",
-                    col_idx, gi, num_groups, e
-                ),
-            )
-        })?;
+        let written =
+            lz4_flex::decompress_into(block, &mut lz4_buf[..decomp_len]).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "corrupt V4 block: col={}, group={}/{}: {}",
+                        col_idx, gi, num_groups, e
+                    ),
+                )
+            })?;
+        if written != decomp_len {
+            return Err(invalid_data("LZ4 decoded length mismatch"));
+        }
         deserialize_column_block_into(
             &lz4_buf[..decomp_len],
             type_tag,
@@ -594,7 +642,14 @@ impl CompressedBlockStore {
         col_idx: usize,
         group_idx: usize,
     ) -> std::io::Result<ColumnData> {
-        let num_groups = self.blocks[col_idx].len();
+        let blocks = self
+            .blocks
+            .get(col_idx)
+            .ok_or_else(|| invalid_data("column index out of bounds"))?;
+        let block = blocks
+            .get(group_idx)
+            .ok_or_else(|| invalid_data("group index out of bounds"))?;
+        let num_groups = blocks.len();
         let type_tag = self.col_type_tags[col_idx];
         let ext_type = DataType::from_u8(self.col_ext_types[col_idx]).unwrap_or(DataType::Null);
         let dict: Option<Arc<[SmartString]>> = if type_tag == COL_DICTIONARY {
@@ -606,13 +661,7 @@ impl CompressedBlockStore {
             None
         };
         self.decompress_block(
-            col_idx,
-            group_idx,
-            &self.blocks[col_idx][group_idx],
-            type_tag,
-            num_groups,
-            dict,
-            ext_type,
+            col_idx, group_idx, block, type_tag, num_groups, dict, ext_type,
         )
     }
 
@@ -634,14 +683,13 @@ impl CompressedBlockStore {
     /// Binary search on a sorted column using row-group zone maps.
     /// Decompresses only the group(s) containing the target value.
     /// Returns global row index (same as ColumnData::binary_search_ge/gt),
-    /// or None when a block fails to decode: the caller must then keep the
-    /// range unnarrowed so the scan reaches the block and reports the error.
+    /// or Ok(None) when narrowing is unsupported. Decode failures are errors.
     pub fn binary_search_ge(
         &self,
         col_idx: usize,
         target: i64,
         row_groups: &[super::column::RowGroupMeta],
-    ) -> Option<usize> {
+    ) -> io::Result<Option<usize>> {
         self.binary_search_impl(col_idx, target, row_groups, false)
     }
 
@@ -650,7 +698,7 @@ impl CompressedBlockStore {
         col_idx: usize,
         target: i64,
         row_groups: &[super::column::RowGroupMeta],
-    ) -> Option<usize> {
+    ) -> io::Result<Option<usize>> {
         self.binary_search_impl(col_idx, target, row_groups, true)
     }
 
@@ -660,8 +708,18 @@ impl CompressedBlockStore {
         target: i64,
         row_groups: &[super::column::RowGroupMeta],
         strict: bool,
-    ) -> Option<usize> {
-        let num_groups = self.blocks[col_idx].len();
+    ) -> io::Result<Option<usize>> {
+        let num_groups = self
+            .blocks
+            .get(col_idx)
+            .ok_or_else(|| invalid_data("column index out of bounds"))?
+            .len();
+        if !matches!(
+            self.col_type_tags[col_idx],
+            super::format::COL_INT64 | super::format::COL_TIMESTAMP
+        ) {
+            return Ok(None);
+        }
 
         // Use zone maps to find the group containing the target.
         // When duplicates span group boundaries, continue to the next group
@@ -682,7 +740,7 @@ impl CompressedBlockStore {
                 if target > max_i64 {
                     continue;
                 }
-                let col = self.group_column(col_idx, gi).ok()?;
+                let col = self.group_column(col_idx, gi)?;
                 let group_rows = (rg.end_idx - rg.start_idx) as usize;
                 let local = if strict {
                     col.binary_search_gt(target)
@@ -690,23 +748,23 @@ impl CompressedBlockStore {
                     col.binary_search_ge(target)
                 };
                 if local < group_rows {
-                    return Some(rg.start_idx as usize + local);
+                    return Ok(Some(rg.start_idx as usize + local));
                 }
             }
-            return Some(self.row_count);
+            return Ok(Some(self.row_count));
         }
 
         if num_groups == 1 {
-            let col = self.group_column(col_idx, 0).ok()?;
-            return Some(if strict {
+            let col = self.group_column(col_idx, 0)?;
+            return Ok(Some(if strict {
                 col.binary_search_gt(target)
             } else {
                 col.binary_search_ge(target)
-            });
+            }));
         }
 
         // Fallback: full column (shouldn't happen for V4 with zone maps)
-        Some(self.row_count)
+        Ok(None)
     }
 
     /// Number of groups for a given column.
@@ -792,7 +850,7 @@ impl CompressedBlockStore {
 /// After OnceLock init, subsequent access is a pointer dereference (free).
 pub struct LazyColumns {
     /// Per-column OnceLock slots. Empty until first access.
-    slots: Vec<OnceLock<ColumnData>>,
+    slots: Vec<OnceLock<Result<ColumnData, ColumnReadError>>>,
     /// Compressed backing store. None for eagerly-loaded columns.
     /// Wrapped in Arc so warm-tier volumes can share the store cheaply.
     compressed_store: Option<Arc<CompressedBlockStore>>,
@@ -808,11 +866,11 @@ impl LazyColumns {
     /// Create from pre-loaded columns (VolumeBuilder::finish(), V4 eager load).
     /// All OnceLock slots are pre-initialized. No compressed store.
     pub fn eager(columns: Vec<ColumnData>, col_data_types: Vec<DataType>) -> Self {
-        let slots: Vec<OnceLock<ColumnData>> = columns
+        let slots: Vec<OnceLock<Result<ColumnData, ColumnReadError>>> = columns
             .into_iter()
             .map(|col| {
                 let cell = OnceLock::new();
-                let _ = cell.set(col);
+                let _ = cell.set(Ok(col));
                 cell
             })
             .collect();
@@ -854,7 +912,7 @@ impl LazyColumns {
     }
 
     /// Create columns with only data types (for cold-tier volumes).
-    /// No columns, no compressed store. Column access will panic;
+    /// No columns, no compressed store. Column access returns an error;
     /// the volume must be reloaded from disk before scanning.
     pub fn metadata_only(col_data_types: Vec<DataType>) -> Self {
         let col_count = col_data_types.len();
@@ -907,6 +965,38 @@ impl LazyColumns {
         self.col_data_types[idx]
     }
 
+    /// Fallible column access; eager access borrows the column without allocation.
+    #[inline]
+    pub fn get(&self, idx: usize) -> io::Result<&ColumnData> {
+        #[cfg(any(test, feature = "test-failpoints"))]
+        crate::test_failpoints::check_cold_read()?;
+        let slot = self
+            .slots
+            .get(idx)
+            .ok_or_else(|| invalid_data("column index out of bounds"))?;
+        if let Some(outcome) = slot.get() {
+            return outcome
+                .as_ref()
+                .map_err(|e| io::Error::new(e.kind, e.message.clone()));
+        }
+        let store = self
+            .compressed_store
+            .as_ref()
+            .ok_or_else(|| invalid_data("cold volume has no loaded column source"))?;
+        let outcome =
+            slot.get_or_init(|| store.decompress_column(idx).map_err(ColumnReadError::from));
+        let col = outcome
+            .as_ref()
+            .map_err(|e| io::Error::new(e.kind, e.message.clone()))?;
+        if !self.is_eager.load(std::sync::atomic::Ordering::Relaxed)
+            && self.slots.iter().all(|s| matches!(s.get(), Some(Ok(_))))
+        {
+            self.is_eager
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+        Ok(col)
+    }
+
     /// Iterator over all columns (triggers decompression of unloaded columns).
     pub fn iter(&self) -> LazyColumnsIter<'_> {
         LazyColumnsIter {
@@ -924,7 +1014,7 @@ impl LazyColumns {
         }
         // Loaded (decompressed) columns
         for slot in &self.slots {
-            if let Some(col) = slot.get() {
+            if let Some(Ok(col)) = slot.get() {
                 size += col.memory_size();
             }
         }
@@ -951,7 +1041,12 @@ impl LazyColumns {
     /// Returns None for non-dictionary columns or cold-tier volumes.
     pub fn get_column_dictionary(&self, col_idx: usize) -> Option<Arc<[SmartString]>> {
         // Fast path: column already loaded in OnceLock
-        if let Some(col) = self.slots.get(col_idx).and_then(|s| s.get()) {
+        if let Some(col) = self
+            .slots
+            .get(col_idx)
+            .and_then(|s| s.get())
+            .and_then(|r| r.as_ref().ok())
+        {
             if let ColumnData::Dictionary { dictionary, .. } = col {
                 return Some(Arc::clone(dictionary));
             }
@@ -975,51 +1070,24 @@ impl LazyColumns {
 
     /// Take ownership of all loaded columns, consuming the LazyColumns.
     /// Used by compress_and_release to avoid cloning.
-    pub fn take_columns(self) -> Vec<ColumnData> {
+    pub fn take_columns(self) -> io::Result<Vec<ColumnData>> {
         let mut result = Vec::with_capacity(self.slots.len());
         for slot in self.slots {
             if let Some(col) = slot.into_inner() {
-                result.push(col);
+                result.push(col.map_err(|e| io::Error::new(e.kind, e.message))?);
             }
         }
-        result
+        Ok(result)
     }
 }
 
+#[cfg(test)]
 impl std::ops::Index<usize> for LazyColumns {
     type Output = ColumnData;
 
     #[inline]
     fn index(&self, idx: usize) -> &ColumnData {
-        // Fast path: already initialized
-        if let Some(col) = self.slots[idx].get() {
-            return col;
-        }
-        // Slow path: decompress on first access via get_or_init (runs closure
-        // exactly once per slot, even under concurrent access).
-        let col = self.slots[idx].get_or_init(|| {
-            self.compressed_store
-                .as_ref()
-                .map(|store| store.decompress_column(idx))
-                .unwrap_or_else(|| {
-                    panic!(
-                        "BUG: column {} accessed on cold volume (no compressed store). \
-                         A caller is missing is_cold() check before column access. \
-                         Run with RUST_BACKTRACE=1 to find the caller.",
-                        idx
-                    )
-                })
-        });
-        // Check if all slots are now populated. This is O(C) where C = column
-        // count, but only runs on the slow path (first access per column).
-        // Avoids the loaded_count race where concurrent threads double-increment.
-        if !self.is_eager.load(std::sync::atomic::Ordering::Relaxed)
-            && self.slots.iter().all(|s| s.get().is_some())
-        {
-            self.is_eager
-                .store(true, std::sync::atomic::Ordering::Relaxed);
-        }
-        col
+        self.get(idx).expect("test column access")
     }
 }
 
@@ -1030,11 +1098,11 @@ pub struct LazyColumnsIter<'a> {
 }
 
 impl<'a> Iterator for LazyColumnsIter<'a> {
-    type Item = &'a ColumnData;
+    type Item = io::Result<&'a ColumnData>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.idx < self.columns.len() {
-            let col = &self.columns[self.idx];
+            let col = self.columns.get(self.idx);
             self.idx += 1;
             Some(col)
         } else {
@@ -1051,7 +1119,7 @@ impl<'a> Iterator for LazyColumnsIter<'a> {
 impl ExactSizeIterator for LazyColumnsIter<'_> {}
 
 impl<'a> IntoIterator for &'a LazyColumns {
-    type Item = &'a ColumnData;
+    type Item = io::Result<&'a ColumnData>;
     type IntoIter = LazyColumnsIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -1691,106 +1759,152 @@ pub fn compute_column_mapping_with_drops(
 }
 
 impl FrozenVolume {
-    /// Get a row using a precomputed column mapping.
-    /// Materializes all schema columns through the mapping.
-    pub fn get_row_mapped(&self, idx: usize, mapping: &ColumnMapping) -> Row {
-        let values: Vec<Value> = mapping
+    /// Fallible identity probe, including the absent-row case.
+    #[inline]
+    pub fn find_row_id(&self, row_id: i64) -> crate::core::Result<Option<usize>> {
+        #[cfg(any(test, feature = "test-failpoints"))]
+        crate::test_failpoints::check_cold_read()?;
+        Ok(self.meta.row_ids.binary_search(&row_id).ok())
+    }
+
+    #[inline]
+    pub fn row_id_at(&self, position: usize) -> crate::core::Result<i64> {
+        #[cfg(any(test, feature = "test-failpoints"))]
+        crate::test_failpoints::check_cold_read()?;
+        self.meta
+            .row_ids
+            .get(position)
+            .copied()
+            .ok_or_else(|| invalid_data("row identity position out of bounds").into())
+    }
+
+    #[inline]
+    fn check_row(&self, idx: usize) -> crate::core::Result<()> {
+        if idx >= self.meta.row_count {
+            return Err(invalid_data("row index out of bounds").into());
+        }
+        Ok(())
+    }
+
+    /// Fetch one checked value, propagating a missing or corrupt column source.
+    #[inline]
+    pub fn get_value(&self, col_idx: usize, row_idx: usize) -> crate::core::Result<Value> {
+        self.check_row(row_idx)?;
+        let col = self.columns.get(col_idx)?;
+        if row_idx >= col.len() {
+            return Err(invalid_data("column row count mismatch").into());
+        }
+        Ok(col.get_value(row_idx))
+    }
+
+    pub fn get_row_mapped(&self, idx: usize, mapping: &ColumnMapping) -> crate::core::Result<Row> {
+        self.check_row(idx)?;
+        let values = mapping
             .sources
             .iter()
             .map(|src| match src {
-                ColSource::Volume(vol_idx) => self.columns[*vol_idx].get_value(idx),
-                ColSource::Default(val) => val.clone(),
+                ColSource::Volume(ci) => self.get_value(*ci, idx),
+                ColSource::Default(value) => Ok(value.clone()),
             })
-            .collect();
-        Row::from_values(values)
+            .collect::<crate::core::Result<Vec<_>>>()?;
+        Ok(Row::from_values(values))
     }
 
-    /// Get specific columns of a row using a precomputed column mapping.
-    /// Only materializes the requested schema columns — skips the rest.
     pub fn get_row_mapped_projected(
         &self,
         idx: usize,
         mapping: &ColumnMapping,
         col_indices: &[usize],
-    ) -> Row {
-        let values: Vec<Value> = col_indices
+    ) -> crate::core::Result<Row> {
+        self.check_row(idx)?;
+        let values = col_indices
             .iter()
-            .map(|&ci| match &mapping.sources[ci] {
-                ColSource::Volume(vol_idx) => self.columns[*vol_idx].get_value(idx),
-                ColSource::Default(val) => val.clone(),
-            })
-            .collect();
-        Row::from_values(values)
-    }
-
-    /// Get a row materializing only columns marked true in the mask.
-    /// Other columns get typed Null (stack-only, zero allocation).
-    /// The row has full schema width so filter column indices work.
-    /// Uses LazyColumns::data_type() for unneeded columns to avoid decompression.
-    #[inline]
-    pub fn get_row_needed(&self, idx: usize, needed: &[bool]) -> Row {
-        let values: Vec<Value> = (0..self.columns.len())
             .map(|ci| {
-                if ci < needed.len() && needed[ci] {
-                    self.columns[ci].get_value(idx)
-                } else {
-                    Value::Null(self.columns.data_type(ci))
+                match mapping
+                    .sources
+                    .get(*ci)
+                    .ok_or_else(|| invalid_data("projection index out of bounds"))?
+                {
+                    ColSource::Volume(vi) => self.get_value(*vi, idx),
+                    ColSource::Default(value) => Ok(value.clone()),
                 }
             })
-            .collect();
-        Row::from_values(values)
+            .collect::<crate::core::Result<Vec<_>>>()?;
+        Ok(Row::from_values(values))
     }
 
-    /// Get a row using a mapping, materializing only needed columns.
-    /// Combines schema evolution (mapping) with column pruning (mask).
-    /// Uses LazyColumns::data_type() for unneeded columns to avoid decompression.
-    #[inline]
+    /// Materialize needed columns only; unused columns retain typed nulls.
+    pub fn get_row_needed(&self, idx: usize, needed: &[bool]) -> crate::core::Result<Row> {
+        self.check_row(idx)?;
+        let values = (0..self.columns.len())
+            .map(|ci| {
+                if needed.get(ci).copied().unwrap_or(false) {
+                    self.get_value(ci, idx)
+                } else {
+                    Ok(Value::Null(self.columns.data_type(ci)))
+                }
+            })
+            .collect::<crate::core::Result<Vec<_>>>()?;
+        Ok(Row::from_values(values))
+    }
+
     pub fn get_row_mapped_needed(
         &self,
         idx: usize,
         mapping: &ColumnMapping,
         needed: &[bool],
-    ) -> Row {
-        let values: Vec<Value> = mapping
+    ) -> crate::core::Result<Row> {
+        self.check_row(idx)?;
+        let values = mapping
             .sources
             .iter()
             .enumerate()
             .map(|(ci, src)| {
-                if ci < needed.len() && needed[ci] {
+                if needed.get(ci).copied().unwrap_or(false) {
                     match src {
-                        ColSource::Volume(vol_idx) => self.columns[*vol_idx].get_value(idx),
-                        ColSource::Default(val) => val.clone(),
+                        ColSource::Volume(vi) => self.get_value(*vi, idx),
+                        ColSource::Default(value) => Ok(value.clone()),
                     }
                 } else {
-                    match src {
-                        ColSource::Volume(vol_idx) => Value::Null(self.columns.data_type(*vol_idx)),
-                        ColSource::Default(val) => Value::Null(val.data_type()),
-                    }
+                    Ok(Value::Null(match src {
+                        ColSource::Volume(vi) => *self
+                            .meta
+                            .column_types
+                            .get(*vi)
+                            .ok_or_else(|| invalid_data("mapping index out of bounds"))?,
+                        ColSource::Default(value) => value.data_type(),
+                    }))
                 }
             })
-            .collect();
-        Row::from_values(values)
+            .collect::<crate::core::Result<Vec<_>>>()?;
+        Ok(Row::from_values(values))
     }
 
-    /// Get a row as a Vec of Values (for executor compatibility).
-    pub fn get_row(&self, idx: usize) -> Row {
-        let values: Vec<Value> = self.columns.iter().map(|col| col.get_value(idx)).collect();
-        Row::from_values(values)
+    pub fn get_row(&self, idx: usize) -> crate::core::Result<Row> {
+        self.check_row(idx)?;
+        let values = (0..self.columns.len())
+            .map(|ci| self.get_value(ci, idx))
+            .collect::<crate::core::Result<Vec<_>>>()?;
+        Ok(Row::from_values(values))
     }
 
-    /// Get specific columns of a row (projection pushdown).
-    pub fn get_row_projected(&self, idx: usize, col_indices: &[usize]) -> Row {
-        let values: Vec<Value> = col_indices
+    pub fn get_row_projected(&self, idx: usize, col_indices: &[usize]) -> crate::core::Result<Row> {
+        self.check_row(idx)?;
+        let values = col_indices
             .iter()
-            .map(|&col| self.columns[col].get_value(idx))
-            .collect();
-        Row::from_values(values)
+            .map(|ci| self.get_value(*ci, idx))
+            .collect::<crate::core::Result<Vec<_>>>()?;
+        Ok(Row::from_values(values))
     }
 
     /// Check if a column is sorted (enables binary search).
     #[inline]
     pub fn is_sorted(&self, col_idx: usize) -> bool {
-        self.meta.sorted_columns[col_idx]
+        self.meta
+            .sorted_columns
+            .get(col_idx)
+            .copied()
+            .unwrap_or(false)
     }
 
     /// Look up a composite unique key in this volume's per-volume hash index.
@@ -1805,114 +1919,80 @@ impl FrozenVolume {
         &self,
         col_indices: &[usize],
         values: &[&Value],
-        mut f: impl FnMut(u32) -> bool, // return true to stop early
-    ) {
+        mut f: impl FnMut(u32) -> bool,
+    ) -> crate::core::Result<()> {
         use std::hash::{Hash, Hasher};
-
-        if col_indices.iter().any(|&idx| idx >= self.columns.len()) {
-            return;
+        if col_indices.len() != values.len() {
+            return Err(invalid_data("unique key column/value count mismatch").into());
         }
-
-        // Compute hash of query values
+        self.prebuild_unique_index(col_indices)?;
+        // Resolve fallible columns before locking the index. A failed read never
+        // invokes the callback with a partial answer or publishes an incomplete index.
+        let columns = col_indices
+            .iter()
+            .map(|ci| self.columns.get(*ci))
+            .collect::<io::Result<Vec<_>>>()?;
         let mut hasher = ahash::AHasher::default();
-        for &val in values {
+        for val in values {
             val.hash(&mut hasher);
         }
         let hash = hasher.finish();
-
-        // Fast path: check if index is already built
-        {
-            let indices = self.unique_indices.read();
-            if let Some(sorted_idx) = indices.get(col_indices) {
-                // Binary search for the hash, then scan all entries with same hash
-                let pos = sorted_idx.partition_point(|&(h, _)| h < hash);
-                for &(h, row_idx) in &sorted_idx[pos..] {
-                    if h != hash {
-                        break;
-                    }
-                    let matches = col_indices.iter().zip(values.iter()).all(|(&ci, &val)| {
-                        let vol_val = self.columns[ci].get_value(row_idx as usize);
-                        !vol_val.is_null() && vol_val == *val
-                    });
-                    if matches && f(row_idx) {
-                        return;
-                    }
-                }
-                return;
-            }
-        }
-
-        // Build sorted index for this column set (first use)
-        let mut entries: Vec<(u64, u32)> = Vec::with_capacity(self.meta.row_count);
-        for row_idx in 0..self.meta.row_count {
-            let mut row_hasher = ahash::AHasher::default();
-            let mut has_null = false;
-            for &ci in col_indices {
-                if self.columns[ci].is_null(row_idx) {
-                    has_null = true;
-                    break;
-                }
-                self.columns[ci].get_value(row_idx).hash(&mut row_hasher);
-            }
-            if has_null {
-                continue;
-            }
-            entries.push((row_hasher.finish(), row_idx as u32));
-        }
-        entries.sort_unstable_by_key(|&(h, _)| h);
-
-        // Look up before storing
+        let indices = self.unique_indices.read();
+        let entries = indices
+            .get(col_indices)
+            .ok_or_else(|| invalid_data("missing prepared unique index"))?;
         let pos = entries.partition_point(|&(h, _)| h < hash);
         for &(h, row_idx) in &entries[pos..] {
             if h != hash {
                 break;
             }
-            let matches = col_indices.iter().zip(values.iter()).all(|(&ci, &val)| {
-                let vol_val = self.columns[ci].get_value(row_idx as usize);
-                !vol_val.is_null() && vol_val == *val
+            let matches = columns.iter().zip(values).all(|(col, value)| {
+                let candidate = col.get_value(row_idx as usize);
+                !candidate.is_null() && candidate == **value
             });
             if matches && f(row_idx) {
                 break;
             }
         }
-
-        // Store the built index
-        self.unique_indices
-            .write()
-            .insert(col_indices.to_vec(), entries);
+        Ok(())
     }
 
-    /// Pre-build the unique sorted index for a set of column indices.
-    /// Called during seal/compaction so the first INSERT after seal doesn't
-    /// pay a ~60ms stall scanning all rows to build the index.
-    pub fn prebuild_unique_index(&self, col_indices: &[usize]) {
+    /// Build the immutable unique index only after all fallible reads succeed.
+    pub fn prebuild_unique_index(&self, col_indices: &[usize]) -> crate::core::Result<()> {
         use std::hash::{Hash, Hasher};
-        if col_indices.iter().any(|&idx| idx >= self.columns.len()) {
-            return;
+        if col_indices.iter().any(|&ci| ci >= self.columns.len()) {
+            return Err(invalid_data("unique column index out of bounds").into());
         }
         if self.unique_indices.read().contains_key(col_indices) {
-            return;
+            return Ok(());
         }
-        let mut entries: Vec<(u64, u32)> = Vec::with_capacity(self.meta.row_count);
+        if self.meta.row_count > u32::MAX as usize {
+            return Err(invalid_data("unique index row position overflow").into());
+        }
+        let columns = col_indices
+            .iter()
+            .map(|ci| self.columns.get(*ci))
+            .collect::<io::Result<Vec<_>>>()?;
+        if columns.iter().any(|col| col.len() != self.meta.row_count) {
+            return Err(invalid_data("unique index column row count mismatch").into());
+        }
+        let mut entries = Vec::with_capacity(self.meta.row_count);
         for row_idx in 0..self.meta.row_count {
-            let mut row_hasher = ahash::AHasher::default();
-            let mut has_null = false;
-            for &ci in col_indices {
-                if self.columns[ci].is_null(row_idx) {
-                    has_null = true;
-                    break;
-                }
-                self.columns[ci].get_value(row_idx).hash(&mut row_hasher);
-            }
-            if has_null {
+            let mut hasher = ahash::AHasher::default();
+            if columns.iter().any(|col| col.is_null(row_idx)) {
                 continue;
             }
-            entries.push((row_hasher.finish(), row_idx as u32));
+            for col in &columns {
+                col.get_value(row_idx).hash(&mut hasher);
+            }
+            entries.push((hasher.finish(), row_idx as u32));
         }
-        entries.sort_unstable_by_key(|&(h, _)| h);
+        entries.sort_unstable_by_key(|&(hash, _)| hash);
         self.unique_indices
             .write()
-            .insert(col_indices.to_vec(), entries);
+            .entry(col_indices.to_vec())
+            .or_insert(entries);
+        Ok(())
     }
 
     /// Find the column index by name. O(1) via precomputed hashmap.
@@ -2009,6 +2089,110 @@ impl FrozenVolume {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn damaged_integer_store(groups: usize) -> CompressedBlockStore {
+        let mut blocks = vec![vec![0u8; 9]; groups];
+        blocks[groups - 1] = lz4_flex::compress(&[0u8; 8]);
+        CompressedBlockStore::from_raw_blocks(
+            vec![blocks],
+            vec![vec![9; groups]],
+            vec![super::super::format::COL_INT64],
+            vec![DataType::Integer],
+            vec![0],
+            vec![],
+            vec![],
+            1,
+            groups,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn fallible_columns_report_short_lz4_output_and_preserve_error_kind() {
+        let _guard = crate::test_failpoints::FailpointGuard::new();
+        for groups in [1, 2] {
+            let store = damaged_integer_store(groups);
+            assert!(store.decompress_column(0).is_err());
+            for _ in 0..2 {
+                let error = store.group_column(0, groups - 1).err().unwrap();
+                assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+            }
+            assert!(store.group_column(1, 0).is_err());
+            assert!(store.group_column(0, groups).is_err());
+            let columns = LazyColumns::deferred(store, vec![DataType::Integer]);
+            assert!(columns.get(0).is_err());
+            assert!(columns.get(0).is_err());
+            assert!(!columns.is_eager());
+        }
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[test]
+    fn cached_column_and_identity_reads_are_fallible() {
+        let _guard = crate::test_failpoints::FailpointGuard::new();
+        let schema = crate::core::SchemaBuilder::new("t")
+            .column("id", DataType::Integer, false, true)
+            .build();
+        let mut builder = VolumeBuilder::new(&schema);
+        builder.add_row(1, &Row::from_values(vec![Value::Integer(1)]));
+        let volume = builder.finish();
+        assert_eq!(volume.get_value(0, 0).unwrap(), Value::Integer(1));
+        crate::test_failpoints::fail_cold_read_on(1);
+        assert!(volume.get_row(0).is_err());
+        assert!(volume.get_row(0).is_ok());
+        crate::test_failpoints::fail_cold_read_on(1);
+        assert!(volume.find_row_id(99).is_err());
+        assert_eq!(volume.find_row_id(99).unwrap(), None);
+        assert!(volume.row_id_at(1).is_err());
+        assert!(volume.get_row_projected(0, &[1]).is_err());
+        assert!(volume.get_row(1).is_err());
+        let store =
+            CompressedBlockStore::compress_columns(&volume.columns, &[DataType::Integer], 1)
+                .unwrap();
+        assert!(store.group_column(0, 0).is_ok());
+        crate::test_failpoints::fail_cold_read_on(1);
+        assert!(store.group_column(0, 0).is_err());
+        assert!(store.group_column(0, 0).is_ok());
+        assert!(damaged_integer_store(1)
+            .binary_search_ge(0, 0, &[])
+            .is_err());
+        assert_eq!(
+            damaged_integer_store(2)
+                .binary_search_ge(0, 0, &[])
+                .unwrap(),
+            None
+        );
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[test]
+    fn unique_index_failure_does_not_publish_partial_index_or_matches() {
+        let _guard = crate::test_failpoints::FailpointGuard::new();
+        let schema = crate::core::SchemaBuilder::new("t")
+            .column("id", DataType::Integer, false, true)
+            .build();
+        let mut builder = VolumeBuilder::new(&schema);
+        builder.add_row(1, &Row::from_values(vec![Value::Integer(1)]));
+        let volume = builder.finish();
+        crate::test_failpoints::fail_cold_read_on(1);
+        let mut called = false;
+        assert!(volume
+            .unique_lookup_all(&[0], &[&Value::Integer(1)], |_| {
+                called = true;
+                true
+            })
+            .is_err());
+        assert!(!called && volume.unique_indices.read().is_empty());
+        volume
+            .unique_lookup_all(&[0], &[&Value::Integer(1)], |_| {
+                called = true;
+                true
+            })
+            .unwrap();
+        assert!(called);
+        let missing_source = volume.to_cold();
+        assert!(missing_source.get_row(0).is_err());
+    }
     use crate::core::SchemaBuilder;
 
     fn test_schema() -> Schema {
@@ -2092,7 +2276,7 @@ mod tests {
         assert!(volume.is_sorted(1)); // time is sorted
 
         // Check row reconstruction
-        let row = volume.get_row(0);
+        let row = volume.get_row(0).unwrap();
         assert_eq!(row.get(0), Some(&Value::Integer(1)));
         assert_eq!(row.get(2), Some(&Value::text("binance")));
     }
@@ -2117,7 +2301,7 @@ mod tests {
         assert!(volume.columns[3].is_null(0));
         assert!(!volume.columns[0].is_null(0));
 
-        let row = volume.get_row(0);
+        let row = volume.get_row(0).unwrap();
         assert_eq!(row.get(0), Some(&Value::Integer(1)));
         assert!(row.get(1).unwrap().is_null());
     }
@@ -2166,7 +2350,7 @@ mod tests {
         let volume = builder.finish();
 
         // Project only id and price (columns 0 and 3)
-        let row = volume.get_row_projected(0, &[0, 3]);
+        let row = volume.get_row_projected(0, &[0, 3]).unwrap();
         assert_eq!(row.len(), 2);
         assert_eq!(row.get(0), Some(&Value::Integer(1)));
         assert_eq!(row.get(1), Some(&Value::Float(100.0)));

--- a/src/test_failpoints.rs
+++ b/src/test_failpoints.rs
@@ -18,7 +18,7 @@
 //! Source code checks these flags inside `#[cfg(test)]` guards, so they
 //! have zero cost in release builds.
 
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Mutex, MutexGuard};
 
 /// Fail WAL `write_to_file()` with an I/O error
@@ -26,6 +26,9 @@ pub static WAL_WRITE_FAIL: AtomicBool = AtomicBool::new(false);
 
 /// Fail WAL `sync_locked()` (fsync) with an I/O error
 pub static WAL_SYNC_FAIL: AtomicBool = AtomicBool::new(false);
+
+/// Fail cleanup after a WAL write/sync failure, leaving its outcome unknown.
+pub static WAL_ROLLBACK_FAIL: AtomicBool = AtomicBool::new(false);
 
 /// Fail snapshot `append_row()` write with an I/O error
 pub static SNAPSHOT_WRITE_FAIL: AtomicBool = AtomicBool::new(false);
@@ -39,6 +42,38 @@ pub static SNAPSHOT_RENAME_FAIL: AtomicBool = AtomicBool::new(false);
 /// Fail checkpoint metadata write
 pub static CHECKPOINT_WRITE_FAIL: AtomicBool = AtomicBool::new(false);
 
+/// Remaining cold reads before a one-shot injected error; zero disables it.
+static COLD_READ_COUNTDOWN: AtomicUsize = AtomicUsize::new(0);
+static TABLE_PUBLISH_COUNTDOWN: AtomicUsize = AtomicUsize::new(0);
+
+/// Fail the nth subsequent table publication after prepare has succeeded.
+pub fn fail_table_publish_on(nth: usize) {
+    TABLE_PUBLISH_COUNTDOWN.store(nth, Ordering::Release);
+}
+
+pub(crate) fn should_fail_table_publish() -> bool {
+    TABLE_PUBLISH_COUNTDOWN.fetch_update(Ordering::AcqRel, Ordering::Acquire, |left| {
+        left.checked_sub(1)
+    }) == Ok(1)
+}
+
+/// Fail the nth subsequent fallible cold read, including an already cached view.
+/// Call under `FailpointGuard`; passing zero disables the injection.
+pub fn fail_cold_read_on(nth: usize) {
+    COLD_READ_COUNTDOWN.store(nth, Ordering::Release);
+}
+
+pub(crate) fn check_cold_read() -> std::io::Result<()> {
+    let previous = COLD_READ_COUNTDOWN.fetch_update(Ordering::AcqRel, Ordering::Acquire, |left| {
+        left.checked_sub(1)
+    });
+    if previous == Ok(1) {
+        Err(std::io::Error::other("injected cold read failure"))
+    } else {
+        Ok(())
+    }
+}
+
 /// Serializes failpoint tests so that only one can run at a time.
 /// Global AtomicBool flags are process-wide; concurrent tests would
 /// interfere with each other without this lock.
@@ -49,10 +84,13 @@ pub fn reset_all() {
     use std::sync::atomic::Ordering::Release;
     WAL_WRITE_FAIL.store(false, Release);
     WAL_SYNC_FAIL.store(false, Release);
+    WAL_ROLLBACK_FAIL.store(false, Release);
     SNAPSHOT_WRITE_FAIL.store(false, Release);
     SNAPSHOT_SYNC_FAIL.store(false, Release);
     SNAPSHOT_RENAME_FAIL.store(false, Release);
     CHECKPOINT_WRITE_FAIL.store(false, Release);
+    COLD_READ_COUNTDOWN.store(0, Release);
+    TABLE_PUBLISH_COUNTDOWN.store(0, Release);
 }
 
 /// RAII guard that serializes failpoint tests and resets all failpoints on drop.

--- a/tests/cold_read_error_test.rs
+++ b/tests/cold_read_error_test.rs
@@ -1,0 +1,304 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cold read errors must survive optimization fallback and cached access.
+
+#![cfg(feature = "test-failpoints")]
+
+use stoolap::core::Row;
+use stoolap::{test_failpoints, Database, Result};
+
+fn fixture() -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let dsn = format!(
+        "file://{}?checkpoint_interval=3600&sync_mode=full",
+        dir.path().display()
+    );
+    let db = Database::open(&dsn).unwrap();
+    db.execute(
+        "CREATE TABLE items (id INTEGER PRIMARY KEY, category TEXT, amount INTEGER, code TEXT UNIQUE)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX items_category ON items(category)", ())
+        .unwrap();
+    db.execute(
+        "INSERT INTO items VALUES (1, 'a', 10, 'one'), (2, 'a', 20, 'two'), (3, 'b', 30, 'three'), (6, 'b', 60, 'six')",
+        (),
+    )
+    .unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    db.close().unwrap();
+    (dir, dsn)
+}
+
+fn rows(db: &Database, sql: &str) -> Result<Vec<Row>> {
+    db.query(sql, ())?
+        .map(|row| row.map(|row| row.into_inner()))
+        .collect()
+}
+
+fn assert_injected<T>(result: Result<T>, context: &str) {
+    let error = match result {
+        Ok(_) => panic!("{context}: injected read was lost or answered as a partial result"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("injected cold read failure"),
+        "{context}: expected the read error, received {error}"
+    );
+}
+
+#[test]
+fn cold_query_errors_survive_first_touch_and_cached_fast_paths() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let (_dir, dsn) = fixture();
+    let queries = [
+        "SELECT amount, code FROM items WHERE id = 2",
+        "SELECT amount + 1, code FROM items ORDER BY id",
+        "SELECT COUNT(*) FROM items WHERE amount >= 20",
+        "SELECT SUM(amount) FROM items WHERE category = 'a'",
+        "SELECT MIN(amount), MAX(amount) FROM items WHERE category = 'a'",
+        "SELECT category, SUM(amount) FROM items GROUP BY category ORDER BY category",
+        "SELECT DISTINCT category FROM items ORDER BY category",
+        "SELECT COUNT(DISTINCT category) FROM items",
+        "SELECT * FROM items ORDER BY id LIMIT 2",
+        "SELECT category, ROW_NUMBER() OVER (PARTITION BY category ORDER BY amount) FROM items ORDER BY category, amount",
+    ];
+
+    for sql in queries {
+        // A new engine resets its volume views and compiled statement cache.
+        let db = Database::open(&dsn).unwrap();
+        test_failpoints::fail_cold_read_on(1);
+        assert_injected(rows(&db, sql), &format!("first access: {sql}"));
+        test_failpoints::fail_cold_read_on(0);
+        let expected = rows(&db, sql).unwrap();
+        assert!(
+            !expected.is_empty(),
+            "fixture query must produce rows: {sql}"
+        );
+
+        // The same SQL now has a compiled plan and warmed column/index state.
+        test_failpoints::fail_cold_read_on(1);
+        assert_injected(rows(&db, sql), &format!("cached access: {sql}"));
+        test_failpoints::fail_cold_read_on(0);
+        assert_eq!(
+            rows(&db, sql).unwrap(),
+            expected,
+            "retry after error: {sql}"
+        );
+        db.close().unwrap();
+    }
+}
+
+#[test]
+fn cold_projection_error_after_identity_lookup_is_not_a_missing_row() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let (_dir, dsn) = fixture();
+    let db = Database::open(&dsn).unwrap();
+    let sql = "SELECT amount, code FROM items WHERE id = 2";
+    test_failpoints::fail_cold_read_on(2);
+    assert_injected(rows(&db, sql), "projection after identity lookup");
+    test_failpoints::fail_cold_read_on(0);
+    let actual = rows(&db, sql).unwrap();
+    assert_eq!(actual.len(), 1);
+    assert_eq!(actual[0].get(0), Some(&stoolap::Value::Integer(20)));
+}
+
+#[test]
+fn cold_constraint_read_error_never_admits_a_write() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let (_dir, dsn) = fixture();
+    let db = Database::open(&dsn).unwrap();
+    // The missing ID is inside the cold volume's range, so the PK proof must read it.
+    let insert = "INSERT INTO items VALUES (4, 'a', 40, 'four')";
+    test_failpoints::fail_cold_read_on(1);
+    assert_injected(db.execute(insert, ()), "cold primary-key absence proof");
+    test_failpoints::fail_cold_read_on(0);
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM items", ())
+            .unwrap(),
+        4
+    );
+
+    // A PK match followed by a distinct UNIQUE probe must preserve the read failure.
+    test_failpoints::fail_cold_read_on(2);
+    assert_injected(db.execute(insert, ()), "cold UNIQUE proof");
+    test_failpoints::fail_cold_read_on(0);
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM items", ())
+            .unwrap(),
+        4
+    );
+    db.execute(insert, ()).unwrap();
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM items", ())
+            .unwrap(),
+        5
+    );
+    assert!(db
+        .execute("INSERT INTO items VALUES (5, 'a', 50, 'two')", ())
+        .is_err());
+}
+
+#[test]
+fn cold_error_after_scan_progress_discards_rows_and_aggregate() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let (_dir, dsn) = fixture();
+    let db = Database::open(&dsn).unwrap();
+    for (sql, nth) in [
+        ("SELECT id, amount, code FROM items ORDER BY id", 7),
+        // The SUM column is bound once; later predicate reads still follow
+        // rows already accumulated and must discard that partial aggregate.
+        ("SELECT SUM(amount) FROM items WHERE amount >= 10", 5),
+    ] {
+        let expected = rows(&db, sql).unwrap();
+        test_failpoints::fail_cold_read_on(nth);
+        assert_injected(rows(&db, sql), &format!("later read: {sql}"));
+        test_failpoints::fail_cold_read_on(0);
+        assert_eq!(rows(&db, sql).unwrap(), expected);
+    }
+}
+
+#[test]
+fn lazy_window_partition_propagates_first_cold_read_error() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open(&format!(
+        "file://{}?checkpoint_interval=3600",
+        dir.path().display()
+    ))
+    .unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, category TEXT, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX idx_category ON t(category)", ())
+        .unwrap();
+    db.execute(
+        "INSERT INTO t VALUES (1, 'a', 10), (2, 'a', 20), (3, 'b', 30)",
+        (),
+    )
+    .unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    test_failpoints::fail_cold_read_on(1);
+    let result = db
+        .query(
+            "SELECT category, ROW_NUMBER() OVER (PARTITION BY category ORDER BY v) FROM t LIMIT 2",
+            (),
+        )
+        .and_then(|rows| rows.collect::<std::result::Result<Vec<_>, _>>());
+    assert!(
+        result.is_err(),
+        "lazy-window optimization swallowed cold read error and returned a fallback result"
+    );
+}
+
+#[test]
+fn dictionary_filter_prepass_preserves_the_original_read_error() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let dir = tempfile::tempdir().unwrap();
+    let dsn = format!("file://{}?checkpoint_interval=3600", dir.path().display());
+    let db = Database::open(&dsn).unwrap();
+    db.execute(
+        "CREATE TABLE strings (id INTEGER PRIMARY KEY, category TEXT, amount INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO strings VALUES (1, 'a', 10), (2, 'a', 20), (3, 'b', 30)",
+        (),
+    )
+    .unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    db.close().unwrap();
+    let db = Database::open(&dsn).unwrap();
+    let sql = "SELECT amount + 1 FROM strings WHERE category = 'a'";
+    test_failpoints::fail_cold_read_on(1);
+    assert_injected(rows(&db, sql), "dictionary prepass");
+    test_failpoints::fail_cold_read_on(0);
+    assert_eq!(rows(&db, sql).unwrap().len(), 2);
+}
+
+#[test]
+fn failed_cold_index_build_never_installs_a_partial_index() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let dir = tempfile::tempdir().unwrap();
+    let dsn = format!("file://{}?checkpoint_interval=3600", dir.path().display());
+    let db = Database::open(&dsn).unwrap();
+    db.execute(
+        "CREATE TABLE ddl_reads (id INTEGER PRIMARY KEY, v INTEGER, embedding VECTOR(3))",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO ddl_reads VALUES (1, 10, '[1,0,0]'), (2, 20, '[0,1,0]'), (3, 30, '[0,0,1]')",
+        (),
+    )
+    .unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    let store = db.engine().get_version_store("ddl_reads").unwrap();
+    for (name, sql) in [
+        (
+            "ddl_unique",
+            "CREATE UNIQUE INDEX ddl_unique ON ddl_reads(v)",
+        ),
+        (
+            "ddl_vector",
+            "CREATE INDEX ddl_vector ON ddl_reads(embedding) USING HNSW",
+        ),
+    ] {
+        test_failpoints::fail_cold_read_on(1);
+        assert_injected(db.execute(sql, ()), "detached cold index build");
+        test_failpoints::fail_cold_read_on(0);
+        assert!(!store.index_exists(name), "failed build installed {name}");
+        db.execute(sql, ()).unwrap();
+        assert!(store.index_exists(name));
+    }
+}
+
+#[test]
+fn unique_index_build_checks_duplicates_across_hot_and_cold() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open(&format!(
+        "file://{}?checkpoint_interval=3600",
+        dir.path().display()
+    ))
+    .unwrap();
+    db.execute(
+        "CREATE TABLE ddl_dupes (id INTEGER PRIMARY KEY, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO ddl_dupes VALUES (1, 10)", ())
+        .unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    db.execute("INSERT INTO ddl_dupes VALUES (2, 10)", ())
+        .unwrap();
+    assert!(db
+        .execute("CREATE UNIQUE INDEX duplicate_key ON ddl_dupes(v)", ())
+        .is_err());
+    assert!(!db
+        .engine()
+        .get_version_store("ddl_dupes")
+        .unwrap()
+        .index_exists("duplicate_key"));
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM ddl_dupes", ())
+            .unwrap(),
+        2
+    );
+}

--- a/tests/decoded_group_cache_test.rs
+++ b/tests/decoded_group_cache_test.rs
@@ -304,7 +304,8 @@ mod invariants {
         };
         assert!(column.memory_size() < 2 * 1024 * 1024);
         let columns = LazyColumns::eager(vec![column], vec![DataType::Text]);
-        let store = CompressedBlockStore::compress_columns(&columns, &[DataType::Text], rows);
+        let store =
+            CompressedBlockStore::compress_columns(&columns, &[DataType::Text], rows).unwrap();
         DECODED_GROUPS.set_budget_bytes(2 * 1024 * 1024);
         let first = store.group_column(0, 0).unwrap();
         let _second = store.group_column(0, 1).unwrap();

--- a/tests/failpoint_io_test.rs
+++ b/tests/failpoint_io_test.rs
@@ -728,3 +728,72 @@ fn test_wal_sync_failure_on_a_delete_keeps_the_row_everywhere() {
     assert!(ids("SELECT id FROM fp_del WHERE k = 'a' AND t = 150").is_empty());
     assert!(ids("SELECT id FROM fp_del WHERE t = 150").is_empty());
 }
+
+#[test]
+fn indeterminate_commit_fences_cached_reads_writes_and_checkpoint_until_reopen() {
+    let _guard = failpoint_guard();
+    let dir = tempdir().unwrap();
+    let dsn = format!("file://{}?sync_mode=full", dir.path().display());
+    let db = Database::open(&dsn).unwrap();
+    db.execute(
+        "CREATE TABLE uncertain (id INTEGER PRIMARY KEY, val INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO uncertain VALUES (1, 10)", ())
+        .unwrap();
+    // Populate cached point-lookup and count execution paths before the failure.
+    for sql in [
+        "SELECT val FROM uncertain WHERE id = 1",
+        "SELECT COUNT(*) FROM uncertain",
+    ] {
+        db.query_one::<i64, _>(sql, ()).unwrap();
+        db.query_one::<i64, _>(sql, ()).unwrap();
+    }
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("UPDATE uncertain SET val = 20 WHERE id = 1", ())
+        .unwrap();
+    test_failpoints::WAL_SYNC_FAIL.store(true, Ordering::Release);
+    test_failpoints::WAL_ROLLBACK_FAIL.store(true, Ordering::Release);
+    let error = db.execute("COMMIT", ()).unwrap_err();
+    assert!(error.to_string().contains("indeterminate"), "{error}");
+    test_failpoints::WAL_SYNC_FAIL.store(false, Ordering::Release);
+    test_failpoints::WAL_ROLLBACK_FAIL.store(false, Ordering::Release);
+    for sql in [
+        "SELECT val FROM uncertain WHERE id = 1",
+        "SELECT COUNT(*) FROM uncertain",
+        "SELECT SUM(val) FROM uncertain",
+    ] {
+        assert!(
+            db.query_one::<i64, _>(sql, ()).is_err(),
+            "query escaped execution fence: {sql}"
+        );
+    }
+    for sql in [
+        "INSERT INTO uncertain VALUES (2, 30)",
+        "UPDATE uncertain SET val = 99 WHERE id = 1",
+        "PRAGMA CHECKPOINT",
+        "BEGIN",
+    ] {
+        assert!(
+            db.execute(sql, ()).is_err(),
+            "operation escaped execution fence: {sql}"
+        );
+    }
+    // Closing must not checkpoint an in-memory decision over the unresolved WAL.
+    let _ = db.close();
+    let db = Database::open(&dsn).unwrap();
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT val FROM uncertain WHERE id = 1", ())
+            .unwrap(),
+        20,
+        "the injected rollback failure leaves a complete commit marker for recovery"
+    );
+    db.execute("INSERT INTO uncertain VALUES (2, 30)", ())
+        .unwrap();
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM uncertain", ())
+            .unwrap(),
+        2
+    );
+}

--- a/tests/hot_index_top_k_test.rs
+++ b/tests/hot_index_top_k_test.rs
@@ -502,15 +502,17 @@ fn test_top_k_during_a_commit_answers_from_the_visible_versions() {
     let name = index.name().to_string();
     let (stopped_tx, stopped_rx) = mpsc::channel();
     let (resume_tx, resume_rx) = mpsc::channel();
-    store.add_index(
-        name,
-        Arc::new(StopAfterIndexAdd {
-            inner: index,
-            armed: AtomicBool::new(true),
-            stopped: stopped_tx,
-            resume: Mutex::new(resume_rx),
-        }),
-    );
+    store
+        .add_index(
+            name,
+            Arc::new(StopAfterIndexAdd {
+                inner: index,
+                armed: AtomicBool::new(true),
+                stopped: stopped_tx,
+                resume: Mutex::new(resume_rx),
+            }),
+        )
+        .unwrap();
     let writer_db = db.clone();
     let writer = std::thread::spawn(move || {
         writer_db
@@ -614,15 +616,17 @@ fn test_top_k_stands_down_until_a_two_table_commit_is_visible() {
     let name = index.name().to_string();
     let (stopped_tx, stopped_rx) = mpsc::channel();
     let (resume_tx, resume_rx) = mpsc::channel();
-    second_store.add_index(
-        name,
-        Arc::new(StopAfterIndexAdd {
-            inner: index,
-            armed: AtomicBool::new(true),
-            stopped: stopped_tx,
-            resume: Mutex::new(resume_rx),
-        }),
-    );
+    second_store
+        .add_index(
+            name,
+            Arc::new(StopAfterIndexAdd {
+                inner: index,
+                armed: AtomicBool::new(true),
+                stopped: stopped_tx,
+                resume: Mutex::new(resume_rx),
+            }),
+        )
+        .unwrap();
     let writer_db = db.clone();
     let writer = std::thread::spawn(move || {
         writer_db.execute("BEGIN", ()).unwrap();

--- a/tests/ordered_limited_scan_test.rs
+++ b/tests/ordered_limited_scan_test.rs
@@ -377,7 +377,9 @@ fn test_top_k_reports_a_block_it_cannot_decode_instead_of_an_empty_answer() {
     let index_offset = 20 + meta_len;
     let mut bytes = original[..index_offset].to_vec();
     bytes.extend_from_slice(&1u64.to_le_bytes());
-    bytes.extend_from_slice(&100u64.to_le_bytes());
+    // Keep the decoded length consistent with the validated column layout.
+    // Only the compressed payload is corrupt, so failure occurs on access.
+    bytes.extend_from_slice(&original[index_offset + 8..index_offset + 16]);
     bytes.push(0xff);
     let crc = crc32fast::hash(&bytes);
     bytes.extend_from_slice(&crc.to_le_bytes());

--- a/tests/phase1_review_correlated_error_test.rs
+++ b/tests/phase1_review_correlated_error_test.rs
@@ -1,0 +1,148 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "test-failpoints")]
+
+use stoolap::{test_failpoints, Database};
+
+fn fixture(cold_target: bool) -> (tempfile::TempDir, Database) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open(&format!(
+        "file://{}?checkpoint_interval=3600&sync_mode=full",
+        dir.path().display()
+    ))
+    .unwrap();
+    let order = if cold_target {
+        ["target", "source"]
+    } else {
+        ["source", "target"]
+    };
+    for (position, name) in order.iter().enumerate() {
+        db.execute(
+            &format!("CREATE TABLE {name} (id INTEGER PRIMARY KEY, amount INTEGER)"),
+            (),
+        )
+        .unwrap();
+        let values = if *name == "source" {
+            "(1, 10), (2, 20), (3, 30)"
+        } else {
+            "(1, 0), (2, 0), (3, 0)"
+        };
+        db.execute(&format!("INSERT INTO {name} VALUES {values}"), ())
+            .unwrap();
+        if position == 0 {
+            db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        }
+    }
+    (dir, db)
+}
+
+fn assert_dml_cold_error(cold_target: bool, sql: &str) {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let (_dir, db) = fixture(cold_target);
+    let mut failures = 0;
+    for nth in 1..=16 {
+        let mut tx = db.begin().unwrap();
+        tx.execute("INSERT INTO target VALUES (99, 99)", ())
+            .unwrap();
+        test_failpoints::fail_cold_read_on(nth);
+        let result = tx.execute(sql, ());
+        test_failpoints::fail_cold_read_on(0);
+        match result {
+            Err(error) => {
+                failures += 1;
+                assert!(
+                    error.to_string().contains("injected cold read failure"),
+                    "read {nth}: {sql}: {error}"
+                );
+                assert_eq!(
+                    tx.query_one::<i64, _>("SELECT SUM(amount) FROM target WHERE id <= 3", ())
+                        .unwrap(),
+                    0
+                );
+                assert_eq!(
+                    tx.query_one::<i64, _>("SELECT COUNT(*) FROM target WHERE id <= 3", ())
+                        .unwrap(),
+                    3
+                );
+                // The failed statement must preserve earlier successful work.
+                tx.commit().unwrap();
+                assert_eq!(
+                    db.query_one::<i64, _>("SELECT amount FROM target WHERE id = 99", ())
+                        .unwrap(),
+                    99
+                );
+                db.execute("DELETE FROM target WHERE id = 99", ()).unwrap();
+            }
+            Ok(count) => {
+                assert_eq!(
+                    count, 3,
+                    "read {nth}: subquery failure reported a successful partial statement: {sql}"
+                );
+                tx.rollback().unwrap();
+            }
+        }
+    }
+    assert!(
+        failures >= 2,
+        "must exercise errors after scan progress: {sql}"
+    );
+}
+
+const SCALAR_UPDATE: &str = "UPDATE target SET amount = (SELECT amount FROM source WHERE source.id = target.id LIMIT 1) WHERE target.id <= 3";
+
+#[test]
+fn scalar_update_propagates_inner_cold_error() {
+    assert_dml_cold_error(false, SCALAR_UPDATE);
+}
+
+#[test]
+fn scalar_update_propagates_outer_cold_error() {
+    assert_dml_cold_error(true, SCALAR_UPDATE);
+}
+
+#[test]
+fn update_correlated_predicate_preserves_cold_errors() {
+    for cold_target in [false, true] {
+        assert_dml_cold_error(cold_target, "UPDATE target SET amount = 5 WHERE target.id <= 3 AND (SELECT amount FROM source WHERE source.id = target.id LIMIT 1) > 0");
+    }
+}
+
+#[test]
+fn delete_correlated_predicate_preserves_cold_errors() {
+    for cold_target in [false, true] {
+        assert_dml_cold_error(cold_target, "DELETE FROM target WHERE target.id <= 3 AND (SELECT amount FROM source WHERE source.id = target.id LIMIT 1) > 0");
+    }
+}
+
+#[test]
+fn delete_returning_propagates_outer_cold_scan_error() {
+    assert_dml_cold_error(true, "DELETE FROM target WHERE target.id <= 3 RETURNING id");
+}
+
+#[test]
+fn correlated_select_propagates_outer_scan_error() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let (_dir, db) = fixture(true);
+    test_failpoints::fail_cold_read_on(1);
+    let result: stoolap::Result<Vec<_>> = db.query(
+        "SELECT id FROM target WHERE EXISTS (SELECT 1 FROM source WHERE source.id = target.id LIMIT 1)", (),
+    ).and_then(|rows| rows.collect());
+    test_failpoints::fail_cold_read_on(0);
+    let error = result.expect_err("correlated SELECT swallowed its cold outer scan error");
+    assert!(
+        error.to_string().contains("injected cold read failure"),
+        "{error}"
+    );
+}

--- a/tests/phase1_review_gc_undo_test.rs
+++ b/tests/phase1_review_gc_undo_test.rs
@@ -1,0 +1,59 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use stoolap::core::{DataType, Row, SchemaBuilder};
+use stoolap::storage::mvcc::{
+    registry::TransactionRegistry,
+    version_store::{TransactionVersionStore, VersionStore},
+};
+
+#[test]
+fn failed_delete_publication_survives_concurrent_vacuum() {
+    let registry = Arc::new(TransactionRegistry::new());
+    let schema = SchemaBuilder::new("gc_undo_review")
+        .column("id", DataType::Integer, false, true)
+        .build();
+    let parent = Arc::new(VersionStore::with_visibility_checker(
+        "gc_undo_review",
+        schema,
+        registry.clone(),
+    ));
+    let (seed_id, _) = registry.begin_transaction();
+    let mut seed = TransactionVersionStore::new(parent.clone(), seed_id);
+    seed.put(1, Row::from(vec![1.into()]), false).unwrap();
+    seed.commit().unwrap();
+    registry.commit_transaction(seed_id);
+    let (delete_id, _) = registry.begin_transaction();
+    let mut deletion = TransactionVersionStore::new(parent.clone(), delete_id);
+    deletion.put(1, Row::from(vec![1.into()]), true).unwrap();
+    registry.start_commit(delete_id);
+    deletion.prepare_publication().unwrap();
+    deletion.apply_prepared_publication().unwrap();
+    registry.abort_transaction(delete_id);
+    std::thread::sleep(std::time::Duration::from_millis(1));
+    // VACUUM/zero-retention background cleanup races between abort and undo.
+    assert_eq!(parent.cleanup_deleted_rows(std::time::Duration::ZERO), 0);
+    assert_eq!(
+        parent.cleanup_old_previous_versions_with_retention(std::time::Duration::ZERO),
+        0
+    );
+    deletion.finish_publication(false).unwrap();
+    let (viewer_id, _) = registry.begin_transaction();
+    assert!(
+        parent.get_visible_version(1, viewer_id).is_some(),
+        "vacuum removed the claimed published delete, so failed-commit undo lost the original row"
+    );
+    assert_eq!(parent.committed_row_count(), 1);
+}

--- a/tests/phase1_review_generation_test.rs
+++ b/tests/phase1_review_generation_test.rs
@@ -1,0 +1,50 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use stoolap::Database;
+
+#[test]
+fn failed_statement_restores_prior_cold_validation_generation() {
+    for failed_statement in [false, true] {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&format!(
+            "file://{}?checkpoint_interval=3600",
+            dir.path().display()
+        ))
+        .unwrap();
+        db.execute(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, u INTEGER UNIQUE)",
+            (),
+        )
+        .unwrap();
+        db.execute("INSERT INTO t VALUES (1, 1)", ()).unwrap();
+        let mut first = db.begin().unwrap();
+        first.execute("INSERT INTO t VALUES (4, 100)", ()).unwrap();
+        db.execute("INSERT INTO t VALUES (5, 100)", ()).unwrap();
+        db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        if failed_statement {
+            assert!(first
+                .execute("INSERT INTO t VALUES (6, 600), (1, 1)", ())
+                .is_err());
+        } else {
+            first.execute("INSERT INTO t VALUES (6, 600)", ()).unwrap();
+        }
+        assert!(first.commit().is_err(), "failed statement advanced seal generation for prior unvalidated writes, allowing duplicate cold UNIQUE value");
+        assert_eq!(
+            db.query_one::<i64, _>("SELECT COUNT(*) FROM t WHERE u = 100", ())
+                .unwrap(),
+            1
+        );
+    }
+}

--- a/tests/phase1_review_grouped_error_test.rs
+++ b/tests/phase1_review_grouped_error_test.rs
@@ -1,0 +1,55 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "test-failpoints")]
+
+use stoolap::{test_failpoints, Database};
+
+#[test]
+fn grouped_correlated_projection_propagates_cold_subquery_error() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open(&format!(
+        "file://{}?checkpoint_interval=3600&sync_mode=full",
+        dir.path().display()
+    ))
+    .unwrap();
+    db.execute(
+        "CREATE TABLE source (id INTEGER PRIMARY KEY, amount INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO source VALUES (1, 10), (2, 20), (3, 30)", ())
+        .unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    db.execute(
+        "CREATE TABLE target (id INTEGER PRIMARY KEY, amount INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO target VALUES (1, 0), (2, 0), (3, 0)", ())
+        .unwrap();
+    test_failpoints::fail_cold_read_on(1);
+    let result = db.query("SELECT id, SUM(amount), (SELECT MAX(amount) FROM source WHERE source.id = target.id) FROM target GROUP BY id", ())
+        .and_then(|rows| rows.collect::<stoolap::Result<Vec<_>>>());
+    test_failpoints::fail_cold_read_on(0);
+    assert!(
+        result.is_err(),
+        "grouped projection swallowed cold subquery error"
+    );
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("injected cold read failure"));
+}

--- a/tests/phase1_review_reservation_test.rs
+++ b/tests/phase1_review_reservation_test.rs
@@ -1,0 +1,241 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, RwLock};
+use stoolap::core::{DataType, Row, SchemaBuilder};
+use stoolap::storage::index::HashIndex;
+use stoolap::storage::mvcc::{
+    table::MVCCTable,
+    version_store::{TransactionVersionStore, VersionStore},
+};
+use stoolap::storage::traits::Table;
+use stoolap::storage::volume::{
+    manifest::{SegmentManager, SegmentMeta},
+    table::SegmentedTable,
+    writer::VolumeBuilder,
+};
+
+#[test]
+fn cold_deleted_unique_key_stays_reserved_until_terminal_outcome() {
+    for evolved_schema in [false, true] {
+        let schema = SchemaBuilder::new("reservation_review")
+            .column("id", DataType::Integer, false, true)
+            .column("u", DataType::Integer, false, false)
+            .build();
+        let parent = Arc::new(VersionStore::new("reservation_review", schema.clone()));
+        parent
+            .add_index(
+                "idx_u".into(),
+                Arc::new(HashIndex::new(
+                    "idx_u".into(),
+                    "reservation_review".into(),
+                    vec!["u".into()],
+                    vec![1],
+                    vec![DataType::Integer],
+                    true,
+                    0,
+                )),
+            )
+            .unwrap();
+        let old_schema = SchemaBuilder::new("reservation_review")
+            .column("id", DataType::Integer, false, true)
+            .column("removed", DataType::Integer, false, false)
+            .column("u", DataType::Integer, false, false)
+            .build();
+        let volume_schema = if evolved_schema { &old_schema } else { &schema };
+        let mut builder = VolumeBuilder::new(volume_schema);
+        builder.add_row(
+            1,
+            &Row::from(if evolved_schema {
+                vec![1.into(), 99.into(), 10.into()]
+            } else {
+                vec![1.into(), 10.into()]
+            }),
+        );
+        let manager = Arc::new(SegmentManager::new("reservation_review", None));
+        manager.register_segment(
+            1,
+            Arc::new(builder.finish()),
+            SegmentMeta {
+                segment_id: 1,
+                file_path: "review.vol".into(),
+                row_count: 1,
+                min_row_id: 1,
+                max_row_id: 1,
+                creation_lsn: 0,
+                seal_seq: 0,
+                schema_version: 0,
+            },
+            Some(volume_schema),
+        );
+        if evolved_schema {
+            manager.invalidate_mappings(&schema);
+        }
+        let first_local = Arc::new(RwLock::new(TransactionVersionStore::new(
+            parent.clone(),
+            10,
+        )));
+        let mut first = SegmentedTable::new(
+            Box::new(MVCCTable::new_with_shared_store(
+                10,
+                parent.clone(),
+                first_local.clone(),
+            )),
+            manager.clone(),
+        );
+        assert_eq!(first.delete_by_row_ids(&[1]).unwrap(), 1);
+        first_local.write().unwrap().prepare_publication().unwrap();
+        for row_id in manager.get_pending_tombstones(10) {
+            let row = manager
+                .get_cold_row_normalized(row_id, &schema)
+                .unwrap()
+                .unwrap();
+            assert_eq!(row.get(1), Some(&10.into()));
+            first_local
+                .write()
+                .unwrap()
+                .reserve_cold_unique_keys(&row)
+                .unwrap();
+        }
+        manager.prepare_tombstone_publication(10, 20);
+        first_local
+            .write()
+            .unwrap()
+            .apply_prepared_publication()
+            .unwrap();
+        manager.commit_pending_tombstones(10, 20);
+        // T1 is paused immediately before recording COMMIT, matching engine ordering.
+        let second_local = Arc::new(RwLock::new(TransactionVersionStore::new(
+            parent.clone(),
+            11,
+        )));
+        let mut second = SegmentedTable::new(
+            Box::new(MVCCTable::new_with_shared_store(
+                11,
+                parent.clone(),
+                second_local.clone(),
+            )),
+            manager.clone(),
+        );
+        let inserted = second.insert_discard(Row::from(vec![2.into(), 10.into()]));
+        let prepared = inserted.and_then(|()| second_local.write().unwrap().prepare_publication());
+        assert!(
+            prepared.is_err(),
+            "cold UNIQUE key removed by an unresolved publisher was available to another publisher"
+        );
+        second_local
+            .write()
+            .unwrap()
+            .finish_publication(false)
+            .unwrap();
+        manager.finish_tombstone_publication(10, false);
+        first_local
+            .write()
+            .unwrap()
+            .finish_publication(false)
+            .unwrap();
+        assert_eq!(
+            manager
+                .get_cold_row_normalized(1, &schema)
+                .unwrap()
+                .unwrap()
+                .get(1),
+            Some(&10.into())
+        );
+    }
+}
+
+#[test]
+fn detached_index_build_excludes_publishers_and_errors_leave_no_catalog_entry() {
+    let schema = SchemaBuilder::new("detached_build")
+        .column("id", DataType::Integer, false, true)
+        .column("u", DataType::Integer, false, false)
+        .build();
+    let registry = Arc::new(stoolap::storage::mvcc::registry::TransactionRegistry::new());
+    let parent = Arc::new(VersionStore::with_visibility_checker(
+        "detached_build",
+        schema,
+        registry.clone(),
+    ));
+    let (seed_id, _) = registry.begin_transaction();
+    let mut seed = TransactionVersionStore::new(parent.clone(), seed_id);
+    seed.put(1, Row::from(vec![1.into(), 10.into()]), false)
+        .unwrap();
+    seed.commit().unwrap();
+    registry.commit_transaction(seed_id);
+    let (builder_id, _) = registry.begin_transaction();
+    let table = MVCCTable::new(
+        builder_id,
+        parent.clone(),
+        TransactionVersionStore::new(parent.clone(), builder_id),
+    );
+    let failed = table.create_index_with_type_and_finalizer(
+        "idx_u",
+        &["u"],
+        true,
+        Some(stoolap::core::IndexType::Hash),
+        &mut |detached, _install| {
+            assert!(parent.get_index("idx_u").is_none());
+            assert_eq!(detached.get_row_ids_equal(&[10.into()]).as_slice(), &[1]);
+            Err(stoolap::core::Error::internal(
+                "cold decode failed before install",
+            ))
+        },
+    );
+    assert!(failed.is_err());
+    assert!(parent.get_index("idx_u").is_none());
+    table
+        .create_index_with_type_and_finalizer(
+            "idx_u",
+            &["u"],
+            true,
+            Some(stoolap::core::IndexType::Hash),
+            &mut |_detached, install| {
+                for before_install in [true, false] {
+                    if !before_install {
+                        install()?;
+                    }
+                    let parent = Arc::clone(&parent);
+                    std::thread::spawn(move || {
+                        let mut writer = TransactionVersionStore::new(parent, 3);
+                        writer
+                            .put(2, Row::from(vec![2.into(), 20.into()]), false)
+                            .unwrap();
+                        assert!(
+                            writer.prepare_publication().is_err(),
+                            "DDL lease must exclude publication during build and installation"
+                        );
+                        writer.finish_publication(false).unwrap();
+                    })
+                    .join()
+                    .unwrap();
+                }
+                Ok(())
+            },
+        )
+        .unwrap();
+    let mut writer = TransactionVersionStore::new(parent.clone(), 4);
+    writer
+        .put(2, Row::from(vec![2.into(), 20.into()]), false)
+        .unwrap();
+    writer.commit().unwrap();
+    assert_eq!(
+        parent
+            .get_index("idx_u")
+            .unwrap()
+            .get_row_ids_equal(&[20.into()])
+            .as_slice(),
+        &[2]
+    );
+}

--- a/tests/statement_atomicity_test.rs
+++ b/tests/statement_atomicity_test.rs
@@ -1,0 +1,234 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use stoolap::Database;
+
+fn values(db: &Database) -> Vec<i64> {
+    db.query("SELECT v FROM t ORDER BY id", ())
+        .unwrap()
+        .map(|row| row.unwrap().get::<i64>(0).unwrap())
+        .collect()
+}
+
+#[test]
+fn failed_multirow_insert_preserves_prior_statements_and_savepoints() {
+    let db = Database::open("memory://statement_insert_undo").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10)", ()).unwrap();
+    db.execute("SAVEPOINT earlier", ()).unwrap();
+    assert!(db
+        .execute("INSERT INTO t VALUES (2, 20), (1, 99)", ())
+        .is_err());
+    assert_eq!(values(&db), vec![10]);
+    db.execute("INSERT INTO t VALUES (3, 30)", ()).unwrap();
+    db.execute("ROLLBACK TO earlier", ()).unwrap();
+    db.execute("COMMIT", ()).unwrap();
+    assert_eq!(values(&db), vec![10]);
+}
+
+#[test]
+fn cached_insert_and_transaction_api_rollback_a_failed_prefix() {
+    let db = Database::open("memory://statement_cached_insert_undo").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    let sql = "INSERT INTO t VALUES ($1, $2), ($3, $4)";
+    tx.execute(sql, (1, 10, 2, 20)).unwrap();
+    assert!(tx.execute(sql, (3, 30, 1, 99)).is_err());
+    tx.execute("UPDATE t SET v = 11 WHERE id = 1", ()).unwrap();
+    tx.commit().unwrap();
+    assert_eq!(values(&db), vec![11, 20]);
+}
+
+#[test]
+fn cascade_failure_keeps_all_tables_and_prior_statement() {
+    let db = Database::open("memory://statement_cascade_undo").unwrap();
+    for sql in [
+        "CREATE TABLE p (id INTEGER PRIMARY KEY)",
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) ON DELETE CASCADE)",
+        "CREATE TABLE g (id INTEGER PRIMARY KEY, cid INTEGER REFERENCES c(id) ON DELETE RESTRICT)",
+        "INSERT INTO p VALUES (1)",
+        "INSERT INTO c VALUES (1, 1), (2, 1)",
+        "INSERT INTO g VALUES (1, 2)",
+        "BEGIN",
+        "INSERT INTO p VALUES (99)",
+    ] {
+        db.execute(sql, ()).unwrap();
+    }
+    assert!(db.execute("DELETE FROM p WHERE id = 1", ()).is_err());
+    db.execute("COMMIT", ()).unwrap();
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM p", ())
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM c", ())
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM g", ())
+            .unwrap(),
+        1
+    );
+}
+
+#[cfg(feature = "test-failpoints")]
+mod failpoints {
+    use super::*;
+    use std::sync::atomic::Ordering;
+    use stoolap::test_failpoints;
+
+    #[test]
+    fn second_table_publication_failure_restores_hot_cold_and_indexes() {
+        let _guard = test_failpoints::FailpointGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let dsn = format!("file://{}", dir.path().display());
+        let db = Database::open(&dsn).unwrap();
+        for table in ["a", "b"] {
+            db.execute(
+                &format!("CREATE TABLE {table} (id INTEGER PRIMARY KEY, v INTEGER UNIQUE)"),
+                (),
+            )
+            .unwrap();
+            db.execute(&format!("INSERT INTO {table} VALUES (1, 10), (2, 20)"), ())
+                .unwrap();
+        }
+        db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        db.execute("BEGIN", ()).unwrap();
+        for table in ["a", "b"] {
+            db.execute(&format!("UPDATE {table} SET v = 11 WHERE id = 1"), ())
+                .unwrap();
+            db.execute(&format!("DELETE FROM {table} WHERE id = 2"), ())
+                .unwrap();
+            db.execute(&format!("INSERT INTO {table} VALUES (3, 30)"), ())
+                .unwrap();
+        }
+        test_failpoints::fail_table_publish_on(2);
+        assert!(db.execute("COMMIT", ()).is_err());
+        for table in ["a", "b"] {
+            assert_eq!(
+                db.query_one::<i64, _>(&format!("SELECT SUM(v) FROM {table}"), ())
+                    .unwrap(),
+                30
+            );
+            db.execute(&format!("INSERT INTO {table} VALUES (3, 30)"), ())
+                .unwrap();
+            assert!(db
+                .execute(&format!("INSERT INTO {table} VALUES (4, 10)"), ())
+                .is_err());
+        }
+        db.close().unwrap();
+        let db = Database::open(&dsn).unwrap();
+        for table in ["a", "b"] {
+            assert_eq!(
+                db.query_one::<i64, _>(&format!("SELECT SUM(v) FROM {table}"), ())
+                    .unwrap(),
+                60
+            );
+        }
+    }
+
+    #[test]
+    fn nth_cold_read_failure_discards_update_and_delete_prefixes() {
+        let _guard = test_failpoints::FailpointGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&format!("file://{}", dir.path().display())).unwrap();
+        db.execute(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER UNIQUE)",
+            (),
+        )
+        .unwrap();
+        db.execute("INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)", ())
+            .unwrap();
+        db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        let mut failures = 0;
+        for sql in [
+            "UPDATE t SET v = v + 100 WHERE id IN (1, 2, 3)",
+            "DELETE FROM t WHERE id IN (1, 2, 3)",
+        ] {
+            for nth in 1..=32 {
+                let mut tx = db.begin().unwrap();
+                tx.execute("INSERT INTO t VALUES (99, 99)", ()).unwrap();
+                test_failpoints::fail_cold_read_on(nth);
+                let result = tx.execute(sql, ());
+                test_failpoints::fail_cold_read_on(0);
+                if result.is_err() {
+                    failures += 1;
+                    assert_eq!(
+                        tx.query_one::<i64, _>("SELECT SUM(v) FROM t WHERE id < 99", ())
+                            .unwrap(),
+                        60,
+                        "failed statement left a prefix after read {nth}: {sql}"
+                    );
+                    tx.commit().unwrap();
+                    assert_eq!(
+                        db.query_one::<i64, _>("SELECT v FROM t WHERE id = 99", ())
+                            .unwrap(),
+                        99
+                    );
+                    db.execute("DELETE FROM t WHERE id = 99", ()).unwrap();
+                } else {
+                    tx.rollback().unwrap();
+                }
+                // A second transaction can reclaim every cold row after failure.
+                let mut probe = db.begin().unwrap();
+                probe
+                    .execute("UPDATE t SET v = v + 1 WHERE id = 1", ())
+                    .unwrap();
+                probe.rollback().unwrap();
+            }
+        }
+        assert!(
+            failures > 2,
+            "must exercise several cold reads, including later rows"
+        );
+    }
+
+    #[test]
+    fn failed_commit_marker_restores_all_published_tables() {
+        let _guard = test_failpoints::FailpointGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let db =
+            Database::open(&format!("file://{}?sync_mode=full", dir.path().display())).unwrap();
+        for table in ["a", "b"] {
+            db.execute(
+                &format!("CREATE TABLE {table} (id INTEGER PRIMARY KEY, v INTEGER UNIQUE)"),
+                (),
+            )
+            .unwrap();
+            db.execute(&format!("INSERT INTO {table} VALUES (1, 10)"), ())
+                .unwrap();
+        }
+        db.execute("BEGIN", ()).unwrap();
+        for table in ["a", "b"] {
+            db.execute(&format!("UPDATE {table} SET v = 20 WHERE id = 1"), ())
+                .unwrap();
+        }
+        test_failpoints::WAL_SYNC_FAIL.store(true, Ordering::Release);
+        assert!(db.execute("COMMIT", ()).is_err());
+        test_failpoints::WAL_SYNC_FAIL.store(false, Ordering::Release);
+        // A definite WAL failure permits reads, but the poisoned WAL rejects writes.
+        for table in ["a", "b"] {
+            assert_eq!(
+                db.query_one::<i64, _>(&format!("SELECT SUM(v) FROM {table}"), ())
+                    .unwrap(),
+                10
+            );
+        }
+    }
+}


### PR DESCRIPTION
I propagate required cold-read errors through SQL execution and roll back the successful prefix of a failed statement. The source diff spans several thousand lines because the fallible table contract, its optimized executor callers and rollback ownership must change together; leaving an adapter behind would either hide an error or retain partial writes. Source line totals include inline unit tests.

I retain statement and publication undo until the transaction outcome is known, protect reserved unique keys and index installation, and preserve errors after partial scan progress. Earlier successful statements and savepoints remain valid after statement failure.

| Added module or public type | Engine caller |
|---|---|
| No new production module | Existing executor, table, transaction and volume paths |
| StatementCheckpoint | SQL DML begin_statement/finish_statement and transaction rollback |
| IndexCatalogLease | CREATE INDEX installation and DML publication exclusion |
| IndexBuildFinalizer | Native/HNSW CREATE INDEX completion after cold validation |

I removed committed probes and raw measurement output and kept contracts.md and concise progress.md. Component GC/undo/reservation fixtures are additional coverage, not SQL or engine allocation evidence.

I verified SQL statement atomicity against the exact parent source in this checkout: two regressions fail there because failed INSERT prefixes remain visible, and all three public SQL regressions pass here. Final checks pass: cargo fmt, strict all-target/all-feature Clippy, 66 touched tests, the same 66 with test-filedb, and the default in-memory suite with test-failpoints (5,351 passed, 3 excluded by the default profile). One targeted run reported a lingering child-process handle; the full suite and file-backed run completed without that notice. Independent source review found no remaining cleanup issue.

I removed newly introduced unwrap/expect calls through existing references or checked errors at fallible boundaries. Existing terminal-cleanup poison and internal invariant panics remain explicit; this is not a panic-free claim.

I withdraw the historical alternating-run latency and allocation comparisons from the acceptance claims. They have not been reproduced under the current measurement protocol. This phase does not establish zero engine allocations, a hard memory limit or competitor performance.


| Diff category | Added | Removed |
|---|---:|---:|
| Source | 4,098 | 1,807 |
| Tests | 1,187 | 20 |
| Docs | 2 | 2 |
| Other | 14 | 2 |

I keep this PR in draft until latency and allocation acceptance is reproduced under the current measurement protocol. Functional cleanup verification does not complete that performance gate.

The exact-parent SQL failure evidence covers statement atomicity. Cold-read propagation has passing SQL coverage, but I have not reproduced every cold-error scenario against Phase 0.
