### PR TITLE
Store hot rows in releasable chunks and account retained allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ radsort = "0.1"  # Radix sort - O(n) for integer keys
 rand = "0.9"  # Random number generation for RANDOM() function
 ahash = "0.8"  # Fast hash for hash indexes (DOS-resistant)
 hashbrown = "0.16"  # HashMap with raw_entry API for efficient group-by
-roaring = "0.11"  # Compressed bitmap indexes (used by Lucene, Druid, Spark)
+roaring = "=0.11.3"  # Point-mutation memory bounds are verified against this version.
 lru = "0.16"  # O(1) LRU cache for compiled expression programs
 
 # Optional benchmark dependencies (for comparison benchmarks)

--- a/design/storage/progress.md
+++ b/design/storage/progress.md
@@ -8,7 +8,7 @@ with no engine caller does not count as an implemented phase.
 |---|---|---|---|
 | 0 | Lifecycle contracts and validation rules | Design accepted | [#115](https://github.com/stoolap/stoolap/pull/115) |
 | 1 | Fallible cold access and statement rollback | Cleanup verified; SQL statement rollback proven against parent | [#116](https://github.com/stoolap/stoolap/pull/116) |
-| 2 | Releasable chunks and retained hot accounting | Engine implementation present; dependency cleanup and verification in progress | [#117](https://github.com/stoolap/stoolap/pull/117) |
+| 2 | Releasable chunks and retained hot accounting | Cleanup verified; SQL arena release proven against parent; performance acceptance pending | [#117](https://github.com/stoolap/stoolap/pull/117) |
 | 3 | Coherent hot/cold reads | Draft; cleanup and final abort-publication correction remain | [#118](https://github.com/stoolap/stoolap/pull/118) |
 | 4 | Bounded streaming seal | Incomplete; unintegrated V5 prototype withdrawn | [#119](https://github.com/stoolap/stoolap/pull/119) |
 | 5 | Durable lifecycle and pressure seal | Incomplete; unintegrated catalog and WAL prototypes withdrawn | [#120](https://github.com/stoolap/stoolap/pull/120) |

--- a/src/common/compact_arc.rs
+++ b/src/common/compact_arc.rs
@@ -21,23 +21,23 @@
 //!
 //! **Use for DSTs** (`str`, `[T]`) when you have many clones sharing one allocation:
 //! - Stack pointer: 8 bytes (thin) vs std::Arc's 16 bytes (fat)
-//! - Heap header: 16 bytes vs std::Arc's 16 bytes
+//! - Heap header: 24 bytes, including an optional allocation account
 //! - Net savings: 8 bytes per clone (thin pointer)
 //!
 //! **Avoid for sized types** (`i64`, `String`, structs):
 //! - Stack pointer: 8 bytes (same as std::Arc)
-//! - Heap header: 16 bytes (same as std::Arc)
+//! - Heap header: 24 bytes, including an optional allocation account
 //! - No advantage over std::Arc
 //!
 //! ## Memory Layout
 //!
-//! All types use a compact 16-byte header. Type-specific drop logic is resolved
+//! All types use a compact 24-byte header on 64-bit targets. Type-specific drop logic is resolved
 //! at compile time via monomorphization (no stored function pointer needed):
 //!
 //! ```text
 //! Stack:  [ptr: 8 bytes] ──────────────────┐
 //!                                          ▼
-//! Heap:   [refcount: 8][len: 8][data...]
+//! Heap:   [refcount: 8][len: 8][account: 8][data...]
 //! ```
 //!
 //! ## Pointer Sizes (All Thin!)
@@ -59,10 +59,11 @@ use std::ops::Deref;
 use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
-use super::CompactVec;
+use super::memory::AccountSlot;
+use super::{CompactVec, MemoryAccount, MemoryAdoption, MemoryCharge};
 
 // ============================================================================
-// Unified Header - 16 bytes (no stored function pointer!)
+// Unified Header - three pointer words (no stored function pointer!)
 // ============================================================================
 
 /// Unified header for all CompactArc allocations.
@@ -73,6 +74,7 @@ struct Header {
     count: AtomicUsize,
     /// Length of data. For sized types: 0 (or metadata). For str: byte length. For [T]: element count.
     len: usize,
+    account: AccountSlot,
     // Data follows immediately after, aligned appropriately
 }
 
@@ -83,6 +85,16 @@ const fn data_offset_for<T>() -> usize {
     let header_size = mem::size_of::<Header>();
     let align = mem::align_of::<T>();
     (header_size + align - 1) & !(align - 1)
+}
+
+fn slice_layout<T>(len: usize) -> Layout {
+    match Layout::array::<T>(len).and_then(|data| Layout::new::<Header>().extend(data)) {
+        Ok((layout, offset)) => {
+            debug_assert_eq!(offset, data_offset_for::<T>());
+            layout
+        }
+        Err(_) => panic!("layout overflow"),
+    }
 }
 
 // ============================================================================
@@ -103,66 +115,122 @@ const fn data_offset_for<T>() -> usize {
 /// header+data allocation using the correct Layout. This trait is
 /// auto-implemented for all types used with CompactArc.
 pub unsafe trait CompactArcDrop {
-    /// Drop the contained data and deallocate the header+data allocation.
+    /// Layout of the live header and data allocation.
     ///
     /// # Safety
+    /// `ptr` must be a live allocation for this exact CompactArc type.
+    unsafe fn allocation_layout(ptr: *mut u8) -> Layout;
+
+    /// Drop data and deallocate its exclusively owned header allocation.
     ///
-    /// `ptr` must point to a valid, exclusively-owned CompactArc allocation
-    /// (starting at the Header) that was created by CompactArc's constructors.
+    /// # Safety
+    /// `ptr` must be a valid final-owned CompactArc allocation of this type.
     unsafe fn drop_and_dealloc(ptr: *mut u8);
 }
 
-// SAFETY: Correctly drops a single T at the computed data offset, then deallocates
-// the header+data allocation with the matching Layout.
+// Retain the charge while destructors run, releasing it only after the backing
+// allocation is freed. This guard also runs during a destructor unwind.
+struct AllocationGuard {
+    ptr: *mut u8,
+    layout: Layout,
+    _charge: Option<MemoryCharge>,
+}
+
+impl AllocationGuard {
+    /// # Safety
+    /// `ptr` must be a live, exclusively owned header allocated with `layout`.
+    unsafe fn new(ptr: *mut u8, layout: Layout) -> Self {
+        let charge = (*(ptr as *mut Header)).account.take(layout.size());
+        Self {
+            ptr,
+            layout,
+            _charge: charge,
+        }
+    }
+}
+
+impl Drop for AllocationGuard {
+    fn drop(&mut self) {
+        // SAFETY: this guard owns the original layout; _charge drops after deallocation.
+        unsafe {
+            dealloc(self.ptr, self.layout);
+        }
+    }
+}
+
+// Array construction owns only its initialized prefix until publication. Field
+// drop releases the backing even if an initialized element's destructor unwinds.
+struct SliceInitGuard<T> {
+    data_ptr: *mut T,
+    written: usize,
+    ptr: *mut u8,
+    layout: Layout,
+}
+
+impl<T> Drop for SliceInitGuard<T> {
+    fn drop(&mut self) {
+        // SAFETY: failed construction exclusively owns the live header and initialized prefix.
+        let _allocation = unsafe { AllocationGuard::new(self.ptr, self.layout) };
+        // SAFETY: written is advanced only after each successful ptr::write.
+        unsafe {
+            ptr::drop_in_place(ptr::slice_from_raw_parts_mut(self.data_ptr, self.written));
+        }
+    }
+}
+
+// SAFETY: the layout matches the sized constructor and data is dropped once.
 unsafe impl<T> CompactArcDrop for T {
     #[inline]
+    unsafe fn allocation_layout(_ptr: *mut u8) -> Layout {
+        Layout::from_size_align_unchecked(
+            data_offset_for::<T>() + mem::size_of::<T>(),
+            mem::align_of::<T>().max(mem::align_of::<Header>()),
+        )
+    }
+
+    #[inline]
     unsafe fn drop_and_dealloc(ptr: *mut u8) {
-        let data_offset = data_offset_for::<T>();
-        let align = mem::align_of::<T>().max(mem::align_of::<Header>());
-
-        // Drop the data
-        let data_ptr = ptr.add(data_offset) as *mut T;
-        ptr::drop_in_place(data_ptr);
-
-        // Deallocate
-        let layout = Layout::from_size_align_unchecked(data_offset + mem::size_of::<T>(), align);
-        dealloc(ptr, layout);
+        let _allocation = AllocationGuard::new(ptr, Self::allocation_layout(ptr));
+        ptr::drop_in_place(ptr.add(data_offset_for::<T>()) as *mut T);
     }
 }
 
-// SAFETY: str bytes (u8) don't need dropping. Reads len from header to compute
-// the correct deallocation Layout, then deallocates.
+// SAFETY: immutable length and byte alignment match the str constructor.
 unsafe impl CompactArcDrop for str {
     #[inline]
+    unsafe fn allocation_layout(ptr: *mut u8) -> Layout {
+        Layout::from_size_align_unchecked(
+            data_offset_for::<u8>() + (*(ptr as *mut Header)).len,
+            mem::align_of::<Header>(),
+        )
+    }
+
+    #[inline]
     unsafe fn drop_and_dealloc(ptr: *mut u8) {
-        let header = ptr as *mut Header;
-        let len = (*header).len;
-        let data_offset = data_offset_for::<u8>(); // str has align 1
-        let total_size = data_offset + len;
-        let layout = Layout::from_size_align_unchecked(total_size, mem::align_of::<Header>());
-        dealloc(ptr, layout);
+        let _allocation = AllocationGuard::new(ptr, Self::allocation_layout(ptr));
     }
 }
 
-#[allow(clippy::manual_slice_size_calculation)]
-// SAFETY: Reads len from header to reconstruct the slice, drops all len elements
-// via drop_in_place, then deallocates the header+data allocation with the matching Layout.
+// SAFETY: constructors checked the length/layout; initialized elements are
+// dropped through a slice, with allocation cleanup protected against unwind.
 unsafe impl<T> CompactArcDrop for [T] {
     #[inline]
+    unsafe fn allocation_layout(ptr: *mut u8) -> Layout {
+        let len = (*(ptr as *mut Header)).len;
+        Layout::from_size_align_unchecked(
+            data_offset_for::<T>() + mem::size_of::<T>() * len,
+            mem::align_of::<T>().max(mem::align_of::<Header>()),
+        )
+    }
+
+    #[inline]
     unsafe fn drop_and_dealloc(ptr: *mut u8) {
-        let header = ptr as *mut Header;
-        let len = (*header).len;
-        let data_offset = data_offset_for::<T>();
-        let align = mem::align_of::<T>().max(mem::align_of::<Header>());
-
-        // Drop elements
-        let data_ptr = ptr.add(data_offset) as *mut T;
-        ptr::drop_in_place(std::ptr::slice_from_raw_parts_mut(data_ptr, len));
-
-        // Deallocate
-        let layout =
-            Layout::from_size_align_unchecked(data_offset + mem::size_of::<T>() * len, align);
-        dealloc(ptr, layout);
+        let len = (*(ptr as *mut Header)).len;
+        let _allocation = AllocationGuard::new(ptr, Self::allocation_layout(ptr));
+        ptr::drop_in_place(ptr::slice_from_raw_parts_mut(
+            ptr.add(data_offset_for::<T>()) as *mut T,
+            len,
+        ));
     }
 }
 
@@ -174,7 +242,7 @@ unsafe impl<T> CompactArcDrop for [T] {
 ///
 /// `CompactArc<T>` provides shared ownership of a value of type `T`, allocated
 /// on the heap. It saves memory compared to `std::sync::Arc`:
-/// - 8 bytes less per allocation (no weak count)
+/// - One optional allocation account without growing the pointer handle
 /// - Thin pointers for DSTs (8 bytes instead of 16 for `str` and `[T]`)
 ///
 /// # Pointer Sizes
@@ -251,6 +319,54 @@ impl<T: ?Sized + CompactArcDrop> Clone for CompactArc<T> {
 // ============================================================================
 
 impl<T: ?Sized + CompactArcDrop> CompactArc<T> {
+    // Only constructors call this, before their fresh allocation is exposed.
+    fn account_new_allocation(&mut self, account: &MemoryAccount) {
+        let bytes = self.allocation_size();
+        // SAFETY: every caller exclusively owns a fresh, untracked header.
+        unsafe {
+            (*self.ptr.as_ptr()).account.install_new(account, bytes);
+        }
+    }
+
+    /// Requested bytes of this allocation only, excluding heaps owned by T.
+    pub fn allocation_size(&self) -> usize {
+        // SAFETY: self keeps this correctly typed allocation alive.
+        unsafe { T::allocation_layout(self.ptr.as_ptr() as *mut u8).size() }
+    }
+
+    pub fn memory_account(&self) -> Option<MemoryAccount> {
+        // SAFETY: self retains the allocation and its account owner.
+        unsafe { (*self.ptr.as_ptr()).account.get() }
+    }
+
+    pub fn belongs_to(&self, account: &MemoryAccount) -> bool {
+        // SAFETY: self retains the header and its installed account during inspection.
+        unsafe { (*self.ptr.as_ptr()).account.belongs_to(account) }
+    }
+
+    /// Adopt this allocation only; this does not certify ownership of T's heaps.
+    pub fn try_adopt_shallow(&self, account: &MemoryAccount) -> MemoryAdoption {
+        // SAFETY: self retains the allocation throughout account publication.
+        unsafe {
+            (*self.ptr.as_ptr())
+                .account
+                .adopt(account, self.allocation_size())
+        }
+    }
+
+    pub(crate) fn is_fully_accounted(&self) -> bool {
+        // SAFETY: self retains the header during the atomic account-tag read.
+        unsafe { (*self.ptr.as_ptr()).account.is_fully_accounted() }
+    }
+
+    /// Call only after the container's ingress accounted for all nested owners.
+    pub(crate) fn mark_fully_accounted(&self) {
+        // SAFETY: self retains the header; ingress has accounted for every nested owner.
+        unsafe {
+            (*self.ptr.as_ptr()).account.mark_fully_accounted();
+        }
+    }
+
     /// Returns `true` if the two `CompactArc`s point to the same allocation.
     #[inline]
     pub fn ptr_eq(this: &Self, other: &Self) -> bool {
@@ -302,6 +418,13 @@ impl<T: CompactArcDrop> CompactArc<T> {
         Self::new_with_meta(data, 0)
     }
 
+    /// Charge this allocation before returning; nested T ownership is separate.
+    pub fn new_in(data: T, account: &MemoryAccount) -> Self {
+        let mut value = Self::new(data);
+        value.account_new_allocation(account);
+        value
+    }
+
     /// Creates a new `CompactArc<T>` containing the given value and metadata.
     /// The metadata is stored in the header's `len` field, which is unused for Sized types.
     #[inline]
@@ -328,6 +451,7 @@ impl<T: CompactArcDrop> CompactArc<T> {
                 header,
                 Header {
                     count: AtomicUsize::new(1),
+                    account: AccountSlot::new(),
                     len: meta,
                 },
             );
@@ -373,7 +497,7 @@ impl<T: CompactArcDrop> CompactArc<T> {
                 let align = mem::align_of::<T>().max(mem::align_of::<Header>());
                 let layout =
                     Layout::from_size_align_unchecked(data_offset + mem::size_of::<T>(), align);
-                dealloc(header as *mut u8, layout);
+                drop(AllocationGuard::new(header as *mut u8, layout));
 
                 Ok(data)
             }
@@ -393,6 +517,7 @@ impl<T: CompactArcDrop> CompactArc<T> {
             // exclusive access. this.ptr is valid and data_offset_for<T>() gives the
             // correct offset to the properly aligned T.
             unsafe {
+                (*this.ptr.as_ptr()).account.clear_fully_accounted();
                 let data_ptr = (this.ptr.as_ptr() as *mut u8).add(data_offset_for::<T>()) as *mut T;
                 Some(&mut *data_ptr)
             }
@@ -412,8 +537,13 @@ impl<T: CompactArcDrop> CompactArc<T> {
         // Check if we're the only reference (uses Acquire ordering)
         if !Self::is_unique(this) {
             let meta = Self::meta(this);
-            // Clone the data since there are other references
-            *this = CompactArc::new_with_meta((**this).clone(), meta);
+            let account = this.memory_account();
+            let mut replacement = CompactArc::new_with_meta((**this).clone(), meta);
+            if let Some(account) = &account {
+                replacement.account_new_allocation(account);
+            }
+            // Cloned nested heaps remain uncertified until the container's ingress checks them.
+            *this = replacement;
         }
         // SAFETY: After the above, we're guaranteed to be the only reference
         Self::get_mut(this).unwrap()
@@ -554,9 +684,7 @@ impl CompactArc<str> {
     pub fn from_str_slice(s: &str) -> Self {
         let len = s.len();
         let data_offset = data_offset_for::<u8>(); // str has align 1
-        let total_size = data_offset + len;
-        let layout = Layout::from_size_align(total_size, mem::align_of::<Header>())
-            .expect("layout overflow");
+        let layout = slice_layout::<u8>(len);
 
         // SAFETY: We allocate memory with the correct layout for Header + str bytes.
         // We initialize all fields before returning. The source string s is valid UTF-8,
@@ -573,6 +701,7 @@ impl CompactArc<str> {
                 header,
                 Header {
                     count: AtomicUsize::new(1),
+                    account: AccountSlot::new(),
                     len,
                 },
             );
@@ -696,6 +825,72 @@ impl AsRef<str> for CompactArc<str> {
 // ============================================================================
 
 impl<T> CompactArc<[T]> {
+    /// Build one charged array without an intermediate Vec. ExactSizeIterator
+    /// supplies a capacity hint, not an unsafe promise: both directions of a
+    /// dishonest length panic with initialized-prefix cleanup.
+    pub(crate) fn from_exact_iter_in<I>(mut values: I, account: &MemoryAccount) -> Self
+    where
+        I: ExactSizeIterator<Item = T>,
+    {
+        let len = values.len();
+        let data_offset = data_offset_for::<T>();
+        let layout = slice_layout::<T>(len);
+        // SAFETY: the checked layout fits len values; publication follows complete initialization.
+        unsafe {
+            let ptr = alloc(layout);
+            if ptr.is_null() {
+                handle_alloc_error(layout);
+            }
+            let header = ptr as *mut Header;
+            ptr::write(
+                header,
+                Header {
+                    count: AtomicUsize::new(1),
+                    len,
+                    account: AccountSlot::new(),
+                },
+            );
+            let data_ptr = ptr.add(data_offset) as *mut T;
+            let mut guard = SliceInitGuard {
+                data_ptr,
+                written: 0,
+                ptr,
+                layout,
+            };
+            // Charge the allocated array before iterator callbacks can observe the account.
+            (*header).account.install_new(account, layout.size());
+            for index in 0..len {
+                let Some(value) = values.next() else {
+                    panic!("exact iterator returned too few values");
+                };
+                ptr::write(data_ptr.add(index), value);
+                guard.written += 1;
+            }
+            assert!(
+                values.next().is_none(),
+                "exact iterator returned too many values"
+            );
+            drop(values);
+            mem::forget(guard);
+            CompactArc {
+                ptr: NonNull::new_unchecked(header),
+                _marker: PhantomData,
+            }
+        }
+    }
+
+    pub fn from_vec_in(values: Vec<T>, account: &MemoryAccount) -> Self {
+        let mut values = Self::from_vec(values);
+        values.account_new_allocation(account);
+        values
+    }
+
+    pub fn from_compact_vec_in(values: CompactVec<T>, account: &MemoryAccount) -> Self {
+        let mut values = Self::from_compact_vec(values);
+        values.account_new_allocation(account);
+        values
+    }
+
     /// Creates a new `CompactArc<[T]>` by moving elements from a Vec.
     ///
     /// This is more efficient than `from_slice` as it moves elements instead of cloning.
@@ -703,10 +898,7 @@ impl<T> CompactArc<[T]> {
     pub fn from_vec(mut vec: Vec<T>) -> Self {
         let len = vec.len();
         let data_offset = data_offset_for::<T>();
-        let align = mem::align_of::<T>().max(mem::align_of::<Header>());
-        let data_size = mem::size_of::<T>() * len;
-        let layout =
-            Layout::from_size_align(data_offset + data_size, align).expect("layout overflow");
+        let layout = slice_layout::<T>(len);
 
         // SAFETY: We allocate memory with the correct layout for Header + [T].
         // We copy (move) the elements from vec into the allocation, then set vec's len to 0
@@ -724,6 +916,7 @@ impl<T> CompactArc<[T]> {
                 header,
                 Header {
                     count: AtomicUsize::new(1),
+                    account: AccountSlot::new(),
                     len,
                 },
             );
@@ -750,10 +943,7 @@ impl<T> CompactArc<[T]> {
     pub fn from_compact_vec(mut vec: CompactVec<T>) -> Self {
         let len = vec.len();
         let data_offset = data_offset_for::<T>();
-        let align = mem::align_of::<T>().max(mem::align_of::<Header>());
-        let data_size = mem::size_of::<T>() * len;
-        let layout =
-            Layout::from_size_align(data_offset + data_size, align).expect("layout overflow");
+        let layout = slice_layout::<T>(len);
 
         // SAFETY: We allocate memory with the correct layout for Header + [T].
         // We copy (move) the elements from vec into the allocation, then set vec's len to 0
@@ -771,6 +961,7 @@ impl<T> CompactArc<[T]> {
                 header,
                 Header {
                     count: AtomicUsize::new(1),
+                    account: AccountSlot::new(),
                     len,
                 },
             );
@@ -791,6 +982,10 @@ impl<T> CompactArc<[T]> {
 }
 
 impl<T: Clone> CompactArc<[T]> {
+    pub fn from_slice_in(values: &[T], account: &MemoryAccount) -> Self {
+        Self::from_exact_iter_in(values.iter().cloned(), account)
+    }
+
     /// Creates a new `CompactArc<[T]>` from a slice by cloning elements.
     ///
     /// The pointer is only 8 bytes (thin), with length stored in heap header.
@@ -803,9 +998,7 @@ impl<T: Clone> CompactArc<[T]> {
     pub fn from_slice(slice: &[T]) -> Self {
         let len = slice.len();
         let data_offset = data_offset_for::<T>();
-        let align = mem::align_of::<T>().max(mem::align_of::<Header>());
-        let layout = Layout::from_size_align(data_offset + mem::size_of_val(slice), align)
-            .expect("layout overflow");
+        let layout = slice_layout::<T>(len);
 
         // SAFETY: We allocate memory with the correct layout for Header + [T].
         // We use a CloneGuard for panic safety - if any clone() panics, the guard
@@ -823,6 +1016,7 @@ impl<T: Clone> CompactArc<[T]> {
                 header,
                 Header {
                     count: AtomicUsize::new(1),
+                    account: AccountSlot::new(),
                     len,
                 },
             );
@@ -843,11 +1037,10 @@ impl<T: Clone> CompactArc<[T]> {
                     // are initialized. We drop those elements, then deallocate the memory
                     // using the stored layout. This is only called on panic during clone.
                     unsafe {
+                        let _allocation = AllocationGuard::new(self.alloc_ptr, self.layout);
                         // Drop all successfully written elements
                         let slice = ptr::slice_from_raw_parts_mut(self.data_ptr, self.written);
                         ptr::drop_in_place(slice);
-                        // Deallocate the memory
-                        dealloc(self.alloc_ptr, self.layout);
                     }
                 }
             }
@@ -989,6 +1182,344 @@ mod tests {
     use super::*;
 
     #[test]
+    fn from_slice_in_accounts_clone_callbacks_and_peak_overlap() {
+        use std::cell::Cell;
+
+        struct Probe<'a> {
+            account: &'a MemoryAccount,
+            clone_retained: &'a Cell<usize>,
+        }
+        impl Clone for Probe<'_> {
+            fn clone(&self) -> Self {
+                self.clone_retained
+                    .set(self.account.snapshot().retained_bytes);
+                // A nested allocation can disappear before construction ends;
+                // its peak must still overlap the destination array's charge.
+                let temporary = MemoryCharge::new(self.account, 4096);
+                drop(temporary);
+                Self {
+                    account: self.account,
+                    clone_retained: self.clone_retained,
+                }
+            }
+        }
+
+        let account = MemoryAccount::new();
+        let clone_retained = Cell::new(0);
+        let source = [Probe {
+            account: &account,
+            clone_retained: &clone_retained,
+        }];
+        let values = CompactArc::from_slice_in(&source, &account);
+        let destination_bytes = values.allocation_size();
+        let snapshot = account.snapshot();
+        assert_eq!(clone_retained.get(), destination_bytes);
+        assert_eq!(snapshot.retained_bytes, destination_bytes);
+        assert_eq!(
+            snapshot.peak_accounted_bytes,
+            snapshot.conservative_bytes + destination_bytes + 4096
+        );
+        drop(values);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn from_slice_in_keeps_charge_through_clone_panic_cleanup() {
+        use std::cell::Cell;
+
+        struct Probe<'a> {
+            account: &'a MemoryAccount,
+            clones: &'a Cell<usize>,
+            drops: &'a Cell<usize>,
+            drop_retained: &'a Cell<usize>,
+            is_clone: bool,
+        }
+        impl Clone for Probe<'_> {
+            fn clone(&self) -> Self {
+                self.clones.set(self.clones.get() + 1);
+                assert_ne!(self.clones.get(), 2, "second clone fails");
+                Self {
+                    account: self.account,
+                    clones: self.clones,
+                    drops: self.drops,
+                    drop_retained: self.drop_retained,
+                    is_clone: true,
+                }
+            }
+        }
+        impl Drop for Probe<'_> {
+            fn drop(&mut self) {
+                if self.is_clone {
+                    self.drops.set(self.drops.get() + 1);
+                    // Record instead of asserting while unwinding: the test
+                    // must report missing accounting without a double panic.
+                    self.drop_retained
+                        .set(self.account.snapshot().retained_bytes);
+                }
+            }
+        }
+
+        let account = MemoryAccount::new();
+        let clones = Cell::new(0);
+        let drops = Cell::new(0);
+        let drop_retained = Cell::new(0);
+        let source = std::array::from_fn::<_, 3, _>(|_| Probe {
+            account: &account,
+            clones: &clones,
+            drops: &drops,
+            drop_retained: &drop_retained,
+            is_clone: false,
+        });
+        let destination_bytes = data_offset_for::<Probe<'_>>() + mem::size_of_val(&source);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            CompactArc::from_slice_in(&source, &account)
+        }));
+        assert!(result.is_err());
+        assert_eq!(clones.get(), 2);
+        assert_eq!(drops.get(), 1);
+        assert_eq!(drop_retained.get(), destination_bytes);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn exact_iterator_has_one_array_and_checks_dishonest_lengths() {
+        use std::sync::atomic::AtomicUsize;
+        use std::sync::Arc;
+        struct Item(Arc<AtomicUsize>);
+        impl Drop for Item {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, AtomicOrdering::Relaxed);
+            }
+        }
+        struct Liar {
+            values: std::vec::IntoIter<Item>,
+            advertised: usize,
+            panic_after: Option<usize>,
+            seen: usize,
+        }
+        impl Iterator for Liar {
+            type Item = Item;
+            fn next(&mut self) -> Option<Item> {
+                if self.panic_after == Some(self.seen) {
+                    panic!("iterator next panic");
+                }
+                self.seen += 1;
+                self.values.next()
+            }
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                (self.advertised, Some(self.advertised))
+            }
+        }
+        impl ExactSizeIterator for Liar {}
+        let account = MemoryAccount::new();
+        for (actual, advertised, panic_after) in [(2, 4, None), (4, 2, None), (3, 3, Some(1))] {
+            let dropped = Arc::new(AtomicUsize::new(0));
+            let values = (0..actual)
+                .map(|_| Item(dropped.clone()))
+                .collect::<Vec<_>>();
+            let iterator = Liar {
+                values: values.into_iter(),
+                advertised,
+                panic_after,
+                seen: 0,
+            };
+            assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                CompactArc::from_exact_iter_in(iterator, &account);
+            }))
+            .is_err());
+            assert_eq!(dropped.load(AtomicOrdering::Relaxed), actual);
+            assert_eq!(account.snapshot().retained_bytes, 0);
+        }
+        let values = CompactArc::from_exact_iter_in([1usize, 2, 3].into_iter(), &account);
+        assert_eq!(&*values, &[1, 2, 3]);
+        assert!(!values.is_fully_accounted());
+        assert_eq!(account.snapshot().retained_bytes, values.allocation_size());
+        drop(values);
+        let empty = CompactArc::<[usize]>::from_exact_iter_in([].into_iter(), &account);
+        assert!(empty.is_empty());
+        drop(empty);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn exact_iterator_accounts_callbacks_and_destructor_unwind() {
+        use std::sync::Arc;
+        let account = MemoryAccount::new();
+        let values = [1usize, 2, 3].into_iter().inspect(|_| {
+            assert!(account.snapshot().retained_bytes > 0);
+        });
+        let array = CompactArc::from_exact_iter_in(values, &account);
+        assert_eq!(account.snapshot().retained_bytes, array.allocation_size());
+        drop(array);
+
+        struct Item(MemoryAccount, Arc<AtomicUsize>);
+        impl Drop for Item {
+            fn drop(&mut self) {
+                assert!(self.0.snapshot().retained_bytes > 0);
+                self.1.fetch_add(1, AtomicOrdering::Relaxed);
+            }
+        }
+        struct PanicDrop(std::vec::IntoIter<Item>);
+        impl Iterator for PanicDrop {
+            type Item = Item;
+            fn next(&mut self) -> Option<Item> {
+                self.0.next()
+            }
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.0.size_hint()
+            }
+        }
+        impl ExactSizeIterator for PanicDrop {}
+        impl Drop for PanicDrop {
+            fn drop(&mut self) {
+                panic!("iterator drop panic");
+            }
+        }
+        let dropped = Arc::new(AtomicUsize::new(0));
+        let values = (0..3)
+            .map(|_| Item(account.clone(), dropped.clone()))
+            .collect::<Vec<_>>();
+        assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            CompactArc::from_exact_iter_in(PanicDrop(values.into_iter()), &account);
+        }))
+        .is_err());
+        assert_eq!(dropped.load(AtomicOrdering::Relaxed), 3);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn charged_str_and_high_alignment_raw_owners_release_exactly() {
+        #[repr(align(128))]
+        #[derive(Clone, Debug, PartialEq)]
+        struct Aligned([u8; 129]);
+        let account = MemoryAccount::new();
+        let value = CompactArc::new_in(Aligned([7; 129]), &account);
+        let bytes = value.allocation_size();
+        let raw = CompactArc::into_raw(value);
+        assert_eq!(raw.addr() % 128, 0);
+        let restored = unsafe { CompactArc::from_raw(raw) };
+        assert_eq!(account.snapshot().retained_bytes, bytes);
+        assert_eq!(CompactArc::try_unwrap(restored).unwrap(), Aligned([7; 129]));
+        assert_eq!(account.snapshot().retained_bytes, 0);
+        let mut text = CompactArc::from_str_slice("charged UTF-8: İstanbul");
+        text.account_new_allocation(&account);
+        let bytes = text.allocation_size();
+        let other = text.clone();
+        drop(text);
+        assert_eq!(account.snapshot().retained_bytes, bytes);
+        assert_eq!(&*other, "charged UTF-8: İstanbul");
+        drop(other);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn charged_cow_and_unwrap_keep_nested_heap_aliases() {
+        #[derive(Clone, Debug)]
+        struct Container {
+            child: super::super::SmartString,
+        }
+        let account = MemoryAccount::new();
+        let child = super::super::SmartString::new("nested child survives COW and unwrap")
+            .into_hot(&account);
+        let child_bytes = account.snapshot().retained_bytes;
+        let mut value = CompactArc::new_in(Container { child }, &account);
+        let outer_bytes = value.allocation_size();
+        value.mark_fully_accounted();
+        let previous = value.clone();
+        assert_eq!(
+            CompactArc::make_mut(&mut value).child.as_str(),
+            "nested child survives COW and unwrap"
+        );
+        assert!(!value.is_fully_accounted());
+        assert_eq!(
+            account.snapshot().retained_bytes,
+            child_bytes + 2 * outer_bytes
+        );
+        let owned = CompactArc::try_unwrap(value).unwrap();
+        drop(previous);
+        assert_eq!(account.snapshot().retained_bytes, child_bytes);
+        assert_eq!(owned.child.as_str(), "nested child survives COW and unwrap");
+        drop(owned);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn accounted_aliases_release_only_final_allocation() {
+        let account = MemoryAccount::new();
+        let values = CompactArc::from_vec_in(vec![1u64, 2, 3], &account);
+        let bytes = values.allocation_size();
+        assert_eq!(account.snapshot().retained_bytes, bytes);
+        let alias = values.clone();
+        drop(values);
+        assert_eq!(account.snapshot().retained_bytes, bytes);
+        assert_eq!(&*alias, &[1, 2, 3]);
+        drop(alias);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn raw_round_trip_unwrap_and_mutable_escape_keep_correct_charge() {
+        let account = MemoryAccount::new();
+        let mut value = CompactArc::new_in(42usize, &account);
+        let bytes = value.allocation_size();
+        value.mark_fully_accounted();
+        assert!(value.is_fully_accounted());
+        *CompactArc::get_mut(&mut value).unwrap() = 43;
+        assert!(!value.is_fully_accounted());
+        value.mark_fully_accounted();
+        let raw = CompactArc::into_raw(value);
+        let mut value = unsafe { CompactArc::from_raw(raw) };
+        assert!(value.is_fully_accounted());
+        let previous = value.clone();
+        *CompactArc::make_mut(&mut value) = 44;
+        assert!(!value.is_fully_accounted());
+        assert!(previous.is_fully_accounted());
+        assert_eq!(account.snapshot().retained_bytes, 2 * bytes);
+        assert_eq!(CompactArc::try_unwrap(value).unwrap(), 44);
+        assert_eq!(account.snapshot().retained_bytes, bytes);
+        drop(previous);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+        let mut unique = CompactArc::new_in(1usize, &account);
+        unique.mark_fully_accounted();
+        CompactArc::make_mut(&mut unique);
+        assert!(!unique.is_fully_accounted());
+    }
+
+    #[test]
+    fn panicking_destructor_still_frees_header_and_charge() {
+        struct Panicking;
+        impl Drop for Panicking {
+            fn drop(&mut self) {
+                panic!("expected destructor panic");
+            }
+        }
+        let account = MemoryAccount::new();
+        let value = CompactArc::new_in(Panicking, &account);
+        assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(value))).is_err());
+        assert_eq!(account.snapshot().retained_bytes, 0);
+        let values = CompactArc::from_vec_in(vec![Panicking], &account);
+        assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(values))).is_err());
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn nested_string_alias_outlives_parent_array() {
+        let account = MemoryAccount::new();
+        let text = super::super::SmartString::new("nested heap backing remains retained")
+            .into_hot(&account);
+        let string_bytes = account.snapshot().retained_bytes;
+        let alias = text.clone();
+        let values = CompactArc::from_vec_in(vec![text], &account);
+        assert!(!values.is_fully_accounted());
+        values.mark_fully_accounted();
+        assert!(values.is_fully_accounted());
+        drop(values);
+        assert_eq!(account.snapshot().retained_bytes, string_bytes);
+        drop(alias);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
     fn test_new_and_deref() {
         let arc = CompactArc::new(42);
         assert_eq!(*arc, 42);
@@ -1120,8 +1651,11 @@ mod tests {
 
     #[test]
     fn test_header_size() {
-        // Header should be exactly 16 bytes (refcount + len, no dropper)
-        assert_eq!(std::mem::size_of::<Header>(), 16);
+        // Three pointer words: refcount, length, optional account.
+        assert_eq!(
+            std::mem::size_of::<Header>(),
+            3 * std::mem::size_of::<usize>()
+        );
     }
 
     #[test]

--- a/src/common/cow_btree.rs
+++ b/src/common/cow_btree.rs
@@ -32,7 +32,7 @@
 //! - Clone: O(1) - just increments reference counts
 //! - Memory: Shared nodes between snapshots
 
-use super::CompactArc;
+use super::{CompactArc, MemoryAccount};
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::Bound;
@@ -162,12 +162,15 @@ impl<V: Clone> NodePtr<V> {
         Self::keys_offset() + ((MAX_KEYS + 1) * 8)
     }
 
-    fn new_leaf() -> Self {
+    fn new_leaf_in(account: Option<&MemoryAccount>) -> Self {
         let size = Self::values_offset() + ((MAX_KEYS + 1) * mem::size_of::<V>());
-        let vec = vec![0u8; size];
-
         let mut ptr = NodePtr {
-            ptr: CompactArc::from_vec(vec),
+            ptr: match account {
+                Some(account) => {
+                    CompactArc::from_exact_iter_in(std::iter::repeat_n(0u8, size), account)
+                }
+                None => CompactArc::from_vec(vec![0u8; size]),
+            },
             _marker: PhantomData,
         };
 
@@ -179,12 +182,15 @@ impl<V: Clone> NodePtr<V> {
         ptr
     }
 
-    fn new_internal() -> Self {
+    fn new_internal_in(account: Option<&MemoryAccount>) -> Self {
         let size = Self::children_offset() + ((MAX_KEYS + 2) * mem::size_of::<NodePtr<V>>());
-        let vec = vec![0u8; size];
-
         let mut ptr = NodePtr {
-            ptr: CompactArc::from_vec(vec),
+            ptr: match account {
+                Some(account) => {
+                    CompactArc::from_exact_iter_in(std::iter::repeat_n(0u8, size), account)
+                }
+                None => CompactArc::from_vec(vec![0u8; size]),
+            },
             _marker: PhantomData,
         };
 
@@ -216,7 +222,7 @@ impl<V: Clone> NodePtr<V> {
         let len = self.len();
 
         if self.is_leaf() {
-            let mut new_node = NodePtr::new_leaf();
+            let mut new_node = NodePtr::new_leaf_in(self.ptr.memory_account().as_ref());
             // Do NOT set len yet to ensure exception safety!
             // If V::clone() panics, new_node.drop() will only drop 0 elements.
 
@@ -246,7 +252,7 @@ impl<V: Clone> NodePtr<V> {
 
             new_node
         } else {
-            let mut new_node = NodePtr::new_internal();
+            let mut new_node = NodePtr::new_internal_in(self.ptr.memory_account().as_ref());
             new_node.set_len(len);
 
             // Copy keys (i64 is Copy)
@@ -458,7 +464,7 @@ impl<V: Clone> NodePtr<V> {
         let len = self.len();
         let mid = len / 2;
         let med_key = self.keys()[mid];
-        let mut right = NodePtr::new_internal();
+        let mut right = NodePtr::new_internal_in(self.ptr.memory_account().as_ref());
         let right_keys_count = len - mid - 1;
         let right_children_count = right_keys_count + 1;
 
@@ -495,7 +501,7 @@ impl<V: Clone> NodePtr<V> {
         // Median is the last key - it goes to parent
         let med_key = self.keys()[len - 1];
 
-        let mut right = NodePtr::new_internal();
+        let mut right = NodePtr::new_internal_in(self.ptr.memory_account().as_ref());
 
         // SAFETY: self is an internal node with MAX_KEYS + 1 keys (MAX_KEYS + 2 children).
         // We move only the last child to right. Children are moved via ptr::read then ptr::write.
@@ -805,7 +811,7 @@ impl<V: Clone> NodePtr<V> {
         let mid = self.len() / 2;
         let right_count = self.len() - mid;
 
-        let mut right = NodePtr::new_leaf();
+        let mut right = NodePtr::new_leaf_in(self.ptr.memory_account().as_ref());
 
         // SAFETY: Both self and right are leaf nodes. We copy keys from indices [mid..len)
         // and values from indices [mid..len) of self into the start of right. The source
@@ -840,7 +846,7 @@ impl<V: Clone> NodePtr<V> {
             "split_leaf_rightmost expects overflow node"
         );
 
-        let mut right = NodePtr::new_leaf();
+        let mut right = NodePtr::new_leaf_in(self.ptr.memory_account().as_ref());
 
         // SAFETY: self is a leaf with MAX_KEYS + 1 elements. We move only the last
         // key/value to right. The key is Copy (i64). The value is moved via ptr::read
@@ -930,6 +936,9 @@ impl NodePath {
 
 pub struct CowBTree<V: Clone> {
     root: Option<NodePtr<V>>,
+    /// Constructor policy for fresh roots, retained even after clear. Shared
+    /// nodes carry their own allocation charge in CompactArc's header.
+    account: Option<MemoryAccount>,
     /// Cached maximum key in the tree. Valid if root.is_some().
     max_key: i64,
     /// Number of elements in the tree
@@ -948,6 +957,7 @@ impl<V: Clone> Clone for CowBTree<V> {
     fn clone(&self) -> Self {
         Self {
             root: self.root.clone(),
+            account: self.account.clone(),
             max_key: self.max_key,
             len: self.len,
         }
@@ -963,9 +973,22 @@ impl<V: Clone> CowBTree<V> {
         );
         Self {
             root: None,
+            account: None,
             max_key: 0,
             len: 0,
         }
+    }
+
+    /// Account every newly allocated fixed node. Cloning the tree shares the
+    /// existing node charges; only a split or COW copy creates another charge.
+    pub fn new_in(account: MemoryAccount) -> Self {
+        let mut tree = Self::new();
+        tree.account = Some(account);
+        tree
+    }
+
+    pub fn memory_account(&self) -> Option<&MemoryAccount> {
+        self.account.as_ref()
     }
 
     #[inline]
@@ -1034,7 +1057,7 @@ impl<V: Clone> CowBTree<V> {
     /// Insert a key-value pair. Returns old value if key existed.
     pub fn insert(&mut self, key: i64, value: V) -> Option<V> {
         if self.root.is_none() {
-            let mut node = NodePtr::new_leaf();
+            let mut node = NodePtr::new_leaf_in(self.account.as_ref());
             node.push_leaf(key, value);
             self.root = Some(node);
             self.max_key = key;
@@ -1057,7 +1080,7 @@ impl<V: Clone> CowBTree<V> {
                 }
                 InsertResult::Split(median, right) => {
                     let old_root = self.root.take().unwrap();
-                    let mut new_root = NodePtr::new_internal();
+                    let mut new_root = NodePtr::new_internal_in(self.account.as_ref());
 
                     // SAFETY: new_root is a freshly created internal node with len=0.
                     // We write old_root to children[0]. Internal nodes have len+1 children,
@@ -1096,7 +1119,7 @@ impl<V: Clone> CowBTree<V> {
             }
             InsertResult::Split(median, right) => {
                 let old_root = self.root.take().unwrap();
-                let mut new_root = NodePtr::new_internal();
+                let mut new_root = NodePtr::new_internal_in(self.account.as_ref());
                 // SAFETY: new_root is a freshly created internal node with len=0.
                 // We write old_root to children[0]. Internal nodes have len+1 children,
                 // so with len=0 we have space for 1 child at index 0. old_root is moved
@@ -1546,7 +1569,7 @@ impl<V: Clone> CowBTree<V> {
             }
             InsertResult::Split(median, right) => {
                 let old_root = self.root.take().unwrap();
-                let mut new_root = NodePtr::new_internal();
+                let mut new_root = NodePtr::new_internal_in(self.account.as_ref());
                 // SAFETY: new_root is a freshly created internal node with len=0.
                 // We write old_root to children[0]. Internal nodes have len+1 children,
                 // so with len=0 we have space for 1 child at index 0. old_root is moved
@@ -1630,7 +1653,7 @@ impl<V: Clone> CowBTree<V> {
             }
             InsertResult::Split(median, right) => {
                 let old_root = self.root.take().unwrap();
-                let mut new_root = NodePtr::new_internal();
+                let mut new_root = NodePtr::new_internal_in(self.account.as_ref());
                 // SAFETY: new_root is a freshly created internal node with len=0.
                 // We write old_root to children[0]. Internal nodes have len+1 children,
                 // so with len=0 we have space for 1 child at index 0. old_root is moved
@@ -2410,7 +2433,8 @@ mod tests {
 
     #[test]
     fn test_memory_size() {
-        assert!(std::mem::size_of::<CowBTree<i64>>() <= 24);
+        // One thin root, length, rightmost-key cache, and origin account.
+        assert!(std::mem::size_of::<CowBTree<i64>>() <= 24 + std::mem::size_of::<usize>());
     }
 
     #[test]
@@ -4053,5 +4077,88 @@ mod tests {
             result,
             vec![10_009, 10_008, 10_007, 10_006, 10_005, 10_004, 10_003, 10_002, 10_001, 10_000]
         );
+    }
+}
+
+#[cfg(test)]
+mod allocation_accounting_tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn distinct_node_bytes(
+        node: &NodePtr<i64>,
+        seen: &mut HashSet<usize>,
+        account: &MemoryAccount,
+    ) -> usize {
+        if !seen.insert(node.ptr.data_ptr_mut() as usize) {
+            return 0;
+        }
+        assert!(node.ptr.memory_account().unwrap().same_origin(account));
+        let mut bytes = node.ptr.allocation_size();
+        if !node.is_leaf() {
+            for child in node.children() {
+                bytes += distinct_node_bytes(child, seen, account);
+            }
+        }
+        bytes
+    }
+
+    fn expected_bytes(trees: &[&CowBTree<i64>], account: &MemoryAccount) -> usize {
+        let mut seen = HashSet::new();
+        trees
+            .iter()
+            .filter_map(|tree| tree.root.as_ref())
+            .map(|root| distinct_node_bytes(root, &mut seen, account))
+            .sum()
+    }
+
+    #[test]
+    fn node_charges_survive_snapshots_cow_splits_merges_and_clear() {
+        let root = MemoryAccount::new();
+        let baseline = root.snapshot().accounted_bytes;
+        let origin = root.child();
+        let mut tree = CowBTree::new_in(origin.clone());
+        assert_eq!(root.snapshot().retained_bytes, 0);
+        // Non-monotonic order exercises ordinary and rightmost leaf/internal
+        // splits while keeping enough nodes to exercise merges on removal.
+        for index in 0..5000 {
+            let key = index * 2;
+            tree.insert(key, key);
+        }
+        for index in (0..5000).rev() {
+            let key = index * 2 + 1;
+            tree.insert(key, key);
+        }
+        let before_clone = root.snapshot().retained_bytes;
+        assert_eq!(before_clone, expected_bytes(&[&tree], &origin));
+        let snapshot = tree.clone();
+        assert_eq!(root.snapshot().retained_bytes, before_clone);
+        tree.insert(123, -1);
+        assert_eq!(snapshot.get(123), Some(&123));
+        assert_eq!(tree.get(123), Some(&-1));
+        assert_eq!(
+            root.snapshot().retained_bytes,
+            expected_bytes(&[&tree, &snapshot], &origin)
+        );
+        for key in 0..9000 {
+            assert!(tree.remove(key).is_some());
+        }
+        assert_eq!(
+            root.snapshot().retained_bytes,
+            expected_bytes(&[&tree, &snapshot], &origin)
+        );
+        tree.clear();
+        assert_eq!(root.snapshot().retained_bytes, before_clone);
+        tree.insert(-1, 42);
+        assert_eq!(
+            root.snapshot().retained_bytes,
+            expected_bytes(&[&tree, &snapshot], &origin)
+        );
+        drop(tree);
+        drop(origin);
+        assert_eq!(root.snapshot().retained_bytes, before_clone);
+        drop(snapshot);
+        assert_eq!(root.snapshot().retained_bytes, 0);
+        assert_eq!(root.snapshot().accounted_bytes, baseline);
     }
 }

--- a/src/common/i64_map.rs
+++ b/src/common/i64_map.rs
@@ -22,6 +22,8 @@
 
 use std::mem::MaybeUninit;
 
+use super::{MemoryAccount, MemoryAdoption, MemoryCharge};
+
 const MIN_CAPACITY: usize = 8;
 const LOAD_FACTOR_NUM: usize = 3;
 const LOAD_FACTOR_DEN: usize = 4;
@@ -52,11 +54,13 @@ pub struct I64Map<V> {
     /// beside the table. Callers hand this map keys derived from user
     /// data, so the full i64 range must be storable.
     min_slot: Option<V>,
+    // The slots and their values are freed before releasing this buffer charge.
+    charge: Option<MemoryCharge>,
 }
 
 impl<V: Clone> Clone for I64Map<V> {
     fn clone(&self) -> Self {
-        let mut new_map = Self::with_capacity(self.len);
+        let mut new_map = Self::with_optional_account(self.len, self.memory_account());
         for (key, value) in self.iter() {
             new_map.insert(key, value.clone());
         }
@@ -105,6 +109,18 @@ impl<V> I64Map<V> {
     }
 
     pub fn with_capacity(capacity: usize) -> Self {
+        Self::with_optional_account(capacity, None)
+    }
+
+    pub fn new_in(account: &MemoryAccount) -> Self {
+        Self::with_capacity_in(0, account)
+    }
+
+    pub fn with_capacity_in(capacity: usize, account: &MemoryAccount) -> Self {
+        Self::with_optional_account(capacity, Some(account))
+    }
+
+    fn with_optional_account(capacity: usize, account: Option<&MemoryAccount>) -> Self {
         let cap = if capacity == 0 {
             MIN_CAPACITY
         } else {
@@ -122,12 +138,40 @@ impl<V> I64Map<V> {
             })
             .collect();
 
+        let slots = slots.into_boxed_slice();
+        let charge =
+            account.map(|account| MemoryCharge::new(account, std::mem::size_of_val(&*slots)));
         Self {
-            slots: slots.into_boxed_slice(),
+            slots,
             len: 0,
             mask: cap - 1,
             min_slot: None,
+            charge,
         }
+    }
+
+    /// Bytes in the physical slot buffer; values' separate allocations retain
+    /// their own ownership accounting. Unused capacity is included.
+    #[inline]
+    pub fn allocation_size(&self) -> usize {
+        std::mem::size_of_val(&*self.slots)
+    }
+
+    pub fn memory_account(&self) -> Option<&MemoryAccount> {
+        self.charge.as_ref().map(MemoryCharge::account)
+    }
+
+    /// Attach only the physical buffer; values own their separate allocations.
+    pub fn attach_memory_account(&mut self, account: &MemoryAccount) -> MemoryAdoption {
+        if let Some(origin) = self.memory_account() {
+            return if origin.same_engine(account) {
+                MemoryAdoption::AlreadyOwned
+            } else {
+                MemoryAdoption::ForeignEngine
+            };
+        }
+        self.charge = Some(MemoryCharge::new(account, self.allocation_size()));
+        MemoryAdoption::Adopted
     }
 
     #[inline(always)]
@@ -173,7 +217,13 @@ impl<V> I64Map<V> {
             })
             .collect();
 
-        let old_slots = std::mem::replace(&mut self.slots, new_slots.into_boxed_slice());
+        let new_slots = new_slots.into_boxed_slice();
+        // Charge both buffers during rehash and release the original charge after its slots.
+        let new_charge = self
+            .memory_account()
+            .map(|account| MemoryCharge::new(account, std::mem::size_of_val(&*new_slots)));
+        let old_slots = std::mem::replace(&mut self.slots, new_slots);
+        let old_charge = std::mem::replace(&mut self.charge, new_charge);
         let old_len = self.len;
         self.len = 0;
         self.mask = new_mask;
@@ -186,6 +236,8 @@ impl<V> I64Map<V> {
             }
         }
 
+        drop(old_slots);
+        drop(old_charge);
         debug_assert_eq!(self.len, old_len);
     }
 
@@ -413,7 +465,13 @@ impl<V> I64Map<V> {
             })
             .collect();
 
-        let old_slots = std::mem::replace(&mut self.slots, new_slots.into_boxed_slice());
+        let new_slots = new_slots.into_boxed_slice();
+        // Charge both buffers during rehash and release the original charge after its slots.
+        let new_charge = self
+            .memory_account()
+            .map(|account| MemoryCharge::new(account, std::mem::size_of_val(&*new_slots)));
+        let old_slots = std::mem::replace(&mut self.slots, new_slots);
+        let old_charge = std::mem::replace(&mut self.charge, new_charge);
         let old_len = self.len;
         self.len = 0;
         self.mask = new_mask;
@@ -426,6 +484,7 @@ impl<V> I64Map<V> {
             }
         }
 
+        drop(old_charge);
         debug_assert_eq!(self.len, old_len);
     }
 
@@ -463,7 +522,13 @@ impl<V> I64Map<V> {
             })
             .collect();
 
-        let old_slots = std::mem::replace(&mut self.slots, new_slots.into_boxed_slice());
+        let new_slots = new_slots.into_boxed_slice();
+        // Charge both buffers during rehash and release the original charge after its slots.
+        let new_charge = self
+            .memory_account()
+            .map(|account| MemoryCharge::new(account, std::mem::size_of_val(&*new_slots)));
+        let old_slots = std::mem::replace(&mut self.slots, new_slots);
+        let old_charge = std::mem::replace(&mut self.charge, new_charge);
         let old_len = self.len;
         self.len = 0;
         self.mask = new_mask;
@@ -476,6 +541,7 @@ impl<V> I64Map<V> {
             }
         }
 
+        drop(old_charge);
         debug_assert_eq!(self.len, old_len);
     }
 
@@ -949,6 +1015,8 @@ pub struct IntoIter<V> {
     pos: usize,
     min_slot: Option<V>,
     remaining: usize,
+    // Owning iteration transfers the buffer and its final-drop obligation.
+    _charge: Option<MemoryCharge>,
 }
 
 impl<V> Iterator for IntoIter<V> {
@@ -1015,6 +1083,7 @@ impl<V> IntoIterator for I64Map<V> {
             pos: 0,
             min_slot,
             remaining,
+            _charge: self.charge.take(),
         }
     }
 }
@@ -1044,11 +1113,12 @@ pub struct I64Set {
     /// of band. Callers pass user data (join keys, IN lists), so the set
     /// must accept the full i64 range instead of panicking.
     has_min: bool,
+    charge: Option<MemoryCharge>,
 }
 
 impl Clone for I64Set {
     fn clone(&self) -> Self {
-        let mut new_set = Self::with_capacity(self.len);
+        let mut new_set = Self::with_optional_account(self.len, self.memory_account());
         for key in self.iter() {
             new_set.insert(key);
         }
@@ -1076,6 +1146,18 @@ impl I64Set {
     }
 
     pub fn with_capacity(capacity: usize) -> Self {
+        Self::with_optional_account(capacity, None)
+    }
+
+    pub fn new_in(account: &MemoryAccount) -> Self {
+        Self::with_capacity_in(0, account)
+    }
+
+    pub fn with_capacity_in(capacity: usize, account: &MemoryAccount) -> Self {
+        Self::with_optional_account(capacity, Some(account))
+    }
+
+    fn with_optional_account(capacity: usize, account: Option<&MemoryAccount>) -> Self {
         let cap = if capacity == 0 {
             MIN_CAPACITY
         } else {
@@ -1088,12 +1170,37 @@ impl I64Set {
 
         let slots: Vec<i64> = vec![EMPTY; cap];
 
+        let slots = slots.into_boxed_slice();
+        let charge =
+            account.map(|account| MemoryCharge::new(account, std::mem::size_of_val(&*slots)));
         Self {
-            slots: slots.into_boxed_slice(),
+            slots,
             len: 0,
             mask: cap - 1,
             has_min: false,
+            charge,
         }
+    }
+
+    pub fn allocation_size(&self) -> usize {
+        std::mem::size_of_val(&*self.slots)
+    }
+
+    pub fn memory_account(&self) -> Option<&MemoryAccount> {
+        self.charge.as_ref().map(MemoryCharge::account)
+    }
+
+    /// Attach only the physical buffer; values own their separate allocations.
+    pub fn attach_memory_account(&mut self, account: &MemoryAccount) -> MemoryAdoption {
+        if let Some(origin) = self.memory_account() {
+            return if origin.same_engine(account) {
+                MemoryAdoption::AlreadyOwned
+            } else {
+                MemoryAdoption::ForeignEngine
+            };
+        }
+        self.charge = Some(MemoryCharge::new(account, self.allocation_size()));
+        MemoryAdoption::Adopted
     }
 
     #[inline(always)]
@@ -1133,7 +1240,12 @@ impl I64Set {
         let new_mask = new_cap - 1;
 
         let new_slots: Vec<i64> = vec![EMPTY; new_cap];
-        let old_slots = std::mem::replace(&mut self.slots, new_slots.into_boxed_slice());
+        let new_slots = new_slots.into_boxed_slice();
+        let new_charge = self
+            .memory_account()
+            .map(|account| MemoryCharge::new(account, std::mem::size_of_val(&*new_slots)));
+        let old_slots = std::mem::replace(&mut self.slots, new_slots);
+        let old_charge = std::mem::replace(&mut self.charge, new_charge);
         let old_len = self.len;
         self.len = 0;
         self.mask = new_mask;
@@ -1144,6 +1256,8 @@ impl I64Set {
             }
         }
 
+        drop(old_slots);
+        drop(old_charge);
         debug_assert_eq!(self.len, old_len);
     }
 
@@ -1298,7 +1412,12 @@ impl I64Set {
         let new_mask = new_cap - 1;
 
         let new_slots: Vec<i64> = vec![EMPTY; new_cap];
-        let old_slots = std::mem::replace(&mut self.slots, new_slots.into_boxed_slice());
+        let new_slots = new_slots.into_boxed_slice();
+        let new_charge = self
+            .memory_account()
+            .map(|account| MemoryCharge::new(account, std::mem::size_of_val(&*new_slots)));
+        let old_slots = std::mem::replace(&mut self.slots, new_slots);
+        let old_charge = std::mem::replace(&mut self.charge, new_charge);
         let old_len = self.len;
         self.len = 0;
         self.mask = new_mask;
@@ -1309,6 +1428,8 @@ impl I64Set {
             }
         }
 
+        drop(old_slots);
+        drop(old_charge);
         debug_assert_eq!(self.len, old_len);
     }
 
@@ -1340,7 +1461,12 @@ impl I64Set {
         let new_mask = new_cap - 1;
 
         let new_slots: Vec<i64> = vec![EMPTY; new_cap];
-        let old_slots = std::mem::replace(&mut self.slots, new_slots.into_boxed_slice());
+        let new_slots = new_slots.into_boxed_slice();
+        let new_charge = self
+            .memory_account()
+            .map(|account| MemoryCharge::new(account, std::mem::size_of_val(&*new_slots)));
+        let old_slots = std::mem::replace(&mut self.slots, new_slots);
+        let old_charge = std::mem::replace(&mut self.charge, new_charge);
         let old_len = self.len;
         self.len = 0;
         self.mask = new_mask;
@@ -1351,6 +1477,8 @@ impl I64Set {
             }
         }
 
+        drop(old_slots);
+        drop(old_charge);
         debug_assert_eq!(self.len, old_len);
     }
 
@@ -1383,18 +1511,21 @@ impl I64Set {
         // Hand the storage to the iterator instead of clearing lazily:
         // a drain dropped half-way used to leave the slots populated
         // while len said the set was empty, so contains() still matched
-        let old_slots = std::mem::replace(
-            &mut self.slots,
-            vec![EMPTY; MIN_CAPACITY].into_boxed_slice(),
-        );
+        let new_slots = vec![EMPTY; MIN_CAPACITY].into_boxed_slice();
+        let new_charge = self
+            .memory_account()
+            .map(|account| MemoryCharge::new(account, std::mem::size_of_val(&*new_slots)));
+        let old_slots = std::mem::replace(&mut self.slots, new_slots);
+        let old_charge = std::mem::replace(&mut self.charge, new_charge);
         let had_min = std::mem::replace(&mut self.has_min, false);
         self.len = 0;
         self.mask = MIN_CAPACITY - 1;
-        old_slots
-            .into_vec()
-            .into_iter()
-            .filter(|&slot| slot != EMPTY)
-            .chain(if had_min { Some(EMPTY) } else { None })
+        I64SetIntoIter {
+            slots: old_slots,
+            pos: 0,
+            has_min: had_min,
+            _charge: old_charge,
+        }
     }
 }
 
@@ -1407,6 +1538,7 @@ impl IntoIterator for I64Set {
             slots: self.slots,
             pos: 0,
             has_min: self.has_min,
+            _charge: self.charge,
         }
     }
 }
@@ -1416,6 +1548,7 @@ pub struct I64SetIntoIter {
     slots: Box<[i64]>,
     pos: usize,
     has_min: bool,
+    _charge: Option<MemoryCharge>,
 }
 
 impl Iterator for I64SetIntoIter {
@@ -1517,7 +1650,7 @@ impl<V> Drop for Drain<'_, V> {
         // for that batch.
         let cap = self.map.slots.len();
         if cap > MIN_SHRINK_CAPACITY && self.start_len < cap / SHRINK_DIVISOR {
-            *self.map = I64Map::with_capacity(self.start_len);
+            *self.map = I64Map::with_optional_account(self.start_len, self.map.memory_account());
         }
     }
 }
@@ -2475,5 +2608,177 @@ mod tests {
         set.clear();
         assert!(set.is_empty());
         assert!(!set.contains(i64::MIN));
+    }
+}
+
+#[cfg(test)]
+mod allocation_accounting_tests {
+    use super::*;
+
+    #[test]
+    fn set_attachment_growth_drain_and_iterator_preserve_ownership() {
+        let root = MemoryAccount::new();
+        let baseline = root.snapshot().accounted_bytes;
+        let origin = root.child();
+        let mut set = I64Set::new();
+        assert_eq!(set.attach_memory_account(&origin), MemoryAdoption::Adopted);
+        assert_eq!(
+            set.attach_memory_account(&origin),
+            MemoryAdoption::AlreadyOwned
+        );
+        assert_eq!(
+            set.attach_memory_account(&MemoryAccount::new()),
+            MemoryAdoption::ForeignEngine
+        );
+        for key in [1, 2, i64::MIN] {
+            set.insert(key);
+        }
+        let before = root.snapshot().accounted_bytes;
+        set.reserve(1000);
+        assert_eq!(root.snapshot().retained_bytes, set.allocation_size());
+        assert_eq!(
+            root.snapshot().peak_accounted_bytes,
+            before + set.allocation_size()
+        );
+        let clone = set.clone();
+        let cloned_bytes = clone.allocation_size();
+        let old_bytes = set.allocation_size();
+        {
+            let mut drain = set.drain();
+            assert!(drain.next().is_some());
+            assert_eq!(
+                root.snapshot().retained_bytes,
+                old_bytes + cloned_bytes + MIN_CAPACITY * std::mem::size_of::<i64>()
+            );
+        }
+        assert_eq!(
+            root.snapshot().retained_bytes,
+            set.allocation_size() + cloned_bytes
+        );
+        drop(set);
+        let mut iterator = clone.into_iter();
+        drop(origin);
+        for _ in iterator.by_ref() {}
+        assert_eq!(root.snapshot().retained_bytes, cloned_bytes);
+        drop(iterator);
+        assert_eq!(root.snapshot().accounted_bytes, baseline);
+    }
+
+    #[test]
+    fn buffers_keep_origin_through_growth_clone_drain_and_owning_iteration() {
+        let root = MemoryAccount::new();
+        let root_baseline = root.snapshot().accounted_bytes;
+        let origin = root.child();
+        let mut map = I64Map::new_in(&origin);
+        let old_bytes = map.allocation_size();
+        let before_growth = root.snapshot().accounted_bytes;
+        for key in [0, 1, i64::MIN] {
+            map.insert(key, key);
+        }
+        assert_eq!(root.snapshot().retained_bytes, old_bytes);
+        map.reserve(1000);
+        let grown_bytes = map.allocation_size();
+        assert_eq!(root.snapshot().retained_bytes, grown_bytes);
+        assert_eq!(
+            root.snapshot().peak_accounted_bytes,
+            before_growth + grown_bytes
+        );
+        assert_eq!(map.get(i64::MIN), Some(&i64::MIN));
+        let copy = map.clone();
+        assert!(copy.memory_account().unwrap().same_origin(&origin));
+        assert_eq!(
+            root.snapshot().retained_bytes,
+            grown_bytes + copy.allocation_size()
+        );
+        // A mostly unused pooled map releases its oversized allocation, retaining
+        // its origin for the small replacement buffer and subsequent growth.
+        drop(map.drain());
+        assert!(map.allocation_size() < grown_bytes);
+        assert!(map.memory_account().unwrap().same_origin(&origin));
+        assert_eq!(
+            root.snapshot().retained_bytes,
+            map.allocation_size() + copy.allocation_size()
+        );
+        let copy_bytes = copy.allocation_size();
+        let mut iterator = copy.into_iter();
+        assert!(iterator.next().is_some());
+        drop(map);
+        drop(origin);
+        assert_eq!(root.snapshot().retained_bytes, copy_bytes);
+        // Even an exhausted iterator keeps its slot allocation until Drop.
+        for _ in iterator.by_ref() {}
+        assert_eq!(root.snapshot().retained_bytes, copy_bytes);
+        drop(iterator);
+        assert_eq!(root.snapshot().retained_bytes, 0);
+        assert_eq!(root.snapshot().accounted_bytes, root_baseline);
+    }
+
+    #[test]
+    fn shrink_accounts_old_and_replacement_buffers_together() {
+        let root = MemoryAccount::new();
+        let mut map = I64Map::with_capacity_in(1000, &root);
+        map.insert(3, 3);
+        let old_bytes = map.allocation_size();
+        let before_shrink = root.snapshot().accounted_bytes;
+        map.shrink_to_fit();
+        assert!(map.allocation_size() < old_bytes);
+        assert_eq!(root.snapshot().retained_bytes, map.allocation_size());
+        assert_eq!(
+            root.snapshot().peak_accounted_bytes,
+            before_shrink + map.allocation_size()
+        );
+        assert_eq!(map.get(3), Some(&3));
+        let unchanged = root.snapshot();
+        map.insert(4, 4);
+        map.insert(3, 30);
+        map.remove(4);
+        map.clear();
+        let after = root.snapshot();
+        assert_eq!(after.retained_bytes, unchanged.retained_bytes);
+        assert_eq!(after.peak_accounted_bytes, unchanged.peak_accounted_bytes);
+        drop(map);
+        assert_eq!(root.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn final_map_and_iterator_value_drops_keep_the_buffer_charged() {
+        #[derive(Clone)]
+        struct Observe {
+            account: MemoryAccount,
+            count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        }
+        impl Drop for Observe {
+            fn drop(&mut self) {
+                assert!(
+                    self.account.snapshot().retained_bytes
+                        >= MIN_CAPACITY * std::mem::size_of::<Slot<Self>>()
+                );
+                self.count
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+        }
+        let root = MemoryAccount::new();
+        let count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        for consume in [false, true] {
+            let mut map = I64Map::new_in(&root);
+            for key in [0, 1, i64::MIN] {
+                map.insert(
+                    key,
+                    Observe {
+                        account: root.clone(),
+                        count: count.clone(),
+                    },
+                );
+            }
+            if consume {
+                let mut iterator = map.into_iter();
+                drop(iterator.next());
+                drop(iterator);
+            } else {
+                drop(map);
+            }
+            assert_eq!(root.snapshot().retained_bytes, 0);
+        }
+        assert_eq!(count.load(std::sync::atomic::Ordering::Relaxed), 6);
     }
 }

--- a/src/common/memory.rs
+++ b/src/common/memory.rs
@@ -1,0 +1,562 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Allocation-lifetime accounting for retained hot storage.
+//!
+//! Accounts observe requested allocation bytes, not RSS. They do not enforce a
+//! limit. Child accounts retain their engine root so dropped-table allocations
+//! remain in the root total until their final owner releases them.
+
+use std::mem::ManuallyDrop;
+use std::ptr;
+use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MemorySnapshot {
+    pub retained_bytes: usize,
+    pub conservative_bytes: usize,
+    pub pending_bytes: usize,
+    pub accounted_bytes: usize,
+    pub peak_accounted_bytes: usize,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    Retained,
+    Conservative,
+    Pending,
+}
+
+#[derive(Default)]
+struct Counters {
+    conservative: AtomicUsize,
+    pending: AtomicUsize,
+    total: AtomicUsize,
+    peak: AtomicUsize,
+}
+
+impl Counters {
+    fn separate_counter(&self, kind: Kind) -> Option<&AtomicUsize> {
+        match kind {
+            Kind::Retained => None,
+            Kind::Conservative => Some(&self.conservative),
+            Kind::Pending => Some(&self.pending),
+        }
+    }
+
+    fn add(&self, bytes: usize, kind: Kind) {
+        if bytes == 0 {
+            return;
+        }
+        // Reject accounting overflow instead of wrapping the retained-byte total.
+        let Ok(previous) = self
+            .total
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                n.checked_add(bytes)
+            })
+        else {
+            panic!("memory accounting overflow");
+        };
+        if let Some(counter) = self.separate_counter(kind) {
+            counter.fetch_add(bytes, Ordering::Relaxed);
+        }
+        let total = previous + bytes;
+        if total > self.peak.load(Ordering::Relaxed) {
+            self.peak.fetch_max(total, Ordering::Relaxed);
+        }
+    }
+
+    fn remove(&self, bytes: usize, kind: Kind) {
+        if bytes == 0 {
+            return;
+        }
+        if let Some(counter) = self.separate_counter(kind) {
+            let previous = counter.fetch_sub(bytes, Ordering::Relaxed);
+            assert!(previous >= bytes, "memory accounting underflow");
+        }
+        let previous = self.total.fetch_sub(bytes, Ordering::Relaxed);
+        assert!(previous >= bytes, "memory accounting total underflow");
+    }
+
+    fn retain_pending(&self, bytes: usize) {
+        if bytes == 0 {
+            return;
+        }
+        let previous = self.pending.fetch_sub(bytes, Ordering::Relaxed);
+        assert!(previous >= bytes, "memory accounting pending underflow");
+        // Total and peak do not change: pending ownership was already charged.
+    }
+
+    fn snapshot(&self) -> MemorySnapshot {
+        let accounted_bytes = self.total.load(Ordering::Relaxed);
+        let conservative_bytes = self.conservative.load(Ordering::Relaxed);
+        let pending_bytes = self.pending.load(Ordering::Relaxed);
+        // Derive retained bytes saturatingly because these loads can straddle an ownership transfer.
+        let retained_bytes =
+            accounted_bytes.saturating_sub(conservative_bytes.saturating_add(pending_bytes));
+        MemorySnapshot {
+            retained_bytes,
+            conservative_bytes,
+            pending_bytes,
+            accounted_bytes,
+            peak_accounted_bytes: self.peak.load(Ordering::Relaxed),
+        }
+    }
+}
+
+// Conservative allowance for the opaque std::Arc control block and padding.
+// The account object itself is retained memory, even when no payload is live.
+const ACCOUNT_BYTES: usize = std::mem::size_of::<AccountInner>() + 4 * std::mem::size_of::<usize>();
+
+struct AccountInner {
+    counters: Counters,
+    // Root accounts have no parent. Children point directly to the root, never
+    // to a mutable table/engine object or to a pool that owns memory charges.
+    root: Option<Arc<AccountInner>>,
+}
+
+impl Drop for AccountInner {
+    fn drop(&mut self) {
+        if let Some(root) = &self.root {
+            root.counters.remove(ACCOUNT_BYTES, Kind::Conservative);
+        }
+    }
+}
+
+/// Cheap shared handle to an engine or origin account. Clone never allocates.
+#[derive(Clone)]
+pub struct MemoryAccount(Arc<AccountInner>);
+
+impl Default for MemoryAccount {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MemoryAccount {
+    pub fn new() -> Self {
+        let account = Self(Arc::new(AccountInner {
+            counters: Counters::default(),
+            root: None,
+        }));
+        account.0.counters.add(ACCOUNT_BYTES, Kind::Conservative);
+        account
+    }
+
+    pub fn child(&self) -> Self {
+        let root = self.0.root.as_ref().unwrap_or(&self.0).clone();
+        let account = Self(Arc::new(AccountInner {
+            counters: Counters::default(),
+            root: Some(root),
+        }));
+        account.add(ACCOUNT_BYTES, Kind::Conservative);
+        account
+    }
+
+    pub fn same_engine(&self, other: &Self) -> bool {
+        Arc::ptr_eq(
+            self.0.root.as_ref().unwrap_or(&self.0),
+            other.0.root.as_ref().unwrap_or(&other.0),
+        )
+    }
+
+    pub fn same_origin(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+
+    /// Counters are read independently; concurrent snapshots are observational,
+    /// not an atomic transaction across all fields. The total is one atomic.
+    pub fn snapshot(&self) -> MemorySnapshot {
+        self.0.counters.snapshot()
+    }
+
+    fn add(&self, bytes: usize, kind: Kind) {
+        if let Some(root) = &self.0.root {
+            root.counters.add(bytes, kind);
+        }
+        self.0.counters.add(bytes, kind);
+    }
+
+    fn remove(&self, bytes: usize, kind: Kind) {
+        self.0.counters.remove(bytes, kind);
+        if let Some(root) = &self.0.root {
+            root.counters.remove(bytes, kind);
+        }
+    }
+
+    fn retain_pending(&self, bytes: usize) {
+        if let Some(root) = &self.0.root {
+            root.counters.retain_pending(bytes);
+        }
+        self.0.counters.retain_pending(bytes);
+    }
+}
+
+/// One unique allocation/capacity owner. Move this token with its buffer.
+/// Aliased allocations store equivalent ownership in their shared header.
+pub struct MemoryCharge {
+    account: MemoryAccount,
+    bytes: usize,
+    kind: Kind,
+}
+
+impl MemoryCharge {
+    pub fn new(account: &MemoryAccount, bytes: usize) -> Self {
+        Self::with_kind(account, bytes, Kind::Retained)
+    }
+
+    pub fn conservative(account: &MemoryAccount, bytes: usize) -> Self {
+        Self::with_kind(account, bytes, Kind::Conservative)
+    }
+
+    fn with_kind(account: &MemoryAccount, bytes: usize, kind: Kind) -> Self {
+        account.add(bytes, kind);
+        Self {
+            account: account.clone(),
+            bytes,
+            kind,
+        }
+    }
+
+    pub fn bytes(&self) -> usize {
+        self.bytes
+    }
+    pub fn account(&self) -> &MemoryAccount {
+        &self.account
+    }
+
+    /// Transfer a replacement allocation into one part of this combined owner.
+    /// Both allocations are already charged. The returned token owns the old
+    /// part and must stay alive until that backing is freed. No counter changes
+    /// occur here, so ownership transfer cannot create a false double-charge
+    /// peak or a gap between freeing the old buffer and retaining its replacement.
+    pub(crate) fn replace_part(&mut self, old_bytes: usize, mut replacement: Self) -> Self {
+        assert!(self.account.same_origin(&replacement.account));
+        assert!(self.kind == replacement.kind);
+        let Some(bytes) = self
+            .bytes
+            .checked_sub(old_bytes)
+            .and_then(|rest| rest.checked_add(replacement.bytes))
+        else {
+            panic!("invalid memory charge replacement");
+        };
+        self.bytes = bytes;
+        replacement.bytes = old_bytes;
+        replacement
+    }
+
+    /// Update observed retained capacity. This does not claim that realloc held
+    /// both buffers simultaneously; a future preallocation reservation records
+    /// that separate bound before an allocation is attempted.
+    pub fn resize(&mut self, bytes: usize) {
+        if bytes == self.bytes {
+            return;
+        }
+        if bytes > self.bytes {
+            self.account.add(bytes - self.bytes, self.kind);
+        } else {
+            self.account.remove(self.bytes - bytes, self.kind);
+        }
+        self.bytes = bytes;
+    }
+
+    fn retain_for_header(self) {
+        let this = ManuallyDrop::new(self);
+        this.account.retain_pending(this.bytes);
+        // SAFETY: the header owns another Arc reference and retains this token's byte charge.
+        unsafe {
+            drop(ptr::read(&this.account));
+        }
+    }
+}
+
+impl Drop for MemoryCharge {
+    fn drop(&mut self) {
+        self.account.remove(self.bytes, self.kind);
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MemoryAdoption {
+    Adopted,
+    AlreadyOwned,
+    ForeignEngine,
+}
+
+/// Exactly one optional pointer word in a shared allocation header.
+/// No Drop impl: the allocation owner must take the charge with its known size.
+#[repr(transparent)]
+pub(crate) struct AccountSlot(AtomicPtr<AccountInner>);
+
+impl AccountSlot {
+    pub(crate) const fn new() -> Self {
+        Self(AtomicPtr::new(ptr::null_mut()))
+    }
+
+    /// Install ownership in a freshly constructed, unexposed allocation.
+    pub(crate) fn install_new(&mut self, account: &MemoryAccount, bytes: usize) {
+        debug_assert!(self.0.get_mut().is_null());
+        account.add(bytes, Kind::Retained);
+        *self.0.get_mut() = Arc::into_raw(account.0.clone()) as *mut AccountInner;
+    }
+
+    pub(crate) fn get(&self) -> Option<MemoryAccount> {
+        let account = self
+            .0
+            .load(Ordering::Acquire)
+            .map_addr(|address| address & !1);
+        if account.is_null() {
+            return None;
+        }
+        // SAFETY: the caller retains the allocation and its immutable account reference.
+        unsafe {
+            Arc::increment_strong_count(account);
+            Some(MemoryAccount(Arc::from_raw(account)))
+        }
+    }
+
+    pub(crate) fn belongs_to(&self, account: &MemoryAccount) -> bool {
+        self.ownership(account) == Some(MemoryAdoption::AlreadyOwned)
+    }
+
+    fn ownership(&self, account: &MemoryAccount) -> Option<MemoryAdoption> {
+        let pointer = self
+            .0
+            .load(Ordering::Acquire)
+            .map_addr(|address| address & !1);
+        if pointer.is_null() {
+            return None;
+        }
+        // SAFETY: the caller retains the allocation, its installed account and immutable root.
+        let current = unsafe { &*pointer };
+        Some(Self::ownership_of(current, account))
+    }
+
+    fn ownership_of(current: &AccountInner, account: &MemoryAccount) -> MemoryAdoption {
+        let current_root = current.root.as_deref().unwrap_or(current);
+        let requested_root = account.0.root.as_deref().unwrap_or(&account.0);
+        if ptr::eq(current_root, requested_root) {
+            MemoryAdoption::AlreadyOwned
+        } else {
+            MemoryAdoption::ForeignEngine
+        }
+    }
+
+    pub(crate) fn adopt(&self, account: &MemoryAccount, bytes: usize) -> MemoryAdoption {
+        if let Some(ownership) = self.ownership(account) {
+            return ownership;
+        }
+        // Pending ownership covers publication until retained finalization, including concurrent reads.
+        let pending = MemoryCharge::with_kind(account, bytes, Kind::Pending);
+        let raw = Arc::into_raw(account.0.clone()) as *mut AccountInner;
+        match self
+            .0
+            .compare_exchange(ptr::null_mut(), raw, Ordering::AcqRel, Ordering::Acquire)
+        {
+            Ok(_) => {
+                pending.retain_for_header();
+                MemoryAdoption::Adopted
+            }
+            Err(installed) => {
+                // SAFETY: raw remains ours; the caller keeps the nonnull CAS winner's owner alive.
+                unsafe {
+                    drop(Arc::from_raw(raw));
+                    drop(pending);
+                    let current = &*installed.map_addr(|address| address & !1);
+                    Self::ownership_of(current, account)
+                }
+            }
+        }
+    }
+
+    pub(crate) fn clear_fully_accounted(&mut self) {
+        let pointer = self.0.get_mut();
+        *pointer = pointer.map_addr(|address| address & !1);
+    }
+
+    pub(crate) fn is_fully_accounted(&self) -> bool {
+        self.0.load(Ordering::Acquire).addr() & 1 != 0
+    }
+
+    /// Only a container's audited ownership ingress may certify its children.
+    /// Generic shallow adoption deliberately leaves this marker clear.
+    pub(crate) fn mark_fully_accounted(&self) {
+        let mut pointer = self.0.load(Ordering::Acquire);
+        loop {
+            assert!(
+                !pointer.is_null(),
+                "cannot certify an unaccounted allocation"
+            );
+            let marked = pointer.map_addr(|address| address | 1);
+            match self.0.compare_exchange_weak(
+                pointer,
+                marked,
+                Ordering::Release,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(actual) => pointer = actual,
+            }
+        }
+    }
+
+    /// Transfer the header's charge to a guard that outlives deallocation.
+    /// Requires exclusive final ownership; no other account accesses may race.
+    pub(crate) fn take(&mut self, bytes: usize) -> Option<MemoryCharge> {
+        let account = self.0.get_mut().map_addr(|address| address & !1);
+        *self.0.get_mut() = ptr::null_mut();
+        if account.is_null() {
+            return None;
+        }
+        // SAFETY: exclusive take transfers the slot's single owned Arc without changing its charge.
+        Some(MemoryCharge {
+            account: MemoryAccount(unsafe { Arc::from_raw(account) }),
+            bytes,
+            kind: Kind::Retained,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retained_residual_tracks_mixed_classes_and_pending_conversion() {
+        let counters = Counters::default();
+        counters.add(80, Kind::Retained);
+        counters.add(120, Kind::Conservative);
+        counters.add(64, Kind::Pending);
+        assert_eq!(
+            counters.snapshot(),
+            MemorySnapshot {
+                retained_bytes: 80,
+                conservative_bytes: 120,
+                pending_bytes: 64,
+                accounted_bytes: 264,
+                peak_accounted_bytes: 264,
+            }
+        );
+        counters.retain_pending(64);
+        assert_eq!(counters.snapshot().retained_bytes, 144);
+        assert_eq!(counters.snapshot().pending_bytes, 0);
+        assert_eq!(counters.snapshot().accounted_bytes, 264);
+        counters.remove(144, Kind::Retained);
+        counters.remove(120, Kind::Conservative);
+        assert_eq!(
+            counters.snapshot(),
+            MemorySnapshot {
+                peak_accounted_bytes: 264,
+                ..MemorySnapshot::default()
+            }
+        );
+    }
+
+    #[test]
+    fn concurrent_mixed_classes_leave_exact_quiescent_totals() {
+        let counters = Counters::default();
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                scope.spawn(|| {
+                    for _ in 0..1000 {
+                        counters.add(80, Kind::Retained);
+                        counters.add(120, Kind::Conservative);
+                        counters.add(64, Kind::Pending);
+                        counters.retain_pending(64);
+                        let sample = counters.snapshot();
+                        assert!(sample.retained_bytes <= sample.accounted_bytes);
+                        counters.remove(144, Kind::Retained);
+                        counters.remove(120, Kind::Conservative);
+                    }
+                });
+            }
+        });
+        let snapshot = counters.snapshot();
+        assert_eq!(snapshot.retained_bytes, 0);
+        assert_eq!(snapshot.conservative_bytes, 0);
+        assert_eq!(snapshot.pending_bytes, 0);
+        assert_eq!(snapshot.accounted_bytes, 0);
+        assert!(snapshot.peak_accounted_bytes >= 264);
+        assert!(snapshot.peak_accounted_bytes <= 8 * 264);
+    }
+
+    #[test]
+    fn replacement_transfers_ownership_without_counter_gap_or_duplicate_peak() {
+        let account = MemoryAccount::new();
+        let mut combined = MemoryCharge::new(&account, 100);
+        let replacement = MemoryCharge::new(&account, 80);
+        let before = account.snapshot();
+        let retired = combined.replace_part(40, replacement);
+        assert_eq!(account.snapshot(), before);
+        assert_eq!(combined.bytes(), 140);
+        assert_eq!(retired.bytes(), 40);
+        drop(retired);
+        assert_eq!(account.snapshot().retained_bytes, 140);
+        drop(combined);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+        assert_eq!(account.snapshot().peak_accounted_bytes, ACCOUNT_BYTES + 180);
+    }
+
+    #[test]
+    fn child_charge_survives_origin_handle_and_moves_without_churn() {
+        let root = MemoryAccount::new();
+        let child = root.child();
+        let mut charge = MemoryCharge::new(&child, 100);
+        drop(child);
+        assert_eq!(root.snapshot().retained_bytes, 100);
+        charge.resize(200);
+        let moved = charge;
+        assert_eq!(root.snapshot().retained_bytes, 200);
+        drop(moved);
+        assert_eq!(root.snapshot().accounted_bytes, ACCOUNT_BYTES);
+        assert_eq!(
+            root.snapshot().peak_accounted_bytes,
+            200 + 2 * ACCOUNT_BYTES
+        );
+    }
+
+    #[test]
+    fn exact_and_conservative_capacity_are_separate() {
+        let root = MemoryAccount::new();
+        let exact = MemoryCharge::new(&root, 80);
+        let estimate = MemoryCharge::conservative(&root, 120);
+        let snapshot = root.snapshot();
+        assert_eq!(snapshot.retained_bytes, 80);
+        assert_eq!(snapshot.conservative_bytes, 120 + ACCOUNT_BYTES);
+        assert_eq!(snapshot.accounted_bytes, 200 + ACCOUNT_BYTES);
+        drop((exact, estimate));
+        assert_eq!(root.snapshot().accounted_bytes, ACCOUNT_BYTES);
+    }
+
+    #[test]
+    fn concurrent_adoption_installs_one_final_charge() {
+        let root = MemoryAccount::new();
+        let slot = Arc::new(AccountSlot::new());
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                let slot = slot.clone();
+                let account = root.child();
+                scope.spawn(move || {
+                    assert_ne!(slot.adopt(&account, 512), MemoryAdoption::ForeignEngine);
+                });
+            }
+        });
+        assert_eq!(root.snapshot().retained_bytes, 512);
+        assert_eq!(root.snapshot().pending_bytes, 0);
+        let mut slot = Arc::try_unwrap(slot).ok().unwrap();
+        drop(slot.take(512));
+        assert_eq!(root.snapshot().accounted_bytes, ACCOUNT_BYTES);
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -29,6 +29,7 @@ pub mod cow_btree;
 pub mod cow_hashmap;
 pub mod i64_map;
 pub mod maps;
+pub mod memory;
 pub mod smart_string;
 pub mod time_compat;
 pub mod version;
@@ -43,6 +44,7 @@ pub use i64_map::{I64Map, I64Set};
 pub use maps::{
     new_cow_btree_map, new_i64_map, new_i64_map_with_capacity, CowBTreeMap, StringMap, StringSet,
 };
+pub use memory::{MemoryAccount, MemoryAdoption, MemoryCharge, MemorySnapshot};
 pub use smart_string::SmartString;
 pub use version::{version, version_info, SemVer, BUILD_TIME, GIT_COMMIT, MAJOR, MINOR, PATCH};
 

--- a/src/common/smart_string.rs
+++ b/src/common/smart_string.rs
@@ -18,7 +18,7 @@
 //! through niche optimization. The design:
 //!
 //! - **Inline**: strings ≤15 bytes stored inline (no heap allocation)
-//! - **Heap**: strings >15 bytes stored as Arc<String> for O(1) clone
+//! - **Heap**: strings >15 bytes use counted backing for O(1) clone
 //!
 //! ## Memory Layout (16 bytes, 8-byte aligned)
 //!
@@ -28,11 +28,11 @@
 //!   tag = 0-15 (encodes length)
 //!
 //! Heap (>15 bytes) on 64-bit:
-//!   [tag: 1 byte] [pad: 7 bytes] [Arc<String>: 8 bytes]
+//!   [tag: 1 byte] [pad: 7 bytes] [HeapString*: 8 bytes]
 //!   tag = 16 (heap marker), pointer at data[7..15]
 //!
 //! Heap (>15 bytes) on 32-bit:
-//!   [tag: 1 byte] [pad: 11 bytes] [Arc<String>: 4 bytes]
+//!   [tag: 1 byte] [pad: 11 bytes] [HeapString*: 4 bytes]
 //!   tag = 16 (heap marker), pointer at data[11..15]
 //! ```
 //!
@@ -46,8 +46,54 @@ use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::mem::{self, ManuallyDrop};
 use std::ops::Deref;
+use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+use super::memory::AccountSlot;
+use super::{MemoryAccount, MemoryAdoption};
+
+#[cfg(test)]
+thread_local! {
+    static BEFORE_STRING_UNIQUE: std::cell::RefCell<Option<Box<dyn FnOnce()>>> = const { std::cell::RefCell::new(None) };
+}
 use std::sync::Arc;
+
+/// No weak references: the account replaces Arc's weak-count word, preserving
+/// the old Arc<String> backing size (40 bytes on 64-bit) and allocation count.
+#[repr(C)]
+struct HeapString {
+    strong: AtomicUsize,
+    account: AccountSlot,
+    text: ManuallyDrop<String>,
+}
+
+impl Deref for HeapString {
+    type Target = String;
+    fn deref(&self) -> &String {
+        &self.text
+    }
+}
+
+impl HeapString {
+    fn allocation_size(&self) -> usize {
+        // String capacity is bounded by isize::MAX, leaving room for this header.
+        mem::size_of::<Self>() + self.text.capacity()
+    }
+
+    unsafe fn release(pointer: *mut Self) {
+        // SAFETY: each string owns a reference; release/acquire orders accesses before final drop.
+        if (*pointer).strong.fetch_sub(1, AtomicOrdering::Release) == 1 {
+            std::sync::atomic::fence(AtomicOrdering::Acquire);
+            let bytes = (*pointer).allocation_size();
+            let charge = (*pointer).account.take(bytes);
+            ManuallyDrop::drop(&mut (*pointer).text);
+            drop(Box::from_raw(pointer));
+            // The text buffer and its header have both been freed.
+            drop(charge);
+        }
+    }
+}
 
 /// Maximum inline string length (15 bytes)
 pub const MAX_INLINE_LEN: usize = 15;
@@ -171,8 +217,12 @@ impl SmartString {
     /// Create a SmartString from an owned String (heap case)
     #[inline]
     fn new_heap(s: String) -> Self {
-        let arc = Arc::new(s);
-        let ptr = Arc::into_raw(arc) as usize;
+        let backing = Box::new(HeapString {
+            strong: AtomicUsize::new(1),
+            account: AccountSlot::new(),
+            text: ManuallyDrop::new(s),
+        });
+        let ptr = Box::into_raw(backing) as usize;
         let mut data = [0u8; 15];
         let end = ptr_layout::OFFSET + ptr_layout::SIZE;
         data[ptr_layout::OFFSET..end].copy_from_slice(&ptr.to_ne_bytes());
@@ -232,12 +282,12 @@ impl SmartString {
             // SAFETY: SmartString only stores valid UTF-8
             unsafe { std::str::from_utf8_unchecked(&self.data[..len]) }
         } else {
-            // Heap case: Arc<String> pointer at platform-specific offset
+            // Heap case: HeapString pointer at platform-specific offset
             let end = ptr_layout::OFFSET + ptr_layout::SIZE;
             let ptr_bytes: ptr_layout::Bytes =
                 self.data[ptr_layout::OFFSET..end].try_into().unwrap();
-            let ptr = usize::from_ne_bytes(ptr_bytes) as *const String;
-            // SAFETY: We only store valid Arc<String> pointers
+            let ptr = usize::from_ne_bytes(ptr_bytes) as *mut HeapString;
+            // SAFETY: We only store valid HeapString pointers
             unsafe { (*ptr).as_str() }
         }
     }
@@ -247,8 +297,8 @@ impl SmartString {
     #[inline]
     pub fn heap_capacity(&self) -> usize {
         if self.tag.is_heap() {
-            // SAFETY: heap strings hold a valid Arc<String> pointer
-            unsafe { (*self.get_arc_ptr()).capacity() }
+            // SAFETY: heap strings hold a valid HeapString pointer
+            unsafe { (*self.get_heap_ptr()).capacity() }
         } else {
             0
         }
@@ -279,13 +329,54 @@ impl SmartString {
         self.tag.is_heap()
     }
 
-    /// Get the raw Arc<String> pointer for heap strings
+    /// Get the raw HeapString pointer for heap strings
     #[inline]
-    fn get_arc_ptr(&self) -> *const String {
+    fn get_heap_ptr(&self) -> *mut HeapString {
         debug_assert!(self.tag.is_heap());
         let end = ptr_layout::OFFSET + ptr_layout::SIZE;
         let ptr_bytes: ptr_layout::Bytes = self.data[ptr_layout::OFFSET..end].try_into().unwrap();
-        usize::from_ne_bytes(ptr_bytes) as *const String
+        usize::from_ne_bytes(ptr_bytes) as *mut HeapString
+    }
+
+    pub fn memory_account(&self) -> Option<MemoryAccount> {
+        if self.tag.is_inline() {
+            return None;
+        }
+        // SAFETY: self retains the immutable backing and its installed account.
+        unsafe { (*self.get_heap_ptr()).account.get() }
+    }
+
+    /// Adopt immutable backing without changing Value/SmartString aliases.
+    /// Inline strings have no heap allocation to adopt.
+    pub fn try_adopt_hot(&self, account: &MemoryAccount) -> MemoryAdoption {
+        if self.tag.is_inline() {
+            return MemoryAdoption::AlreadyOwned;
+        }
+        // SAFETY: the non-inline string keeps its immutable backing alive through adoption.
+        unsafe {
+            let backing = &*self.get_heap_ptr();
+            backing.account.adopt(account, backing.allocation_size())
+        }
+    }
+
+    /// Reuse same-engine backing, adopting unowned bytes once. Foreign backing
+    /// is copied so each physical allocation has one engine owner.
+    pub fn into_hot(self, account: &MemoryAccount) -> Self {
+        if self.try_adopt_hot(account) != MemoryAdoption::ForeignEngine {
+            return self;
+        }
+        let replacement = Self::from_string(self.as_str().to_owned());
+        replacement.try_adopt_hot(account);
+        replacement
+    }
+
+    fn replacement(&self, string: String) -> Self {
+        let replacement = Self::from_string(string);
+        if let Some(account) = self.memory_account() {
+            replacement.into_hot(&account)
+        } else {
+            replacement
+        }
     }
 
     /// Convert to a version that will use Arc for future clones (no-op now, kept for API compat)
@@ -322,7 +413,7 @@ impl SmartString {
         // Need to go to heap or already on heap
         let mut s = self.as_str().to_string();
         s.push(ch);
-        *self = Self::from_string(s);
+        *self = self.replacement(s);
     }
 
     /// Appends a string slice to the string.
@@ -346,7 +437,7 @@ impl SmartString {
         // Need to go to heap or already on heap
         let mut s = self.as_str().to_string();
         s.push_str(string);
-        *self = Self::from_string(s);
+        *self = self.replacement(s);
     }
 
     /// Lowercase copy. An inline ASCII string, which is what nearly every
@@ -362,7 +453,7 @@ impl SmartString {
                 return copy;
             }
         }
-        SmartString::from_string(self.as_str().to_lowercase())
+        self.replacement(self.as_str().to_lowercase())
     }
 
     /// Uppercase copy, with the same inline ASCII fast path as
@@ -376,7 +467,7 @@ impl SmartString {
                 return copy;
             }
         }
-        SmartString::from_string(self.as_str().to_uppercase())
+        self.replacement(self.as_str().to_uppercase())
     }
 
     #[inline]
@@ -391,7 +482,7 @@ impl SmartString {
         } else {
             let mut s = self.as_str().to_string();
             s.make_ascii_uppercase();
-            *self = Self::from_string(s);
+            *self = self.replacement(s);
         }
     }
 
@@ -402,26 +493,46 @@ impl SmartString {
         } else {
             let mut s = self.as_str().to_string();
             s.make_ascii_lowercase();
-            *self = Self::from_string(s);
+            *self = self.replacement(s);
         }
     }
 
     #[inline]
     pub fn into_string(self) -> String {
         if self.tag.is_inline() {
-            self.as_str().to_owned()
-        } else {
-            // Take ownership of the Arc without incrementing refcount
-            let ptr = self.get_arc_ptr();
-            std::mem::forget(self); // Prevent Drop from decrementing
-                                    // SAFETY: ptr is a valid Arc<String> pointer, and we've prevented
-                                    // self's Drop from running, so we're taking over its ownership
-            let arc = unsafe { Arc::from_raw(ptr) };
-            match Arc::try_unwrap(arc) {
-                Ok(s) => s,
-                Err(arc) => (*arc).clone(),
+            return self.as_str().to_owned();
+        }
+        let pointer = self.get_heap_ptr();
+        #[cfg(test)]
+        BEFORE_STRING_UNIQUE.with(|hook| {
+            if let Some(hook) = hook.borrow_mut().take() {
+                hook();
+            }
+        });
+        // SAFETY: self retains the backing; the CAS acquires exclusive ownership before charge removal.
+        unsafe {
+            if (*pointer)
+                .strong
+                .compare_exchange(1, 0, AtomicOrdering::Acquire, AtomicOrdering::Relaxed)
+                .is_ok()
+            {
+                mem::forget(self);
+                let mut backing = Box::from_raw(pointer);
+                let bytes = backing.allocation_size();
+                let charge = backing.account.take(bytes);
+                let text = ManuallyDrop::take(&mut backing.text);
+                drop(backing);
+                if charge.is_some() {
+                    // Keep the moved buffer charged until destruction; the returned String owns a copy.
+                    let copy = text.clone();
+                    drop(text);
+                    drop(charge);
+                    return copy;
+                }
+                return text;
             }
         }
+        self.as_str().to_owned()
     }
 
     #[inline]
@@ -500,9 +611,14 @@ impl Clone for SmartString {
     fn clone(&self) -> Self {
         if self.tag.is_heap() {
             // Heap: increment Arc refcount to balance the new owner's Drop
-            // SAFETY: get_arc_ptr() returns a valid Arc<String> pointer
+            // SAFETY: get_heap_ptr() returns a valid HeapString pointer
             unsafe {
-                Arc::increment_strong_count(self.get_arc_ptr());
+                let previous = (*self.get_heap_ptr())
+                    .strong
+                    .fetch_add(1, AtomicOrdering::Relaxed);
+                if previous > isize::MAX as usize {
+                    std::process::abort();
+                }
             }
         }
         // Data bytes already contain the correct content (inline bytes or pointer)
@@ -518,10 +634,10 @@ impl Drop for SmartString {
     fn drop(&mut self) {
         if self.tag.is_heap() {
             // Heap: decrement Arc refcount
-            let ptr = self.get_arc_ptr();
-            // SAFETY: We only store valid Arc<String> pointers
+            let ptr = self.get_heap_ptr();
+            // SAFETY: We only store valid HeapString pointers
             unsafe {
-                Arc::from_raw(ptr);
+                HeapString::release(ptr);
             }
         }
     }
@@ -717,6 +833,89 @@ impl fmt::Write for SmartString {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn heap_accounting_keeps_compact_layout_and_alias_lifetime() {
+        assert_eq!(mem::size_of::<SmartString>(), 16);
+        #[cfg(target_pointer_width = "64")]
+        assert_eq!(mem::size_of::<HeapString>(), 40);
+        let account = MemoryAccount::new();
+        let mut buffer = String::with_capacity(200);
+        buffer.push_str("heap string retained by several aliases");
+        let value = SmartString::from_string(buffer).into_hot(&account);
+        let expected = 200 + mem::size_of::<HeapString>();
+        assert_eq!(account.snapshot().retained_bytes, expected);
+        let alias = value.clone();
+        drop(value);
+        assert_eq!(alias.as_str(), "heap string retained by several aliases");
+        assert_eq!(account.snapshot().retained_bytes, expected);
+        drop(alias);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn charged_string_conversion_and_mutation_keep_real_owners_charged() {
+        let account = MemoryAccount::new();
+        let mut value = SmartString::new("tracked text with heap backing").into_hot(&account);
+        let original = value.clone();
+        let original_bytes = account.snapshot().retained_bytes;
+        value.push_str(" and more");
+        assert!(value.memory_account().unwrap().same_engine(&account));
+        assert!(account.snapshot().retained_bytes > original_bytes);
+        let plain = value.into_string();
+        assert_eq!(plain, "tracked text with heap backing and more");
+        assert_eq!(account.snapshot().retained_bytes, original_bytes);
+        drop(original);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+        assert_eq!(plain, "tracked text with heap backing and more");
+    }
+
+    #[test]
+    fn cross_engine_string_adoption_copies_only_foreign_backing() {
+        let first = MemoryAccount::new();
+        let second = MemoryAccount::new();
+        let a = SmartString::new("a string too long to store inline").into_hot(&first);
+        assert_eq!(a.try_adopt_hot(&second), MemoryAdoption::ForeignEngine);
+        let b = a.clone().into_hot(&second);
+        assert_ne!(a.as_str().as_ptr(), b.as_str().as_ptr());
+        assert_eq!(a, b);
+        let bytes = second.snapshot().retained_bytes;
+        drop(a);
+        assert_eq!(first.snapshot().retained_bytes, 0);
+        assert_eq!(second.snapshot().retained_bytes, bytes);
+        drop(b);
+        assert_eq!(second.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn adoption_before_string_unique_cas_cannot_escape_charge() {
+        use std::sync::Barrier;
+        let account = MemoryAccount::new();
+        let value = SmartString::new("shared string adopted during conversion");
+        let other = value.clone();
+        let paused = Arc::new(Barrier::new(2));
+        let resume = Arc::new(Barrier::new(2));
+        let ready = paused.clone();
+        let release = resume.clone();
+        let consumer = std::thread::spawn(move || {
+            BEFORE_STRING_UNIQUE.with(|hook| {
+                *hook.borrow_mut() = Some(Box::new(move || {
+                    ready.wait();
+                    release.wait();
+                }))
+            });
+            value.into_string()
+        });
+        paused.wait();
+        assert_eq!(other.try_adopt_hot(&account), MemoryAdoption::Adopted);
+        assert!(account.snapshot().retained_bytes > 0);
+        drop(other);
+        resume.wait();
+        let text = consumer.join().unwrap();
+        assert_eq!(text, "shared string adopted during conversion");
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+
     use std::collections::HashMap;
     use std::mem::size_of;
 

--- a/src/core/row.rs
+++ b/src/core/row.rs
@@ -529,6 +529,43 @@ impl Row {
         matches!(self.storage, RowStorage::Owned(_))
     }
 
+    /// Retain this row in a hot account. The certification bit is installed
+    /// only after every independently shared backing belongs to this engine.
+    pub(crate) fn into_hot(self, account: &crate::common::memory::MemoryAccount) -> Self {
+        use crate::common::memory::{MemoryAdoption, MemoryCharge};
+        match self.storage {
+            RowStorage::Owned(mut values) => {
+                let source_charge =
+                    MemoryCharge::new(account, values.capacity() * std::mem::size_of::<Value>());
+                for value in values.iter_mut() {
+                    *value = std::mem::take(value).into_hot(account);
+                }
+                let data = CompactArc::from_compact_vec_in(values, account);
+                drop(source_charge);
+                data.mark_fully_accounted();
+                Self::from_arc(data)
+            }
+            RowStorage::Shared(data) => {
+                if data.is_fully_accounted() && data.belongs_to(account) {
+                    return Self::from_arc(data);
+                }
+                if data.iter().all(|value| value.try_adopt_hot(account))
+                    && data.try_adopt_shallow(account) != MemoryAdoption::ForeignEngine
+                {
+                    data.mark_fully_accounted();
+                    return Self::from_arc(data);
+                }
+                // Copy the outer array and foreign nested allocations, preserving their original charges.
+                let copied = CompactArc::from_exact_iter_in(
+                    data.iter().cloned().map(|value| value.into_hot(account)),
+                    account,
+                );
+                copied.mark_fully_accounted();
+                Self::from_arc(copied)
+            }
+        }
+    }
+
     /// Convert Row to CompactArc<[Value]>, consuming self
     /// - Shared: returns the CompactArc directly (O(1))
     /// - Owned: creates new Arc (O(n))
@@ -815,6 +852,258 @@ macro_rules! row {
     ($($value:expr),+ $(,)?) => {
         $crate::core::Row::from_values(vec![$($crate::core::Value::from($value)),+])
     };
+}
+
+#[cfg(test)]
+mod hot_accounting_tests {
+    use super::*;
+    use crate::common::{MemoryAccount, SmartString};
+    use std::collections::HashSet;
+
+    fn text_bytes(text: &SmartString) -> usize {
+        if text.is_heap() {
+            text.heap_capacity() + std::mem::size_of::<String>() + 2 * std::mem::size_of::<usize>()
+        } else {
+            0
+        }
+    }
+
+    fn values() -> Vec<Value> {
+        let mut text = String::with_capacity(96);
+        text.push_str("retained nested text with spare capacity");
+        vec![
+            Value::text(text),
+            Value::json(r#"{"nested":[1,2,3]}"#),
+            Value::integer(7),
+        ]
+    }
+
+    fn assert_hot_graph(row: &Row, account: &MemoryAccount) {
+        let RowStorage::Shared(outer) = &row.storage else {
+            panic!("hot row must be shared")
+        };
+        assert!(outer.is_fully_accounted());
+        assert!(outer.belongs_to(account));
+        for value in row.iter() {
+            match value {
+                Value::Text(text) if text.is_heap() => {
+                    assert!(text.memory_account().unwrap().same_engine(account));
+                }
+                Value::Extension(bytes) => assert!(bytes.belongs_to(account)),
+                _ => {}
+            }
+        }
+    }
+
+    // Count physical allocations once across aliases, independently of origin
+    // labels. The same engine may own source children retained by another row.
+    fn owned_bytes(rows: &[&Row], account: &MemoryAccount) -> usize {
+        let mut seen = HashSet::new();
+        let mut total = 0;
+        for row in rows {
+            if let RowStorage::Shared(outer) = &row.storage {
+                if outer.belongs_to(account) && seen.insert(row.as_slice().as_ptr() as usize) {
+                    total += outer.allocation_size();
+                }
+            }
+            for value in row.iter() {
+                match value {
+                    Value::Text(text) if text.is_heap() => {
+                        if text
+                            .memory_account()
+                            .is_some_and(|owner| owner.same_engine(account))
+                            && seen.insert(text.as_str().as_ptr() as usize)
+                        {
+                            total += text_bytes(text);
+                        }
+                    }
+                    Value::Extension(bytes)
+                        if bytes.belongs_to(account) && seen.insert(bytes.as_ptr() as usize) =>
+                    {
+                        total += bytes.allocation_size();
+                    }
+                    _ => {}
+                }
+            }
+        }
+        total
+    }
+
+    #[test]
+    fn nested_owners_outlive_row_and_origin_with_exact_charges() {
+        let root = MemoryAccount::new();
+        let base = root.snapshot().accounted_bytes;
+        let origin = root.child();
+        let source = values();
+        let text = source[0].clone();
+        let extension = source[1].clone();
+        let row = Row::from_values(source).into_hot(&origin);
+        assert_hot_graph(&row, &root);
+        assert_eq!(root.snapshot().retained_bytes, owned_bytes(&[&row], &root));
+        let Value::Text(text) = text else {
+            unreachable!()
+        };
+        let Value::Extension(extension) = extension else {
+            unreachable!()
+        };
+        let Value::Text(row_text) = &row[0] else {
+            unreachable!()
+        };
+        let Value::Extension(row_extension) = &row[1] else {
+            unreachable!()
+        };
+        assert_eq!(text.as_str().as_ptr(), row_text.as_str().as_ptr());
+        assert!(CompactArc::ptr_eq(&extension, row_extension));
+        let text_charge = text_bytes(&text);
+        let extension_charge = extension.allocation_size();
+        drop((row, origin));
+        assert_eq!(
+            root.snapshot().retained_bytes,
+            text_charge + extension_charge
+        );
+        drop(text);
+        assert_eq!(root.snapshot().retained_bytes, extension_charge);
+        drop(extension);
+        assert_eq!(root.snapshot().accounted_bytes, base);
+    }
+
+    #[test]
+    fn shallow_outer_account_does_not_certify_nested_ownership() {
+        let account = MemoryAccount::new();
+        let outer = CompactArc::from_vec_in(values(), &account);
+        assert!(!outer.is_fully_accounted());
+        let pointer = outer.as_ptr();
+        assert_eq!(account.snapshot().retained_bytes, outer.allocation_size());
+        let row = Row::from_arc(outer).into_hot(&account);
+        assert_eq!(row.as_slice().as_ptr(), pointer);
+        assert_hot_graph(&row, &account);
+        assert_eq!(
+            account.snapshot().retained_bytes,
+            owned_bytes(&[&row], &account)
+        );
+        drop(row);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn same_engine_origins_reuse_the_whole_graph() {
+        let root = MemoryAccount::new();
+        let first = root.child();
+        let second = root.child();
+        let row = Row::from_values(values()).into_hot(&first);
+        let before = root.snapshot();
+        let alias = row.clone().into_hot(&second);
+        assert_eq!(row.as_slice().as_ptr(), alias.as_slice().as_ptr());
+        assert_eq!(root.snapshot(), before);
+        let RowStorage::Shared(outer) = &alias.storage else {
+            unreachable!()
+        };
+        assert!(outer.memory_account().unwrap().same_origin(&first));
+        assert_hot_graph(&alias, &second);
+        drop((row, alias));
+        assert_eq!(root.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn foreign_engine_copies_outer_and_foreign_children() {
+        let first = MemoryAccount::new();
+        let second = MemoryAccount::new();
+        let source = Row::from_values(values()).into_hot(&first);
+        let before = first.snapshot();
+        let copied = source.clone().into_hot(&second);
+        assert_eq!(source, copied);
+        assert_ne!(source.as_slice().as_ptr(), copied.as_slice().as_ptr());
+        let (Value::Text(a), Value::Text(b)) = (&source[0], &copied[0]) else {
+            unreachable!()
+        };
+        assert_ne!(a.as_str().as_ptr(), b.as_str().as_ptr());
+        let (Value::Extension(a), Value::Extension(b)) = (&source[1], &copied[1]) else {
+            unreachable!()
+        };
+        assert!(!CompactArc::ptr_eq(a, b));
+        assert_hot_graph(&source, &first);
+        assert_hot_graph(&copied, &second);
+        assert_eq!(first.snapshot(), before);
+        assert_eq!(
+            second.snapshot().retained_bytes,
+            owned_bytes(&[&copied], &second)
+        );
+        drop(source);
+        assert_eq!(first.snapshot().retained_bytes, 0);
+        assert_hot_graph(&copied, &second);
+        drop(copied);
+        assert_eq!(second.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn concurrent_engine_adoption_never_certifies_a_foreign_child() {
+        use std::sync::Barrier;
+        for pre_split in [false, true] {
+            for _ in 0..16 {
+                let first = MemoryAccount::new();
+                let second = MemoryAccount::new();
+                let source = Row::from_arc(CompactArc::from_vec(values()));
+                if pre_split {
+                    assert!(source[0].try_adopt_hot(&first));
+                    assert!(source[1].try_adopt_hot(&second));
+                }
+                let start = Barrier::new(2);
+                let (left, right) = std::thread::scope(|scope| {
+                    let a = source.clone();
+                    let b = source.clone();
+                    let left = scope.spawn(|| {
+                        start.wait();
+                        a.into_hot(&first)
+                    });
+                    let right = scope.spawn(|| {
+                        start.wait();
+                        b.into_hot(&second)
+                    });
+                    (left.join().unwrap(), right.join().unwrap())
+                });
+                assert_eq!(source, left);
+                assert_eq!(source, right);
+                assert_hot_graph(&left, &first);
+                assert_hot_graph(&right, &second);
+                for account in [&first, &second] {
+                    assert_eq!(account.snapshot().pending_bytes, 0);
+                    assert_eq!(
+                        account.snapshot().retained_bytes,
+                        owned_bytes(&[&source, &left, &right], account)
+                    );
+                }
+                drop((source, left, right));
+                assert_eq!(first.snapshot().retained_bytes, 0);
+                assert_eq!(second.snapshot().retained_bytes, 0);
+            }
+        }
+    }
+
+    #[test]
+    fn row_mutation_loses_the_old_graph_certificate() {
+        let account = MemoryAccount::new();
+        let original = Row::from_values(values()).into_hot(&account);
+        for mutation in 0..3 {
+            let mut changed = original.clone();
+            let replacement = Value::text("new untracked text inserted after hot sharing");
+            match mutation {
+                0 => changed.set(0, replacement).unwrap(),
+                1 => *changed.get_mut(0).unwrap() = replacement,
+                _ => *changed.iter_mut().next().unwrap() = replacement,
+            }
+            assert!(changed.is_owned());
+            assert_hot_graph(&original, &account);
+            let changed = changed.into_hot(&account);
+            assert_hot_graph(&changed, &account);
+            assert_eq!(
+                account.snapshot().retained_bytes,
+                owned_bytes(&[&original, &changed], &account)
+            );
+            assert_ne!(original[0], changed[0]);
+        }
+        drop(original);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
 }
 
 #[cfg(test)]

--- a/src/core/value.rs
+++ b/src/core/value.rs
@@ -104,6 +104,34 @@ pub enum Value {
 pub const NULL_VALUE: Value = Value::Null(DataType::Null);
 
 impl Value {
+    /// Adopt independently shared immutable backings without changing this
+    /// Value. Foreign backing needs an owned replacement in the caller.
+    pub(crate) fn try_adopt_hot(&self, account: &crate::common::memory::MemoryAccount) -> bool {
+        use crate::common::memory::MemoryAdoption;
+        match self {
+            Self::Text(text) => text.try_adopt_hot(account) != MemoryAdoption::ForeignEngine,
+            Self::Extension(bytes) => {
+                bytes.try_adopt_shallow(account) != MemoryAdoption::ForeignEngine
+            }
+            _ => true,
+        }
+    }
+
+    pub(crate) fn into_hot(self, account: &crate::common::memory::MemoryAccount) -> Self {
+        use crate::common::memory::MemoryAdoption;
+        match self {
+            Self::Text(text) => Self::Text(text.into_hot(account)),
+            Self::Extension(bytes) => {
+                if bytes.try_adopt_shallow(account) == MemoryAdoption::ForeignEngine {
+                    Self::Extension(CompactArc::from_slice_in(bytes.as_ref(), account))
+                } else {
+                    Self::Extension(bytes)
+                }
+            }
+            value => value,
+        }
+    }
+
     // =========================================================================
     // Constructors
     // =========================================================================
@@ -1513,6 +1541,63 @@ fn compare_floats(a: f64, b: f64) -> Ordering {
 mod tests {
     use super::*;
     use chrono::{Datelike, Timelike};
+
+    #[test]
+    fn hot_inline_values_need_no_retained_allocation() {
+        let account = crate::common::MemoryAccount::new();
+        let before = account.snapshot();
+        for value in [
+            Value::null_unknown(),
+            Value::integer(4),
+            Value::float(1.5),
+            Value::boolean(true),
+            Value::text("inline"),
+        ] {
+            let expected = value.clone();
+            assert!(value.try_adopt_hot(&account));
+            assert_eq!(value.into_hot(&account), expected);
+        }
+        assert_eq!(account.snapshot(), before);
+    }
+
+    #[test]
+    fn hot_extension_copy_keeps_type_bytes_and_final_owner_charge() {
+        use crate::common::MemoryAccount;
+        for source in [
+            Value::json(r#"{"n":123}"#),
+            Value::vector(vec![1.0, -2.5, 0.0]),
+        ] {
+            let first = MemoryAccount::new();
+            let second = MemoryAccount::new();
+            let first_value = source.clone().into_hot(&first);
+            let second_value = source.clone().into_hot(&second);
+            assert_eq!(source, first_value);
+            assert_eq!(source, second_value);
+            assert_eq!(source.data_type(), second_value.data_type());
+            let Value::Extension(first_bytes) = first_value else {
+                unreachable!()
+            };
+            let Value::Extension(second_bytes) = second_value else {
+                unreachable!()
+            };
+            assert!(!CompactArc::ptr_eq(&first_bytes, &second_bytes));
+            assert_eq!(
+                first.snapshot().retained_bytes,
+                first_bytes.allocation_size()
+            );
+            assert_eq!(
+                second.snapshot().retained_bytes,
+                second_bytes.allocation_size()
+            );
+            drop(first_bytes);
+            assert!(first.snapshot().retained_bytes > 0);
+            drop(source);
+            assert_eq!(first.snapshot().retained_bytes, 0);
+            assert!(second.snapshot().retained_bytes > 0);
+            drop(second_bytes);
+            assert_eq!(second.snapshot().retained_bytes, 0);
+        }
+    }
 
     // =========================================================================
     // Size verification tests

--- a/src/executor/context.rs
+++ b/src/executor/context.rs
@@ -638,9 +638,6 @@ pub fn clear_all_thread_local_caches() {
     crate::core::row_vec::clear_row_vec_pool();
     crate::core::row_vec::clear_row_id_vec_pool();
 
-    // Clear global transaction version map pools
-    crate::storage::mvcc::clear_version_map_pools();
-
     // Clear global LRU caches
     super::expression::clear_program_cache();
     super::query_classification::clear_classification_cache();

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -9846,6 +9846,13 @@ impl Executor {
                     "chain_entries".to_string(),
                     "volume_bytes".to_string(),
                     "admission_waits".to_string(),
+                    "retained_hot_bytes".to_string(),
+                    "conservative_hot_bytes".to_string(),
+                    "pending_hot_bytes".to_string(),
+                    "accounted_hot_bytes".to_string(),
+                    "peak_accounted_hot_bytes".to_string(),
+                    "accounting_scope".to_string(),
+                    "hard_limit_enforced".to_string(),
                 ];
 
                 let stats = self.engine.memory_stats();
@@ -9862,6 +9869,13 @@ impl Executor {
                             Value::Integer(stat.chain_entries as i64),
                             Value::Integer(stat.volume_bytes as i64),
                             Value::Integer(stat.admission_waits as i64),
+                            Value::Integer(stat.retained_hot_bytes as i64),
+                            Value::Integer(stat.conservative_hot_bytes as i64),
+                            Value::Integer(stat.pending_hot_bytes as i64),
+                            Value::Integer(stat.accounted_hot_bytes as i64),
+                            Value::Integer(stat.peak_accounted_hot_bytes as i64),
+                            Value::text("hot_owned; accounting_only; excludes_catalog_query_cold_maintenance"),
+                            Value::Boolean(false),
                         ]),
                     ));
                 }

--- a/src/storage/index/accounted_map.rs
+++ b/src/storage/index/accounted_map.rs
@@ -1,0 +1,665 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Incremental ownership accounting under each index's existing write lock.
+
+use crate::common::{CompactArc, CompactArcDrop, CompactVec, MemoryAccount, MemoryCharge};
+use crate::core::Value;
+use std::borrow::Borrow;
+use std::collections::{BTreeMap, BTreeSet};
+use std::hash::{BuildHasher, Hash};
+use std::ops::{Deref, DerefMut};
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct HeapBytes {
+    pub retained: usize,
+    pub conservative: usize,
+}
+impl HeapBytes {
+    fn plus(self, other: Self) -> Self {
+        Self {
+            retained: self.retained + other.retained,
+            conservative: self.conservative + other.conservative,
+        }
+    }
+}
+
+/// Shared allocations carry their own charge. This counts only private buffers
+/// nested inside an entry, without adding a sidecar to every key or posting.
+pub(crate) trait PrivateHeap {
+    const HAS_HEAP: bool = true;
+    const MUTATION_BOUND_SUPPLIED: bool = false;
+    fn private_heap(&self) -> HeapBytes;
+}
+macro_rules! no_heap {
+    ($($t:ty),*) => {$(impl PrivateHeap for $t {
+        const HAS_HEAP: bool = false;
+        fn private_heap(&self) -> HeapBytes { HeapBytes::default() }
+    })*};
+}
+no_heap!(i64, u64, u32, usize, Value);
+impl<T: ?Sized> PrivateHeap for std::sync::Arc<T> {
+    const HAS_HEAP: bool = false;
+    fn private_heap(&self) -> HeapBytes {
+        HeapBytes::default()
+    }
+}
+impl PrivateHeap for String {
+    fn private_heap(&self) -> HeapBytes {
+        HeapBytes {
+            retained: self.capacity(),
+            conservative: 0,
+        }
+    }
+}
+impl<T: CompactArcDrop + ?Sized> PrivateHeap for CompactArc<T> {
+    const HAS_HEAP: bool = false;
+    fn private_heap(&self) -> HeapBytes {
+        HeapBytes::default()
+    }
+}
+impl<T: PrivateHeap> PrivateHeap for Vec<T> {
+    fn private_heap(&self) -> HeapBytes {
+        let mut bytes = HeapBytes {
+            retained: self.capacity() * std::mem::size_of::<T>(),
+            conservative: 0,
+        };
+        if T::HAS_HEAP {
+            for value in self {
+                bytes = bytes.plus(value.private_heap());
+            }
+        }
+        bytes
+    }
+}
+impl<T: PrivateHeap> PrivateHeap for CompactVec<T> {
+    fn private_heap(&self) -> HeapBytes {
+        let mut bytes = HeapBytes {
+            retained: self.capacity() * std::mem::size_of::<T>(),
+            conservative: 0,
+        };
+        if T::HAS_HEAP {
+            for value in self {
+                bytes = bytes.plus(value.private_heap());
+            }
+        }
+        bytes
+    }
+}
+impl<A: PrivateHeap, B: PrivateHeap> PrivateHeap for (A, B) {
+    const HAS_HEAP: bool = A::HAS_HEAP || B::HAS_HEAP;
+    fn private_heap(&self) -> HeapBytes {
+        self.0.private_heap().plus(self.1.private_heap())
+    }
+}
+
+/// Conservative node bound for the supported std BTree layout (B=6, 11 keys,
+/// 12 edges, >=5 keys per nonroot node). Charge every possible node as internal
+/// and include padding. An empty allocated root is retained until explicit clear.
+pub(crate) fn btree_bound<K, V>(len: usize, initialized: bool) -> usize {
+    if !initialized {
+        return 0;
+    }
+    let alignment = std::mem::align_of::<K>()
+        .max(std::mem::align_of::<V>())
+        .max(std::mem::align_of::<usize>());
+    let node = 16
+        + 11 * (std::mem::size_of::<K>() + std::mem::size_of::<V>())
+        + 12 * std::mem::size_of::<usize>()
+        + 4 * alignment;
+    (1 + len.saturating_sub(1) / 5) * node
+}
+impl<T: Ord> PrivateHeap for BTreeSet<T> {
+    fn private_heap(&self) -> HeapBytes {
+        HeapBytes {
+            retained: 0,
+            conservative: btree_bound::<T, ()>(self.len(), true),
+        }
+    }
+}
+
+#[derive(Default)]
+struct NestedCharge {
+    bytes: HeapBytes,
+    retained: Option<MemoryCharge>,
+    conservative: Option<MemoryCharge>,
+}
+impl NestedCharge {
+    fn attach(&mut self, account: &MemoryAccount) {
+        self.retained = Some(MemoryCharge::new(account, self.bytes.retained));
+        self.conservative = Some(MemoryCharge::conservative(account, self.bytes.conservative));
+    }
+    fn account(&self) -> Option<&MemoryAccount> {
+        self.retained.as_ref().map(MemoryCharge::account)
+    }
+    fn change(&mut self, before: HeapBytes, after: HeapBytes) {
+        self.bytes.retained = self.bytes.retained - before.retained + after.retained;
+        self.bytes.conservative =
+            self.bytes.conservative - before.conservative + after.conservative;
+        if let Some(charge) = &mut self.retained {
+            if charge.bytes() != self.bytes.retained {
+                charge.resize(self.bytes.retained);
+            }
+        }
+        if let Some(charge) = &mut self.conservative {
+            if charge.bytes() != self.bytes.conservative {
+                charge.resize(self.bytes.conservative);
+            }
+        }
+    }
+}
+
+pub(crate) struct ValueMut<'a, V: PrivateHeap> {
+    value: &'a mut V,
+    before: HeapBytes,
+    charge: &'a mut NestedCharge,
+}
+impl<V: PrivateHeap> Deref for ValueMut<'_, V> {
+    type Target = V;
+    fn deref(&self) -> &V {
+        self.value
+    }
+}
+impl<V: PrivateHeap> DerefMut for ValueMut<'_, V> {
+    fn deref_mut(&mut self) -> &mut V {
+        self.value
+    }
+}
+impl<V: PrivateHeap> Drop for ValueMut<'_, V> {
+    fn drop(&mut self) {
+        let after = self.value.private_heap();
+        if !V::MUTATION_BOUND_SUPPLIED && after.retained > self.before.retained {
+            // Bound old/new allocation overlap when opaque collection growth changes retained capacity.
+            if let Some(account) = self.charge.account() {
+                drop(MemoryCharge::conservative(account, after.retained));
+            }
+        }
+        self.charge.change(self.before, after);
+    }
+}
+
+pub(crate) struct TrackedBTree<K: Ord + PrivateHeap, V: PrivateHeap> {
+    data: BTreeMap<K, V>,
+    initialized: bool,
+    nested: NestedCharge,
+    nodes: Option<MemoryCharge>,
+}
+impl<K: Ord + PrivateHeap, V: PrivateHeap> Default for TrackedBTree<K, V> {
+    fn default() -> Self {
+        Self {
+            data: BTreeMap::new(),
+            initialized: false,
+            nested: NestedCharge::default(),
+            nodes: None,
+        }
+    }
+}
+impl<K: Ord + PrivateHeap, V: PrivateHeap> Deref for TrackedBTree<K, V> {
+    type Target = BTreeMap<K, V>;
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+impl<K: Ord + PrivateHeap, V: PrivateHeap> TrackedBTree<K, V> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn attach(&mut self, account: &MemoryAccount) {
+        // Reuse private capacities maintained before attachment without rescanning the startup index.
+        self.nested.attach(account);
+        self.nodes = Some(MemoryCharge::conservative(
+            account,
+            btree_bound::<K, V>(self.data.len(), self.initialized),
+        ));
+    }
+    fn refresh_nodes(&mut self, len: usize) {
+        if let Some(nodes) = &mut self.nodes {
+            let bytes = btree_bound::<K, V>(len, self.initialized);
+            if nodes.bytes() != bytes {
+                nodes.resize(bytes);
+            }
+        }
+    }
+    pub fn mutate_remove_if<Q: Ord + ?Sized>(
+        &mut self,
+        key: &Q,
+        mutate: impl FnOnce(&mut V) -> bool,
+    ) -> bool
+    where
+        K: Borrow<Q>,
+    {
+        let remove = match self.get_mut(key) {
+            Some(mut value) => mutate(&mut value),
+            None => false,
+        };
+        if remove {
+            self.remove(key);
+        }
+        remove
+    }
+    pub fn get_mut<Q: Ord + ?Sized>(&mut self, key: &Q) -> Option<ValueMut<'_, V>>
+    where
+        K: Borrow<Q>,
+    {
+        let value = self.data.get_mut(key)?;
+        Some(ValueMut {
+            before: value.private_heap(),
+            value,
+            charge: &mut self.nested,
+        })
+    }
+    pub fn entry(&mut self, key: K) -> BTreeEntry<'_, K, V> {
+        let future_len = self.data.len() + 1;
+        BTreeEntry {
+            entry: self.data.entry(key),
+            nested: &mut self.nested,
+            nodes: &mut self.nodes,
+            initialized: &mut self.initialized,
+            future_len,
+        }
+    }
+    pub fn insert(&mut self, key: K, value: V) {
+        let future_len = self.data.len() + usize::from(!self.data.contains_key(&key));
+        self.initialized = true;
+        self.refresh_nodes(future_len);
+        let key_bytes = key.private_heap();
+        let new_bytes = value.private_heap();
+        // Existing BTree keys are retained on replacement.
+        let existing = self.data.contains_key(&key);
+        self.nested.change(
+            HeapBytes::default(),
+            new_bytes.plus(if existing {
+                HeapBytes::default()
+            } else {
+                key_bytes
+            }),
+        );
+        if let Some(old) = self.data.insert(key, value) {
+            let old_bytes = old.private_heap();
+            drop(old);
+            self.nested.change(old_bytes, HeapBytes::default());
+        }
+    }
+    pub fn remove<Q: Ord + ?Sized>(&mut self, key: &Q) -> Option<()>
+    where
+        K: Borrow<Q>,
+    {
+        let (key, value) = self.data.remove_entry(key)?;
+        let bytes = key.private_heap().plus(value.private_heap());
+        drop((key, value));
+        self.nested.change(bytes, HeapBytes::default());
+        self.refresh_nodes(self.data.len());
+        Some(())
+    }
+    pub fn clear(&mut self) {
+        self.data = BTreeMap::new();
+        self.initialized = false;
+        self.nested.change(self.nested.bytes, HeapBytes::default());
+        self.refresh_nodes(0);
+    }
+}
+pub(crate) struct BTreeEntry<'a, K: Ord + PrivateHeap, V: PrivateHeap> {
+    entry: std::collections::btree_map::Entry<'a, K, V>,
+    nested: &'a mut NestedCharge,
+    nodes: &'a mut Option<MemoryCharge>,
+    initialized: &'a mut bool,
+    future_len: usize,
+}
+impl<'a, K: Ord + PrivateHeap, V: PrivateHeap + Default> BTreeEntry<'a, K, V> {
+    pub fn or_default(self) -> ValueMut<'a, V> {
+        let value = match self.entry {
+            std::collections::btree_map::Entry::Occupied(entry) => entry.into_mut(),
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                *self.initialized = true;
+                if let Some(nodes) = self.nodes {
+                    let bound = btree_bound::<K, V>(self.future_len, true);
+                    if nodes.bytes() != bound {
+                        nodes.resize(bound);
+                    }
+                }
+                let value = V::default();
+                self.nested.change(
+                    HeapBytes::default(),
+                    entry.key().private_heap().plus(value.private_heap()),
+                );
+                entry.insert(value)
+            }
+        };
+        ValueMut {
+            before: value.private_heap(),
+            value,
+            charge: self.nested,
+        }
+    }
+}
+
+pub(crate) struct TrackedHash<K: Eq + Hash + PrivateHeap, V: PrivateHeap, S: BuildHasher + Clone> {
+    data: hashbrown::HashMap<K, V, S>,
+    nested: NestedCharge,
+    buffer: Option<MemoryCharge>,
+}
+impl<K: Eq + Hash + PrivateHeap, V: PrivateHeap, S: BuildHasher + Clone + Default> Default
+    for TrackedHash<K, V, S>
+{
+    fn default() -> Self {
+        Self::with_capacity_and_hasher(0, S::default())
+    }
+}
+impl<K: Eq + Hash + PrivateHeap, V: PrivateHeap, S: BuildHasher + Clone> Deref
+    for TrackedHash<K, V, S>
+{
+    type Target = hashbrown::HashMap<K, V, S>;
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+impl<K: Eq + Hash + PrivateHeap, V: PrivateHeap, S: BuildHasher + Clone> TrackedHash<K, V, S> {
+    pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
+        Self {
+            data: hashbrown::HashMap::with_capacity_and_hasher(capacity, hasher),
+            nested: NestedCharge::default(),
+            buffer: None,
+        }
+    }
+    pub fn attach(&mut self, account: &MemoryAccount) {
+        // Reuse private capacities maintained before attachment without rescanning the startup index.
+        self.nested.attach(account);
+        self.buffer = Some(MemoryCharge::new(account, self.data.allocation_size()));
+    }
+    pub fn reserve(&mut self, additional: usize) {
+        let needed = self.data.len() + additional;
+        if needed <= self.data.capacity() {
+            return;
+        }
+        let capacity = needed.max(self.data.capacity().saturating_mul(2));
+        let mut replacement =
+            hashbrown::HashMap::with_capacity_and_hasher(capacity, self.data.hasher().clone());
+        let replacement_charge = self
+            .buffer
+            .as_ref()
+            .map(|charge| MemoryCharge::new(charge.account(), replacement.allocation_size()));
+        for (key, value) in self.data.drain() {
+            replacement.insert(key, value);
+        }
+        let old = std::mem::replace(&mut self.data, replacement);
+        let old_charge = std::mem::replace(&mut self.buffer, replacement_charge);
+        drop(old);
+        drop(old_charge);
+    }
+    fn room_for(&mut self, key: &K) {
+        if self.data.len() == self.data.capacity() && !self.data.contains_key(key) {
+            self.reserve(1);
+        }
+    }
+    pub fn mutate_remove_if<Q: Eq + Hash + ?Sized>(
+        &mut self,
+        key: &Q,
+        mutate: impl FnOnce(&mut V) -> bool,
+    ) -> bool
+    where
+        K: Borrow<Q>,
+    {
+        let remove = match self.get_mut(key) {
+            Some(mut value) => mutate(&mut value),
+            None => false,
+        };
+        if remove {
+            self.remove(key);
+        }
+        remove
+    }
+    pub fn get_mut<Q: Eq + Hash + ?Sized>(&mut self, key: &Q) -> Option<ValueMut<'_, V>>
+    where
+        K: Borrow<Q>,
+    {
+        let value = self.data.get_mut(key)?;
+        Some(ValueMut {
+            before: value.private_heap(),
+            value,
+            charge: &mut self.nested,
+        })
+    }
+    pub fn entry(&mut self, key: K) -> HashEntry<'_, K, V, S> {
+        self.room_for(&key);
+        match self.data.entry(key) {
+            hashbrown::hash_map::Entry::Occupied(entry) => HashEntry::Occupied(HashOccupiedEntry {
+                entry,
+                nested: &mut self.nested,
+            }),
+            hashbrown::hash_map::Entry::Vacant(entry) => HashEntry::Vacant(HashVacantEntry {
+                entry,
+                nested: &mut self.nested,
+            }),
+        }
+    }
+    pub fn insert(&mut self, key: K, value: V) {
+        self.room_for(&key);
+        match self.data.entry(key) {
+            hashbrown::hash_map::Entry::Occupied(mut entry) => {
+                let before = entry.get().private_heap();
+                self.nested
+                    .change(HeapBytes::default(), value.private_heap());
+                drop(entry.insert(value));
+                self.nested.change(before, HeapBytes::default());
+            }
+            hashbrown::hash_map::Entry::Vacant(entry) => {
+                self.nested.change(
+                    HeapBytes::default(),
+                    entry.key().private_heap().plus(value.private_heap()),
+                );
+                entry.insert(value);
+            }
+        }
+    }
+    pub fn remove<Q: Eq + Hash + ?Sized>(&mut self, key: &Q) -> Option<()>
+    where
+        K: Borrow<Q>,
+    {
+        let (key, value) = self.data.remove_entry(key)?;
+        let before = key.private_heap().plus(value.private_heap());
+        drop((key, value));
+        self.nested.change(before, HeapBytes::default());
+        Some(())
+    }
+    /// Removal may return only a value whose allocations own independent charges.
+    /// Private Vec/String buffers must instead remain in an owned charge guard.
+    pub fn remove_value<Q: Eq + Hash + ?Sized>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+    {
+        assert!(
+            !V::HAS_HEAP,
+            "private buffers require an owned removal charge"
+        );
+        let (key, value) = self.data.remove_entry(key)?;
+        let before = key.private_heap();
+        drop(key);
+        self.nested.change(before, HeapBytes::default());
+        Some(value)
+    }
+    pub fn clear(&mut self) {
+        self.data.clear();
+        self.nested.change(self.nested.bytes, HeapBytes::default());
+    }
+}
+pub(crate) enum HashEntry<'a, K: Eq + Hash + PrivateHeap, V: PrivateHeap, S: BuildHasher + Clone> {
+    Occupied(HashOccupiedEntry<'a, K, V, S>),
+    Vacant(HashVacantEntry<'a, K, V, S>),
+}
+pub(crate) struct HashOccupiedEntry<
+    'a,
+    K: Eq + Hash + PrivateHeap,
+    V: PrivateHeap,
+    S: BuildHasher + Clone,
+> {
+    entry: hashbrown::hash_map::OccupiedEntry<'a, K, V, S>,
+    nested: &'a mut NestedCharge,
+}
+pub(crate) struct HashVacantEntry<
+    'a,
+    K: Eq + Hash + PrivateHeap,
+    V: PrivateHeap,
+    S: BuildHasher + Clone,
+> {
+    entry: hashbrown::hash_map::VacantEntry<'a, K, V, S>,
+    nested: &'a mut NestedCharge,
+}
+impl<'a, K: Eq + Hash + PrivateHeap, V: PrivateHeap, S: BuildHasher + Clone>
+    HashOccupiedEntry<'a, K, V, S>
+{
+    pub fn get(&self) -> &V {
+        self.entry.get()
+    }
+    pub fn into_mut(self) -> ValueMut<'a, V> {
+        let value = self.entry.into_mut();
+        ValueMut {
+            before: value.private_heap(),
+            value,
+            charge: self.nested,
+        }
+    }
+}
+impl<'a, K: Eq + Hash + PrivateHeap, V: PrivateHeap, S: BuildHasher + Clone>
+    HashVacantEntry<'a, K, V, S>
+{
+    pub fn insert(self, value: V) -> ValueMut<'a, V> {
+        self.nested.change(
+            HeapBytes::default(),
+            self.entry.key().private_heap().plus(value.private_heap()),
+        );
+        let value = self.entry.insert(value);
+        ValueMut {
+            before: value.private_heap(),
+            value,
+            charge: self.nested,
+        }
+    }
+}
+impl<'a, K: Eq + Hash + PrivateHeap, V: PrivateHeap + Default, S: BuildHasher + Clone>
+    HashEntry<'a, K, V, S>
+{
+    pub fn or_default(self) -> ValueMut<'a, V> {
+        match self {
+            Self::Occupied(entry) => entry.into_mut(),
+            Self::Vacant(entry) => entry.insert(V::default()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    type Rows = CompactVec<i64>;
+    type Map = TrackedHash<u64, Rows, std::collections::hash_map::RandomState>;
+    #[test]
+    fn tracked_hash_only_charges_live_private_capacities_and_final_buffer() {
+        let root = MemoryAccount::new();
+        let mut map = Map::default();
+        map.attach(&root);
+        for key in 0..20 {
+            for row in 0..20 {
+                map.entry(key).or_default().push(row);
+            }
+        }
+        let rows = map
+            .data
+            .values()
+            .map(|rows| rows.capacity() * std::mem::size_of::<i64>())
+            .sum::<usize>();
+        assert_eq!(
+            root.snapshot().retained_bytes,
+            rows + map.data.allocation_size()
+        );
+        for key in 0..10 {
+            map.remove(&key);
+        }
+        assert_eq!(
+            root.snapshot().retained_bytes,
+            rows / 2 + map.data.allocation_size()
+        );
+        map.clear();
+        assert_eq!(root.snapshot().retained_bytes, map.data.allocation_size());
+        drop(map);
+        assert_eq!(root.snapshot().retained_bytes, 0);
+    }
+    #[test]
+    fn tracked_btree_separates_exact_posting_capacity_and_opaque_nodes() {
+        let root = MemoryAccount::new();
+        let base = root.snapshot().conservative_bytes;
+        let mut map = TrackedBTree::<i64, Rows>::new();
+        map.attach(&root);
+        for key in 0..100 {
+            for row in 0..20 {
+                map.entry(key).or_default().push(row);
+            }
+        }
+        let exact = map
+            .data
+            .values()
+            .map(|rows| rows.capacity() * std::mem::size_of::<i64>())
+            .sum::<usize>();
+        assert_eq!(root.snapshot().retained_bytes, exact);
+        assert_eq!(
+            root.snapshot().conservative_bytes,
+            base + btree_bound::<i64, Rows>(100, true)
+        );
+        for key in 0..100 {
+            map.remove(&key);
+        }
+        assert_eq!(root.snapshot().retained_bytes, 0);
+        assert_eq!(
+            root.snapshot().conservative_bytes,
+            base + btree_bound::<i64, Rows>(0, true)
+        );
+        map.clear();
+        assert_eq!(root.snapshot().conservative_bytes, base);
+    }
+    #[derive(Clone, Default)]
+    struct CollidingHasher;
+    impl std::hash::Hasher for CollidingHasher {
+        fn write(&mut self, _: &[u8]) {}
+        fn finish(&self) -> u64 {
+            0
+        }
+    }
+
+    #[test]
+    fn hash_tombstones_keep_physical_bucket_charge() {
+        let account = MemoryAccount::new();
+        let mut map =
+            TrackedHash::<u64, Vec<i64>, std::hash::BuildHasherDefault<CollidingHasher>>::default();
+        map.attach(&account);
+        map.reserve(112);
+        for key in 0..112 {
+            map.insert(key, vec![key as i64]);
+        }
+        let physical = map.allocation_size();
+        for key in 0..70 {
+            map.remove(&key);
+        }
+        assert_eq!(map.allocation_size(), physical);
+        assert_eq!(account.snapshot().retained_bytes, physical + 42 * 8);
+        for key in 112..400 {
+            map.insert(key, vec![key as i64]);
+        }
+        assert_eq!(
+            account.snapshot().retained_bytes,
+            map.allocation_size() + 330 * 8
+        );
+        map.clear();
+        assert_eq!(account.snapshot().retained_bytes, map.allocation_size());
+        drop(map);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+}

--- a/src/storage/index/bitmap.rs
+++ b/src/storage/index/bitmap.rs
@@ -48,10 +48,113 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
 use ahash::AHashMap;
 use roaring::RoaringTreemap;
 
-use crate::common::{CompactArc, I64Map};
+use super::accounted_map::{btree_bound, HeapBytes, PrivateHeap, TrackedHash};
+use super::memory::IndexMemory;
+use crate::common::{CompactArc, I64Map, MemoryAccount, MemoryCharge};
+type BitmapMap = TrackedHash<CompactArc<Value>, AccountedBitmap, ahash::RandomState>;
 use crate::core::{DataType, Error, IndexEntry, IndexType, Operator, Result, RowIdVec, Value};
 use crate::storage::expression::Expression;
 use crate::storage::traits::Index;
+
+/// Conservative bounds for a bitmap built only by point insertion and removal.
+#[derive(Default)]
+struct AccountedBitmap {
+    data: RoaringTreemap,
+    rows: usize,
+    blocks: usize,
+    groups: usize,
+    insert_allowance: usize,
+    directory_allowance: usize,
+}
+impl std::ops::Deref for AccountedBitmap {
+    type Target = RoaringTreemap;
+    fn deref(&self) -> &RoaringTreemap {
+        &self.data
+    }
+}
+impl PrivateHeap for AccountedBitmap {
+    const MUTATION_BOUND_SUPPLIED: bool = true;
+    fn private_heap(&self) -> HeapBytes {
+        let stores = self.blocks.saturating_mul(8192).min(self.insert_allowance);
+        let directories = self
+            .groups
+            .saturating_mul(65536 * 64)
+            .min(self.directory_allowance);
+        HeapBytes {
+            retained: 0,
+            conservative: stores
+                .saturating_add(directories)
+                .saturating_add(btree_bound::<u32, roaring::RoaringBitmap>(
+                    self.groups,
+                    self.rows != 0,
+                )),
+        }
+    }
+}
+impl AccountedBitmap {
+    fn contains_prefix(&self, value: u64, bits: u32) -> bool {
+        let mut values = self.data.iter();
+        values.advance_to((value >> bits) << bits);
+        values
+            .next()
+            .is_some_and(|next| next >> bits == value >> bits)
+    }
+
+    fn mutate(&mut self, value: u64, inserting: bool, account: Option<&MemoryAccount>) -> bool {
+        let new_block = inserting && !self.contains_prefix(value, 16);
+        let new_group = new_block && !self.contains_prefix(value, 32);
+        let mut extra: usize = if inserting { 24 * 1024 } else { 8 * 1024 };
+        if new_block {
+            extra = extra.saturating_add(
+                self.directory_allowance
+                    .saturating_mul(2)
+                    .saturating_add(256)
+                    .min(65536 * 64),
+            );
+        }
+        if new_group {
+            extra = extra.saturating_add(btree_bound::<u32, roaring::RoaringBitmap>(
+                self.groups.saturating_add(1),
+                true,
+            ));
+        }
+        let temporary = account.map(|account| MemoryCharge::conservative(account, extra));
+        let changed = if inserting {
+            self.data.insert(value)
+        } else {
+            self.data.remove(value)
+        };
+        if changed {
+            if inserting {
+                self.rows += 1;
+                self.blocks += usize::from(new_block);
+                self.groups += usize::from(new_group);
+                self.insert_allowance = self.insert_allowance.saturating_add(8);
+                if new_block {
+                    self.directory_allowance = self.directory_allowance.saturating_add(256);
+                }
+            } else {
+                self.rows -= 1;
+                if self.rows == 0 {
+                    *self = Self::default();
+                } else if !self.contains_prefix(value, 16) {
+                    self.blocks -= 1;
+                    if !self.contains_prefix(value, 32) {
+                        self.groups -= 1;
+                    }
+                }
+            }
+        }
+        drop(temporary);
+        changed
+    }
+    fn insert(&mut self, value: u64, account: Option<&MemoryAccount>) -> bool {
+        self.mutate(value, true, account)
+    }
+    fn remove(&mut self, value: u64, account: Option<&MemoryAccount>) -> bool {
+        self.mutate(value, false, account)
+    }
+}
 
 /// Warning threshold for cardinality
 const HIGH_CARDINALITY_WARNING_THRESHOLD: usize = 1000;
@@ -89,7 +192,7 @@ pub struct BitmapIndex {
     /// Maps CompactArc<Value> -> RoaringTreemap of row IDs (supports full u64 range)
     /// Uses CompactArc<Value> keys for memory efficiency (8 bytes per key)
     /// AHash for HashDoS resistance (user-controlled indexed values)
-    bitmaps: RwLock<AHashMap<CompactArc<Value>, RoaringTreemap>>,
+    bitmaps: RwLock<BitmapMap>,
 
     /// Reverse mapping: row_id -> CompactArc<Value> for efficient removal
     /// Uses I64Map for fast O(1) lookups and CompactArc<Value> (8 bytes per entry)
@@ -97,6 +200,7 @@ pub struct BitmapIndex {
 
     /// Track cardinality for warnings
     distinct_count: AtomicUsize,
+    memory: IndexMemory,
 }
 
 impl std::fmt::Debug for BitmapIndex {
@@ -139,13 +243,14 @@ impl BitmapIndex {
             data_types,
             is_unique,
             closed: AtomicBool::new(false),
-            bitmaps: RwLock::new(AHashMap::default()),
+            bitmaps: RwLock::new(BitmapMap::default()),
             row_to_value: RwLock::new(if expected_rows > 0 {
                 I64Map::with_capacity(expected_rows)
             } else {
                 I64Map::new()
             }),
             distinct_count: AtomicUsize::new(0),
+            memory: IndexMemory::default(),
         }
     }
 
@@ -164,7 +269,7 @@ impl BitmapIndex {
         // Intern value to get Arc for lookup
         let arc_key = self.value_to_arc_key(std::slice::from_ref(value));
         let bitmaps = self.bitmaps.read();
-        bitmaps.get(&arc_key).cloned()
+        bitmaps.get(&arc_key).map(|bitmap| bitmap.data.clone())
     }
 
     /// Perform AND operation on multiple values (for multi-predicate queries)
@@ -177,8 +282,8 @@ impl BitmapIndex {
             let arc_key = self.value_to_arc_key(std::slice::from_ref(value));
             if let Some(bitmap) = bitmaps.get(&arc_key) {
                 result = Some(match result {
-                    Some(r) => r & bitmap,
-                    None => bitmap.clone(),
+                    Some(r) => r & &bitmap.data,
+                    None => bitmap.data.clone(),
                 });
             } else {
                 // Value not found - result is empty
@@ -198,7 +303,7 @@ impl BitmapIndex {
         for value in values {
             let arc_key = self.value_to_arc_key(std::slice::from_ref(value));
             if let Some(bitmap) = bitmaps.get(&arc_key) {
-                result |= bitmap;
+                result |= &bitmap.data;
             }
         }
 
@@ -215,12 +320,12 @@ impl BitmapIndex {
         // Get all row IDs (union of all bitmaps)
         let mut all_rows = RoaringTreemap::new();
         for bitmap in bitmaps.values() {
-            all_rows |= bitmap;
+            all_rows |= &bitmap.data;
         }
 
         // Subtract the matching bitmap
         if let Some(bitmap) = bitmaps.get(&arc_key) {
-            all_rows - bitmap
+            all_rows - &bitmap.data
         } else {
             all_rows
         }
@@ -247,6 +352,21 @@ impl BitmapIndex {
         }
     }
 
+    /// The lookup wrapper is fresh and uniquely owned. Reuse its allocation
+    /// when it becomes retained; only foreign nested backing needs a copy.
+    fn retain_fresh_key(&self, mut key: CompactArc<Value>) -> CompactArc<Value> {
+        if let Some(account) = self.memory.account() {
+            let Some(value) = CompactArc::get_mut(&mut key) else {
+                unreachable!("fresh bitmap key is uniquely owned");
+            };
+            let owned = std::mem::replace(value, Value::Null(DataType::Null));
+            *value = owned.into_hot(account);
+            let adoption = key.try_adopt_shallow(account);
+            debug_assert_ne!(adoption, crate::common::MemoryAdoption::ForeignEngine);
+        }
+        key
+    }
+
     /// Slow path for multi-column indexes (rare case)
     /// Creates composite key and handles add operation
     #[cold]
@@ -255,7 +375,7 @@ impl BitmapIndex {
         values: &[Value],
         row_id: i64,
         row_id_u64: u64,
-        mut bitmaps: parking_lot::RwLockWriteGuard<'_, AHashMap<CompactArc<Value>, RoaringTreemap>>,
+        mut bitmaps: parking_lot::RwLockWriteGuard<'_, BitmapMap>,
         mut row_to_value: parking_lot::RwLockWriteGuard<'_, I64Map<CompactArc<Value>>>,
     ) -> Result<()> {
         // Create composite key for multi-column lookup
@@ -286,21 +406,22 @@ impl BitmapIndex {
 
         // Check if row already exists with a different value
         if let Some(old_arc_key) = row_to_value.get(row_id).cloned() {
-            if !CompactArc::ptr_eq(&old_arc_key, &arc_key) {
-                if let Some(old_bitmap) = bitmaps.get_mut(&old_arc_key) {
-                    old_bitmap.remove(row_id_u64);
-                    if old_bitmap.is_empty() {
-                        bitmaps.remove(&old_arc_key);
-                        self.distinct_count.fetch_sub(1, AtomicOrdering::Relaxed);
-                    }
-                }
+            if !CompactArc::ptr_eq(&old_arc_key, &arc_key)
+                && bitmaps.mutate_remove_if(&old_arc_key, |old_bitmap| {
+                    old_bitmap.remove(row_id_u64, self.memory.account());
+                    old_bitmap.is_empty()
+                })
+            {
+                self.distinct_count.fetch_sub(1, AtomicOrdering::Relaxed);
             }
         }
 
+        let arc_key = self.retain_fresh_key(arc_key);
         // Add to bitmap
         let is_new_value = !bitmaps.contains_key(&arc_key);
-        let bitmap = bitmaps.entry(CompactArc::clone(&arc_key)).or_default();
-        bitmap.insert(row_id_u64);
+        let mut bitmap = bitmaps.entry(CompactArc::clone(&arc_key)).or_default();
+        bitmap.insert(row_id_u64, self.memory.account());
+        drop(bitmap);
 
         // Update reverse mapping
         row_to_value.insert(row_id, arc_key);
@@ -314,6 +435,35 @@ impl BitmapIndex {
 }
 
 impl Index for BitmapIndex {
+    fn attach_memory_account(&mut self, account: &MemoryAccount) -> Result<()> {
+        if !self.memory.needs_attachment(account)? {
+            return Ok(());
+        }
+        for key in self.bitmaps.get_mut().keys() {
+            IndexMemory::adopt_value_arc(key, account)?;
+        }
+        for key in self.row_to_value.get_mut().values() {
+            IndexMemory::adopt_value_arc(key, account)?;
+        }
+        let metadata = self.name.capacity()
+            + self.table_name.capacity()
+            + self.column_names.capacity() * std::mem::size_of::<String>()
+            + self
+                .column_names
+                .iter()
+                .map(String::capacity)
+                .sum::<usize>()
+            + self.column_ids.capacity() * std::mem::size_of::<i32>()
+            + self.data_types.capacity() * std::mem::size_of::<DataType>();
+        self.memory.attach::<Self>(account, metadata);
+        self.bitmaps.get_mut().attach(account);
+        self.row_to_value.get_mut().attach_memory_account(account);
+        Ok(())
+    }
+    fn memory_account(&self) -> Option<&MemoryAccount> {
+        self.memory.account()
+    }
+
     fn name(&self) -> &str {
         &self.name
     }
@@ -389,7 +539,7 @@ impl Index for BitmapIndex {
                 (CompactArc::clone(existing_arc), false)
             } else {
                 // New unique value - create Arc once
-                (CompactArc::new(lookup_value.clone()), true)
+                (self.memory.value_arc(lookup_value), true)
             };
 
         // Check if row already exists with a different value (for updates)
@@ -397,19 +547,19 @@ impl Index for BitmapIndex {
             // Compare Arc pointers - if same Arc, same value
             if !CompactArc::ptr_eq(&old_arc_key, &arc_key) {
                 // Remove from old bitmap
-                if let Some(old_bitmap) = bitmaps.get_mut(&old_arc_key) {
-                    old_bitmap.remove(row_id_u64);
-                    if old_bitmap.is_empty() {
-                        bitmaps.remove(&old_arc_key);
-                        self.distinct_count.fetch_sub(1, AtomicOrdering::Relaxed);
-                    }
+                if bitmaps.mutate_remove_if(&old_arc_key, |old_bitmap| {
+                    old_bitmap.remove(row_id_u64, self.memory.account());
+                    old_bitmap.is_empty()
+                }) {
+                    self.distinct_count.fetch_sub(1, AtomicOrdering::Relaxed);
                 }
             }
         }
 
         // Add to bitmap
-        let bitmap = bitmaps.entry(CompactArc::clone(&arc_key)).or_default();
-        bitmap.insert(row_id_u64);
+        let mut bitmap = bitmaps.entry(CompactArc::clone(&arc_key)).or_default();
+        bitmap.insert(row_id_u64, self.memory.account());
+        drop(bitmap);
 
         // Update reverse mapping with Arc reference
         row_to_value.insert(row_id, arc_key);
@@ -450,12 +600,11 @@ impl Index for BitmapIndex {
         let mut row_to_value = self.row_to_value.write();
 
         // Remove from bitmap
-        if let Some(bitmap) = bitmaps.get_mut(&arc_key) {
-            bitmap.remove(row_id_u64);
-            if bitmap.is_empty() {
-                bitmaps.remove(&arc_key);
-                self.distinct_count.fetch_sub(1, AtomicOrdering::Relaxed);
-            }
+        if bitmaps.mutate_remove_if(&arc_key, |bitmap| {
+            bitmap.remove(row_id_u64, self.memory.account());
+            bitmap.is_empty()
+        }) {
+            self.distinct_count.fetch_sub(1, AtomicOrdering::Relaxed);
         }
 
         // Remove from reverse mapping
@@ -559,27 +708,27 @@ impl Index for BitmapIndex {
                 if let Some((existing_arc, _)) = bitmaps.get_key_value(&arc_key) {
                     (CompactArc::clone(existing_arc), false)
                 } else {
-                    (arc_key, true)
+                    (self.retain_fresh_key(arc_key), true)
                 };
 
             // Handle update case - remove from old bitmap
             if let Some(old_arc_key) = row_to_value.get(row_id).cloned() {
-                if !CompactArc::ptr_eq(&old_arc_key, &final_arc_key) {
-                    if let Some(old_bitmap) = bitmaps.get_mut(&old_arc_key) {
-                        old_bitmap.remove(row_id_u64);
-                        if old_bitmap.is_empty() {
-                            bitmaps.remove(&old_arc_key);
-                            self.distinct_count.fetch_sub(1, AtomicOrdering::Relaxed);
-                        }
-                    }
+                if !CompactArc::ptr_eq(&old_arc_key, &final_arc_key)
+                    && bitmaps.mutate_remove_if(&old_arc_key, |old_bitmap| {
+                        old_bitmap.remove(row_id_u64, self.memory.account());
+                        old_bitmap.is_empty()
+                    })
+                {
+                    self.distinct_count.fetch_sub(1, AtomicOrdering::Relaxed);
                 }
             }
 
             // Add to bitmap
-            let bitmap = bitmaps
+            let mut bitmap = bitmaps
                 .entry(CompactArc::clone(&final_arc_key))
                 .or_default();
-            bitmap.insert(row_id_u64);
+            bitmap.insert(row_id_u64, self.memory.account());
+            drop(bitmap);
 
             // Update reverse mapping
             row_to_value.insert(row_id, final_arc_key);
@@ -615,12 +764,11 @@ impl Index for BitmapIndex {
             let arc_key = self.value_to_arc_key(values);
 
             // Remove from bitmap
-            if let Some(bitmap) = bitmaps.get_mut(&arc_key) {
-                bitmap.remove(row_id_u64);
-                if bitmap.is_empty() {
-                    bitmaps.remove(&arc_key);
-                    self.distinct_count.fetch_sub(1, AtomicOrdering::Relaxed);
-                }
+            if bitmaps.mutate_remove_if(&arc_key, |bitmap| {
+                bitmap.remove(row_id_u64, self.memory.account());
+                bitmap.is_empty()
+            }) {
+                self.distinct_count.fetch_sub(1, AtomicOrdering::Relaxed);
             }
 
             // Remove from reverse mapping
@@ -641,12 +789,11 @@ impl Index for BitmapIndex {
                 continue;
             }
             if let Some(arc_key) = row_to_value.remove(row_id) {
-                if let Some(bitmap) = bitmaps.get_mut(&arc_key) {
-                    bitmap.remove(row_id as u64);
-                    if bitmap.is_empty() {
-                        bitmaps.remove(&arc_key);
-                        self.distinct_count.fetch_sub(1, AtomicOrdering::Relaxed);
-                    }
+                if bitmaps.mutate_remove_if(&arc_key, |bitmap| {
+                    bitmap.remove(row_id as u64, self.memory.account());
+                    bitmap.is_empty()
+                }) {
+                    self.distinct_count.fetch_sub(1, AtomicOrdering::Relaxed);
                 }
             }
         }
@@ -790,7 +937,7 @@ impl Index for BitmapIndex {
         let bitmaps = self.bitmaps.read();
         let mut all_rows = RoaringTreemap::new();
         for bitmap in bitmaps.values() {
-            all_rows |= bitmap;
+            all_rows |= &bitmap.data;
         }
         let _ = expr;
         let collected: Vec<i64> = all_rows.iter().map(|id| id as i64).collect();
@@ -1174,5 +1321,98 @@ mod tests {
         // Removal of negative row ID should also be rejected
         let result = index.remove(&[Value::Text("pending".into())], -1, 0);
         assert!(result.is_err());
+    }
+}
+
+#[cfg(test)]
+mod accounting_tests {
+    use super::*;
+    #[test]
+    fn sparse_dense_and_high_group_changes_preserve_conservative_bounds() {
+        let account = MemoryAccount::new();
+        let baseline = account.snapshot().conservative_bytes;
+        let mut maps = BitmapMap::default();
+        maps.attach(&account);
+        let key = CompactArc::new(Value::Integer(1));
+        for row in 0..4097u64 {
+            maps.entry(key.clone())
+                .or_default()
+                .insert(row, Some(&account));
+        }
+        maps.entry(key.clone())
+            .or_default()
+            .insert(1u64 << 48, Some(&account));
+        let bitmap = maps.get(&key).unwrap();
+        let bound = bitmap.private_heap().conservative;
+        // Roaring 0.11.3 reports u16 array slots as u32 bytes and bitsets in bits.
+        let reported: usize = bitmap
+            .data
+            .bitmaps()
+            .map(|(_, group)| {
+                let stats = group.statistics();
+                (stats.n_bytes_array_containers / 2 + stats.n_bytes_bitset_containers / 8) as usize
+            })
+            .sum();
+        assert!(bound >= reported);
+        assert_eq!((bitmap.rows, bitmap.blocks, bitmap.groups), (4098, 2, 2));
+        assert_eq!(account.snapshot().retained_bytes, maps.allocation_size());
+        maps.get_mut(&key)
+            .unwrap()
+            .remove(1u64 << 48, Some(&account));
+        maps.get_mut(&key).unwrap().remove(4096, Some(&account));
+        let bitmap = maps.get(&key).unwrap();
+        assert_eq!((bitmap.rows, bitmap.blocks, bitmap.groups), (4096, 1, 1));
+        assert!(bitmap.private_heap().conservative < bound);
+        for row in 0..4096u64 {
+            maps.get_mut(&key).unwrap().remove(row, Some(&account));
+        }
+        assert_eq!(maps.get(&key).unwrap().private_heap().conservative, 0);
+        maps.clear();
+        assert_eq!(account.snapshot().retained_bytes, maps.allocation_size());
+        drop(maps);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+        assert_eq!(account.snapshot().conservative_bytes, baseline);
+    }
+
+    #[test]
+    fn bitmap_bounds_cover_retained_arrays_and_repeated_group_churn() {
+        let mut bitmap = AccountedBitmap::default();
+        bitmap.insert(0, None);
+        let singleton = bitmap.private_heap().conservative;
+        assert!(singleton < 1024);
+        assert!(!bitmap.insert(0, None));
+        assert!(!bitmap.remove(1, None));
+        assert_eq!(bitmap.private_heap().conservative, singleton);
+        for group in 1..8u64 {
+            let start = group << 32;
+            for value in start..start + 4097 {
+                bitmap.insert(value, None);
+            }
+            for _ in 0..3 {
+                bitmap.remove(start + 4096, None);
+                bitmap.insert(start + 4096, None);
+            }
+            for value in start + 1..start + 4097 {
+                bitmap.remove(value, None);
+            }
+            let reported: usize = bitmap
+                .data
+                .bitmaps()
+                .map(|(_, group)| {
+                    let stats = group.statistics();
+                    (stats.n_bytes_array_containers / 2 + stats.n_bytes_bitset_containers / 8)
+                        as usize
+                })
+                .sum();
+            assert!(bitmap.private_heap().conservative >= reported);
+        }
+        for group in 1..8u64 {
+            bitmap.remove(group << 32, None);
+        }
+        assert_eq!((bitmap.rows, bitmap.blocks, bitmap.groups), (1, 1, 1));
+        bitmap.remove(0, None);
+        assert_eq!(bitmap.private_heap().conservative, 0);
+        bitmap.insert(0, None);
+        assert_eq!(bitmap.private_heap().conservative, singleton);
     }
 }

--- a/src/storage/index/btree.rs
+++ b/src/storage/index/btree.rs
@@ -38,7 +38,9 @@ use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-use crate::common::{CompactArc, CompactVec, I64Map};
+use super::accounted_map::TrackedBTree;
+use super::memory::IndexMemory;
+use crate::common::{CompactArc, CompactVec, I64Map, MemoryAccount};
 use crate::core::{DataType, Error, IndexEntry, IndexType, Operator, Result, RowIdVec, Value};
 use crate::storage::expression::Expression;
 use crate::storage::traits::Index;
@@ -96,7 +98,7 @@ pub struct BTreeIndex {
     /// Sorted value to row IDs mapping (main index for range and equality queries)
     /// BTreeMap provides O(log n) lookups and efficient range iteration
     /// Uses CompactArc<Value> to share references with ValueArena (8 bytes per entry)
-    sorted_values: RwLock<BTreeMap<CompactArc<Value>, RowIdSet>>,
+    sorted_values: RwLock<TrackedBTree<CompactArc<Value>, RowIdSet>>,
 
     /// Row ID to value mapping (for removal operations)
     /// Uses I64Map for fast O(1) lookups with CompactArc<Value> (8 bytes per entry)
@@ -113,6 +115,7 @@ pub struct BTreeIndex {
 
     /// Reference ID counter
     next_ref_id: RwLock<i64>,
+    memory: IndexMemory,
 }
 
 impl BTreeIndex {
@@ -135,14 +138,12 @@ impl BTreeIndex {
         }
         let mut any_removed = false;
         for (arc_value, ids) in by_key {
-            if let Some(rows) = sorted_values.get_mut(&arc_value) {
+            sorted_values.mutate_remove_if(&arc_value, |rows| {
                 let before = rows.len();
                 super::subtract_sorted(rows, &ids);
                 any_removed |= rows.len() != before;
-                if rows.is_empty() {
-                    sorted_values.remove(&arc_value);
-                }
-            }
+                rows.is_empty()
+            });
         }
 
         drop(sorted_values);
@@ -176,7 +177,7 @@ impl BTreeIndex {
             data_type,
             unique,
             closed: AtomicBool::new(false),
-            sorted_values: RwLock::new(BTreeMap::new()),
+            sorted_values: RwLock::new(TrackedBTree::new()),
             row_to_value: RwLock::new(if expected_rows > 0 {
                 I64Map::with_capacity(expected_rows)
             } else {
@@ -186,6 +187,7 @@ impl BTreeIndex {
             cached_max: RwLock::new(None),
             cache_valid: AtomicBool::new(true),
             next_ref_id: RwLock::new(0),
+            memory: IndexMemory::default(),
         }
     }
 
@@ -425,6 +427,37 @@ impl BTreeIndex {
 }
 
 impl Index for BTreeIndex {
+    fn attach_memory_account(&mut self, account: &MemoryAccount) -> Result<()> {
+        if !self.memory.needs_attachment(account)? {
+            return Ok(());
+        }
+        for value in self.sorted_values.get_mut().keys() {
+            IndexMemory::adopt_value_arc(value, account)?;
+        }
+        for value in self.row_to_value.get_mut().values() {
+            IndexMemory::adopt_value_arc(value, account)?;
+        }
+        for value in [
+            self.cached_min.get_mut().as_ref(),
+            self.cached_max.get_mut().as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            IndexMemory::adopt_value_arc(value, account)?;
+        }
+        let metadata =
+            self.name.capacity() + self.table_name.capacity() + self.column_name.capacity();
+        self.memory.attach::<Self>(account, metadata);
+        self.sorted_values.get_mut().attach(account);
+        self.row_to_value.get_mut().attach_memory_account(account);
+        Ok(())
+    }
+
+    fn memory_account(&self) -> Option<&MemoryAccount> {
+        self.memory.account()
+    }
+
     fn name(&self) -> &str {
         &self.name
     }
@@ -463,14 +496,12 @@ impl Index for BTreeIndex {
             }
             // Different value - remove old entry from sorted index
             let old_arc = old_arc.clone();
-            if let Some(rows) = sorted_values.get_mut(&old_arc) {
+            sorted_values.mutate_remove_if(&old_arc, |rows| {
                 if let Ok(pos) = rows.binary_search(&row_id) {
                     rows.remove(pos);
                 }
-                if rows.is_empty() {
-                    sorted_values.remove(&old_arc);
-                }
-            }
+                rows.is_empty()
+            });
         }
 
         // Check uniqueness constraint using BTreeMap O(log n) lookup
@@ -496,17 +527,18 @@ impl Index for BTreeIndex {
             CompactArc::clone(existing_arc)
         } else {
             // New unique value - create Arc once
-            CompactArc::new(value.clone())
+            self.memory.value_arc(value)
         };
 
         // Add to sorted index (for O(log n) range and equality queries)
         // Insert in sorted order for O(N+M) intersection/union without re-sorting
-        let btree_rows = sorted_values
+        let mut btree_rows = sorted_values
             .entry(CompactArc::clone(&arc_value))
             .or_default();
         if let Err(pos) = btree_rows.binary_search(&row_id) {
             btree_rows.insert(pos, row_id);
         }
+        drop(btree_rows);
 
         // Add to row -> value mapping (stores Arc reference)
         row_to_value.insert(row_id, arc_value);
@@ -540,14 +572,12 @@ impl Index for BTreeIndex {
         // Check if the row exists and remove atomically
         if let Some(arc_value) = row_to_value.remove(row_id) {
             // Remove from sorted index (row_ids are sorted, use binary search)
-            if let Some(rows) = sorted_values.get_mut(&arc_value) {
+            sorted_values.mutate_remove_if(&arc_value, |rows| {
                 if let Ok(pos) = rows.binary_search(&row_id) {
                     rows.remove(pos);
                 }
-                if rows.is_empty() {
-                    sorted_values.remove(&arc_value);
-                }
-            }
+                rows.is_empty()
+            });
 
             // Drop locks before invalidating cache
             drop(sorted_values);
@@ -651,30 +681,29 @@ impl Index for BTreeIndex {
                 }
                 // Different value - remove old entry
                 let old_arc = old_arc.clone();
-                if let Some(rows) = sorted_values.get_mut(&old_arc) {
+                sorted_values.mutate_remove_if(&old_arc, |rows| {
                     if let Ok(pos) = rows.binary_search(&row_id) {
                         rows.remove(pos);
                     }
-                    if rows.is_empty() {
-                        sorted_values.remove(&old_arc);
-                    }
-                }
+                    rows.is_empty()
+                });
             }
 
             // Try to reuse existing Arc if value exists (memory deduplication)
             let arc_value = if let Some((existing_arc, _)) = sorted_values.get_key_value(value) {
                 CompactArc::clone(existing_arc)
             } else {
-                CompactArc::new(value.clone())
+                self.memory.value_arc(value)
             };
 
             // Add to sorted index (sorted insertion)
-            let btree_rows = sorted_values
+            let mut btree_rows = sorted_values
                 .entry(CompactArc::clone(&arc_value))
                 .or_default();
             if let Err(pos) = btree_rows.binary_search(&row_id) {
                 btree_rows.insert(pos, row_id);
             }
+            drop(btree_rows);
 
             // Add to row_to_value
             row_to_value.insert(row_id, arc_value);

--- a/src/storage/index/hash.rs
+++ b/src/storage/index/hash.rs
@@ -61,7 +61,14 @@ use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
 use rustc_hash::FxHashMap;
 
-use crate::common::{CompactArc, CompactVec, I64Map};
+use super::accounted_map::TrackedHash;
+use super::memory::IndexMemory;
+use crate::common::{CompactArc, CompactVec, I64Map, MemoryAccount};
+type HashValues = TrackedHash<
+    u64,
+    Vec<(Vec<CompactArc<Value>>, CompactVec<i64>)>,
+    std::hash::BuildHasherDefault<rustc_hash::FxHasher>,
+>;
 use crate::core::{DataType, Error, IndexEntry, IndexType, Operator, Result, RowIdVec, Value};
 use crate::storage::expression::{ComparisonExpr, Expression, InListExpr};
 use crate::storage::traits::Index;
@@ -119,7 +126,8 @@ pub struct HashIndex {
     /// Maps hash -> (values as CompactArc<Value>, row_ids) for collision resolution
     /// Uses CompactArc<Value> to share references with ValueArena (8 bytes per value)
     #[allow(clippy::type_complexity)]
-    hash_to_values: RwLock<FxHashMap<u64, Vec<(Vec<CompactArc<Value>>, CompactVec<i64>)>>>,
+    hash_to_values: RwLock<HashValues>,
+    memory: IndexMemory,
 }
 
 impl std::fmt::Debug for HashIndex {
@@ -163,11 +171,11 @@ impl HashIndex {
             } else {
                 I64Map::new()
             }),
-            hash_to_values: RwLock::new(if expected_rows > 0 {
-                FxHashMap::with_capacity_and_hasher(expected_rows, Default::default())
-            } else {
-                FxHashMap::default()
-            }),
+            hash_to_values: RwLock::new(HashValues::with_capacity_and_hasher(
+                expected_rows,
+                Default::default(),
+            )),
+            memory: IndexMemory::default(),
         }
     }
 
@@ -178,7 +186,7 @@ impl HashIndex {
         values: &[Value],
         row_id: i64,
         hash: u64,
-        hash_to_values: &FxHashMap<u64, Vec<(Vec<CompactArc<Value>>, CompactVec<i64>)>>,
+        hash_to_values: &HashValues,
     ) -> Result<()> {
         if !self.is_unique {
             return Ok(());
@@ -242,6 +250,36 @@ impl HashIndex {
 }
 
 impl Index for HashIndex {
+    fn attach_memory_account(&mut self, account: &MemoryAccount) -> Result<()> {
+        if !self.memory.needs_attachment(account)? {
+            return Ok(());
+        }
+        for entries in self.hash_to_values.get_mut().values() {
+            for (values, _) in entries {
+                for value in values {
+                    IndexMemory::adopt_value_arc(value, account)?;
+                }
+            }
+        }
+        let metadata = self.name.capacity()
+            + self.table_name.capacity()
+            + self.column_names.capacity() * std::mem::size_of::<String>()
+            + self
+                .column_names
+                .iter()
+                .map(String::capacity)
+                .sum::<usize>()
+            + self.column_ids.capacity() * std::mem::size_of::<i32>()
+            + self.data_types.capacity() * std::mem::size_of::<DataType>();
+        self.memory.attach::<Self>(account, metadata);
+        self.hash_to_values.get_mut().attach(account);
+        self.row_to_hash.get_mut().attach_memory_account(account);
+        Ok(())
+    }
+    fn memory_account(&self) -> Option<&MemoryAccount> {
+        self.memory.account()
+    }
+
     fn name(&self) -> &str {
         &self.name
     }
@@ -294,15 +332,13 @@ impl Index for HashIndex {
 
             // Different hash (or same hash with different values) - remove old entry
             // Remove from values storage
-            if let Some(entries) = hash_to_values.get_mut(&old_hash) {
+            hash_to_values.mutate_remove_if(&old_hash, |entries| {
                 for (_, row_ids) in entries.iter_mut() {
                     row_ids.retain(|id| *id != row_id);
                 }
                 entries.retain(|(_, row_ids)| !row_ids.is_empty());
-                if entries.is_empty() {
-                    hash_to_values.remove(&old_hash);
-                }
-            }
+                entries.is_empty()
+            });
         }
 
         // Check uniqueness constraint
@@ -313,7 +349,7 @@ impl Index for HashIndex {
 
         // Add to hash_to_values for collision handling
         // Use CompactArc<Value> via arena for memory efficiency
-        let entries = hash_to_values.entry(hash).or_default();
+        let mut entries = hash_to_values.entry(hash).or_default();
         let mut found = false;
         for (stored_values, row_ids) in entries.iter_mut() {
             // Compare CompactArc<Value> contents with input values
@@ -329,7 +365,7 @@ impl Index for HashIndex {
         if !found {
             // Wrap values in Arc for O(1) cloning
             let arc_values: Vec<CompactArc<Value>> =
-                values.iter().map(|v| CompactArc::new(v.clone())).collect();
+                values.iter().map(|v| self.memory.value_arc(v)).collect();
             let mut row_ids = CompactVec::new();
             row_ids.push(row_id); // First element, already sorted
             entries.push((arc_values, row_ids));
@@ -359,7 +395,7 @@ impl Index for HashIndex {
         row_to_hash.remove(row_id);
 
         // Remove from hash_to_values (row_ids are sorted, use binary search)
-        if let Some(entries) = hash_to_values.get_mut(&hash) {
+        hash_to_values.mutate_remove_if(&hash, |entries| {
             for (stored_values, row_ids) in entries.iter_mut() {
                 // Compare CompactArc<Value> contents with input values
                 if Self::values_match(stored_values, values) {
@@ -370,10 +406,8 @@ impl Index for HashIndex {
                 }
             }
             entries.retain(|(_, row_ids)| !row_ids.is_empty());
-            if entries.is_empty() {
-                hash_to_values.remove(&hash);
-            }
-        }
+            entries.is_empty()
+        });
 
         Ok(())
     }
@@ -478,22 +512,20 @@ impl Index for HashIndex {
                 }
 
                 // Different hash (or same hash with different values) - remove old entry
-                if let Some(val_entries) = hash_to_values.get_mut(&old_hash) {
+                hash_to_values.mutate_remove_if(&old_hash, |val_entries| {
                     for (_, row_ids) in val_entries.iter_mut() {
                         row_ids.retain(|id| *id != row_id);
                     }
                     val_entries.retain(|(_, row_ids)| !row_ids.is_empty());
-                    if val_entries.is_empty() {
-                        hash_to_values.remove(&old_hash);
-                    }
-                }
+                    val_entries.is_empty()
+                });
             }
 
             // Add to row_to_hash
             row_to_hash.insert(row_id, hash);
 
             // Add to hash_to_values
-            let val_entries = hash_to_values.entry(hash).or_default();
+            let mut val_entries = hash_to_values.entry(hash).or_default();
             let mut found = false;
             for (stored_values, row_ids) in val_entries.iter_mut() {
                 if Self::values_match(stored_values, values) {
@@ -506,7 +538,7 @@ impl Index for HashIndex {
             }
             if !found {
                 let arc_values: Vec<CompactArc<Value>> =
-                    values.iter().map(|v| CompactArc::new(v.clone())).collect();
+                    values.iter().map(|v| self.memory.value_arc(v)).collect();
                 let mut row_ids = CompactVec::new();
                 row_ids.push(row_id);
                 val_entries.push((arc_values, row_ids));
@@ -539,7 +571,7 @@ impl Index for HashIndex {
             row_to_hash.remove(row_id);
 
             // Remove from hash_to_values
-            if let Some(val_entries) = hash_to_values.get_mut(&hash) {
+            hash_to_values.mutate_remove_if(&hash, |val_entries| {
                 for (stored_values, row_ids) in val_entries.iter_mut() {
                     if Self::values_match(stored_values, values) {
                         if let Ok(pos) = row_ids.binary_search(&row_id) {
@@ -549,10 +581,8 @@ impl Index for HashIndex {
                     }
                 }
                 val_entries.retain(|(_, row_ids)| !row_ids.is_empty());
-                if val_entries.is_empty() {
-                    hash_to_values.remove(&hash);
-                }
-            }
+                val_entries.is_empty()
+            });
         }
 
         Ok(())
@@ -574,15 +604,13 @@ impl Index for HashIndex {
         }
         for (hash, mut ids) in by_hash {
             ids.sort_unstable();
-            if let Some(val_entries) = hash_to_values.get_mut(&hash) {
+            hash_to_values.mutate_remove_if(&hash, |val_entries| {
                 for (_, bucket) in val_entries.iter_mut() {
                     super::subtract_sorted(bucket, &ids);
                 }
                 val_entries.retain(|(_, bucket)| !bucket.is_empty());
-                if val_entries.is_empty() {
-                    hash_to_values.remove(&hash);
-                }
-            }
+                val_entries.is_empty()
+            });
         }
         Some(Ok(()))
     }

--- a/src/storage/index/hnsw.rs
+++ b/src/storage/index/hnsw.rs
@@ -21,10 +21,11 @@
 //! - `ef_construction`: Beam width during build (default: 200, higher = better recall)
 //! - `ef_search`: Beam width during search (default: 200, higher = better recall)
 
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use std::collections::BinaryHeap;
 
-use crate::common::{I64Map, I64Set};
+use super::memory::{reserve_vec, IndexMemory};
+use crate::common::{I64Map, I64Set, MemoryAccount, MemoryCharge};
 use crate::core::{DataType, IndexEntry, IndexType, Operator, Result, RowIdVec, Value};
 use crate::storage::expression::Expression;
 use crate::storage::traits::index_trait::Index;
@@ -140,15 +141,52 @@ struct SearchScratch {
     candidates: BinaryHeap<MinEntry>,
     /// Reusable max-heap for result pruning
     result: BinaryHeap<MaxEntry>,
+    charge: Option<MemoryCharge>,
 }
 
 impl SearchScratch {
     fn new() -> Self {
+        Self::new_in(None)
+    }
+
+    fn new_in(account: Option<&MemoryAccount>) -> Self {
         Self {
             visited: Vec::new(),
             candidates: BinaryHeap::new(),
             result: BinaryHeap::new(),
+            charge: account.map(|account| MemoryCharge::new(account, 0)),
         }
+    }
+
+    fn allocation_bytes(&self) -> usize {
+        self.visited.capacity() * std::mem::size_of::<u64>()
+            + self.candidates.capacity() * std::mem::size_of::<MinEntry>()
+            + self.result.capacity() * std::mem::size_of::<MaxEntry>()
+    }
+
+    fn refresh_charge(&mut self) {
+        let bytes = self.allocation_bytes();
+        if let Some(charge) = &mut self.charge {
+            if charge.bytes() != bytes {
+                charge.resize(bytes);
+            }
+        }
+    }
+
+    #[inline]
+    fn push_candidate(&mut self, value: MinEntry) {
+        if self.candidates.len() == self.candidates.capacity() {
+            reserve_aggregate_heap(&mut self.candidates, &mut self.charge);
+        }
+        self.candidates.push(value);
+    }
+
+    #[inline]
+    fn push_result(&mut self, value: MaxEntry) {
+        if self.result.len() == self.result.capacity() {
+            reserve_aggregate_heap(&mut self.result, &mut self.charge);
+        }
+        self.result.push(value);
     }
 
     /// Prepare for a new search_layer call. Grows bitset if needed, clears visited bits.
@@ -156,6 +194,7 @@ impl SearchScratch {
     fn reset(&mut self, node_count: usize) {
         let words = (node_count + 63) >> 6;
         if self.visited.len() < words {
+            reserve_aggregate_vec(&mut self.visited, words, &mut self.charge);
             self.visited.resize(words, 0);
         } else {
             // Clear only the portion we need — memset is fast for L1-sized data
@@ -164,53 +203,133 @@ impl SearchScratch {
         }
         self.candidates.clear();
         self.result.clear();
+        self.refresh_charge();
     }
 }
 
-/// Reusable scratch buffers for query-time search_layer calls.
-/// Uses bitset for visited tracking (1 bit/node) — 32x smaller than FxHashSet,
-/// keeps working set in L1 cache for dramatically fewer cache misses.
-/// Thread-local storage avoids per-call heap allocation after the first invocation.
-struct QueryScratch {
-    /// Bitset for visited nodes: bit N = node N has been visited this call
-    visited: Vec<u64>,
-    candidates: BinaryHeap<MinEntry>,
-    result: BinaryHeap<MaxEntry>,
+// A bounded pool belongs to one index, so idle scratch cannot outlive its
+// account on process worker threads. Parallel workers lease buffers briefly;
+// oversized or excess buffers are released when the operation finishes.
+const SCRATCH_SLOTS: usize = 4;
+const MAX_IDLE_SCRATCH_BYTES: usize = 4 * 1024 * 1024;
+
+struct ScratchPool {
+    slots: Mutex<[Option<SearchScratch>; SCRATCH_SLOTS]>,
+    account: Option<MemoryAccount>,
 }
 
-impl QueryScratch {
-    fn new() -> Self {
+impl ScratchPool {
+    fn new(account: Option<&MemoryAccount>) -> Self {
         Self {
-            visited: Vec::new(),
-            candidates: BinaryHeap::new(),
-            result: BinaryHeap::new(),
+            slots: Mutex::new(std::array::from_fn(|_| None)),
+            account: account.cloned(),
         }
     }
 
-    #[inline]
-    fn reset(&mut self, node_count: usize) {
-        let words = (node_count + 63) >> 6;
-        if self.visited.len() < words {
-            self.visited.resize(words, 0);
-        } else {
-            self.visited[..words].fill(0);
+    fn with<R>(&self, use_scratch: impl FnOnce(&mut SearchScratch) -> R) -> R {
+        let cached = self.slots.lock().iter_mut().find_map(Option::take);
+        let mut scratch = cached.unwrap_or_else(|| SearchScratch::new_in(self.account.as_ref()));
+        let result = use_scratch(&mut scratch);
+        if scratch.allocation_bytes() <= MAX_IDLE_SCRATCH_BYTES / SCRATCH_SLOTS {
+            let mut slots = self.slots.lock();
+            if let Some(slot) = slots.iter_mut().find(|slot| slot.is_none()) {
+                *slot = Some(scratch);
+            }
         }
-        self.candidates.clear();
-        self.result.clear();
+        result
     }
 }
 
-thread_local! {
-    static QUERY_SCRATCH: std::cell::RefCell<QueryScratch> =
-        std::cell::RefCell::new(QueryScratch::new());
+fn reserve_aggregate_vec<T>(values: &mut Vec<T>, needed: usize, charge: &mut Option<MemoryCharge>) {
+    if needed <= values.capacity() {
+        return;
+    }
+    let capacity = needed.max(values.capacity().saturating_mul(2)).max(4);
+    let mut replacement = Vec::with_capacity(capacity);
+    if let Some(charge) = charge {
+        charge.resize(charge.bytes() + replacement.capacity() * std::mem::size_of::<T>());
+    }
+    replacement.append(values);
+    let old = std::mem::replace(values, replacement);
+    let bytes = old.capacity() * std::mem::size_of::<T>();
+    drop(old);
+    if let Some(charge) = charge {
+        charge.resize(charge.bytes() - bytes);
+    }
 }
 
-// Bitset-based scratch for parallel build (zero-overhead visited tracking).
-// Uses Vec<u64> bitset (1 bit/node) — 32x smaller than generation array, fits L1 cache.
-#[cfg(feature = "parallel")]
-thread_local! {
-    static BUILD_SCRATCH: std::cell::RefCell<SearchScratch> =
-        std::cell::RefCell::new(SearchScratch::new());
+fn reserve_aggregate_heap<T: Ord>(heap: &mut BinaryHeap<T>, charge: &mut Option<MemoryCharge>) {
+    let capacity = (heap.len() + 1)
+        .max(heap.capacity().saturating_mul(2))
+        .max(4);
+    let mut replacement = Vec::with_capacity(capacity);
+    if let Some(charge) = charge {
+        charge.resize(charge.bytes() + replacement.capacity() * std::mem::size_of::<T>());
+    }
+    replacement.extend(heap.drain());
+    let old = std::mem::replace(heap, BinaryHeap::from(replacement));
+    let bytes = old.capacity() * std::mem::size_of::<T>();
+    drop(old);
+    if let Some(charge) = charge {
+        charge.resize(charge.bytes() - bytes);
+    }
+}
+
+#[derive(Default)]
+struct GraphMemory {
+    nodes: Option<MemoryCharge>,
+    vectors: Option<MemoryCharge>,
+    row_ids: Option<MemoryCharge>,
+    deleted: Option<MemoryCharge>,
+    neighbors: Option<MemoryCharge>,
+    unique_rows: Option<MemoryCharge>,
+    unique_buckets: Option<MemoryCharge>,
+    // Usable HashMap capacity may shrink after deletion without freeing any
+    // buckets. Keep the allocated bound even before startup attachment.
+    unique_bucket_allocation: usize,
+}
+
+impl GraphMemory {
+    fn new(account: Option<&MemoryAccount>) -> Self {
+        Self {
+            nodes: account.map(|a| MemoryCharge::new(a, 0)),
+            vectors: account.map(|a| MemoryCharge::new(a, 0)),
+            row_ids: account.map(|a| MemoryCharge::new(a, 0)),
+            deleted: account.map(|a| MemoryCharge::new(a, 0)),
+            neighbors: account.map(|a| MemoryCharge::new(a, 0)),
+            unique_rows: account.map(|a| MemoryCharge::new(a, 0)),
+            unique_buckets: account.map(|a| MemoryCharge::conservative(a, 0)),
+            unique_bucket_allocation: 0,
+        }
+    }
+
+    fn resize(charge: &mut Option<MemoryCharge>, bytes: usize) {
+        if let Some(charge) = charge {
+            if charge.bytes() != bytes {
+                charge.resize(bytes);
+            }
+        }
+    }
+
+    fn add_neighbors(&mut self, bytes: usize) {
+        if let Some(charge) = &mut self.neighbors {
+            charge.resize(charge.bytes() + bytes);
+        }
+    }
+
+    fn remove_neighbors(&mut self, bytes: usize) {
+        if let Some(charge) = &mut self.neighbors {
+            charge.resize(charge.bytes() - bytes);
+        }
+    }
+
+    fn unique_bucket_bytes(capacity: usize) -> usize {
+        if capacity == 0 {
+            return 0;
+        }
+        // Bound opaque HashMap buckets, including one control byte per bucket and SIMD padding.
+        (capacity + 1).next_power_of_two() * (std::mem::size_of::<(u64, Vec<i64>)>() + 1) + 32
+    }
 }
 
 struct HnswInner {
@@ -241,6 +360,9 @@ struct HnswInner {
     /// Maps ahash(raw_vec_bytes) → list of live row_ids with that hash.
     /// `None` when UNIQUE is not enabled; built via `build_unique_map()`.
     unique_map: Option<ahash::AHashMap<u64, Vec<i64>>>,
+    scratch_pool: ScratchPool,
+    // Last: release capacity charges after their owned buffers.
+    memory: GraphMemory,
 }
 
 impl HnswInner {
@@ -257,7 +379,115 @@ impl HnswInner {
             scratch: SearchScratch::new(),
             deleted_bits: Vec::new(),
             unique_map: None,
+            scratch_pool: ScratchPool::new(None),
+            memory: GraphMemory::default(),
         }
+    }
+
+    fn new_in(dims: usize, metric: HnswDistanceMetric, account: Option<&MemoryAccount>) -> Self {
+        let mut inner = Self::new(dims, metric);
+        if let Some(account) = account {
+            inner.attach_memory_account(account);
+        }
+        inner
+    }
+
+    // Startup attachment may walk a loaded graph once. Steady-state updates
+    // maintain capacity deltas only for the modified buffers and edge lists.
+    fn attach_memory_account(&mut self, account: &MemoryAccount) {
+        let neighbors = self
+            .nodes
+            .iter()
+            .map(|node| {
+                node.neighbors.capacity() * std::mem::size_of::<Vec<(u32, f32)>>()
+                    + node
+                        .neighbors
+                        .iter()
+                        .map(|layer| layer.capacity() * std::mem::size_of::<(u32, f32)>())
+                        .sum::<usize>()
+            })
+            .sum();
+        let unique_rows = self.unique_map.as_ref().map_or(0, |map| {
+            map.values()
+                .map(|rows| rows.capacity() * std::mem::size_of::<i64>())
+                .sum()
+        });
+        let unique_buckets = self.memory.unique_bucket_allocation;
+        self.memory = GraphMemory {
+            nodes: Some(MemoryCharge::new(
+                account,
+                self.nodes.capacity() * std::mem::size_of::<HnswNode>(),
+            )),
+            vectors: Some(MemoryCharge::new(account, self.vectors.capacity())),
+            row_ids: Some(MemoryCharge::new(
+                account,
+                self.node_to_row_id.capacity() * std::mem::size_of::<i64>(),
+            )),
+            deleted: Some(MemoryCharge::new(
+                account,
+                self.deleted_bits.capacity() * std::mem::size_of::<u64>(),
+            )),
+            neighbors: Some(MemoryCharge::new(account, neighbors)),
+            unique_rows: Some(MemoryCharge::new(account, unique_rows)),
+            unique_buckets: Some(MemoryCharge::conservative(account, unique_buckets)),
+            unique_bucket_allocation: unique_buckets,
+        };
+        self.row_id_to_node.attach_memory_account(account);
+        self.scratch.charge = Some(MemoryCharge::new(account, self.scratch.allocation_bytes()));
+        self.scratch_pool = ScratchPool::new(Some(account));
+    }
+
+    fn reserve_nodes(&mut self, additional: usize) {
+        let nodes = self.nodes.len() + additional;
+        reserve_vec(&mut self.nodes, nodes, &mut self.memory.nodes);
+        reserve_vec(
+            &mut self.vectors,
+            nodes * self.dims_bytes,
+            &mut self.memory.vectors,
+        );
+        reserve_vec(&mut self.node_to_row_id, nodes, &mut self.memory.row_ids);
+        self.row_id_to_node.reserve(additional);
+    }
+
+    fn prepare_new_node(&mut self, level: usize) -> HnswNode {
+        self.reserve_nodes(1);
+        let neighbors = vec![Vec::new(); level + 1];
+        self.memory
+            .add_neighbors(neighbors.capacity() * std::mem::size_of::<Vec<(u32, f32)>>());
+        HnswNode { neighbors }
+    }
+
+    fn push_neighbor(&mut self, node: u32, layer: usize, value: (u32, f32)) {
+        let values = &mut self.nodes[node as usize].neighbors[layer];
+        reserve_aggregate_vec(values, values.len() + 1, &mut self.memory.neighbors);
+        values.push(value);
+    }
+
+    fn replace_neighbors(&mut self, node: u32, layer: usize, values: Vec<(u32, f32)>) {
+        self.memory
+            .add_neighbors(values.capacity() * std::mem::size_of::<(u32, f32)>());
+        let old = std::mem::replace(&mut self.nodes[node as usize].neighbors[layer], values);
+        let bytes = old.capacity() * std::mem::size_of::<(u32, f32)>();
+        drop(old);
+        self.memory.remove_neighbors(bytes);
+    }
+
+    fn clear_unique_map(&mut self) {
+        self.unique_map = None;
+        GraphMemory::resize(&mut self.memory.unique_rows, 0);
+        GraphMemory::resize(&mut self.memory.unique_buckets, 0);
+        self.memory.unique_bucket_allocation = 0;
+    }
+
+    /// Install a newly allocated empty table. Callers construct it here rather
+    /// than importing an existing table whose deletion history is unknown.
+    fn init_unique_map(&mut self, map: ahash::AHashMap<u64, Vec<i64>>) {
+        debug_assert!(map.is_empty());
+        self.clear_unique_map();
+        let bytes = GraphMemory::unique_bucket_bytes(map.capacity());
+        GraphMemory::resize(&mut self.memory.unique_buckets, bytes);
+        self.memory.unique_bucket_allocation = bytes;
+        self.unique_map = Some(map);
     }
 
     /// Hash raw vector bytes for the unique_map.
@@ -271,19 +501,12 @@ impl HnswInner {
 
     /// Build the unique_map from all live (non-deleted) vectors.
     fn build_unique_map(&mut self) {
-        let mut map: ahash::AHashMap<u64, Vec<i64>> =
-            ahash::AHashMap::with_capacity(self.nodes.len());
-        for (node_idx, &row_id) in self.node_to_row_id.iter().enumerate() {
-            if self.is_deleted(node_idx as u32) {
-                continue;
-            }
-            let offset = node_idx * self.dims_bytes;
-            if let Some(vec_bytes) = self.vectors.get(offset..offset + self.dims_bytes) {
-                let hash = Self::hash_vec_bytes(vec_bytes);
-                map.entry(hash).or_default().push(row_id);
+        self.init_unique_map(ahash::AHashMap::new());
+        for node_idx in 0..self.nodes.len() {
+            if !self.is_deleted(node_idx as u32) {
+                self.unique_map_insert(node_idx as u32);
             }
         }
-        self.unique_map = Some(map);
     }
 
     /// Add a node to the unique_map (if it exists).
@@ -293,7 +516,22 @@ impl HnswInner {
             let row_id = self.node_to_row_id[node_id as usize];
             let offset = node_id as usize * self.dims_bytes;
             let hash = Self::hash_vec_bytes(&self.vectors[offset..offset + self.dims_bytes]);
-            map.entry(hash).or_default().push(row_id);
+            if !map.contains_key(&hash) && map.len() == map.capacity() {
+                let mut replacement = ahash::AHashMap::with_capacity(
+                    (map.len() + 1).max(map.capacity().saturating_mul(2)),
+                );
+                let old_bytes = self.memory.unique_bucket_allocation;
+                let new_bytes = GraphMemory::unique_bucket_bytes(replacement.capacity());
+                GraphMemory::resize(&mut self.memory.unique_buckets, old_bytes + new_bytes);
+                replacement.extend(map.drain());
+                let old = std::mem::replace(map, replacement);
+                drop(old);
+                GraphMemory::resize(&mut self.memory.unique_buckets, new_bytes);
+                self.memory.unique_bucket_allocation = new_bytes;
+            }
+            let rows = map.entry(hash).or_default();
+            reserve_aggregate_vec(rows, rows.len() + 1, &mut self.memory.unique_rows);
+            rows.push(row_id);
         }
     }
 
@@ -307,7 +545,11 @@ impl HnswInner {
             if let Some(row_ids) = map.get_mut(&hash) {
                 row_ids.retain(|&r| r != row_id);
                 if row_ids.is_empty() {
+                    let bytes = row_ids.capacity() * std::mem::size_of::<i64>();
                     map.remove(&hash);
+                    if let Some(charge) = &mut self.memory.unique_rows {
+                        charge.resize(charge.bytes() - bytes);
+                    }
                 }
             }
         }
@@ -347,6 +589,11 @@ impl HnswInner {
         let node_count = self.nodes.len(); // already pushed to nodes Vec
         let words_needed = (node_count + 63) >> 6;
         if self.deleted_bits.len() < words_needed {
+            reserve_vec(
+                &mut self.deleted_bits,
+                words_needed,
+                &mut self.memory.deleted,
+            );
             self.deleted_bits.resize(words_needed, 0);
         }
         // The new bit is already 0 (alive) from the resize or from previous state
@@ -397,8 +644,7 @@ impl HnswInner {
         ef: usize,
         layer: usize,
     ) -> Vec<MaxEntry> {
-        QUERY_SCRATCH.with(|cell| {
-            let mut scratch = cell.borrow_mut();
+        self.scratch_pool.with(|scratch| {
             let node_count = self.nodes.len();
             scratch.reset(node_count);
 
@@ -427,11 +673,11 @@ impl HnswInner {
                     HnswDistanceMetric::Cosine => cosine_distance_f32(v_slice, query),
                     HnswDistanceMetric::InnerProduct => ip_distance_f32(v_slice, query),
                 };
-                scratch.candidates.push(MinEntry {
+                scratch.push_candidate(MinEntry {
                     distance: d,
                     node: ep,
                 });
-                scratch.result.push(MaxEntry {
+                scratch.push_result(MaxEntry {
                     distance: d,
                     node: ep,
                 });
@@ -528,11 +774,11 @@ impl HnswInner {
                         };
 
                         if d < farthest_dist || result_len < ef {
-                            scratch.candidates.push(MinEntry {
+                            scratch.push_candidate(MinEntry {
                                 distance: d,
                                 node: neighbor,
                             });
-                            scratch.result.push(MaxEntry {
+                            scratch.push_result(MaxEntry {
                                 distance: d,
                                 node: neighbor,
                             });
@@ -655,11 +901,11 @@ impl HnswInner {
                 HnswDistanceMetric::Cosine => cosine_distance_f32(v_slice, query),
                 HnswDistanceMetric::InnerProduct => ip_distance_f32(v_slice, query),
             };
-            scratch.candidates.push(MinEntry {
+            scratch.push_candidate(MinEntry {
                 distance: d,
                 node: ep,
             });
-            scratch.result.push(MaxEntry {
+            scratch.push_result(MaxEntry {
                 distance: d,
                 node: ep,
             });
@@ -759,11 +1005,11 @@ impl HnswInner {
                     };
 
                     if d < farthest_dist || result_len < ef {
-                        scratch.candidates.push(MinEntry {
+                        scratch.push_candidate(MinEntry {
                             distance: d,
                             node: neighbor,
                         });
-                        scratch.result.push(MaxEntry {
+                        scratch.push_result(MaxEntry {
                             distance: d,
                             node: neighbor,
                         });
@@ -847,7 +1093,7 @@ impl HnswInner {
 
         // Room available — just push.
         if cur_len < max_conn {
-            self.nodes[target as usize].neighbors[layer].push((new_nb, new_dist));
+            self.push_neighbor(target, layer, (new_nb, new_dist));
             return;
         }
 
@@ -910,7 +1156,7 @@ impl HnswInner {
 
         let cur_len = neighbors.len();
         if cur_len < max_conn {
-            self.nodes[target as usize].neighbors[layer].push((new_nb, new_dist));
+            self.push_neighbor(target, layer, (new_nb, new_dist));
             return;
         }
 
@@ -946,7 +1192,7 @@ impl HnswInner {
         });
 
         let pruned = self.select_neighbors(candidates, max_conn);
-        self.nodes[target as usize].neighbors[layer] = pruned;
+        self.replace_neighbors(target, layer, pruned);
     }
 
     /// Insert a vector into the graph
@@ -1000,7 +1246,7 @@ impl HnswInner {
                         }
                         entry_points.clear();
                         entry_points.extend(neighbors.iter().map(|&(n, _)| n));
-                        self.nodes[existing_node as usize].neighbors[l] = neighbors;
+                        self.replace_neighbors(existing_node, l, neighbors);
                     }
                 }
                 return;
@@ -1011,13 +1257,9 @@ impl HnswInner {
         let node_id = self.nodes.len() as u32;
         let level = random_level(ml);
 
-        // Store vector data
+        let node = self.prepare_new_node(level);
         self.vectors.extend_from_slice(vector_bytes);
-
-        // Create node
-        self.nodes.push(HnswNode {
-            neighbors: vec![Vec::new(); level + 1],
-        });
+        self.nodes.push(node);
         self.push_node_alive();
 
         // Store mappings
@@ -1075,7 +1317,7 @@ impl HnswInner {
             // Update entry points for next layer, then store neighbors
             entry_points.clear();
             entry_points.extend(neighbors.iter().map(|&(n, _)| n));
-            self.nodes[node_id as usize].neighbors[l] = neighbors;
+            self.replace_neighbors(node_id, l, neighbors);
         }
 
         // Update entry point if new node has higher level
@@ -1248,10 +1490,9 @@ impl HnswInner {
             let node_id = self.nodes.len() as u32;
             let level = random_level(ml);
 
+            let node = self.prepare_new_node(level);
             self.vectors.extend_from_slice(vec_bytes);
-            self.nodes.push(HnswNode {
-                neighbors: vec![Vec::new(); level + 1],
-            });
+            self.nodes.push(node);
             self.push_node_alive();
             self.node_to_row_id.push(row_id);
             self.row_id_to_node.insert(row_id, node_id);
@@ -1351,7 +1592,7 @@ impl HnswInner {
                     }
                     entry_points.clear();
                     entry_points.extend(neighbors.iter().map(|&(n, _)| n));
-                    self.nodes[node_id as usize].neighbors[l] = neighbors;
+                    self.replace_neighbors(node_id, l, neighbors);
                 }
 
                 // Update entry point if this node has higher level
@@ -1378,6 +1619,7 @@ impl HnswInner {
                     let start = task.node_id as usize * dims_bytes;
                     let query = as_f32_slice(&vectors[start..start + dims_bytes]);
                     let candidates = search_layer_shared(
+                        &self.scratch_pool,
                         nodes,
                         deleted_bits,
                         vectors,
@@ -1408,7 +1650,7 @@ impl HnswInner {
                 }
                 self.update_connection(nb, node_id, dist, 0, m0, false);
             }
-            self.nodes[node_id as usize].neighbors[0] = neighbors;
+            self.replace_neighbors(node_id, 0, neighbors);
         }
     }
 
@@ -1473,6 +1715,15 @@ impl HnswInner {
 
     /// Deserialize an HNSW graph from bytes.
     fn deserialize_graph(data: &[u8]) -> std::result::Result<Self, String> {
+        Self::deserialize_graph_in(data, None)
+    }
+
+    fn deserialize_graph_in(
+        data: &[u8],
+        account: Option<&MemoryAccount>,
+    ) -> std::result::Result<Self, String> {
+        // Declare charges first so decode buffers are freed before their charges during unwinding.
+        let mut memory = GraphMemory::new(account);
         if data.len() < 25 {
             return Err("HNSW data too short for header".to_string());
         }
@@ -1504,6 +1755,7 @@ impl HnswInner {
             return Err("HNSW data truncated at vectors".to_string());
         }
         let vectors = data[pos..pos + vec_size].to_vec();
+        GraphMemory::resize(&mut memory.vectors, vectors.capacity());
         pos += vec_size;
 
         // Row IDs
@@ -1512,7 +1764,14 @@ impl HnswInner {
             return Err("HNSW data truncated at row_ids".to_string());
         }
         let mut node_to_row_id = Vec::with_capacity(node_count);
-        let mut row_id_to_node = I64Map::with_capacity(node_count);
+        GraphMemory::resize(
+            &mut memory.row_ids,
+            node_to_row_id.capacity() * std::mem::size_of::<i64>(),
+        );
+        let mut row_id_to_node = account.map_or_else(
+            || I64Map::with_capacity(node_count),
+            |a| I64Map::with_capacity_in(node_count, a),
+        );
         for i in 0..node_count {
             let off = pos + i * 8;
             let rid = i64::from_le_bytes([
@@ -1532,8 +1791,16 @@ impl HnswInner {
 
         // Graph structure
         let mut nodes = Vec::with_capacity(node_count);
+        GraphMemory::resize(
+            &mut memory.nodes,
+            nodes.capacity() * std::mem::size_of::<HnswNode>(),
+        );
         let deleted_words = (node_count + 63) >> 6;
         let mut deleted_bits = vec![0u64; deleted_words];
+        GraphMemory::resize(
+            &mut memory.deleted,
+            deleted_bits.capacity() * std::mem::size_of::<u64>(),
+        );
         for node_idx in 0..node_count {
             if pos + 2 > data.len() {
                 return Err("HNSW data truncated at node header".to_string());
@@ -1546,6 +1813,7 @@ impl HnswInner {
             pos += 2;
 
             let mut neighbors = Vec::with_capacity(num_layers);
+            memory.add_neighbors(neighbors.capacity() * std::mem::size_of::<Vec<(u32, f32)>>());
             for _ in 0..num_layers {
                 if pos + 2 > data.len() {
                     return Err("HNSW data truncated at layer header".to_string());
@@ -1558,6 +1826,7 @@ impl HnswInner {
                         return Err("HNSW data truncated at neighbor list".to_string());
                     }
                     let mut layer = Vec::with_capacity(count);
+                    memory.add_neighbors(layer.capacity() * std::mem::size_of::<(u32, f32)>());
                     for j in 0..count {
                         let off = pos + j * 8;
                         let nid = u32::from_le_bytes([
@@ -1582,6 +1851,7 @@ impl HnswInner {
                         return Err("HNSW data truncated at neighbor list".to_string());
                     }
                     let mut layer = Vec::with_capacity(count);
+                    memory.add_neighbors(layer.capacity() * std::mem::size_of::<(u32, f32)>());
                     for j in 0..count {
                         let off = pos + j * 4;
                         let nid = u32::from_le_bytes([
@@ -1635,9 +1905,11 @@ impl HnswInner {
             node_to_row_id,
             row_id_to_node,
             metric,
-            scratch: SearchScratch::new(),
+            scratch: SearchScratch::new_in(account),
             deleted_bits,
             unique_map: None,
+            scratch_pool: ScratchPool::new(account),
+            memory,
         };
 
         // Version 1 didn't store distances — recompute them
@@ -2317,6 +2589,7 @@ fn random_level(ml: f64) -> usize {
 /// Uses bitset-based visited tracking for zero-overhead mark/check.
 #[allow(clippy::too_many_arguments)]
 fn search_layer_shared(
+    pool: &ScratchPool,
     nodes: &[HnswNode],
     deleted_bits: &[u64],
     vectors: &[u8],
@@ -2327,8 +2600,7 @@ fn search_layer_shared(
     ef: usize,
     layer: usize,
 ) -> Vec<MaxEntry> {
-    BUILD_SCRATCH.with(|cell| {
-        let mut scratch = cell.borrow_mut();
+    pool.with(|scratch| {
         scratch.reset(nodes.len());
 
         let dims = dims_bytes / 4;
@@ -2354,11 +2626,11 @@ fn search_layer_shared(
                 HnswDistanceMetric::Cosine => cosine_distance_f32(v_slice, query),
                 HnswDistanceMetric::InnerProduct => ip_distance_f32(v_slice, query),
             };
-            scratch.candidates.push(MinEntry {
+            scratch.push_candidate(MinEntry {
                 distance: d,
                 node: ep,
             });
-            scratch.result.push(MaxEntry {
+            scratch.push_result(MaxEntry {
                 distance: d,
                 node: ep,
             });
@@ -2454,11 +2726,11 @@ fn search_layer_shared(
                     };
 
                     if d < farthest_dist || result_len < ef {
-                        scratch.candidates.push(MinEntry {
+                        scratch.push_candidate(MinEntry {
                             distance: d,
                             node: neighbor,
                         });
-                        scratch.result.push(MaxEntry {
+                        scratch.push_result(MaxEntry {
                             distance: d,
                             node: neighbor,
                         });
@@ -2560,6 +2832,7 @@ pub struct HnswIndex {
     ml: f64,
     metric: HnswDistanceMetric,
     is_unique: bool,
+    memory: IndexMemory,
 }
 
 impl HnswIndex {
@@ -2605,6 +2878,7 @@ impl HnswIndex {
             ml,
             metric,
             is_unique: false,
+            memory: IndexMemory::default(),
         }
     }
 
@@ -2615,7 +2889,7 @@ impl HnswIndex {
         if unique {
             self.inner.write().build_unique_map();
         } else {
-            self.inner.write().unique_map = None;
+            self.inner.write().clear_unique_map();
         }
     }
 
@@ -2822,10 +3096,60 @@ impl HnswIndex {
                     ml,
                     metric,
                     is_unique: false,
+                    memory: IndexMemory::default(),
                 }))
             }
             Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
         }
+    }
+
+    /// Load a graph with an attached origin before decoding its owned buffers.
+    /// The legacy `load_graph` helper remains available for standalone users.
+    #[allow(clippy::too_many_arguments)]
+    pub fn load_graph_in(
+        path: &std::path::Path,
+        name: String,
+        table_name: String,
+        column_name: String,
+        column_id: i32,
+        dims: usize,
+        m: usize,
+        ef_construction: usize,
+        ef_search: usize,
+        account: &MemoryAccount,
+    ) -> std::io::Result<Option<Self>> {
+        if !path.exists() {
+            return Ok(None);
+        }
+        let mut index = Self::new(
+            name,
+            table_name,
+            column_name,
+            column_id,
+            dims,
+            m,
+            ef_construction,
+            ef_search,
+            HnswDistanceMetric::L2,
+        );
+        index
+            .attach_memory_account(account)
+            .map_err(std::io::Error::other)?;
+        let data = std::fs::read(path)?;
+        let charge = MemoryCharge::new(account, data.capacity());
+        // Tuple fields drop in order: release the file buffer before its charge.
+        let input = (data, charge);
+        let inner = HnswInner::deserialize_graph_in(&input.0, index.memory.account())
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        if inner.dims_bytes != dims * 4 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "HNSW graph dimension mismatch",
+            ));
+        }
+        index.metric = inner.metric;
+        *index.inner.get_mut() = inner;
+        Ok(Some(index))
     }
 
     /// Serialize the graph to bytes (for use by snapshot code).
@@ -2842,6 +3166,29 @@ impl HnswIndex {
 }
 
 impl Index for HnswIndex {
+    fn attach_memory_account(&mut self, parent: &MemoryAccount) -> Result<()> {
+        if !self.memory.needs_attachment(parent)? {
+            return Ok(());
+        }
+        let metadata = self.name.capacity()
+            + self.table_name.capacity()
+            + self.column_ids.capacity() * std::mem::size_of::<i32>()
+            + self.column_names.capacity() * std::mem::size_of::<String>()
+            + self
+                .column_names
+                .iter()
+                .map(String::capacity)
+                .sum::<usize>()
+            + self.data_types.capacity() * std::mem::size_of::<DataType>();
+        self.memory.attach::<Self>(parent, metadata);
+        self.inner.get_mut().attach_memory_account(parent);
+        Ok(())
+    }
+
+    fn memory_account(&self) -> Option<&MemoryAccount> {
+        self.memory.account()
+    }
+
     fn name(&self) -> &str {
         &self.name
     }
@@ -2886,7 +3233,6 @@ impl Index for HnswIndex {
 
     fn add_batch(&self, entries: &I64Map<Vec<Value>>) -> Result<()> {
         let mut inner = self.inner.write();
-        let dims_bytes = inner.dims_bytes;
         let expected_vec_len = self.dims * 4;
 
         // Collect valid entries for parallel path
@@ -2929,10 +3275,7 @@ impl Index for HnswIndex {
             }
         }
 
-        inner.vectors.reserve(prepared.len() * dims_bytes);
-        inner.nodes.reserve(prepared.len());
-        inner.node_to_row_id.reserve(prepared.len());
-        inner.row_id_to_node.reserve(prepared.len());
+        inner.reserve_nodes(prepared.len());
 
         self.insert_prepared(&mut inner, &prepared);
         Ok(())
@@ -2960,7 +3303,6 @@ impl Index for HnswIndex {
 
     fn add_batch_slice(&self, entries: &[(i64, &[Value])]) -> Result<()> {
         let mut inner = self.inner.write();
-        let dims_bytes = inner.dims_bytes;
         let expected_vec_len = self.dims * 4;
 
         // Collect valid entries for parallel path
@@ -3003,10 +3345,7 @@ impl Index for HnswIndex {
             }
         }
 
-        inner.vectors.reserve(prepared.len() * dims_bytes);
-        inner.nodes.reserve(prepared.len());
-        inner.node_to_row_id.reserve(prepared.len());
-        inner.row_id_to_node.reserve(prepared.len());
+        inner.reserve_nodes(prepared.len());
 
         self.insert_prepared(&mut inner, &prepared);
         Ok(())
@@ -3095,7 +3434,7 @@ impl Index for HnswIndex {
 
     fn clear(&self) -> Result<()> {
         let mut inner = self.inner.write();
-        *inner = HnswInner::new(self.dims, self.metric);
+        *inner = HnswInner::new_in(self.dims, self.metric, self.memory.account());
         if self.is_unique {
             inner.unique_map = Some(ahash::AHashMap::new());
         }
@@ -3135,7 +3474,7 @@ impl Index for HnswIndex {
         }
 
         // Build fresh graph from live nodes only
-        let mut fresh = HnswInner::new(self.dims, self.metric);
+        let mut fresh = HnswInner::new_in(self.dims, self.metric, self.memory.account());
         if !live_entries.is_empty() {
             // Borrow vector data as slices for insert
             let prepared: Vec<(&[u8], i64)> = live_entries
@@ -3143,10 +3482,7 @@ impl Index for HnswIndex {
                 .map(|&(offset, row_id)| (&inner.vectors[offset..offset + dims_bytes], row_id))
                 .collect();
 
-            fresh.vectors.reserve(live_count * dims_bytes);
-            fresh.nodes.reserve(live_count);
-            fresh.node_to_row_id.reserve(live_count);
-            fresh.row_id_to_node.reserve(live_count);
+            fresh.reserve_nodes(live_count);
 
             #[cfg(feature = "parallel")]
             {
@@ -3487,5 +3823,299 @@ mod tests {
         let bytes: Vec<u8> = floats.iter().flat_map(|f| f.to_le_bytes()).collect();
         let slice = as_f32_slice(&bytes);
         assert_eq!(slice, &floats);
+    }
+}
+
+#[cfg(test)]
+mod accounting_tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+
+    fn index() -> HnswIndex {
+        HnswIndex::new(
+            "ann".into(),
+            "items".into(),
+            "embedding".into(),
+            0,
+            2,
+            4,
+            16,
+            16,
+            HnswDistanceMetric::L2,
+        )
+    }
+
+    fn value(row: i64) -> Value {
+        Value::vector(vec![row as f32, (row * 3) as f32])
+    }
+
+    fn assert_exact_capacities(index: &HnswIndex, account: &MemoryAccount) {
+        let inner = index.inner.read();
+        let metadata = index.name.capacity()
+            + index.table_name.capacity()
+            + index.column_ids.capacity() * std::mem::size_of::<i32>()
+            + index.column_names.capacity() * std::mem::size_of::<String>()
+            + index
+                .column_names
+                .iter()
+                .map(String::capacity)
+                .sum::<usize>()
+            + index.data_types.capacity() * std::mem::size_of::<DataType>();
+        let neighbors: usize = inner
+            .nodes
+            .iter()
+            .map(|node| {
+                node.neighbors.capacity() * std::mem::size_of::<Vec<(u32, f32)>>()
+                    + node
+                        .neighbors
+                        .iter()
+                        .map(|layer| layer.capacity() * std::mem::size_of::<(u32, f32)>())
+                        .sum::<usize>()
+            })
+            .sum();
+        assert_eq!(inner.memory.neighbors.as_ref().unwrap().bytes(), neighbors);
+        let rows = inner.unique_map.as_ref().map_or(0, |map| {
+            map.values()
+                .map(|rows| rows.capacity() * std::mem::size_of::<i64>())
+                .sum()
+        });
+        assert_eq!(inner.memory.unique_rows.as_ref().unwrap().bytes(), rows);
+        let buckets = inner.memory.unique_bucket_allocation;
+        assert_eq!(
+            inner.memory.unique_buckets.as_ref().unwrap().bytes(),
+            buckets
+        );
+        let pooled: usize = inner
+            .scratch_pool
+            .slots
+            .lock()
+            .iter()
+            .flatten()
+            .map(SearchScratch::allocation_bytes)
+            .sum();
+        let expected = metadata
+            + neighbors
+            + rows
+            + pooled
+            + inner.scratch.allocation_bytes()
+            + inner.nodes.capacity() * std::mem::size_of::<HnswNode>()
+            + inner.vectors.capacity()
+            + inner.node_to_row_id.capacity() * std::mem::size_of::<i64>()
+            + inner.deleted_bits.capacity() * std::mem::size_of::<u64>()
+            + inner.row_id_to_node.allocation_size();
+        assert_eq!(account.snapshot().retained_bytes, expected);
+    }
+
+    #[test]
+    fn insert_delete_reinsert_cleanup_and_clear_account_real_capacities() {
+        let root = MemoryAccount::new();
+        let base = root.snapshot().accounted_bytes;
+        let mut index = index();
+        index.attach_memory_account(&root).unwrap();
+        index.set_unique(true);
+        for row in 0..128 {
+            index.add(&[value(row)], row, row).unwrap();
+            if row % 17 == 0 {
+                assert_exact_capacities(&index, &root);
+            }
+        }
+        assert_eq!(
+            std::mem::size_of::<HnswNode>(),
+            std::mem::size_of::<Vec<Vec<(u32, f32)>>>(),
+            "accounting must not add a per-node allocation or token"
+        );
+        assert_exact_capacities(&index, &root);
+        for row in 0..32 {
+            index.remove(&[], row, row).unwrap();
+        }
+        assert_exact_capacities(&index, &root);
+        index.add(&[value(0)], 0, 0).unwrap();
+        assert_exact_capacities(&index, &root);
+        index.cleanup().unwrap();
+        assert_eq!(index.node_count(), 97);
+        assert_exact_capacities(&index, &root);
+        let query = value(80);
+        let bytes = HnswIndex::extract_vector_bytes(&query).unwrap();
+        assert_eq!(index.search_nearest(bytes, 1, 16)[0].0, 80);
+        assert_exact_capacities(&index, &root);
+        index.clear().unwrap();
+        assert_exact_capacities(&index, &root);
+        drop(index);
+        assert_eq!(root.snapshot().accounted_bytes, base);
+    }
+
+    #[test]
+    fn attachment_is_idempotent_and_rejects_foreign_engines() {
+        let root = MemoryAccount::new();
+        let foreign = MemoryAccount::new();
+        let mut index = index();
+        index.add(&[value(0)], 0, 0).unwrap();
+        index.attach_memory_account(&root).unwrap();
+        assert_exact_capacities(&index, &root);
+        let before = root.snapshot();
+        index.attach_memory_account(&root).unwrap();
+        assert_eq!(root.snapshot(), before);
+        assert!(index.attach_memory_account(&foreign).is_err());
+        assert_eq!(root.snapshot(), before);
+        assert_eq!(foreign.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn scratch_pool_is_bounded_and_releases_with_its_origin() {
+        let root = MemoryAccount::new();
+        let base = root.snapshot().accounted_bytes;
+        let pool = Arc::new(ScratchPool::new(Some(&root)));
+        let start = Arc::new(Barrier::new(SCRATCH_SLOTS + 2));
+        std::thread::scope(|scope| {
+            for _ in 0..SCRATCH_SLOTS + 2 {
+                let pool = pool.clone();
+                let start = start.clone();
+                scope.spawn(move || {
+                    pool.with(|scratch| {
+                        scratch.reset(4096);
+                        for node in 0..24 {
+                            scratch.push_candidate(MinEntry {
+                                distance: node as f32,
+                                node,
+                            });
+                        }
+                        start.wait();
+                    })
+                });
+            }
+        });
+        let slots = pool.slots.lock();
+        assert_eq!(slots.iter().flatten().count(), SCRATCH_SLOTS);
+        let bytes = slots
+            .iter()
+            .flatten()
+            .map(SearchScratch::allocation_bytes)
+            .sum::<usize>();
+        assert_eq!(root.snapshot().retained_bytes, bytes);
+        assert!(bytes <= MAX_IDLE_SCRATCH_BYTES);
+        drop(slots);
+        drop(pool);
+        assert_eq!(root.snapshot().accounted_bytes, base);
+
+        let pool = ScratchPool::new(Some(&root));
+        pool.with(|scratch| scratch.reset(MAX_IDLE_SCRATCH_BYTES * 8));
+        assert!(pool.slots.lock().iter().all(Option::is_none));
+        assert_eq!(root.snapshot().retained_bytes, 0);
+        let failed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            pool.with(|scratch| {
+                scratch.reset(4096);
+                panic!("search unwind");
+            });
+        }));
+        assert!(failed.is_err());
+        assert_eq!(root.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn tracked_load_and_failed_decode_release_all_owners() {
+        let root = MemoryAccount::new();
+        let base = root.snapshot().accounted_bytes;
+        let source = index();
+        for row in 0..32 {
+            source.add(&[value(row)], row, row).unwrap();
+        }
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("graph.bin");
+        source.save_graph(&path).unwrap();
+        let loaded = HnswIndex::load_graph_in(
+            &path,
+            "ann".into(),
+            "items".into(),
+            "embedding".into(),
+            0,
+            2,
+            4,
+            16,
+            16,
+            &root,
+        )
+        .unwrap()
+        .unwrap();
+        assert_exact_capacities(&loaded, &root);
+        drop(loaded);
+        assert_eq!(root.snapshot().accounted_bytes, base);
+        let mut corrupt = source.serialize_graph_bytes();
+        corrupt.pop();
+        std::fs::write(&path, corrupt).unwrap();
+        assert!(HnswIndex::load_graph_in(
+            &path,
+            "ann".into(),
+            "items".into(),
+            "embedding".into(),
+            0,
+            2,
+            4,
+            16,
+            16,
+            &root
+        )
+        .is_err());
+        assert_eq!(root.snapshot().accounted_bytes, base);
+    }
+    #[test]
+    fn unique_bucket_charge_survives_tombstones_before_attachment_and_growth() {
+        let state = ahash::RandomState::with_seeds(1, 2, 3, 4);
+        let table = ahash::AHashMap::with_capacity_and_hasher(112, state.clone());
+        let allocated_bound = GraphMemory::unique_bucket_bytes(table.capacity());
+        let ids: Vec<u64> = (0u64..)
+            .filter(|key| state.hash_one(*key) & 127 == 0)
+            .take(112)
+            .collect();
+        let root = MemoryAccount::new();
+        let base = root.snapshot().accounted_bytes;
+        let mut index = index();
+        // Match production ownership: register the fresh allocation before
+        // mutations, including while no memory account has been attached.
+        index.inner.get_mut().init_unique_map(table);
+        let map = index.inner.get_mut().unique_map.as_mut().unwrap();
+        for key in &ids {
+            map.insert(*key, vec![1i64]);
+        }
+        for key in &ids[..70] {
+            map.remove(key);
+        }
+        assert_eq!(map.len(), 42);
+        assert_eq!(map.capacity(), 42);
+        assert!(GraphMemory::unique_bucket_bytes(map.capacity()) < allocated_bound);
+        index.attach_memory_account(&root).unwrap();
+        assert_eq!(
+            index
+                .inner
+                .read()
+                .memory
+                .unique_buckets
+                .as_ref()
+                .unwrap()
+                .bytes(),
+            allocated_bound
+        );
+        let before_growth = root.snapshot().accounted_bytes;
+        let entry = (0i64..)
+            .map(value)
+            .find(|value| {
+                let hash =
+                    HnswInner::hash_vec_bytes(HnswIndex::extract_vector_bytes(value).unwrap());
+                !index
+                    .inner
+                    .read()
+                    .unique_map
+                    .as_ref()
+                    .unwrap()
+                    .contains_key(&hash)
+            })
+            .unwrap();
+        index.add(&[entry], 0, 0).unwrap();
+        assert!(
+            root.snapshot().peak_accounted_bytes >= before_growth + allocated_bound,
+            "the old physical buckets must remain charged during table replacement"
+        );
+        assert_exact_capacities(&index, &root);
+        drop(index);
+        assert_eq!(root.snapshot().accounted_bytes, base);
     }
 }

--- a/src/storage/index/memory.rs
+++ b/src/storage/index/memory.rs
@@ -1,0 +1,286 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Physical ownership helpers shared by the hot index implementations.
+
+use crate::common::{MemoryAccount, MemoryCharge};
+use crate::core::{Error, Result};
+
+/// One immutable origin per index. Keep this field after all owned collections
+/// so their buffers and key aliases are dropped before the metadata charge.
+#[derive(Default)]
+pub(super) struct IndexMemory {
+    account: Option<MemoryAccount>,
+    _metadata: Option<MemoryCharge>,
+    _object: Option<MemoryCharge>,
+}
+
+impl IndexMemory {
+    pub fn account(&self) -> Option<&MemoryAccount> {
+        self.account.as_ref()
+    }
+
+    pub fn value_arc(
+        &self,
+        value: &crate::core::Value,
+    ) -> crate::common::CompactArc<crate::core::Value> {
+        match self.account() {
+            Some(account) => {
+                crate::common::CompactArc::new_in(value.clone().into_hot(account), account)
+            }
+            None => crate::common::CompactArc::new(value.clone()),
+        }
+    }
+
+    pub fn value(&self, value: &crate::core::Value) -> crate::core::Value {
+        match self.account() {
+            Some(account) => value.clone().into_hot(account),
+            None => value.clone(),
+        }
+    }
+
+    /// Startup-only adoption preserves key identity and rejects foreign backing.
+    pub fn adopt_value_arc(
+        value: &crate::common::CompactArc<crate::core::Value>,
+        account: &MemoryAccount,
+    ) -> Result<()> {
+        use crate::common::MemoryAdoption;
+        if !value.try_adopt_hot(account)
+            || value.try_adopt_shallow(account) == MemoryAdoption::ForeignEngine
+        {
+            return Err(Error::internal(
+                "prebuilt index key belongs to another engine",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Returns false for idempotent same-engine attachment. An index is never
+    /// reparented after a first account has taken physical ownership.
+    pub fn needs_attachment(&self, parent: &MemoryAccount) -> Result<bool> {
+        match &self.account {
+            None => Ok(true),
+            Some(origin) if origin.same_engine(parent) => Ok(false),
+            Some(_) => Err(Error::internal("index belongs to another memory account")),
+        }
+    }
+
+    pub fn attach<T>(&mut self, parent: &MemoryAccount, metadata_bytes: usize) {
+        debug_assert!(self.account.is_none());
+        let account = parent.clone();
+        self._metadata = Some(MemoryCharge::new(&account, metadata_bytes));
+        // Bound the index object, its inline handles and std::Arc's opaque control block.
+        self._object = Some(MemoryCharge::conservative(
+            &account,
+            std::mem::size_of::<T>() + 4 * std::mem::size_of::<usize>(),
+        ));
+        self.account = Some(account);
+    }
+}
+
+/// Grow a known vector allocation with explicit old/new ownership overlap.
+/// Existing-capacity mutations do not touch counters or allocate a charge.
+pub(super) fn reserve_vec<T>(
+    values: &mut Vec<T>,
+    needed: usize,
+    charge: &mut Option<MemoryCharge>,
+) {
+    if needed <= values.capacity() {
+        return;
+    }
+    let capacity = needed.max(values.capacity().saturating_mul(2)).max(4);
+    let mut replacement = Vec::with_capacity(capacity);
+    let replacement_charge = charge.as_ref().map(|charge| {
+        MemoryCharge::new(
+            charge.account(),
+            replacement.capacity() * std::mem::size_of::<T>(),
+        )
+    });
+    replacement.append(values);
+    let old = std::mem::replace(values, replacement);
+    let old_charge = std::mem::replace(charge, replacement_charge);
+    drop(old);
+    drop(old_charge);
+}
+
+#[cfg(test)]
+mod ownership_tests {
+    use super::*;
+    use crate::core::{DataType, Value};
+    use crate::storage::index::{BTreeIndex, BitmapIndex, HashIndex, MultiColumnIndex};
+    use crate::storage::traits::Index;
+    use std::sync::Arc;
+
+    fn keyed_indexes() -> Vec<Box<dyn Index>> {
+        vec![
+            Box::new(BTreeIndex::new(
+                "b".into(),
+                "t".into(),
+                0,
+                "v".into(),
+                DataType::Text,
+                false,
+                0,
+            )),
+            Box::new(BitmapIndex::new(
+                "m".into(),
+                "t".into(),
+                vec!["v".into()],
+                vec![0],
+                vec![DataType::Text],
+                false,
+                0,
+            )),
+            Box::new(HashIndex::new(
+                "h".into(),
+                "t".into(),
+                vec!["v".into()],
+                vec![0],
+                vec![DataType::Text],
+                false,
+                0,
+            )),
+            Box::new(MultiColumnIndex::new(
+                "c".into(),
+                "t".into(),
+                vec!["v".into()],
+                vec![0],
+                vec![DataType::Text],
+                false,
+                0,
+            )),
+        ]
+    }
+
+    #[test]
+    fn prebuilt_index_attachment_and_last_owner_cover_every_keyed_family() {
+        for mut index in keyed_indexes() {
+            let root = MemoryAccount::new();
+            let origin = root.child();
+            let baseline = root.snapshot().accounted_bytes;
+            let key = Value::text("prebuilt index text with independently shared heap backing");
+            index.add(std::slice::from_ref(&key), 1, 0).unwrap();
+            index.attach_memory_account(&origin).unwrap();
+            let attached = root.snapshot();
+            index.attach_memory_account(&origin).unwrap();
+            assert_eq!(root.snapshot(), attached);
+            assert!(index.attach_memory_account(&MemoryAccount::new()).is_err());
+            for row in 2..100 {
+                index.add(std::slice::from_ref(&key), row, 0).unwrap();
+            }
+            assert_eq!(
+                index.get_row_ids_equal(std::slice::from_ref(&key)).len(),
+                99
+            );
+            assert!(
+                origin.snapshot().retained_bytes > 0,
+                "index attribution must remain on its table origin"
+            );
+            drop(key);
+            let owner: Arc<dyn Index> = Arc::from(index);
+            let alias = owner.clone();
+            let retained = root.snapshot().accounted_bytes;
+            drop(owner);
+            assert_eq!(root.snapshot().accounted_bytes, retained);
+            alias
+                .remove_batch_ids(&(1..50).collect::<Vec<_>>())
+                .unwrap()
+                .unwrap();
+            drop(alias);
+            assert_eq!(root.snapshot().retained_bytes, 0);
+            assert_eq!(root.snapshot().accounted_bytes, baseline);
+        }
+    }
+
+    #[test]
+    fn returned_text_alias_outlives_btree_and_foreign_insert_copies_origin() {
+        let first = MemoryAccount::new();
+        let second = MemoryAccount::new();
+        let input = Value::text("a foreign engine text backing that must never be reparented")
+            .into_hot(&first);
+        let mut index = BTreeIndex::new(
+            "b".into(),
+            "t".into(),
+            0,
+            "v".into(),
+            DataType::Text,
+            false,
+            0,
+        );
+        index.attach_memory_account(&second).unwrap();
+        index.add(std::slice::from_ref(&input), 1, 0).unwrap();
+        let alias = index.get_min_value().unwrap();
+        let Value::Text(text) = &alias else {
+            unreachable!()
+        };
+        assert!(text.memory_account().unwrap().same_engine(&second));
+        drop(index);
+        assert!(second.snapshot().retained_bytes > 0);
+        drop(alias);
+        assert_eq!(second.snapshot().retained_bytes, 0);
+        assert!(first.snapshot().retained_bytes > 0);
+        drop(input);
+        assert_eq!(first.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn lookup_bounds_do_not_adopt_external_text_into_hot_storage() {
+        for mut index in keyed_indexes() {
+            let account = MemoryAccount::new();
+            index.attach_memory_account(&account).unwrap();
+            index
+                .add(
+                    &[Value::text("stored long text that belongs to the index")],
+                    1,
+                    0,
+                )
+                .unwrap();
+            let query = Value::text("external query text with a separate heap allocation");
+            let before = account.snapshot();
+            index.find(std::slice::from_ref(&query)).unwrap();
+            if index.as_any().is::<BTreeIndex>() {
+                for op in [
+                    crate::core::Operator::Lt,
+                    crate::core::Operator::Lte,
+                    crate::core::Operator::Gt,
+                    crate::core::Operator::Gte,
+                ] {
+                    index
+                        .find_with_operator(op, std::slice::from_ref(&query))
+                        .unwrap();
+                }
+            }
+            assert_eq!(account.snapshot(), before);
+            let Value::Text(text) = &query else {
+                unreachable!()
+            };
+            assert!(text.memory_account().is_none());
+        }
+    }
+
+    #[test]
+    fn prebuilt_foreign_payload_attachment_is_rejected() {
+        let first = MemoryAccount::new();
+        let second = MemoryAccount::new();
+        let key = Value::text("foreign-owned backing inside an otherwise untracked index")
+            .into_hot(&first);
+        for mut index in keyed_indexes() {
+            index.add(std::slice::from_ref(&key), 1, 0).unwrap();
+            assert!(index.attach_memory_account(&second).is_err());
+            assert!(index.memory_account().is_none());
+            drop(index);
+            assert_eq!(second.snapshot().retained_bytes, 0);
+        }
+    }
+}

--- a/src/storage/index/mod.rs
+++ b/src/storage/index/mod.rs
@@ -23,10 +23,12 @@
 //! - [`MultiColumnIndex`] - Composite index for multi-column queries
 //! - [`PkIndex`] - Primary key index (virtual, auto-created)
 
+pub(crate) mod accounted_map;
 pub mod bitmap;
 pub mod btree;
 pub mod hash;
 pub mod hnsw;
+mod memory;
 pub mod multi_column;
 pub mod pk;
 

--- a/src/storage/index/multi_column.rs
+++ b/src/storage/index/multi_column.rs
@@ -35,13 +35,17 @@
 //! - `prefix_indexes` are built on first partial query per prefix length
 
 use parking_lot::RwLock;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::ops::Bound;
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
 use rustc_hash::FxHashMap;
 
-use crate::common::{CompactArc, CompactVec, I64Map};
+use super::accounted_map::{HeapBytes, PrivateHeap, TrackedBTree, TrackedHash};
+use super::memory::IndexMemory;
+use crate::common::{CompactArc, CompactVec, I64Map, MemoryAccount, MemoryAdoption};
+type KeyMap<V> = TrackedHash<CompositeKey, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
+type SharedKey = CompactArc<[CompactArc<Value>]>;
 use crate::core::{DataType, Error, IndexEntry, IndexType, Operator, Result, RowIdVec, Value};
 use crate::storage::expression::Expression;
 use crate::storage::traits::Index;
@@ -54,6 +58,14 @@ use crate::storage::traits::Index;
 /// Wraps Vec<Value> with proper Ord implementation
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompositeKey(pub Vec<Value>);
+impl PrivateHeap for CompositeKey {
+    fn private_heap(&self) -> HeapBytes {
+        HeapBytes {
+            retained: self.0.capacity() * std::mem::size_of::<Value>(),
+            conservative: 0,
+        }
+    }
+}
 
 impl PartialOrd for CompositeKey {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
@@ -113,20 +125,20 @@ pub struct MultiColumnIndex {
     closed: AtomicBool,
 
     /// Main BTree index for range queries - LAZY built on first range query
-    sorted_values: RwLock<BTreeMap<CompositeKey, CompactVec<i64>>>,
+    sorted_values: RwLock<TrackedBTree<CompositeKey, CompactVec<i64>>>,
     btree_built: AtomicBool,
 
     /// Hash index for exact lookups (full key) - always maintained
-    value_to_rows: RwLock<FxHashMap<CompositeKey, CompactVec<i64>>>,
+    value_to_rows: RwLock<KeyMap<CompactVec<i64>>>,
 
     /// Prefix indexes: LAZY built on first partial query
     /// Index 0 = first column, Index 1 = first two columns, etc.
-    prefix_indexes: Vec<RwLock<FxHashMap<CompositeKey, CompactVec<i64>>>>,
+    prefix_indexes: Vec<RwLock<KeyMap<CompactVec<i64>>>>,
     prefix_built: Vec<AtomicBool>,
 
     /// Reverse mapping for removal - uses Vec<CompactArc<Value>> for memory efficiency
     /// Arc references are shared with ValueArena (8 bytes per value)
-    row_to_key: RwLock<I64Map<Vec<CompactArc<Value>>>>,
+    row_to_key: RwLock<I64Map<SharedKey>>,
 
     /// Per prefix group, its rows ordered by the column after the prefix:
     /// built when a walk first asks for the group, kept up to date by single
@@ -134,7 +146,8 @@ pub struct MultiColumnIndex {
     /// Writers touch it last, after the prefix indexes a build reads, and a
     /// build holds its write lock from that read to the insert, so a row is
     /// either in the group when it is built or added to it afterwards.
-    walk_orders: RwLock<FxHashMap<CompositeKey, BTreeSet<(Value, i64)>>>,
+    walk_orders: RwLock<KeyMap<BTreeSet<(Value, i64)>>>,
+    memory: IndexMemory,
 }
 
 impl std::fmt::Debug for MultiColumnIndex {
@@ -168,7 +181,7 @@ impl MultiColumnIndex {
         let mut prefix_indexes = Vec::with_capacity(num_cols);
         let mut prefix_built = Vec::with_capacity(num_cols);
         for _ in 0..num_cols {
-            prefix_indexes.push(RwLock::new(FxHashMap::default()));
+            prefix_indexes.push(RwLock::new(KeyMap::default()));
             prefix_built.push(AtomicBool::new(false));
         }
 
@@ -180,13 +193,12 @@ impl MultiColumnIndex {
             data_types,
             is_unique,
             closed: AtomicBool::new(false),
-            sorted_values: RwLock::new(BTreeMap::new()),
+            sorted_values: RwLock::new(TrackedBTree::new()),
             btree_built: AtomicBool::new(false),
-            value_to_rows: RwLock::new(if expected_rows > 0 {
-                FxHashMap::with_capacity_and_hasher(expected_rows, Default::default())
-            } else {
-                FxHashMap::default()
-            }),
+            value_to_rows: RwLock::new(KeyMap::with_capacity_and_hasher(
+                expected_rows,
+                Default::default(),
+            )),
             prefix_indexes,
             prefix_built,
             row_to_key: RwLock::new(if expected_rows > 0 {
@@ -194,7 +206,40 @@ impl MultiColumnIndex {
             } else {
                 I64Map::new()
             }),
-            walk_orders: RwLock::new(FxHashMap::default()),
+            walk_orders: RwLock::new(KeyMap::default()),
+            memory: IndexMemory::default(),
+        }
+    }
+
+    fn owned_key(&self, values: &[Value]) -> CompositeKey {
+        CompositeKey(
+            values
+                .iter()
+                .map(|value| self.memory.value(value))
+                .collect(),
+        )
+    }
+    fn shared_key(&self, values: &[Value]) -> SharedKey {
+        match self.memory.account() {
+            Some(account) => CompactArc::from_exact_iter_in(
+                values.iter().map(|value| self.memory.value_arc(value)),
+                account,
+            ),
+            None => CompactArc::from_vec(
+                values
+                    .iter()
+                    .map(|value| self.memory.value_arc(value))
+                    .collect(),
+            ),
+        }
+    }
+    fn adopt_key(key: &CompositeKey, account: &MemoryAccount) -> Result<()> {
+        if key.0.iter().all(|value| value.try_adopt_hot(account)) {
+            Ok(())
+        } else {
+            Err(Error::internal(
+                "prebuilt index key belongs to another engine",
+            ))
         }
     }
 
@@ -209,8 +254,8 @@ impl MultiColumnIndex {
     fn order_insert(&self, values: &[Value], row_id: i64) {
         let mut orders = self.walk_orders.write();
         for prefix_len in 1..values.len() {
-            if let Some(order) = orders.get_mut(&CompositeKey(values[..prefix_len].to_vec())) {
-                order.insert((values[prefix_len].clone(), row_id));
+            if let Some(mut order) = orders.get_mut(&CompositeKey(values[..prefix_len].to_vec())) {
+                order.insert((self.memory.value(&values[prefix_len]), row_id));
             }
         }
     }
@@ -218,7 +263,7 @@ impl MultiColumnIndex {
     fn order_remove(&self, values: &[Value], row_id: i64) {
         let mut orders = self.walk_orders.write();
         for prefix_len in 1..values.len() {
-            if let Some(order) = orders.get_mut(&CompositeKey(values[..prefix_len].to_vec())) {
+            if let Some(mut order) = orders.get_mut(&CompositeKey(values[..prefix_len].to_vec())) {
                 order.remove(&(values[prefix_len].clone(), row_id));
             }
         }
@@ -361,7 +406,7 @@ impl MultiColumnIndex {
         &self,
         key: &CompositeKey,
         row_id: i64,
-        value_to_rows: &FxHashMap<CompositeKey, CompactVec<i64>>,
+        value_to_rows: &KeyMap<CompactVec<i64>>,
     ) -> Result<()> {
         if !self.is_unique {
             return Ok(());
@@ -389,6 +434,68 @@ impl MultiColumnIndex {
 }
 
 impl Index for MultiColumnIndex {
+    fn attach_memory_account(&mut self, account: &MemoryAccount) -> Result<()> {
+        if !self.memory.needs_attachment(account)? {
+            return Ok(());
+        }
+        for key in self.value_to_rows.get_mut().keys() {
+            Self::adopt_key(key, account)?;
+        }
+        for key in self.sorted_values.get_mut().keys() {
+            Self::adopt_key(key, account)?;
+        }
+        for prefix in &mut self.prefix_indexes {
+            for key in prefix.get_mut().keys() {
+                Self::adopt_key(key, account)?;
+            }
+        }
+        for (key, order) in self.walk_orders.get_mut().iter() {
+            Self::adopt_key(key, account)?;
+            for (value, _) in order {
+                if !value.try_adopt_hot(account) {
+                    return Err(Error::internal(
+                        "prebuilt index key belongs to another engine",
+                    ));
+                }
+            }
+        }
+        for key in self.row_to_key.get_mut().values() {
+            for value in key.iter() {
+                IndexMemory::adopt_value_arc(value, account)?;
+            }
+            if key.try_adopt_shallow(account) == MemoryAdoption::ForeignEngine {
+                return Err(Error::internal(
+                    "prebuilt index key belongs to another engine",
+                ));
+            }
+        }
+        let metadata = self.name.capacity()
+            + self.table_name.capacity()
+            + self.column_names.capacity() * std::mem::size_of::<String>()
+            + self
+                .column_names
+                .iter()
+                .map(String::capacity)
+                .sum::<usize>()
+            + self.column_ids.capacity() * std::mem::size_of::<i32>()
+            + self.data_types.capacity() * std::mem::size_of::<DataType>()
+            + self.prefix_indexes.capacity()
+                * std::mem::size_of::<RwLock<KeyMap<CompactVec<i64>>>>()
+            + self.prefix_built.capacity() * std::mem::size_of::<AtomicBool>();
+        self.memory.attach::<Self>(account, metadata);
+        self.sorted_values.get_mut().attach(account);
+        self.value_to_rows.get_mut().attach(account);
+        for prefix in &mut self.prefix_indexes {
+            prefix.get_mut().attach(account);
+        }
+        self.walk_orders.get_mut().attach(account);
+        self.row_to_key.get_mut().attach_memory_account(account);
+        Ok(())
+    }
+    fn memory_account(&self) -> Option<&MemoryAccount> {
+        self.memory.account()
+    }
+
     fn name(&self) -> &str {
         &self.name
     }
@@ -415,10 +522,10 @@ impl Index for MultiColumnIndex {
             )));
         }
 
-        let key = CompositeKey(values.to_vec());
+        let key = self.owned_key(values);
 
         // Track old key if this is an update (for BTree/prefix cleanup after releasing locks)
-        let mut old_key_for_cleanup: Option<Vec<CompactArc<Value>>> = None;
+        let mut old_key_for_cleanup: Option<SharedKey> = None;
 
         // Acquire BOTH write locks FIRST to prevent race conditions during updates
         // Lock order: value_to_rows → row_to_key (same as remove())
@@ -442,12 +549,10 @@ impl Index for MultiColumnIndex {
                 CompositeKey(existing_arc_values.iter().map(|a| (**a).clone()).collect());
 
             // Remove old entry from value_to_rows
-            if let Some(rows) = value_to_rows.get_mut(&existing_key) {
+            value_to_rows.mutate_remove_if(&existing_key, |rows| {
                 rows.retain(|id| *id != row_id);
-                if rows.is_empty() {
-                    value_to_rows.remove(&existing_key);
-                }
-            }
+                rows.is_empty()
+            });
             // Note: row_to_key will be overwritten below, no need to remove here
         }
 
@@ -458,17 +563,17 @@ impl Index for MultiColumnIndex {
         let btree_needs_update = self.btree_built.load(AtomicOrdering::Acquire);
 
         // Wrap values in Arc for O(1) cloning in row_to_key
-        let arc_values: Vec<CompactArc<Value>> =
-            values.iter().map(|v| CompactArc::new(v.clone())).collect();
+        let arc_values = self.shared_key(values);
 
         // Add to hash index (for exact lookups) - ALWAYS maintained
         // Clone key once for hash index, keep original for BTree
         // Insert in sorted order for O(N+M) merge operations
         let key_for_hash = key.clone();
-        let hash_rows = value_to_rows.entry(key_for_hash).or_default();
+        let mut hash_rows = value_to_rows.entry(key_for_hash).or_default();
         if let Err(pos) = hash_rows.binary_search(&row_id) {
             hash_rows.insert(pos, row_id);
         }
+        drop(hash_rows);
 
         // Store CompactArc<Value> references in row_to_key (memory efficient)
         row_to_key.insert(row_id, arc_values);
@@ -486,16 +591,14 @@ impl Index for MultiColumnIndex {
             if let Some(ref old_arc_values) = old_key_for_cleanup {
                 let existing_key =
                     CompositeKey(old_arc_values.iter().map(|a| (**a).clone()).collect());
-                if let Some(rows) = sorted_values.get_mut(&existing_key) {
+                sorted_values.mutate_remove_if(&existing_key, |rows| {
                     rows.retain(|id| *id != row_id);
-                    if rows.is_empty() {
-                        sorted_values.remove(&existing_key);
-                    }
-                }
+                    rows.is_empty()
+                });
             }
 
             // Then add new entry
-            let btree_rows = sorted_values.entry(key).or_default();
+            let mut btree_rows = sorted_values.entry(key).or_default();
             if let Err(pos) = btree_rows.binary_search(&row_id) {
                 btree_rows.insert(pos, row_id);
             }
@@ -517,18 +620,16 @@ impl Index for MultiColumnIndex {
                                 .map(|a| (**a).clone())
                                 .collect(),
                         );
-                        if let Some(rows) = prefix_index.get_mut(&old_prefix_key) {
+                        prefix_index.mutate_remove_if(&old_prefix_key, |rows| {
                             rows.retain(|id| *id != row_id);
-                            if rows.is_empty() {
-                                prefix_index.remove(&old_prefix_key);
-                            }
-                        }
+                            rows.is_empty()
+                        });
                     }
                 }
 
                 // Then add new entry
-                let prefix_key = CompositeKey(values[..prefix_len].to_vec());
-                let prefix_rows = prefix_index.entry(prefix_key).or_default();
+                let prefix_key = self.owned_key(&values[..prefix_len]);
+                let mut prefix_rows = prefix_index.entry(prefix_key).or_default();
                 if let Err(pos) = prefix_rows.binary_search(&row_id) {
                     prefix_rows.insert(pos, row_id);
                 }
@@ -565,14 +666,12 @@ impl Index for MultiColumnIndex {
             let mut row_to_key = self.row_to_key.write();
 
             // Remove from hash index (row_ids are sorted, use binary search)
-            if let Some(rows) = value_to_rows.get_mut(&key) {
+            value_to_rows.mutate_remove_if(&key, |rows| {
                 if let Ok(pos) = rows.binary_search(&row_id) {
                     rows.remove(pos);
                 }
-                if rows.is_empty() {
-                    value_to_rows.remove(&key);
-                }
-            }
+                rows.is_empty()
+            });
 
             // Remove reverse mapping - ALWAYS maintained
             row_to_key.remove(row_id);
@@ -581,14 +680,12 @@ impl Index for MultiColumnIndex {
         // Only update BTree if it was built (row_ids are sorted, use binary search)
         if self.btree_built.load(AtomicOrdering::Acquire) {
             let mut sorted_values = self.sorted_values.write();
-            if let Some(rows) = sorted_values.get_mut(&key) {
+            sorted_values.mutate_remove_if(&key, |rows| {
                 if let Ok(pos) = rows.binary_search(&row_id) {
                     rows.remove(pos);
                 }
-                if rows.is_empty() {
-                    sorted_values.remove(&key);
-                }
-            }
+                rows.is_empty()
+            });
         }
 
         // Only update prefix indexes if they were built (row_ids are sorted, use binary search)
@@ -597,14 +694,12 @@ impl Index for MultiColumnIndex {
             if self.prefix_built[idx].load(AtomicOrdering::Acquire) {
                 let prefix_key = CompositeKey(values[..prefix_len].to_vec());
                 let mut prefix_index = self.prefix_indexes[idx].write();
-                if let Some(rows) = prefix_index.get_mut(&prefix_key) {
+                prefix_index.mutate_remove_if(&prefix_key, |rows| {
                     if let Ok(pos) = rows.binary_search(&row_id) {
                         rows.remove(pos);
                     }
-                    if rows.is_empty() {
-                        prefix_index.remove(&prefix_key);
-                    }
-                }
+                    rows.is_empty()
+                });
             }
         }
 
@@ -668,7 +763,7 @@ impl Index for MultiColumnIndex {
                     continue;
                 }
 
-                let key = CompositeKey(values.to_vec());
+                let key = self.owned_key(values);
 
                 // Check intra-batch duplicates
                 if let Some(&existing_row_id) = batch_keys.get(&key) {
@@ -702,15 +797,14 @@ impl Index for MultiColumnIndex {
 
         // Collect old keys for rows that need updating (to remove from BTree/prefix later)
         // We need to collect these before modifying row_to_key
-        let mut updates_to_old_key: Vec<(i64, Vec<CompactArc<Value>>)> = Vec::new();
+        let mut updates_to_old_key: Vec<(i64, SharedKey)> = Vec::new();
 
         // Now add all entries
         for &(row_id, values) in entries {
-            let key = CompositeKey(values.to_vec());
+            let key = self.owned_key(values);
 
             // Wrap values in Arc for O(1) cloning in row_to_key
-            let arc_values: Vec<CompactArc<Value>> =
-                values.iter().map(|v| CompactArc::new(v.clone())).collect();
+            let arc_values = self.shared_key(values);
 
             // Check if row already exists with different key (for updates)
             if let Some(existing_arc_values) = row_to_key.get(row_id) {
@@ -722,17 +816,15 @@ impl Index for MultiColumnIndex {
                     let existing_key =
                         CompositeKey(existing_arc_values.iter().map(|a| (**a).clone()).collect());
 
-                    if let Some(rows) = value_to_rows.get_mut(&existing_key) {
+                    value_to_rows.mutate_remove_if(&existing_key, |rows| {
                         rows.retain(|id| *id != row_id);
-                        if rows.is_empty() {
-                            value_to_rows.remove(&existing_key);
-                        }
-                    }
+                        rows.is_empty()
+                    });
                 }
             }
 
             // Add to hash index - insert in sorted order
-            let hash_rows = value_to_rows.entry(key).or_default();
+            let mut hash_rows = value_to_rows.entry(key).or_default();
             if let Err(pos) = hash_rows.binary_search(&row_id) {
                 hash_rows.insert(pos, row_id);
             }
@@ -753,18 +845,16 @@ impl Index for MultiColumnIndex {
             for (row_id, existing_arc_values) in &updates_to_old_key {
                 let existing_key =
                     CompositeKey(existing_arc_values.iter().map(|a| (**a).clone()).collect());
-                if let Some(rows) = sorted_values.get_mut(&existing_key) {
+                sorted_values.mutate_remove_if(&existing_key, |rows| {
                     rows.retain(|id| *id != *row_id);
-                    if rows.is_empty() {
-                        sorted_values.remove(&existing_key);
-                    }
-                }
+                    rows.is_empty()
+                });
             }
 
             // Then add new entries
             for &(row_id, values) in entries {
-                let key = CompositeKey(values.to_vec());
-                let btree_rows = sorted_values.entry(key).or_default();
+                let key = self.owned_key(values);
+                let mut btree_rows = sorted_values.entry(key).or_default();
                 if let Err(pos) = btree_rows.binary_search(&row_id) {
                     btree_rows.insert(pos, row_id);
                 }
@@ -786,19 +876,17 @@ impl Index for MultiColumnIndex {
                                 .map(|a| (**a).clone())
                                 .collect(),
                         );
-                        if let Some(rows) = prefix_index.get_mut(&prefix_key) {
+                        prefix_index.mutate_remove_if(&prefix_key, |rows| {
                             rows.retain(|id| *id != *row_id);
-                            if rows.is_empty() {
-                                prefix_index.remove(&prefix_key);
-                            }
-                        }
+                            rows.is_empty()
+                        });
                     }
                 }
 
                 // Then add new entries
                 for &(row_id, values) in entries {
-                    let prefix_key = CompositeKey(values[..prefix_len].to_vec());
-                    let prefix_rows = prefix_index.entry(prefix_key).or_default();
+                    let prefix_key = self.owned_key(&values[..prefix_len]);
+                    let mut prefix_rows = prefix_index.entry(prefix_key).or_default();
                     if let Err(pos) = prefix_rows.binary_search(&row_id) {
                         prefix_rows.insert(pos, row_id);
                     }
@@ -840,12 +928,10 @@ impl Index for MultiColumnIndex {
             let mut row_to_key = self.row_to_key.write();
 
             for (key, ids) in removed {
-                if let Some(rows) = value_to_rows.get_mut(&key) {
+                value_to_rows.mutate_remove_if(&key, |rows| {
                     super::subtract_sorted(rows, &ids);
-                    if rows.is_empty() {
-                        value_to_rows.remove(&key);
-                    }
-                }
+                    rows.is_empty()
+                });
             }
             for &(row_id, _) in chunk {
                 row_to_key.remove(row_id);
@@ -858,12 +944,10 @@ impl Index for MultiColumnIndex {
             let removed = Self::group_removed_by_key(entries, self.column_ids.len());
             let mut sorted_values = self.sorted_values.write();
             for (key, ids) in removed {
-                if let Some(rows) = sorted_values.get_mut(&key) {
+                sorted_values.mutate_remove_if(&key, |rows| {
                     super::subtract_sorted(rows, &ids);
-                    if rows.is_empty() {
-                        sorted_values.remove(&key);
-                    }
-                }
+                    rows.is_empty()
+                });
             }
         }
 
@@ -873,12 +957,10 @@ impl Index for MultiColumnIndex {
                 let removed = Self::group_removed_by_key(entries, prefix_len);
                 let mut prefix_index = self.prefix_indexes[idx].write();
                 for (key, ids) in removed {
-                    if let Some(rows) = prefix_index.get_mut(&key) {
+                    prefix_index.mutate_remove_if(&key, |rows| {
                         super::subtract_sorted(rows, &ids);
-                        if rows.is_empty() {
-                            prefix_index.remove(&key);
-                        }
-                    }
+                        rows.is_empty()
+                    });
                 }
             }
         }
@@ -1117,7 +1199,7 @@ impl Index for MultiColumnIndex {
                         }
                     }
                     entries.sort_unstable();
-                    orders.insert(group.clone(), entries.into_iter().collect());
+                    orders.insert(self.owned_key(prefix), entries.into_iter().collect());
                 }
                 parking_lot::RwLockWriteGuard::downgrade(orders)
             }
@@ -1476,5 +1558,49 @@ mod tests {
             })
         );
         assert_eq!(ordered, vec![1, 2]);
+    }
+}
+
+#[cfg(test)]
+mod accounting_tests {
+    use super::*;
+    #[test]
+    fn reverse_key_alias_and_lazy_structures_keep_exact_owners() {
+        let account = MemoryAccount::new();
+        let mut index = MultiColumnIndex::new(
+            "m".into(),
+            "t".into(),
+            vec!["a".into(), "b".into()],
+            vec![0, 1],
+            vec![DataType::Integer, DataType::Text],
+            false,
+            0,
+        );
+        index.attach_memory_account(&account).unwrap();
+        for row in 0..300 {
+            index
+                .add(
+                    &[
+                        Value::Integer(row % 3),
+                        Value::text(format!("retained long indexed text {row:05}")),
+                    ],
+                    row,
+                    0,
+                )
+                .unwrap();
+        }
+        let alias = index.row_to_key.read().get(4).unwrap().clone();
+        let before_lazy = account.snapshot().retained_bytes;
+        index.ensure_btree_built();
+        index.ensure_prefix_built(1);
+        index.walk_prefix_ordered(&[Value::Integer(1)], None, None, true, &mut |_, _| true);
+        assert!(account.snapshot().retained_bytes > before_lazy);
+        index.remove_batch_ids(&[4]).unwrap().unwrap();
+        assert_eq!(alias[0].as_ref(), &Value::Integer(1));
+        index.clear().unwrap();
+        drop(index);
+        assert!(account.snapshot().retained_bytes >= alias.allocation_size());
+        drop(alias);
+        assert_eq!(account.snapshot().retained_bytes, 0);
     }
 }

--- a/src/storage/index/pk.rs
+++ b/src/storage/index/pk.rs
@@ -30,7 +30,8 @@
 use parking_lot::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::common::{I64Map, I64Set};
+use super::memory::{reserve_vec, IndexMemory};
+use crate::common::{I64Map, I64Set, MemoryAccount, MemoryCharge};
 use crate::core::{DataType, IndexEntry, IndexType, Operator, Result, RowIdVec, Value};
 use crate::storage::expression::Expression;
 use crate::storage::Index;
@@ -55,6 +56,7 @@ struct PkIndexInner {
     /// Separate flag for i64::MIN which I64Set cannot store (used as sentinel).
     /// Exact count of present entries.
     count: usize,
+    words_charge: Option<MemoryCharge>,
 }
 
 impl PkIndexInner {
@@ -63,6 +65,7 @@ impl PkIndexInner {
             words: Vec::new(),
             overflow: I64Set::new(),
             count: 0,
+            words_charge: None,
         }
     }
 
@@ -82,7 +85,10 @@ impl PkIndexInner {
     #[inline]
     fn insert(&mut self, id: i64) -> bool {
         if let Some((word_idx, mask)) = to_word_bit(id) {
-            ensure_capacity(&mut self.words, word_idx);
+            reserve_vec(&mut self.words, word_idx + 1, &mut self.words_charge);
+            if word_idx >= self.words.len() {
+                self.words.resize(word_idx + 1, 0);
+            }
             if (self.words[word_idx] & mask) == 0 {
                 self.words[word_idx] |= mask;
                 self.count += 1;
@@ -126,7 +132,10 @@ impl PkIndexInner {
     /// Reset everything.
     fn clear(&mut self) {
         self.words.clear();
-        self.overflow = I64Set::new();
+        self.overflow = match self.words_charge.as_ref() {
+            Some(charge) => I64Set::new_in(charge.account()),
+            None => I64Set::new(),
+        };
         self.count = 0;
     }
 }
@@ -145,14 +154,6 @@ fn to_word_bit(row_id: i64) -> Option<(usize, u64)> {
         }
     }
     None
-}
-
-/// Grow `words` so that `word_idx` is valid.
-#[inline]
-fn ensure_capacity(words: &mut Vec<u64>, word_idx: usize) {
-    if word_idx >= words.len() {
-        words.resize(word_idx + 1, 0);
-    }
 }
 
 /// Total bit capacity of a word slice.
@@ -290,6 +291,7 @@ pub struct PkIndex {
     column_name: String,
     data: RwLock<PkIndexInner>,
     closed: AtomicBool,
+    memory: IndexMemory,
 }
 
 impl PkIndex {
@@ -301,6 +303,7 @@ impl PkIndex {
             column_name,
             data: RwLock::new(PkIndexInner::new()),
             closed: AtomicBool::new(false),
+            memory: IndexMemory::default(),
         }
     }
 
@@ -340,6 +343,26 @@ impl PkIndex {
 // ---------------------------------------------------------------------------
 
 impl Index for PkIndex {
+    fn attach_memory_account(&mut self, account: &MemoryAccount) -> Result<()> {
+        if !self.memory.needs_attachment(account)? {
+            return Ok(());
+        }
+        let metadata =
+            self.name.capacity() + self.table_name.capacity() + self.column_name.capacity();
+        self.memory.attach::<Self>(account, metadata);
+        let inner = self.data.get_mut();
+        inner.words_charge = Some(MemoryCharge::new(
+            account,
+            inner.words.capacity() * std::mem::size_of::<u64>(),
+        ));
+        inner.overflow.attach_memory_account(account);
+        Ok(())
+    }
+
+    fn memory_account(&self) -> Option<&MemoryAccount> {
+        self.memory.account()
+    }
+
     fn name(&self) -> &str {
         &self.name
     }
@@ -944,6 +967,58 @@ impl Index for PkIndex {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod memory_tests {
+    use super::*;
+
+    #[test]
+    fn attached_pk_buffers_follow_the_final_index_owner() {
+        let root = MemoryAccount::new();
+        let baseline = root.snapshot().accounted_bytes;
+        let mut index = PkIndex::new("pk".into(), "t".into(), 0, "id".into());
+        index.attach_memory_account(&root).unwrap();
+        let initial = root.snapshot().retained_bytes;
+        index.add(&[Value::Integer(1)], 1, 1).unwrap();
+        let bitset_bytes = index.data.read().words.capacity() * std::mem::size_of::<u64>();
+        assert_eq!(root.snapshot().retained_bytes, initial + bitset_bytes);
+        let before_overflow = index.data.read().overflow.allocation_size();
+        for row in -500..0 {
+            index.add(&[Value::Integer(row)], row, row).unwrap();
+        }
+        assert_eq!(
+            root.snapshot().retained_bytes,
+            initial + bitset_bytes + index.data.read().overflow.allocation_size() - before_overflow
+        );
+        index.attach_memory_account(&root).unwrap();
+        assert!(index.attach_memory_account(&MemoryAccount::new()).is_err());
+        let owner = std::sync::Arc::new(index);
+        let alias = owner.clone();
+        let retained = root.snapshot().accounted_bytes;
+        drop(owner);
+        assert_eq!(root.snapshot().accounted_bytes, retained);
+        alias.clear().unwrap();
+        assert_eq!(root.snapshot().retained_bytes, initial + bitset_bytes);
+        drop(alias);
+        assert_eq!(root.snapshot().retained_bytes, 0);
+        assert_eq!(root.snapshot().accounted_bytes, baseline);
+    }
+
+    #[test]
+    fn populated_pk_attaches_existing_capacity_without_changing_membership() {
+        let root = MemoryAccount::new();
+        let baseline = root.snapshot().accounted_bytes;
+        let mut index = PkIndex::new("pk".into(), "t".into(), 0, "id".into());
+        index.add(&[Value::Integer(1)], 1, 1).unwrap();
+        index.add(&[Value::Integer(-1)], -1, 1).unwrap();
+        index.attach_memory_account(&root).unwrap();
+        assert!(root.snapshot().accounted_bytes > baseline);
+        assert!(index.data.read().contains(1));
+        assert!(index.data.read().contains(-1));
+        drop(index);
+        assert_eq!(root.snapshot().accounted_bytes, baseline);
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/storage/mvcc/accounting.rs
+++ b/src/storage/mvcc/accounting.rs
@@ -1,0 +1,247 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Capacity owners for transaction buffers. These measure allocation lifetime;
+//! admission and fallible reservation are added with the pressure-seal stages.
+
+use std::ops::{Deref, DerefMut};
+
+use smallvec::{Array, SmallVec};
+
+use crate::common::memory::{MemoryAccount, MemoryCharge};
+
+pub(crate) struct RetainedSmallVec<A: Array> {
+    values: SmallVec<A>,
+    // Fields drop in order: the buffer must be freed before its charge.
+    charge: Option<MemoryCharge>,
+}
+
+impl<A: Array> RetainedSmallVec<A> {
+    pub(crate) fn new() -> Self {
+        Self {
+            values: SmallVec::new(),
+            charge: None,
+        }
+    }
+
+    pub(crate) fn from_inner(values: SmallVec<A>, account: &MemoryAccount) -> Self {
+        let bytes = Self::bytes(&values);
+        Self {
+            values,
+            charge: (bytes != 0).then(|| MemoryCharge::new(account, bytes)),
+        }
+    }
+
+    fn bytes(values: &SmallVec<A>) -> usize {
+        if values.spilled() {
+            values.capacity() * std::mem::size_of::<A::Item>()
+        } else {
+            0
+        }
+    }
+
+    /// Inline storage belongs to the enclosing owner and retains no account.
+    /// The first spill selects an origin; later growth keeps that same origin.
+    pub(crate) fn push(&mut self, value: A::Item, account: &MemoryAccount) {
+        if self.values.len() == self.values.capacity() {
+            let Some(capacity) = self.values.capacity().checked_mul(2) else {
+                panic!("transaction buffer capacity overflow");
+            };
+            let capacity = capacity.max(if self.values.capacity() == 0 { 4 } else { 1 });
+            let replacement = SmallVec::with_capacity(capacity);
+            let new_bytes = Self::bytes(&replacement);
+            let charge = self
+                .charge
+                .get_or_insert_with(|| MemoryCharge::new(account, 0));
+            charge.resize(charge.bytes() + new_bytes);
+            let old = std::mem::replace(&mut self.values, replacement);
+            self.values.extend(old);
+            charge.resize(new_bytes);
+        }
+        self.values.push(value);
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<A::Item> {
+        self.values.pop()
+    }
+    pub(crate) fn clear(&mut self) {
+        self.values.clear();
+    }
+    pub(crate) fn as_slice(&self) -> &[A::Item] {
+        self.values.as_slice()
+    }
+    pub(crate) fn extend<T: IntoIterator<Item = A::Item>>(
+        &mut self,
+        values: T,
+        account: &MemoryAccount,
+    ) {
+        for value in values {
+            self.push(value, account);
+        }
+    }
+    #[cfg(test)]
+    pub(crate) fn allocation_size(&self) -> usize {
+        self.charge.as_ref().map_or(0, MemoryCharge::bytes)
+    }
+}
+
+impl<A: Array> Deref for RetainedSmallVec<A> {
+    type Target = [A::Item];
+    fn deref(&self) -> &Self::Target {
+        &self.values
+    }
+}
+
+impl<A: Array> DerefMut for RetainedSmallVec<A> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.values
+    }
+}
+
+impl<'a, A: Array> IntoIterator for &'a RetainedSmallVec<A> {
+    type Item = &'a A::Item;
+    type IntoIter = std::slice::Iter<'a, A::Item>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.iter()
+    }
+}
+
+impl<'a, A: Array> IntoIterator for &'a mut RetainedSmallVec<A> {
+    type Item = &'a mut A::Item;
+    type IntoIter = std::slice::IterMut<'a, A::Item>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.iter_mut()
+    }
+}
+
+pub(crate) struct RetainedSmallVecIntoIter<A: Array> {
+    values: smallvec::IntoIter<A>,
+    _charge: Option<MemoryCharge>,
+}
+
+impl<A: Array> IntoIterator for RetainedSmallVec<A> {
+    type Item = A::Item;
+    type IntoIter = RetainedSmallVecIntoIter<A>;
+    fn into_iter(self) -> Self::IntoIter {
+        RetainedSmallVecIntoIter {
+            values: self.values.into_iter(),
+            _charge: self.charge,
+        }
+    }
+}
+
+impl<A: Array> Iterator for RetainedSmallVecIntoIter<A> {
+    type Item = A::Item;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.values.next()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.values.size_hint()
+    }
+}
+
+impl<A: Array> ExactSizeIterator for RetainedSmallVecIntoIter<A> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inline_values_do_not_keep_the_supplied_origin_alive() {
+        let root = MemoryAccount::new();
+        let empty = root.snapshot().accounted_bytes;
+        let origin = root.child();
+        let mut values = RetainedSmallVec::<[u64; 2]>::new();
+        values.push(7, &origin);
+        values.extend([9], &origin);
+        let copied = RetainedSmallVec::from_inner(SmallVec::<[u64; 2]>::from_slice(&[11]), &origin);
+        drop(origin);
+        // A zero-byte MemoryCharge would keep the child's own allocation alive.
+        // Inline values need neither that owner nor a separately charged buffer.
+        assert_eq!(root.snapshot().accounted_bytes, empty);
+        let mut iter = values.into_iter();
+        assert_eq!(iter.next(), Some(7));
+        assert_eq!(iter.next(), Some(9));
+        assert_eq!(copied.as_slice(), &[11]);
+        drop((iter, copied));
+        assert_eq!(root.snapshot().accounted_bytes, empty);
+    }
+
+    #[test]
+    fn spilled_buffer_and_iterator_keep_the_first_origin_through_final_drop() {
+        let root = MemoryAccount::new();
+        let empty = root.snapshot().accounted_bytes;
+        let origin = root.child();
+        let origin_bytes = root.snapshot().accounted_bytes - empty;
+        let other_root = MemoryAccount::new();
+        let other_empty = other_root.snapshot();
+        let mut values = RetainedSmallVec::<[u64; 1]>::new();
+        values.extend([7, 9], &origin);
+        drop(origin);
+        assert_eq!(root.snapshot().accounted_bytes, empty + origin_bytes + 16);
+        // Moving the vector does not reparent its existing allocation when a
+        // later caller supplies a different account at the growth seam.
+        values.push(11, &other_root);
+        assert_eq!(other_root.snapshot(), other_empty);
+        assert_eq!(root.snapshot().accounted_bytes, empty + origin_bytes + 32);
+        let mut iter = values.into_iter();
+        assert_eq!(iter.next(), Some(7));
+        assert_eq!(root.snapshot().accounted_bytes, empty + origin_bytes + 32);
+        drop(iter);
+        assert_eq!(root.snapshot().accounted_bytes, empty);
+    }
+
+    #[test]
+    fn interrupted_extend_keeps_initialized_values_and_spill_ownership() {
+        let root = MemoryAccount::new();
+        let empty = root.snapshot().accounted_bytes;
+        let mut values = RetainedSmallVec::<[u64; 1]>::new();
+        let failure = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            values.extend(
+                (0..3).inspect(|&value| {
+                    assert!(value < 2, "input iterator failed");
+                }),
+                &root,
+            );
+        }));
+        assert!(failure.is_err());
+        assert_eq!(values.as_slice(), &[0, 1]);
+        assert_eq!(root.snapshot().accounted_bytes, empty + 16);
+        drop(values);
+        assert_eq!(root.snapshot().accounted_bytes, empty);
+    }
+
+    #[test]
+    fn inline_growth_clear_and_owned_iterator_keep_physical_capacity_charged() {
+        let account = MemoryAccount::new();
+        let mut values = RetainedSmallVec::<[u64; 1]>::new();
+        values.push(1, &account);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+        values.push(2, &account);
+        assert_eq!(account.snapshot().retained_bytes, 16);
+        values.push(3, &account);
+        assert_eq!(account.snapshot().retained_bytes, 32);
+        values.extend([4, 5], &account);
+        let base = account.snapshot().conservative_bytes;
+        assert_eq!(account.snapshot().peak_accounted_bytes, base + 96);
+        values.clear();
+        assert_eq!(account.snapshot().retained_bytes, 64);
+        values.extend([4, 5], &account);
+        let mut iter = values.into_iter();
+        assert_eq!(iter.next(), Some(4));
+        assert_eq!(account.snapshot().retained_bytes, 64);
+        drop(iter);
+        assert_eq!(account.snapshot().retained_bytes, 0);
+    }
+}

--- a/src/storage/mvcc/arena.rs
+++ b/src/storage/mvcc/arena.rs
@@ -12,29 +12,101 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Arena-based row storage for O(1) clone reads
+//! Chunked row storage with stable, thin handles and shared row payloads.
 //!
-//! This module provides Arc-based storage for row data,
-//! enabling O(1) row cloning on read (just CompactArc::clone).
-//!
-//! Key insight: Store row data as CompactArc<[Value]> for O(1) clone on read.
-//! Single clone on insert, zero clone on read.
-//!
-//! # Lock Design
-//!
-//! Uses a single RwLock for both data and metadata to:
-//! - Ensure consistent lock ordering (eliminates deadlock risk)
-//! - Reduce lock acquisition overhead (one lock vs two)
-//! - Guarantee atomic insert operations
+//! One lock protects the directory, payloads, metadata and active free list.
+//! A chunk starts with no slot allocation and grows only as rows arrive.
+//! Frozen chunks remain mutable, but their vacant slots are never reused.
 
+use hashbrown::HashMap;
 use parking_lot::{Mutex, RwLock};
+use smallvec::SmallVec;
+use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::common::CompactArc;
-use crate::core::{Row, Value};
+use crate::common::{CompactArc, MemoryAccount, MemoryCharge};
+use crate::core::{Error, Result, Row, Value};
 
-/// Bytes a row holds: the values in place plus what text and extension
-/// values keep on the heap
+pub const ARENA_CHUNK_SHIFT: u32 = 18;
+pub const ARENA_CHUNK_ROWS: usize = 1 << ARENA_CHUNK_SHIFT;
+pub const ARENA_CHUNK_MASK: u64 = (ARENA_CHUNK_ROWS - 1) as u64;
+const MAX_CHUNK_ID: u64 = u64::MAX >> ARENA_CHUNK_SHIFT;
+const LSN_LEAF_SHIFT: usize = 8;
+const LSN_LEAF_ROWS: usize = 1 << LSN_LEAF_SHIFT;
+
+/// Monotonically allocated chunk identity. It is independent of SQL row IDs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct ChunkId(u64);
+
+impl ChunkId {
+    pub fn new(value: u64) -> Result<Self> {
+        if value > MAX_CHUNK_ID {
+            return Err(Error::internal("arena chunk address space exhausted"));
+        }
+        Ok(Self(value))
+    }
+
+    #[inline]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// An encoded chunk/slot address plus one. `Option<ArenaId>` is also 8 bytes.
+/// A handle must be checked against row/transaction identity before mutation;
+/// vacant slots in the active chunk can be reused.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct ArenaId(NonZeroU64);
+
+impl ArenaId {
+    pub fn from_parts(chunk_id: ChunkId, slot: usize) -> Result<Self> {
+        if slot >= ARENA_CHUNK_ROWS {
+            return Err(Error::internal("arena slot exceeds chunk capacity"));
+        }
+        let encoded = chunk_id
+            .0
+            .checked_mul(ARENA_CHUNK_ROWS as u64)
+            .and_then(|base| base.checked_add(slot as u64))
+            .and_then(|address| address.checked_add(1))
+            .and_then(NonZeroU64::new)
+            .ok_or_else(|| Error::internal("arena address space exhausted"))?;
+        Ok(Self(encoded))
+    }
+
+    #[inline]
+    pub const fn from_nonzero(encoded: NonZeroU64) -> Self {
+        Self(encoded)
+    }
+
+    #[inline]
+    pub const fn as_nonzero(self) -> NonZeroU64 {
+        self.0
+    }
+
+    #[inline]
+    pub const fn chunk_id(self) -> ChunkId {
+        ChunkId((self.0.get() - 1) >> ARENA_CHUNK_SHIFT)
+    }
+
+    #[inline]
+    pub const fn slot(self) -> usize {
+        ((self.0.get() - 1) & ARENA_CHUNK_MASK) as usize
+    }
+}
+
+const _: () = {
+    assert!(std::mem::size_of::<ArenaId>() == 8);
+    assert!(std::mem::size_of::<Option<ArenaId>>() == 8);
+    assert!(
+        std::mem::size_of::<Option<CompactArc<[Value]>>>()
+            == std::mem::size_of::<CompactArc<[Value]>>()
+    );
+};
+
+/// Bytes referenced by a committed slot, distinct from structural capacity.
+/// Shared payload allocation accounting follows the final payload owner.
 pub fn row_bytes(values: &[Value]) -> usize {
     let mut bytes = 16 + std::mem::size_of_val(values);
     for value in values {
@@ -47,430 +119,1110 @@ pub fn row_bytes(values: &[Value]) -> usize {
     bytes
 }
 
-/// Metadata for a row stored in the arena
-///
-/// Note: create_time is NOT stored here to save 8 bytes per row.
-/// It's available via RowVersion in the version chain when needed.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ArenaRowMeta {
-    /// Row ID
     pub row_id: i64,
-    /// Transaction ID that created this row
+    /// Transaction that created the payload. Zero denotes a vacant slot.
     pub txn_id: i64,
-    /// Transaction ID that deleted this row (0 if not deleted)
     pub deleted_at_txn_id: i64,
+    /// WAL record needed to reconstruct the latest mutation, including DELETE.
+    /// None denotes an unlogged row or the separately retained legacy baseline.
+    pub source_lsn: Option<NonZeroU64>,
 }
 
 impl ArenaRowMeta {
-    /// Check if this row is deleted
     #[inline]
     pub fn is_deleted(&self) -> bool {
         self.deleted_at_txn_id != 0
     }
+
+    #[inline]
+    pub fn mutation_txn_id(&self) -> i64 {
+        if self.is_deleted() {
+            self.deleted_at_txn_id
+        } else {
+            self.txn_id
+        }
+    }
 }
 
-/// Inner arena data protected by single lock
-///
-/// NOTE: This struct is on the hot read path. Keep it minimal.
-/// The free_list is stored separately in RowArena to avoid bloating this struct.
-pub struct ArenaInner {
-    /// Arc storage per row (for O(1) clone on read)
-    /// Stores CompactArc<[Value]> for efficient row sharing
-    pub data: Vec<CompactArc<[Value]>>,
-    /// Row metadata
-    pub meta: Vec<ArenaRowMeta>,
+const _: () = assert!(std::mem::size_of::<ArenaRowMeta>() == 32);
+
+#[inline]
+fn min_lsn(a: Option<NonZeroU64>, b: Option<NonZeroU64>) -> Option<NonZeroU64> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (a, None) => a,
+        (None, b) => b,
+    }
 }
 
-/// Arena-based storage for row data
-///
-/// Row data is stored as CompactArc<[Value]> for O(1) clone on read.
-/// Single clone on insert, zero clone on read.
-///
-/// Uses single RwLock for atomicity and deadlock prevention.
-/// Free list is stored separately to avoid bloating the hot read path.
+fn reserve_error(error: std::collections::TryReserveError) -> Error {
+    Error::internal(format!("arena allocation failed: {error}"))
+}
+
+/// Grow accounted buffers explicitly so the old and new allocation coexist
+/// under separate charges. An opaque realloc cannot expose that overlap.
+fn reserve_charged_vec<T>(
+    buffer: &mut Vec<T>,
+    desired: usize,
+    charge: &mut Option<MemoryCharge>,
+) -> Result<()> {
+    if desired <= buffer.capacity() {
+        return Ok(());
+    }
+    let Some(charge) = charge else {
+        return buffer
+            .try_reserve_exact(desired - buffer.len())
+            .map_err(reserve_error);
+    };
+    let mut replacement = Vec::new();
+    replacement
+        .try_reserve_exact(desired)
+        .map_err(reserve_error)?;
+    let replacement_charge = MemoryCharge::new(
+        charge.account(),
+        replacement.capacity() * std::mem::size_of::<T>(),
+    );
+    let old_bytes = buffer.capacity() * std::mem::size_of::<T>();
+    replacement.append(buffer);
+    let retired = std::mem::replace(buffer, replacement);
+    let retired_charge = charge.replace_part(old_bytes, replacement_charge);
+    drop(retired);
+    drop(retired_charge);
+    Ok(())
+}
+
+/// A binary tree over 256-slot leaf minima. It is absent for unlogged chunks.
+/// Growth occurs once per leaf-capacity doubling, never on an existing-row update.
+#[derive(Default)]
+struct LsnMinTree {
+    nodes: Vec<Option<NonZeroU64>>,
+    leaf_capacity: usize,
+    // Own the buffer independently so growth can retain old and new charges.
+    charge: Option<MemoryCharge>,
+}
+
+impl LsnMinTree {
+    fn new(account: Option<&MemoryAccount>) -> Self {
+        Self {
+            charge: account.map(|account| MemoryCharge::new(account, 0)),
+            ..Self::default()
+        }
+    }
+
+    fn reserve_slot(&mut self, slot: usize) -> Result<()> {
+        let needed = (slot >> LSN_LEAF_SHIFT) + 1;
+        if needed <= self.leaf_capacity {
+            return Ok(());
+        }
+        let new_capacity = needed.next_power_of_two();
+        let mut nodes = Vec::new();
+        nodes
+            .try_reserve_exact(new_capacity * 2)
+            .map_err(reserve_error)?;
+        let new_charge = self.charge.as_ref().map(|charge| {
+            MemoryCharge::new(
+                charge.account(),
+                nodes.capacity() * std::mem::size_of::<Option<NonZeroU64>>(),
+            )
+        });
+        nodes.resize(new_capacity * 2, None);
+        if self.leaf_capacity != 0 {
+            nodes[new_capacity..new_capacity + self.leaf_capacity]
+                .copy_from_slice(&self.nodes[self.leaf_capacity..self.leaf_capacity * 2]);
+        }
+        for parent in (1..new_capacity).rev() {
+            nodes[parent] = min_lsn(nodes[parent * 2], nodes[parent * 2 + 1]);
+        }
+        let old_nodes = std::mem::replace(&mut self.nodes, nodes);
+        let old_charge = std::mem::replace(&mut self.charge, new_charge);
+        drop(old_nodes);
+        drop(old_charge);
+        self.leaf_capacity = new_capacity;
+        Ok(())
+    }
+
+    #[inline]
+    fn first(&self) -> Option<NonZeroU64> {
+        self.nodes.get(1).copied().flatten()
+    }
+
+    fn changed(
+        &mut self,
+        slot: usize,
+        old: Option<NonZeroU64>,
+        new: Option<NonZeroU64>,
+        meta: &[ArenaRowMeta],
+    ) {
+        if old == new || self.leaf_capacity == 0 {
+            return;
+        }
+        let leaf = slot >> LSN_LEAF_SHIFT;
+        if leaf >= self.leaf_capacity {
+            debug_assert!(new.is_none());
+            return;
+        }
+        let mut node = self.leaf_capacity + leaf;
+        let previous = self.nodes[node];
+        let minimum = if new.is_some() && (previous.is_none() || new < previous) {
+            new
+        } else if old.is_some() && old == previous {
+            let begin = leaf * LSN_LEAF_ROWS;
+            let end = (begin + LSN_LEAF_ROWS).min(meta.len());
+            meta[begin..end]
+                .iter()
+                .filter_map(|row| row.source_lsn)
+                .min()
+        } else {
+            return;
+        };
+        if minimum == previous {
+            return;
+        }
+        self.nodes[node] = minimum;
+        while node > 1 {
+            node /= 2;
+            let value = min_lsn(self.nodes[node * 2], self.nodes[node * 2 + 1]);
+            if self.nodes[node] == value {
+                break;
+            }
+            self.nodes[node] = value;
+        }
+    }
+}
+
+struct Chunk {
+    id: ChunkId,
+    data: Vec<Option<CompactArc<[Value]>>>,
+    meta: Vec<ArenaRowMeta>,
+    lsn_minima: LsnMinTree,
+    occupied: usize,
+    frozen: bool,
+    // Last field: vector allocations are freed before their charge is released.
+    charge: Option<MemoryCharge>,
+}
+
+impl Chunk {
+    fn new(id: ChunkId, account: Option<&MemoryAccount>) -> Self {
+        Self {
+            id,
+            data: Vec::new(),
+            meta: Vec::new(),
+            lsn_minima: LsnMinTree::new(account),
+            occupied: 0,
+            frozen: false,
+            charge: account.map(|account| MemoryCharge::new(account, 0)),
+        }
+    }
+
+    fn capacity_bytes(&self) -> usize {
+        // The LSN tree owns a separate charge for its explicit replacement buffer.
+        self.data.capacity() * std::mem::size_of::<Option<CompactArc<[Value]>>>()
+            + self.meta.capacity() * std::mem::size_of::<ArenaRowMeta>()
+    }
+
+    fn refresh_charge(&mut self) {
+        let bytes = self.capacity_bytes();
+        if let Some(charge) = &mut self.charge {
+            if charge.bytes() != bytes {
+                charge.resize(bytes);
+            }
+        }
+    }
+
+    fn reserve_lsn(&mut self, slot: usize) -> Result<()> {
+        let result = self.lsn_minima.reserve_slot(slot);
+        self.refresh_charge();
+        result
+    }
+
+    fn reserve_slot(&mut self, slot: usize, hint: usize, logged: bool) -> Result<()> {
+        // Account for any vector growth even if the next reservation fails.
+        let result = self.reserve_slot_inner(slot, hint, logged);
+        self.refresh_charge();
+        result
+    }
+
+    fn reserve_slot_inner(&mut self, slot: usize, hint: usize, logged: bool) -> Result<()> {
+        debug_assert!(slot < ARENA_CHUNK_ROWS);
+        let capacity = self.data.capacity().min(self.meta.capacity());
+        if slot >= capacity {
+            let desired = (slot + 1)
+                .max(capacity.saturating_mul(2))
+                .max(hint)
+                .clamp(4, ARENA_CHUNK_ROWS);
+            reserve_charged_vec(&mut self.data, desired, &mut self.charge)?;
+            reserve_charged_vec(&mut self.meta, desired, &mut self.charge)?;
+        }
+        if logged {
+            self.lsn_minima.reserve_slot(slot)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn get(&self, slot: usize) -> Option<(&ArenaRowMeta, &CompactArc<[Value]>)> {
+        Some((self.meta.get(slot)?, self.data.get(slot)?.as_ref()?))
+    }
+}
+
+struct ArenaInner {
+    chunks: Vec<Chunk>,
+    active: Option<ChunkId>,
+    next_chunk_id: u64,
+    /// Intrusive links live in row_id only while metadata.txn_id == 0.
+    /// Frozen chunks never consult their retired links.
+    free_head: Option<u32>,
+    occupied: usize,
+    slot_count: usize,
+    initial_capacity: usize,
+    // Kept after chunks so the directory buffer is released first on Drop.
+    directory_charge: Option<MemoryCharge>,
+}
+
+impl ArenaInner {
+    fn refresh_directory_charge(&mut self) {
+        if let Some(charge) = &mut self.directory_charge {
+            let bytes = self.chunks.capacity() * std::mem::size_of::<Chunk>();
+            if charge.bytes() != bytes {
+                charge.resize(bytes);
+            }
+        }
+    }
+
+    fn reserve_directory_slot(&mut self) -> Result<()> {
+        if self.chunks.len() < self.chunks.capacity() {
+            return Ok(());
+        }
+        let desired = self.chunks.capacity().saturating_mul(2).max(4);
+        let mut chunks = Vec::new();
+        chunks.try_reserve_exact(desired).map_err(reserve_error)?;
+        let new_charge = self.directory_charge.as_ref().map(|charge| {
+            MemoryCharge::new(
+                charge.account(),
+                chunks.capacity() * std::mem::size_of::<Chunk>(),
+            )
+        });
+        // Retain both allocations until the nonallocating chunk transfer finishes.
+        chunks.append(&mut self.chunks);
+        let old_chunks = std::mem::replace(&mut self.chunks, chunks);
+        let old_charge = std::mem::replace(&mut self.directory_charge, new_charge);
+        drop(old_chunks);
+        drop(old_charge);
+        Ok(())
+    }
+
+    #[inline]
+    fn position(&self, id: ChunkId) -> Option<usize> {
+        self.chunks.binary_search_by_key(&id, |chunk| chunk.id).ok()
+    }
+
+    fn get(&self, id: ArenaId) -> Option<(&ArenaRowMeta, &CompactArc<[Value]>)> {
+        self.chunks
+            .get(self.position(id.chunk_id())?)?
+            .get(id.slot())
+    }
+
+    fn insert(
+        &mut self,
+        row_id: i64,
+        txn_id: i64,
+        data: CompactArc<[Value]>,
+        source_lsn: Option<NonZeroU64>,
+    ) -> Result<ArenaId> {
+        if txn_id == 0 {
+            return Err(Error::internal("arena transaction identity cannot be zero"));
+        }
+        if let Some(active) = self.active {
+            let last = self.chunks.len() - 1;
+            debug_assert_eq!(self.chunks[last].id, active);
+            let slot = self
+                .free_head
+                .map_or(self.chunks[last].meta.len(), |slot| slot as usize);
+            if slot < ARENA_CHUNK_ROWS {
+                let id = ArenaId::from_parts(active, slot)?;
+                let chunk = &mut self.chunks[last];
+                chunk.reserve_slot(slot, self.initial_capacity, source_lsn.is_some())?;
+                let meta = ArenaRowMeta {
+                    row_id,
+                    txn_id,
+                    deleted_at_txn_id: 0,
+                    source_lsn,
+                };
+                if self.free_head.is_some() {
+                    debug_assert!(chunk.data[slot].is_none());
+                    debug_assert_eq!(chunk.meta[slot].txn_id, 0);
+                    self.free_head = match chunk.meta[slot].row_id {
+                        0 => None,
+                        next => Some((next - 1) as u32),
+                    };
+                    chunk.data[slot] = Some(data);
+                    chunk.meta[slot] = meta;
+                } else {
+                    chunk.data.push(Some(data));
+                    chunk.meta.push(meta);
+                    self.slot_count += 1;
+                }
+                chunk.occupied += 1;
+                self.occupied += 1;
+                chunk
+                    .lsn_minima
+                    .changed(slot, None, source_lsn, &chunk.meta);
+                return Ok(id);
+            }
+        }
+        // Validate addresses and reserve storage before publishing or freezing chunks.
+        let chunk_id = ChunkId::new(self.next_chunk_id)?;
+        let id = ArenaId::from_parts(chunk_id, 0)?;
+        let account = self.directory_charge.as_ref().map(MemoryCharge::account);
+        let mut chunk = Chunk::new(chunk_id, account);
+        chunk.reserve_slot(0, self.initial_capacity, source_lsn.is_some())?;
+        self.reserve_directory_slot()?;
+        chunk.data.push(Some(data));
+        chunk.meta.push(ArenaRowMeta {
+            row_id,
+            txn_id,
+            deleted_at_txn_id: 0,
+            source_lsn,
+        });
+        chunk.occupied = 1;
+        chunk.lsn_minima.changed(0, None, source_lsn, &chunk.meta);
+        if let Some(previous) = self.chunks.last_mut() {
+            previous.frozen = true;
+        }
+        self.free_head = None;
+        self.chunks.push(chunk);
+        self.active = Some(chunk_id);
+        self.next_chunk_id += 1;
+        self.occupied += 1;
+        self.slot_count += 1;
+        Ok(id)
+    }
+
+    fn clear(&mut self, id: ArenaId, row_id: i64, txn_id: i64) -> usize {
+        let Some(position) = self.position(id.chunk_id()) else {
+            return 0;
+        };
+        let chunk = &mut self.chunks[position];
+        let slot = id.slot();
+        let Some((meta, payload)) = chunk.get(slot) else {
+            return 0;
+        };
+        if meta.row_id != row_id || meta.mutation_txn_id() != txn_id {
+            return 0;
+        }
+        let bytes = row_bytes(payload);
+        let old_lsn = meta.source_lsn;
+        chunk.data[slot] = None;
+        chunk.meta[slot] = ArenaRowMeta::default();
+        chunk.occupied -= 1;
+        chunk.lsn_minima.changed(slot, old_lsn, None, &chunk.meta);
+        self.occupied -= 1;
+        if chunk.occupied == 0 {
+            self.slot_count -= chunk.meta.len();
+            if self.active == Some(chunk.id) {
+                self.active = None;
+                self.free_head = None;
+            }
+            self.chunks.remove(position);
+            if self.chunks.is_empty() {
+                self.chunks = Vec::new();
+                self.refresh_directory_charge();
+            }
+        } else if self.active == Some(chunk.id) {
+            // Link the next free slot through vacant metadata; txn_id distinguishes valid zero keys.
+            chunk.meta[slot].row_id = self.free_head.map_or(0, |next| i64::from(next) + 1);
+            self.free_head = Some(slot as u32);
+        }
+        bytes
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Receipt {
+    lsn: NonZeroU64,
+    token: u64,
+}
+
+type ReceiptHeap = SmallVec<[Receipt; 1]>;
+type ReceiptPositions = HashMap<u64, (ChunkId, usize)>;
+
+/// Receipt maps use primitive, non-panicking keys. Allocate and charge a
+/// replacement before moving entries so rehash retains the old bucket owner.
+fn reserve_receipt_map<K: Eq + std::hash::Hash, V>(
+    map: &mut HashMap<K, V>,
+    additional: usize,
+    charge: &mut Option<MemoryCharge>,
+) -> Result<()> {
+    let needed = map
+        .len()
+        .checked_add(additional)
+        .ok_or_else(|| Error::internal("arena receipt capacity overflow"))?;
+    if needed <= map.capacity() {
+        return Ok(());
+    }
+    let Some(charge) = charge else {
+        return map.try_reserve(additional).map_err(|error| {
+            Error::internal(format!("arena receipt allocation failed: {error:?}"))
+        });
+    };
+    let desired = needed.max(map.capacity().saturating_mul(2));
+    let mut replacement = HashMap::with_hasher(map.hasher().clone());
+    replacement
+        .try_reserve(desired)
+        .map_err(|error| Error::internal(format!("arena receipt allocation failed: {error:?}")))?;
+    let replacement_charge = MemoryCharge::new(charge.account(), replacement.allocation_size());
+    let old_bytes = map.allocation_size();
+    // The replacement has room for all entries; fixed-key rehashing cannot allocate or unwind.
+    replacement.extend(map.drain());
+    let retired = std::mem::replace(map, replacement);
+    let retired_charge = charge.replace_part(old_bytes, replacement_charge);
+    drop(retired);
+    drop(retired_charge);
+    Ok(())
+}
+
+/// Indexed per-chunk min-heaps. A pin or release touches only its chunk's
+/// heap, and token lookup is independent of how many other chunks are pinned.
+#[derive(Default)]
+struct ReceiptRegistry {
+    /// Ordinary one-chunk publication needs no receipt-table allocations.
+    /// Inline and indexed states are mutually exclusive.
+    inline: Option<(ChunkId, Receipt)>,
+    chunks: HashMap<ChunkId, ReceiptHeap>,
+    positions: ReceiptPositions,
+    next_token: u64,
+    spilled_heap_bytes: usize,
+    #[cfg(test)]
+    fail_promotion_after_positions: bool,
+    // Hash tables/heaps above are destroyed before releasing their charge.
+    charge: Option<MemoryCharge>,
+}
+
+impl ReceiptRegistry {
+    fn new(account: Option<&MemoryAccount>) -> Self {
+        Self {
+            charge: account.map(|account| MemoryCharge::new(account, 0)),
+            ..Self::default()
+        }
+    }
+
+    fn heap_bytes(heap: &ReceiptHeap) -> usize {
+        if heap.spilled() {
+            heap.capacity() * std::mem::size_of::<Receipt>()
+        } else {
+            0
+        }
+    }
+
+    fn reserve_heap(
+        heap: &mut ReceiptHeap,
+        additional: usize,
+        charge: &mut Option<MemoryCharge>,
+    ) -> Result<()> {
+        let needed = heap
+            .len()
+            .checked_add(additional)
+            .ok_or_else(|| Error::internal("arena receipt capacity overflow"))?;
+        if needed <= heap.capacity() {
+            return Ok(());
+        }
+        let Some(charge) = charge else {
+            return heap.try_reserve(additional).map_err(|error| {
+                Error::internal(format!("arena receipt allocation failed: {error:?}"))
+            });
+        };
+        let desired = needed.max(heap.capacity().saturating_mul(2));
+        let mut replacement = ReceiptHeap::new();
+        replacement.try_reserve_exact(desired).map_err(|error| {
+            Error::internal(format!("arena receipt allocation failed: {error:?}"))
+        })?;
+        let replacement_charge =
+            MemoryCharge::new(charge.account(), Self::heap_bytes(&replacement));
+        let old_bytes = Self::heap_bytes(heap);
+        // Receipt is Copy and the full destination capacity is already present.
+        replacement.extend_from_slice(heap.as_slice());
+        let retired = std::mem::replace(heap, replacement);
+        let retired_charge = charge.replace_part(old_bytes, replacement_charge);
+        drop(retired);
+        drop(retired_charge);
+        Ok(())
+    }
+
+    fn refresh_charge(&mut self) {
+        let bytes = self.capacity_bytes();
+        if let Some(charge) = &mut self.charge {
+            if charge.bytes() != bytes {
+                charge.resize(bytes);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn first(&self, chunk: Option<ChunkId>) -> Option<NonZeroU64> {
+        if let Some((id, receipt)) = self.inline {
+            return chunk
+                .is_none_or(|requested| requested == id)
+                .then_some(receipt.lsn);
+        }
+        if let Some(id) = chunk {
+            self.chunks
+                .get(&id)
+                .and_then(|heap| heap.first())
+                .map(|receipt| receipt.lsn)
+        } else {
+            self.chunks
+                .values()
+                .filter_map(|heap| heap.first().map(|receipt| receipt.lsn))
+                .min()
+        }
+    }
+
+    fn swap(heap: &mut ReceiptHeap, positions: &mut ReceiptPositions, a: usize, b: usize) {
+        heap.swap(a, b);
+        let Some(position) = positions.get_mut(&heap[a].token) else {
+            unreachable!("arena receipt position is missing");
+        };
+        position.1 = a;
+        let Some(position) = positions.get_mut(&heap[b].token) else {
+            unreachable!("arena receipt position is missing");
+        };
+        position.1 = b;
+    }
+
+    fn sift_up(heap: &mut ReceiptHeap, positions: &mut ReceiptPositions, mut slot: usize) {
+        while slot > 0 {
+            let parent = (slot - 1) / 2;
+            if heap[parent] <= heap[slot] {
+                break;
+            }
+            Self::swap(heap, positions, parent, slot);
+            slot = parent;
+        }
+    }
+
+    fn sift_down(heap: &mut ReceiptHeap, positions: &mut ReceiptPositions, mut slot: usize) {
+        loop {
+            let left = slot * 2 + 1;
+            if left >= heap.len() {
+                break;
+            }
+            let right = left + 1;
+            let child = if right < heap.len() && heap[right] < heap[left] {
+                right
+            } else {
+                left
+            };
+            if heap[slot] <= heap[child] {
+                break;
+            }
+            Self::swap(heap, positions, slot, child);
+            slot = child;
+        }
+    }
+
+    fn insert(&mut self, chunk_id: ChunkId, lsn: NonZeroU64) -> Result<u64> {
+        let result = self.insert_inner(chunk_id, lsn);
+        self.refresh_charge();
+        result
+    }
+
+    fn insert_inner(&mut self, chunk_id: ChunkId, lsn: NonZeroU64) -> Result<u64> {
+        let token = self
+            .next_token
+            .checked_add(1)
+            .ok_or_else(|| Error::internal("arena LSN receipt identities exhausted"))?;
+        if self.positions.is_empty() {
+            if let Some((old_chunk, old_receipt)) = self.inline {
+                // Keep the inline receipt, token and minimum until all promotion allocations succeed.
+                reserve_receipt_map(&mut self.positions, 2, &mut self.charge)?;
+                #[cfg(test)]
+                if std::mem::take(&mut self.fail_promotion_after_positions) {
+                    return Err(Error::internal(
+                        "injected arena receipt promotion allocation failure",
+                    ));
+                }
+                reserve_receipt_map(&mut self.chunks, 2, &mut self.charge)?;
+                let mut heap = ReceiptHeap::new();
+                Self::reserve_heap(
+                    &mut heap,
+                    if old_chunk == chunk_id { 2 } else { 1 },
+                    &mut self.charge,
+                )?;
+                heap.push(old_receipt);
+                self.positions.insert(old_receipt.token, (old_chunk, 0));
+                if old_chunk == chunk_id {
+                    heap.push(Receipt { lsn, token });
+                    self.positions.insert(token, (chunk_id, 1));
+                    Self::sift_up(&mut heap, &mut self.positions, 1);
+                } else {
+                    let mut other = ReceiptHeap::new();
+                    other.push(Receipt { lsn, token });
+                    self.chunks.insert(chunk_id, other);
+                    self.positions.insert(token, (chunk_id, 0));
+                }
+                self.spilled_heap_bytes += Self::heap_bytes(&heap);
+                self.chunks.insert(old_chunk, heap);
+                self.inline = None;
+            } else {
+                self.inline = Some((chunk_id, Receipt { lsn, token }));
+            }
+            self.next_token = token;
+            return Ok(token);
+        }
+        reserve_receipt_map(&mut self.positions, 1, &mut self.charge)?;
+        if let Some(heap) = self.chunks.get_mut(&chunk_id) {
+            let previous_bytes = Self::heap_bytes(heap);
+            Self::reserve_heap(heap, 1, &mut self.charge)?;
+            self.spilled_heap_bytes += Self::heap_bytes(heap) - previous_bytes;
+            let slot = heap.len();
+            heap.push(Receipt { lsn, token });
+            self.positions.insert(token, (chunk_id, slot));
+            Self::sift_up(heap, &mut self.positions, slot);
+        } else {
+            reserve_receipt_map(&mut self.chunks, 1, &mut self.charge)?;
+            // The first receipt is inline; no separate allocation per handle.
+            let mut heap = ReceiptHeap::new();
+            heap.push(Receipt { lsn, token });
+            self.chunks.insert(chunk_id, heap);
+            self.positions.insert(token, (chunk_id, 0));
+        }
+        self.next_token = token;
+        Ok(token)
+    }
+
+    fn remove(&mut self, token: u64) {
+        if let Some((_, receipt)) = self.inline {
+            if receipt.token == token {
+                self.inline = None;
+                // A failed promotion may have reserved empty hash tables.
+                self.positions = HashMap::new();
+                self.chunks = HashMap::new();
+                self.refresh_charge();
+            }
+            return;
+        }
+        let Some((chunk_id, slot)) = self.positions.remove(&token) else {
+            return;
+        };
+        let Some(heap) = self.chunks.get_mut(&chunk_id) else {
+            unreachable!("arena receipt chunk is missing");
+        };
+        heap.swap_remove(slot);
+        if slot < heap.len() {
+            let Some(position) = self.positions.get_mut(&heap[slot].token) else {
+                unreachable!("arena receipt position is missing");
+            };
+            position.1 = slot;
+            if slot > 0 && heap[slot] < heap[(slot - 1) / 2] {
+                Self::sift_up(heap, &mut self.positions, slot);
+            } else {
+                Self::sift_down(heap, &mut self.positions, slot);
+            }
+        }
+        if heap.is_empty() {
+            self.spilled_heap_bytes -= Self::heap_bytes(heap);
+            self.chunks.remove(&chunk_id);
+        } else if heap.len() == 1 && heap.spilled() {
+            // Return to inline storage without allocating in Drop.
+            let remaining = heap[0];
+            self.spilled_heap_bytes -= Self::heap_bytes(heap);
+            *heap = ReceiptHeap::new();
+            heap.push(remaining);
+        }
+        if self.positions.len() <= 1 {
+            self.inline = self
+                .positions
+                .iter()
+                .next()
+                .map(|(&token, &(chunk, slot))| {
+                    let receipt = self.chunks[&chunk][slot];
+                    debug_assert_eq!(receipt.token, token);
+                    (chunk, receipt)
+                });
+            self.positions = HashMap::new();
+            self.chunks = HashMap::new();
+            self.spilled_heap_bytes = 0;
+        }
+        self.refresh_charge();
+    }
+
+    fn capacity_bytes(&self) -> usize {
+        self.chunks.allocation_size() + self.positions.allocation_size() + self.spilled_heap_bytes
+    }
+}
+
+/// A durability pin independent of the chunk's allocation. Held through commit
+/// or undo, it prevents a replaced/deleted row from advancing the WAL floor.
+/// A later durable manifest receipt can take ownership with `pin_lsn`.
+pub struct ArenaLsnPin {
+    registry: CompactArc<Mutex<ReceiptRegistry>>,
+    token: u64,
+}
+
+impl Drop for ArenaLsnPin {
+    fn drop(&mut self) {
+        self.registry.lock().remove(self.token);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ArenaCapacity {
+    pub directory_bytes: usize,
+    pub payload_slots_bytes: usize,
+    pub metadata_bytes: usize,
+    pub free_list_bytes: usize,
+    pub lsn_tree_bytes: usize,
+    pub receipt_bytes: usize,
+}
+
+impl ArenaCapacity {
+    pub fn total(self) -> usize {
+        self.directory_bytes
+            + self.payload_slots_bytes
+            + self.metadata_bytes
+            + self.free_list_bytes
+            + self.lsn_tree_bytes
+            + self.receipt_bytes
+    }
+}
+
 pub struct RowArena {
-    /// Combined data and metadata under single lock
     inner: RwLock<ArenaInner>,
-    /// Free list of cleared slot indices for reuse (separate lock, write-path only)
-    /// This prevents unbounded arena growth during insert/delete cycles
-    free_list: Mutex<Vec<usize>>,
-    /// Bytes of the rows in live slots, kept exact by every mutation
+    receipts: CompactArc<Mutex<ReceiptRegistry>>,
+    /// Committed-slot payload estimate, separate from capacity/last-owner charge.
     bytes: AtomicUsize,
 }
 
 impl RowArena {
-    /// Create a new arena.
-    ///
-    /// Nothing is reserved up front. Reserving 10,000 slots cost every table
-    /// 320 KB before it held a row (80 KB of pointers plus 240 KB of metadata),
-    /// which a schema with many small tables pays over and over, and it bought
-    /// very little: growing a Vec by doubling copies about 2n elements in total
-    /// whatever it starts from, so a 10,000 slot head start only saves copying
-    /// the first 10,000, and the expensive doublings at the end happen either
-    /// way. A caller that knows the size should use [`RowArena::with_capacity`].
     pub fn new() -> Self {
-        Self {
-            inner: RwLock::new(ArenaInner {
-                data: Vec::new(),
-                meta: Vec::new(),
-            }),
-            free_list: Mutex::new(Vec::new()),
-            bytes: AtomicUsize::new(0),
-        }
+        Self::with_capacity(0)
     }
 
-    /// Create a new arena with pre-allocated capacity
+    /// A lazy hint, capped to one chunk. No slot vectors are allocated yet.
     pub fn with_capacity(row_capacity: usize) -> Self {
+        Self::with_optional_account(row_capacity, None)
+    }
+
+    /// Account arena capacity and receipt ownership. Payloads retain their own
+    /// allocation accounts; VersionStore certifies them through Row::into_hot
+    /// before insertion. Standalone callers must account payloads separately.
+    pub fn with_account(row_capacity: usize, account: &MemoryAccount) -> Self {
+        Self::with_optional_account(row_capacity, Some(account))
+    }
+
+    fn with_optional_account(row_capacity: usize, account: Option<&MemoryAccount>) -> Self {
+        let registry = Mutex::new(ReceiptRegistry::new(account));
+        let receipts = match account {
+            Some(account) => CompactArc::new_in(registry, account),
+            None => CompactArc::new(registry),
+        };
         Self {
             inner: RwLock::new(ArenaInner {
-                data: Vec::with_capacity(row_capacity),
-                meta: Vec::with_capacity(row_capacity),
+                chunks: Vec::new(),
+                active: None,
+                next_chunk_id: 0,
+                free_head: None,
+                occupied: 0,
+                slot_count: 0,
+                initial_capacity: row_capacity.min(ARENA_CHUNK_ROWS),
+                directory_charge: account.map(|account| MemoryCharge::new(account, 0)),
             }),
-            free_list: Mutex::new(Vec::new()),
+            receipts,
             bytes: AtomicUsize::new(0),
         }
     }
 
-    /// Insert a row into the arena
-    ///
-    /// Returns the index of the row metadata.
-    /// Reuses cleared slots from the free list to prevent unbounded growth.
-    #[inline]
-    pub fn insert(&self, row_id: i64, txn_id: i64, values: &[Value]) -> usize {
-        // Check free list first (separate lock, doesn't affect read path)
-        let reuse_idx = self.free_list.lock().pop();
-
-        let mut inner = self.inner.write();
-
-        // Convert values to CompactArc<[Value]>
-        let arc_data: CompactArc<[Value]> = CompactArc::from(values.to_vec());
-        self.bytes.fetch_add(row_bytes(values), Ordering::Relaxed);
-
-        let meta = ArenaRowMeta {
-            row_id,
-            txn_id,
-            deleted_at_txn_id: 0,
-        };
-
-        // Reuse a slot from the free list if available
-        if let Some(idx) = reuse_idx {
-            inner.data[idx] = arc_data;
-            inner.meta[idx] = meta;
-            idx
-        } else {
-            inner.data.push(arc_data);
-            let idx = inner.meta.len();
-            inner.meta.push(meta);
-            idx
-        }
+    /// Convenience constructors preserve CompactArc's allocation behavior;
+    /// Result covers arena address and structural capacity failures. Payload
+    /// construction occurs before any arena state changes.
+    pub fn insert(
+        &self,
+        row_id: i64,
+        txn_id: i64,
+        values: &[Value],
+        source_lsn: Option<NonZeroU64>,
+    ) -> Result<ArenaId> {
+        self.insert_arc(row_id, txn_id, CompactArc::from_slice(values), source_lsn)
     }
 
-    /// Insert a row from a Row struct
-    /// Handles all storage types: Shared Arc is cloned O(1), Owned values create new Arc.
-    /// Reuses cleared slots from the free list to prevent unbounded growth.
-    #[inline]
-    pub fn insert_row(&self, row_id: i64, txn_id: i64, row: &Row) -> usize {
-        // Check free list first (separate lock, doesn't affect read path)
-        let reuse_idx = self.free_list.lock().pop();
-
-        let mut inner = self.inner.write();
-
-        // Store Arc for O(1) clone on read
-        // If row is Shared, clone the Arc (O(1))
-        // If row is Owned, create new Arc from values
-        let arc_data = match row.as_arc() {
-            Some(arc) => CompactArc::clone(arc),
-            None => {
-                // Owned storage: create new Arc from values
-                let values: Vec<Value> = row.iter().cloned().collect();
-                CompactArc::from(values)
-            }
-        };
-        self.bytes
-            .fetch_add(row_bytes(&arc_data), Ordering::Relaxed);
-
-        let meta = ArenaRowMeta {
-            row_id,
-            txn_id,
-            deleted_at_txn_id: 0,
-        };
-
-        // Reuse a slot from the free list if available
-        if let Some(idx) = reuse_idx {
-            inner.data[idx] = arc_data;
-            inner.meta[idx] = meta;
-            idx
-        } else {
-            inner.data.push(arc_data);
-            let idx = inner.meta.len();
-            inner.meta.push(meta);
-            idx
-        }
+    pub fn insert_row(
+        &self,
+        row_id: i64,
+        txn_id: i64,
+        row: &Row,
+        source_lsn: Option<NonZeroU64>,
+    ) -> Result<ArenaId> {
+        let data = row
+            .as_arc()
+            .cloned()
+            .unwrap_or_else(|| CompactArc::from(row.iter().cloned().collect::<Vec<_>>()));
+        self.insert_arc(row_id, txn_id, data, source_lsn)
     }
 
-    /// Insert a row and return both the index AND the Arc
-    /// This allows the caller to reuse the Arc for O(1) clones
-    /// Handles all storage types: Shared Arc is cloned O(1), Owned values create new Arc.
-    /// Reuses cleared slots from the free list to prevent unbounded growth.
-    #[inline]
     pub fn insert_row_get_arc(
         &self,
         row_id: i64,
         txn_id: i64,
         row: &Row,
-    ) -> (usize, CompactArc<[Value]>) {
-        // Check free list first (separate lock, doesn't affect read path)
-        let reuse_idx = self.free_list.lock().pop();
+        source_lsn: Option<NonZeroU64>,
+    ) -> Result<(ArenaId, CompactArc<[Value]>)> {
+        let data = row
+            .as_arc()
+            .cloned()
+            .unwrap_or_else(|| CompactArc::from(row.iter().cloned().collect::<Vec<_>>()));
+        let id = self.insert_arc(row_id, txn_id, data.clone(), source_lsn)?;
+        Ok((id, data))
+    }
 
+    /// Insert an existing payload without changing its allocation account.
+    pub fn insert_arc(
+        &self,
+        row_id: i64,
+        txn_id: i64,
+        data: CompactArc<[Value]>,
+        source_lsn: Option<NonZeroU64>,
+    ) -> Result<ArenaId> {
+        let bytes = row_bytes(&data);
         let mut inner = self.inner.write();
+        let id = inner.insert(row_id, txn_id, data, source_lsn)?;
+        self.bytes.fetch_add(bytes, Ordering::Relaxed);
+        Ok(id)
+    }
 
-        // Create Arc once, clone for storage and return
-        let arc_data = match row.as_arc() {
-            Some(arc) => CompactArc::clone(arc),
-            None => {
-                // Owned storage: create new Arc from values
-                let values: Vec<Value> = row.iter().cloned().collect();
-                CompactArc::from(values)
-            }
+    /// Replace an occupied slot belonging to this row, including a frozen slot.
+    /// LSN tree growth can fail before a formerly unlogged slot is changed.
+    pub fn update_at(
+        &self,
+        id: ArenaId,
+        row_id: i64,
+        txn_id: i64,
+        data: CompactArc<[Value]>,
+        source_lsn: Option<NonZeroU64>,
+    ) -> Result<bool> {
+        if txn_id == 0 {
+            return Err(Error::internal("arena transaction identity cannot be zero"));
+        }
+        let mut inner = self.inner.write();
+        let Some(position) = inner.position(id.chunk_id()) else {
+            return Ok(false);
         };
-        self.bytes
-            .fetch_add(row_bytes(&arc_data), Ordering::Relaxed);
-
-        let meta = ArenaRowMeta {
+        let chunk = &mut inner.chunks[position];
+        let Some((meta, old_data)) = chunk.get(id.slot()) else {
+            return Ok(false);
+        };
+        if meta.row_id != row_id {
+            return Ok(false);
+        }
+        let old_lsn = meta.source_lsn;
+        let old_bytes = row_bytes(old_data);
+        if source_lsn.is_some() {
+            chunk.reserve_lsn(id.slot())?;
+        }
+        let new_bytes = row_bytes(&data);
+        chunk.data[id.slot()] = Some(data);
+        chunk.meta[id.slot()] = ArenaRowMeta {
             row_id,
             txn_id,
             deleted_at_txn_id: 0,
+            source_lsn,
         };
-
-        // Reuse a slot from the free list if available
-        let idx = if let Some(idx) = reuse_idx {
-            inner.data[idx] = CompactArc::clone(&arc_data);
-            inner.meta[idx] = meta;
-            idx
-        } else {
-            inner.data.push(CompactArc::clone(&arc_data));
-            let idx = inner.meta.len();
-            inner.meta.push(meta);
-            idx
-        };
-        (idx, arc_data)
+        chunk
+            .lsn_minima
+            .changed(id.slot(), old_lsn, source_lsn, &chunk.meta);
+        self.bytes.fetch_add(new_bytes, Ordering::Relaxed);
+        self.bytes.fetch_sub(old_bytes, Ordering::Relaxed);
+        Ok(true)
     }
 
-    /// Insert an already-created Arc directly - avoids copy when caller has Arc
-    /// Returns the index where it was stored
-    /// Reuses cleared slots from the free list to prevent unbounded growth.
-    #[inline]
-    pub fn insert_arc(&self, row_id: i64, txn_id: i64, arc_data: CompactArc<[Value]>) -> usize {
-        // Check free list first (separate lock, doesn't affect read path)
-        let reuse_idx = self.free_list.lock().pop();
-
+    pub fn mark_deleted(
+        &self,
+        id: ArenaId,
+        row_id: i64,
+        deleted_at_txn_id: i64,
+        source_lsn: Option<NonZeroU64>,
+    ) -> Result<bool> {
+        if deleted_at_txn_id == 0 {
+            return Err(Error::internal(
+                "arena deletion transaction identity cannot be zero",
+            ));
+        }
         let mut inner = self.inner.write();
-        self.bytes
-            .fetch_add(row_bytes(&arc_data), Ordering::Relaxed);
-
-        let meta = ArenaRowMeta {
-            row_id,
-            txn_id,
-            deleted_at_txn_id: 0,
+        let Some(position) = inner.position(id.chunk_id()) else {
+            return Ok(false);
         };
-
-        // Reuse a slot from the free list if available
-        if let Some(idx) = reuse_idx {
-            inner.data[idx] = arc_data;
-            inner.meta[idx] = meta;
-            idx
-        } else {
-            inner.data.push(arc_data);
-            let idx = inner.meta.len();
-            inner.meta.push(meta);
-            idx
+        let chunk = &mut inner.chunks[position];
+        let Some((meta, _)) = chunk.get(id.slot()) else {
+            return Ok(false);
+        };
+        if meta.row_id != row_id {
+            return Ok(false);
         }
+        let old_lsn = meta.source_lsn;
+        if source_lsn.is_some() {
+            chunk.reserve_lsn(id.slot())?;
+        }
+        chunk.meta[id.slot()].deleted_at_txn_id = deleted_at_txn_id;
+        chunk.meta[id.slot()].source_lsn = source_lsn;
+        chunk
+            .lsn_minima
+            .changed(id.slot(), old_lsn, source_lsn, &chunk.meta);
+        Ok(true)
     }
 
-    /// Mark a row as deleted
-    #[inline]
-    pub fn mark_deleted(&self, row_idx: usize, deleted_at_txn_id: i64) {
+    /// Clear only the expected latest mutation. Duplicate/stale clears do not
+    /// release another row's bytes or add duplicate free-list entries.
+    pub fn clear_at(&self, id: ArenaId, row_id: i64, txn_id: i64) -> bool {
         let mut inner = self.inner.write();
-        if row_idx < inner.meta.len() {
-            inner.meta[row_idx].deleted_at_txn_id = deleted_at_txn_id;
-        }
+        let freed = inner.clear(id, row_id, txn_id);
+        self.bytes.fetch_sub(freed, Ordering::Relaxed);
+        freed != 0
     }
 
-    /// Clear a slot in the arena to release memory
-    ///
-    /// This replaces the data with an empty Arc and marks the metadata as cleared
-    /// (row_id = 0). The slot index is added to the free list for reuse.
-    /// This is used during cleanup of deleted rows.
-    #[inline]
-    pub fn clear_at(&self, arena_idx: usize) -> bool {
-        let cleared = {
-            let mut inner = self.inner.write();
-            if arena_idx < inner.meta.len() {
-                self.bytes
-                    .fetch_sub(row_bytes(&inner.data[arena_idx]), Ordering::Relaxed);
-                // Replace data with empty Arc to release memory
-                inner.data[arena_idx] = CompactArc::from(Vec::<Value>::new());
-                // Mark metadata as cleared (txn_id = 0 is the cleared sentinel;
-                // row_id = 0 is a valid user PK, but txn_id is always > 0 for real rows)
-                inner.meta[arena_idx] = ArenaRowMeta {
-                    row_id: 0,
-                    txn_id: 0,
-                    deleted_at_txn_id: 0,
-                };
-                true
-            } else {
-                false
-            }
-        };
-
-        if cleared {
-            // Add to free list for reuse (separate lock)
-            self.free_list.lock().push(arena_idx);
+    pub fn clear_batch(&self, identities: &[(ArenaId, i64, i64)]) -> usize {
+        let mut inner = self.inner.write();
+        let mut count = 0;
+        let mut bytes = 0;
+        for &(id, row_id, txn_id) in identities {
+            let freed = inner.clear(id, row_id, txn_id);
+            count += usize::from(freed != 0);
+            bytes += freed;
         }
-        cleared
-    }
-
-    /// Clear multiple slots in the arena efficiently (single lock acquisition)
-    ///
-    /// Returns the number of slots actually cleared.
-    /// Cleared indices are added to the free list for reuse.
-    #[inline]
-    pub fn clear_batch(&self, arena_indices: &[usize]) -> usize {
-        let mut cleared_indices = Vec::with_capacity(arena_indices.len());
-
-        {
-            let mut inner = self.inner.write();
-            let empty_data: CompactArc<[Value]> = CompactArc::from(Vec::<Value>::new());
-            let cleared_meta = ArenaRowMeta {
-                row_id: 0,
-                txn_id: 0,
-                deleted_at_txn_id: 0,
-            };
-
-            let mut freed = 0usize;
-            for &arena_idx in arena_indices {
-                if arena_idx < inner.meta.len() {
-                    freed += row_bytes(&inner.data[arena_idx]);
-                    inner.data[arena_idx] = CompactArc::clone(&empty_data);
-                    inner.meta[arena_idx] = cleared_meta;
-                    cleared_indices.push(arena_idx);
-                }
-            }
-            self.bytes.fetch_sub(freed, Ordering::Relaxed);
-        }
-
-        // Add to free list for reuse (separate lock, after releasing inner lock)
-        let count = cleared_indices.len();
-        if count > 0 {
-            let mut free_list = self.free_list.lock();
-            free_list.reserve(count);
-            free_list.extend(cleared_indices);
-        }
+        self.bytes.fetch_sub(bytes, Ordering::Relaxed);
         count
     }
 
-    /// Update data at an existing arena index (for slot reuse during UPDATEs)
-    ///
-    /// This replaces both data and metadata at the given index, avoiding
-    /// unbounded arena growth during update-heavy workloads.
-    /// Returns true if the update was successful, false if index out of bounds.
-    #[inline]
-    pub fn update_at(
-        &self,
-        arena_idx: usize,
-        row_id: i64,
-        txn_id: i64,
-        arc_data: CompactArc<[Value]>,
-    ) -> bool {
+    /// Retire the current free list. The next active chunk starts unallocated.
+    #[cfg(test)]
+    pub fn freeze_active(&self) -> Result<Option<ChunkId>> {
         let mut inner = self.inner.write();
-        if arena_idx < inner.meta.len() {
-            let old = row_bytes(&inner.data[arena_idx]);
-            self.bytes
-                .fetch_add(row_bytes(&arc_data), Ordering::Relaxed);
-            self.bytes.fetch_sub(old, Ordering::Relaxed);
-            inner.data[arena_idx] = arc_data;
-            inner.meta[arena_idx] = ArenaRowMeta {
-                row_id,
-                txn_id,
-                deleted_at_txn_id: 0,
-            };
-            true
-        } else {
-            false
-        }
+        let Some(active) = inner.active else {
+            return Ok(None);
+        };
+        // Do not freeze successfully if opening a successor can never succeed.
+        ChunkId::new(inner.next_chunk_id)?;
+        inner.chunks.last_mut().unwrap().frozen = true;
+        inner.active = None;
+        inner.free_head = None;
+        Ok(Some(active))
     }
 
-    /// Drop all data and release the memory.
-    /// This releases all memory immediately (O(1) memory release)
-    /// unlike clear_batch which only clears slots but retains Vec capacity.
+    /// Release every slot allocation without recycling chunk identities or
+    /// releasing independently owned durability receipts.
     pub fn clear_all(&self) {
         let mut inner = self.inner.write();
-        inner.data = Vec::new();
-        inner.meta = Vec::new();
-        self.free_list.lock().clear();
+        inner.chunks = Vec::new();
+        inner.refresh_directory_charge();
+        inner.active = None;
+        inner.free_head = None;
+        inner.occupied = 0;
+        inner.slot_count = 0;
         self.bytes.store(0, Ordering::Relaxed);
     }
 
-    /// Get the number of rows (including deleted)
-    #[inline]
     pub fn len(&self) -> usize {
-        self.inner.read().meta.len()
+        self.inner.read().occupied
     }
-
-    /// Bytes of the rows in live slots
-    #[inline]
+    pub fn slot_count(&self) -> usize {
+        self.inner.read().slot_count
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
     pub fn bytes(&self) -> usize {
         self.bytes.load(Ordering::Relaxed)
     }
 
-    /// Bytes the slot vectors reserve, used or not
-    pub fn capacity_bytes(&self) -> usize {
+    pub fn capacity(&self) -> ArenaCapacity {
         let inner = self.inner.read();
-        inner.data.capacity() * std::mem::size_of::<CompactArc<[Value]>>()
-            + inner.meta.capacity() * std::mem::size_of::<ArenaRowMeta>()
+        let receipts = self.receipts.lock();
+        let mut result = ArenaCapacity {
+            directory_bytes: inner.chunks.capacity() * std::mem::size_of::<Chunk>(),
+            // Free links occupy otherwise vacant metadata, counted below.
+            free_list_bytes: 0,
+            receipt_bytes: self.receipts.allocation_size() + receipts.capacity_bytes(),
+            ..ArenaCapacity::default()
+        };
+        for chunk in &inner.chunks {
+            result.payload_slots_bytes +=
+                chunk.data.capacity() * std::mem::size_of::<Option<CompactArc<[Value]>>>();
+            result.metadata_bytes += chunk.meta.capacity() * std::mem::size_of::<ArenaRowMeta>();
+            result.lsn_tree_bytes +=
+                chunk.lsn_minima.nodes.capacity() * std::mem::size_of::<Option<NonZeroU64>>();
+        }
+        result
     }
 
-    /// Check if the arena is empty
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.inner.read().meta.is_empty()
+    pub fn capacity_bytes(&self) -> usize {
+        self.capacity().total()
     }
 
-    /// Get read guard for arena data
-    ///
-    /// Returns a guard that provides access to both metadata and data slices.
-    /// Single lock acquisition for both.
-    #[inline]
     pub fn read_guard(&self) -> ArenaReadGuard<'_> {
         ArenaReadGuard {
             inner: self.inner.read(),
         }
     }
 
-    /// Get Arc for a row by arena index - O(1) clone
-    #[inline]
-    pub fn get_arc(&self, arena_idx: usize) -> Option<CompactArc<[Value]>> {
-        let inner = self.inner.read();
-        inner.data.get(arena_idx).cloned()
+    pub fn get_arc(&self, id: ArenaId) -> Option<CompactArc<[Value]>> {
+        self.inner.read().get(id).map(|(_, data)| data.clone())
     }
 
-    /// Get both metadata and Arc for a row by arena index - O(1) with single lock
-    ///
-    /// This is optimized for the visibility fast path where we need to check
-    /// txn_id and deleted_at_txn_id before returning the data.
-    #[inline]
-    pub fn get_meta_and_arc(
-        &self,
-        arena_idx: usize,
-    ) -> Option<(ArenaRowMeta, CompactArc<[Value]>)> {
+    pub fn get_meta_and_arc(&self, id: ArenaId) -> Option<(ArenaRowMeta, CompactArc<[Value]>)> {
+        self.inner
+            .read()
+            .get(id)
+            .map(|(meta, data)| (*meta, data.clone()))
+    }
+
+    #[cfg(test)]
+    pub fn chunk_first_lsn(&self, id: ChunkId) -> Option<NonZeroU64> {
         let inner = self.inner.read();
-        if arena_idx < inner.meta.len() {
-            let meta = inner.meta[arena_idx];
-            let arc = CompactArc::clone(&inner.data[arena_idx]);
-            Some((meta, arc))
-        } else {
-            None
-        }
+        let rows = inner
+            .position(id)
+            .and_then(|position| inner.chunks[position].lsn_minima.first());
+        min_lsn(rows, self.receipts.lock().first(Some(id)))
+    }
+
+    #[cfg(test)]
+    pub fn first_lsn(&self) -> Option<NonZeroU64> {
+        let inner = self.inner.read();
+        let rows = inner
+            .chunks
+            .iter()
+            .filter_map(|chunk| chunk.lsn_minima.first())
+            .min();
+        min_lsn(rows, self.receipts.lock().first(None))
+    }
+
+    /// Pin the current row minimum before publication. Existing receipts are
+    /// deliberately not inherited: overlapping writers must let completed
+    /// predecessors release their older floor.
+    pub fn pin_chunk_lsn(&self, id: ChunkId) -> Result<Option<ArenaLsnPin>> {
+        let inner = self.inner.read();
+        let rows = inner
+            .position(id)
+            .and_then(|position| inner.chunks[position].lsn_minima.first());
+        let Some(lsn) = rows else {
+            return Ok(None);
+        };
+        let mut receipts = self.receipts.lock();
+        let token = receipts.insert(id, lsn)?;
+        Ok(Some(ArenaLsnPin {
+            registry: CompactArc::clone(&self.receipts),
+            token,
+        }))
+    }
+
+    /// Acquire an explicit receipt before relinquishing the row or old receipt
+    /// whose durability ownership is being transferred.
+    #[cfg(test)]
+    pub fn pin_lsn(&self, id: ChunkId, lsn: NonZeroU64) -> Result<ArenaLsnPin> {
+        let token = self.receipts.lock().insert(id, lsn)?;
+        Ok(ArenaLsnPin {
+            registry: CompactArc::clone(&self.receipts),
+            token,
+        })
     }
 }
 
@@ -480,271 +1232,687 @@ impl Default for RowArena {
     }
 }
 
-/// Read guard for arena providing access to both data and metadata
+/// Read-only chunk slices. Payload and metadata positions are parallel;
+/// vacant payloads are None and metadata.txn_id is zero.
+#[derive(Clone, Copy)]
+pub struct ArenaChunkRef<'a> {
+    chunk: &'a Chunk,
+}
+
+impl<'a> ArenaChunkRef<'a> {
+    pub fn id(self) -> ChunkId {
+        self.chunk.id
+    }
+    #[cfg(test)]
+    pub fn is_frozen(self) -> bool {
+        self.chunk.frozen
+    }
+    pub fn len(self) -> usize {
+        self.chunk.occupied
+    }
+    pub fn is_empty(self) -> bool {
+        self.chunk.occupied == 0
+    }
+    pub fn slot_count(self) -> usize {
+        self.chunk.meta.len()
+    }
+    pub fn data(self) -> &'a [Option<CompactArc<[Value]>>] {
+        &self.chunk.data
+    }
+    pub fn meta(self) -> &'a [ArenaRowMeta] {
+        &self.chunk.meta
+    }
+    #[cfg(test)]
+    pub fn row_first_lsn(self) -> Option<NonZeroU64> {
+        self.chunk.lsn_minima.first()
+    }
+    pub fn iter(
+        self,
+    ) -> impl Iterator<Item = (ArenaId, &'a ArenaRowMeta, &'a CompactArc<[Value]>)> + 'a {
+        self.chunk
+            .meta
+            .iter()
+            .zip(&self.chunk.data)
+            .enumerate()
+            .filter_map(move |(slot, (meta, data))| {
+                data.as_ref().map(|data| {
+                    let Ok(id) = ArenaId::from_parts(self.chunk.id, slot) else {
+                        unreachable!("allocated arena address is valid");
+                    };
+                    (id, meta, data)
+                })
+            })
+    }
+}
+
 pub struct ArenaReadGuard<'a> {
     inner: parking_lot::RwLockReadGuard<'a, ArenaInner>,
 }
 
-impl<'a> ArenaReadGuard<'a> {
-    /// Get data slice
-    #[inline]
-    pub fn data(&self) -> &[CompactArc<[Value]>] {
-        &self.inner.data
+impl ArenaReadGuard<'_> {
+    pub fn get(&self, id: ArenaId) -> Option<&CompactArc<[Value]>> {
+        self.inner.get(id).map(|(_, data)| data)
     }
-
-    /// Get metadata slice
-    #[inline]
-    pub fn meta(&self) -> &[ArenaRowMeta] {
-        &self.inner.meta
+    pub fn get_meta(&self, id: ArenaId) -> Option<&ArenaRowMeta> {
+        self.inner.get(id).map(|(meta, _)| meta)
     }
-
-    /// Get length
-    #[inline]
+    pub fn get_entry(&self, id: ArenaId) -> Option<(&ArenaRowMeta, &CompactArc<[Value]>)> {
+        self.inner.get(id)
+    }
+    /// Reuse the directory position while reading nearby rows. The guard
+    /// prevents directory mutation; usize::MAX is an empty cache.
+    pub fn get_entry_cached(
+        &self,
+        id: ArenaId,
+        cache: &mut usize,
+    ) -> Option<(&ArenaRowMeta, &CompactArc<[Value]>)> {
+        if self
+            .inner
+            .chunks
+            .get(*cache)
+            .is_none_or(|chunk| chunk.id != id.chunk_id())
+        {
+            *cache = self.inner.position(id.chunk_id())?;
+        }
+        self.inner.chunks[*cache].get(id.slot())
+    }
+    pub fn chunks(&self) -> impl DoubleEndedIterator<Item = ArenaChunkRef<'_>> + ExactSizeIterator {
+        self.inner
+            .chunks
+            .iter()
+            .map(|chunk| ArenaChunkRef { chunk })
+    }
+    pub fn iter(&self) -> impl Iterator<Item = (ArenaId, &ArenaRowMeta, &CompactArc<[Value]>)> {
+        self.chunks().flat_map(ArenaChunkRef::iter)
+    }
     pub fn len(&self) -> usize {
-        self.inner.meta.len()
+        self.inner.occupied
     }
-
-    /// Check if empty
-    #[inline]
+    pub fn slot_count(&self) -> usize {
+        self.inner.slot_count
+    }
     pub fn is_empty(&self) -> bool {
-        self.inner.meta.is_empty()
+        self.inner.occupied == 0
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::Value;
+
+    fn lsn(value: u64) -> Option<NonZeroU64> {
+        NonZeroU64::new(value)
+    }
+
+    fn payload(value: i64) -> CompactArc<[Value]> {
+        CompactArc::from(vec![Value::Integer(value)])
+    }
 
     #[test]
-    fn bytes_follow_inserts_updates_and_clears() {
-        let arena = RowArena::new();
-        assert_eq!(arena.bytes(), 0);
-        let short = vec![Value::Integer(1), Value::text("inline")];
-        let long = vec![
-            Value::Integer(1),
-            Value::text("a text value that lives on the heap"),
-        ];
-        let mut spacious = String::with_capacity(4096);
-        spacious.push_str("a text value that lives on the heap");
-        let spacious = vec![
-            Value::Integer(1),
-            Value::Text(crate::common::SmartString::from_string(spacious)),
-        ];
-        assert!(
-            row_bytes(&spacious) >= row_bytes(&long) + 4096 - 64,
-            "a String's spare capacity is memory the row owns"
-        );
-        let idx = arena.insert(1, 1, &short);
-        assert_eq!(arena.bytes(), row_bytes(&short));
-        assert!(row_bytes(&long) > row_bytes(&short));
-        arena.update_at(idx, 1, 2, CompactArc::from(long.clone()));
-        assert_eq!(arena.bytes(), row_bytes(&long));
-        let other = arena.insert(2, 2, &short);
-        assert_eq!(arena.bytes(), row_bytes(&long) + row_bytes(&short));
-        arena.clear_batch(&[idx]);
-        assert_eq!(arena.bytes(), row_bytes(&short));
-        assert!(arena.clear_at(other));
-        assert_eq!(arena.bytes(), 0);
-        let reused = arena.insert(3, 3, &long);
-        assert_eq!(arena.bytes(), row_bytes(&long));
+    fn structural_charges_follow_capacity_and_the_last_receipt_owner() {
+        let root = MemoryAccount::new();
+        let baseline = root.snapshot().accounted_bytes;
+        let origin = root.child();
+        let arena = RowArena::with_account(0, &origin);
+        assert_eq!(root.snapshot().retained_bytes, arena.capacity_bytes());
+        let data = payload(7); // Payload accounting belongs to hot ingress.
+        let mut ids = Vec::new();
+        for row in 0..=LSN_LEAF_ROWS {
+            ids.push(arena.insert_arc(row as i64, 1, data.clone(), None).unwrap());
+        }
+        assert_eq!(root.snapshot().retained_bytes, arena.capacity_bytes());
+        arena
+            .update_at(ids[0], 0, 2, data.clone(), lsn(10))
+            .unwrap();
+        arena
+            .update_at(
+                ids[LSN_LEAF_ROWS],
+                LSN_LEAF_ROWS as i64,
+                2,
+                data.clone(),
+                lsn(20),
+            )
+            .unwrap();
+        assert_eq!(root.snapshot().retained_bytes, arena.capacity_bytes());
+        let pin = arena.pin_chunk_lsn(ids[0].chunk_id()).unwrap().unwrap();
+        let more = arena
+            .pin_lsn(ids[0].chunk_id(), NonZeroU64::new(30).unwrap())
+            .unwrap();
+        assert_eq!(root.snapshot().retained_bytes, arena.capacity_bytes());
+        drop(more);
+        assert_eq!(root.snapshot().retained_bytes, arena.capacity_bytes());
+        arena.freeze_active().unwrap();
         arena.clear_all();
+        assert_eq!(root.snapshot().retained_bytes, arena.capacity_bytes());
+        let receipt_capacity = arena.capacity().receipt_bytes;
+        drop(origin);
+        drop(arena);
+        assert_eq!(root.snapshot().retained_bytes, receipt_capacity);
+        drop(pin);
+        assert_eq!(root.snapshot().retained_bytes, 0);
+        assert_eq!(root.snapshot().accounted_bytes, baseline);
+    }
+
+    #[test]
+    fn lsn_tree_growth_accounts_the_simultaneously_live_buffers() {
+        let root = MemoryAccount::new();
+        // Preallocate the parallel slot arrays so only the LSN tree grows.
+        let arena = RowArena::with_account(LSN_LEAF_ROWS + 1, &root);
+        let data = payload(1);
+        let ids: Vec<_> = (0..=LSN_LEAF_ROWS)
+            .map(|slot| {
+                arena
+                    .insert_arc(slot as i64, 1, data.clone(), None)
+                    .unwrap()
+            })
+            .collect();
+        arena
+            .update_at(ids[0], 0, 2, data.clone(), lsn(10))
+            .unwrap();
+        let before = root.snapshot().accounted_bytes;
+        let old_tree_bytes = arena.capacity().lsn_tree_bytes;
+        assert_eq!(old_tree_bytes, 16);
+        arena
+            .update_at(ids[LSN_LEAF_ROWS], LSN_LEAF_ROWS as i64, 2, data, lsn(20))
+            .unwrap();
+        let new_tree_bytes = arena.capacity().lsn_tree_bytes;
+        assert_eq!(new_tree_bytes, 32);
+        assert_eq!(
+            root.snapshot().peak_accounted_bytes,
+            before + new_tree_bytes
+        );
+        assert_eq!(root.snapshot().retained_bytes, arena.capacity_bytes());
+    }
+
+    #[test]
+    fn directory_growth_accounts_the_simultaneously_live_buffers() {
+        let root = MemoryAccount::new();
+        let arena = RowArena::with_account(0, &root);
+        let mut inner = arena.inner.write();
+        inner.reserve_directory_slot().unwrap();
+        let count = inner.chunks.capacity();
+        // Empty test chunks isolate the directory's physical allocations.
+        for value in 0..count {
+            inner
+                .chunks
+                .push(Chunk::new(ChunkId::new(value as u64).unwrap(), Some(&root)));
+        }
+        let before = root.snapshot().accounted_bytes;
+        inner.reserve_directory_slot().unwrap();
+        let new_directory_bytes = inner.chunks.capacity() * std::mem::size_of::<Chunk>();
+        assert_eq!(
+            root.snapshot().peak_accounted_bytes,
+            before + new_directory_bytes
+        );
+        drop(inner);
+        assert_eq!(root.snapshot().retained_bytes, arena.capacity_bytes());
+    }
+
+    #[test]
+    fn one_receipt_promotes_and_demotes_without_losing_identity_or_charge() {
+        let root = MemoryAccount::new();
+        let arena = RowArena::with_account(0, &root);
+        let baseline = root.snapshot().retained_bytes;
+        let first_chunk = ChunkId::new(3).unwrap();
+        let other_chunk = ChunkId::new(9).unwrap();
+        for _ in 0..32 {
+            let single = arena
+                .pin_lsn(first_chunk, NonZeroU64::new(20).unwrap())
+                .unwrap();
+            assert_eq!(root.snapshot().retained_bytes, baseline);
+            assert_eq!(arena.chunk_first_lsn(first_chunk), lsn(20));
+            assert_eq!(arena.chunk_first_lsn(other_chunk), None);
+            drop(single);
+            assert_eq!(arena.first_lsn(), None);
+            assert_eq!(root.snapshot().retained_bytes, baseline);
+        }
+        let first = arena
+            .pin_lsn(first_chunk, NonZeroU64::new(20).unwrap())
+            .unwrap();
+        let second = arena
+            .pin_lsn(first_chunk, NonZeroU64::new(10).unwrap())
+            .unwrap();
+        assert!(root.snapshot().retained_bytes > baseline);
+        assert_eq!(root.snapshot().retained_bytes, arena.capacity_bytes());
+        assert_eq!(arena.first_lsn(), lsn(10));
+        drop(first);
+        assert_eq!(root.snapshot().retained_bytes, baseline);
+        assert_eq!(arena.first_lsn(), lsn(10));
+        let third = arena
+            .pin_lsn(other_chunk, NonZeroU64::new(5).unwrap())
+            .unwrap();
+        assert_eq!(arena.chunk_first_lsn(first_chunk), lsn(10));
+        assert_eq!(arena.chunk_first_lsn(other_chunk), lsn(5));
+        drop(second);
+        assert_eq!(root.snapshot().retained_bytes, baseline);
+        assert_eq!(arena.chunk_first_lsn(first_chunk), None);
+        assert_eq!(arena.first_lsn(), lsn(5));
+        // Token exhaustion is checked before changing the existing inline pin.
+        arena.receipts.lock().next_token = u64::MAX;
+        assert!(arena
+            .pin_lsn(first_chunk, NonZeroU64::new(1).unwrap())
+            .is_err());
+        assert_eq!(arena.first_lsn(), lsn(5));
+        assert_eq!(root.snapshot().retained_bytes, baseline);
+        drop(third);
+        assert_eq!(arena.first_lsn(), None);
+        assert_eq!(root.snapshot().retained_bytes, baseline);
+    }
+
+    #[test]
+    fn partial_receipt_promotion_failure_preserves_the_original_pin() {
+        let root = MemoryAccount::new();
+        let arena = RowArena::with_account(0, &root);
+        let baseline = root.snapshot().retained_bytes;
+        let chunk = ChunkId::new(7).unwrap();
+        let first = arena.pin_lsn(chunk, NonZeroU64::new(10).unwrap()).unwrap();
+        let token = first.token;
+        arena.receipts.lock().fail_promotion_after_positions = true;
+        assert!(arena.pin_lsn(chunk, NonZeroU64::new(5).unwrap()).is_err());
+        assert_eq!(arena.first_lsn(), lsn(10));
+        assert_eq!(arena.receipts.lock().next_token, token);
+        // The first hash allocation succeeded before the injected second
+        // allocation failure. Its retained bytes must not disappear from the ledger.
+        assert!(root.snapshot().retained_bytes > baseline);
+        assert_eq!(root.snapshot().retained_bytes, arena.capacity_bytes());
+        let second = arena.pin_lsn(chunk, NonZeroU64::new(5).unwrap()).unwrap();
+        assert_eq!(second.token, token + 1);
+        drop(second);
+        assert_eq!(arena.first_lsn(), lsn(10));
+        assert_eq!(root.snapshot().retained_bytes, baseline);
+        // Failure followed by release (instead of retry) frees partial capacity too.
+        arena.receipts.lock().fail_promotion_after_positions = true;
+        assert!(arena.pin_lsn(chunk, NonZeroU64::new(5).unwrap()).is_err());
+        drop(first);
+        assert_eq!(arena.first_lsn(), None);
+        assert_eq!(root.snapshot().retained_bytes, baseline);
+    }
+
+    #[test]
+    fn receipt_map_replacement_charges_exact_old_and_new_buckets() {
+        let root = MemoryAccount::new();
+        let mut charge = Some(MemoryCharge::new(&root, 0));
+        let mut map = ReceiptPositions::new();
+        reserve_receipt_map(&mut map, 2, &mut charge).unwrap();
+        for token in 0..map.capacity() {
+            map.insert(token as u64, (ChunkId::new(7).unwrap(), token));
+        }
+        let old_bytes = map.allocation_size();
+        let before = root.snapshot();
+        reserve_receipt_map(&mut map, 1, &mut charge).unwrap();
+        let new_bytes = map.allocation_size();
+        assert!(new_bytes > old_bytes);
+        assert_eq!(root.snapshot().retained_bytes, new_bytes);
+        assert_eq!(
+            root.snapshot().peak_accounted_bytes,
+            before.accounted_bytes + new_bytes
+        );
+        for (token, &(chunk, position)) in &map {
+            assert_eq!(chunk, ChunkId::new(7).unwrap());
+            assert_eq!(*token, position as u64);
+        }
+        let before_failure = root.snapshot();
+        assert!(reserve_receipt_map(&mut map, usize::MAX, &mut charge).is_err());
+        assert_eq!(root.snapshot(), before_failure);
+        drop(map);
+        drop(charge);
+        assert_eq!(root.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn receipt_heap_replacement_charges_exact_old_and_new_buffers() {
+        let root = MemoryAccount::new();
+        let mut charge = Some(MemoryCharge::new(&root, 0));
+        let mut heap = ReceiptHeap::new();
+        heap.push(Receipt {
+            token: 1,
+            lsn: lsn(10).unwrap(),
+        });
+        ReceiptRegistry::reserve_heap(&mut heap, 1, &mut charge).unwrap();
+        heap.push(Receipt {
+            token: 2,
+            lsn: lsn(20).unwrap(),
+        });
+        let before = root.snapshot();
+        ReceiptRegistry::reserve_heap(&mut heap, 1, &mut charge).unwrap();
+        let new_bytes = ReceiptRegistry::heap_bytes(&heap);
+        assert_eq!(root.snapshot().retained_bytes, new_bytes);
+        assert_eq!(
+            root.snapshot().peak_accounted_bytes,
+            before.accounted_bytes + new_bytes
+        );
+        assert_eq!(heap[0].token, 1);
+        assert_eq!(heap[1].token, 2);
+        let before_failure = root.snapshot();
+        assert!(ReceiptRegistry::reserve_heap(&mut heap, usize::MAX, &mut charge).is_err());
+        assert_eq!(root.snapshot(), before_failure);
+        drop(heap);
+        drop(charge);
+        assert_eq!(root.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn addresses_are_checked_and_keep_the_nonzero_niche() {
+        let first = ArenaId::from_parts(ChunkId::new(0).unwrap(), 0).unwrap();
+        assert_eq!(first.as_nonzero().get(), 1);
+        assert_eq!(first.chunk_id().get(), 0);
+        assert_eq!(first.slot(), 0);
+        assert!(ChunkId::new(MAX_CHUNK_ID + 1).is_err());
+        let last_chunk = ChunkId::new(MAX_CHUNK_ID).unwrap();
+        assert!(ArenaId::from_parts(last_chunk, ARENA_CHUNK_ROWS - 1).is_err());
+        assert!(ArenaId::from_parts(last_chunk, ARENA_CHUNK_ROWS).is_err());
+        let last = ArenaId::from_parts(last_chunk, ARENA_CHUNK_ROWS - 2).unwrap();
+        assert_eq!(last.as_nonzero().get(), u64::MAX);
+        assert_eq!(ArenaId::from_nonzero(last.as_nonzero()), last);
+
+        let arena = RowArena::new();
+        arena.inner.write().next_chunk_id = MAX_CHUNK_ID + 1;
+        let capacity = arena.capacity();
+        assert!(arena.insert_arc(0, 1, payload(0), lsn(1)).is_err());
+        assert!(arena.is_empty());
         assert_eq!(arena.bytes(), 0);
-        assert!(reused < 2);
+        assert_eq!(arena.capacity(), capacity);
     }
 
     #[test]
-    fn test_arena_insert_and_iterate() {
+    fn real_chunk_boundary_releases_the_old_allocation() {
         let arena = RowArena::new();
-
-        // Insert some rows
-        arena.insert(
-            1,
-            100,
-            &[Value::Integer(1), Value::text("Alice"), Value::Float(100.0)],
-        );
-        arena.insert(
-            2,
-            100,
-            &[Value::Integer(2), Value::text("Bob"), Value::Float(200.0)],
-        );
-        arena.insert(
-            3,
-            100,
-            &[Value::Integer(3), Value::text("Carol"), Value::Float(300.0)],
-        );
-
-        assert_eq!(arena.len(), 3);
-
-        // Iterate using read_guard
-        let guard = arena.read_guard();
-        let mut count = 0;
-        let mut sum = 0.0f64;
-
-        for (idx, _meta) in guard.meta().iter().enumerate() {
-            count += 1;
-            if let Some(Value::Float(v)) = guard.data()[idx].get(2) {
-                sum += v;
-            }
+        let data = payload(7);
+        let first = arena.insert_arc(0, 1, data.clone(), None).unwrap();
+        for row_id in 1..=ARENA_CHUNK_ROWS {
+            let id = arena
+                .insert_arc(row_id as i64, 1, data.clone(), None)
+                .unwrap();
+            assert_eq!(id.chunk_id().get(), (row_id / ARENA_CHUNK_ROWS) as u64);
+            assert_eq!(id.slot(), row_id % ARENA_CHUNK_ROWS);
         }
-
-        assert_eq!(count, 3);
-        assert_eq!(sum, 600.0);
-    }
-
-    #[test]
-    fn test_arena_arc_clone() {
-        let arena = RowArena::new();
-
-        arena.insert(1, 100, &[Value::Integer(42), Value::text("test")]);
-
-        let guard = arena.read_guard();
-        assert_eq!(guard.len(), 1);
-
-        // Get row as Arc - O(1) clone
-        let row_arc = CompactArc::clone(&guard.data()[0]);
-        assert_eq!(row_arc.len(), 2);
-
-        if let Value::Integer(v) = &row_arc[0] {
-            assert_eq!(*v, 42);
-        } else {
-            panic!("Expected Integer");
-        }
-    }
-
-    #[test]
-    fn test_arena_deletion() {
-        let arena = RowArena::new();
-
-        let idx = arena.insert(1, 100, &[Value::Integer(1), Value::text("test")]);
-
-        // Mark as deleted
-        arena.mark_deleted(idx, 101);
-
-        let guard = arena.read_guard();
-        assert!(guard.meta()[0].is_deleted());
-        assert_eq!(guard.meta()[0].deleted_at_txn_id, 101);
-    }
-
-    #[test]
-    fn test_arena_get_column_value() {
-        let arena = RowArena::new();
-
-        arena.insert(
-            1,
-            100,
-            &[Value::Integer(42), Value::text("hello"), Value::Float(3.15)],
-        );
-
-        let guard = arena.read_guard();
-
-        // Get column 0
-        let val = guard.data()[0].first().cloned();
-        assert_eq!(val, Some(Value::Integer(42)));
-
-        // Get column 1
-        let val = guard.data()[0].get(1).cloned();
-        assert_eq!(val, Some(Value::text("hello")));
-
-        // Get column 2
-        let val = guard.data()[0].get(2).cloned();
-        assert_eq!(val, Some(Value::Float(3.15)));
-
-        // Out of bounds column - returns None
-        let val: Option<Value> = guard.data()[0].get(3).cloned();
-        assert_eq!(val, None);
-    }
-
-    #[test]
-    fn test_arena_read_guard() {
-        let arena = RowArena::new();
-
-        arena.insert(1, 100, &[Value::Integer(1), Value::text("a")]);
-        arena.insert(2, 100, &[Value::Integer(2), Value::text("b")]);
-
-        let guard = arena.read_guard();
-        assert_eq!(guard.len(), 2);
-        assert_eq!(guard.meta()[0].row_id, 1);
-        assert_eq!(guard.meta()[1].row_id, 2);
-    }
-
-    #[test]
-    fn test_arena_free_list_reuse() {
-        let arena = RowArena::new();
-
-        // Insert 5 rows
-        for i in 1..=5 {
-            arena.insert(
-                i,
-                100,
-                &[Value::Integer(i), Value::text(format!("row{}", i))],
+        let next = ArenaId::from_parts(ChunkId::new(1).unwrap(), 0).unwrap();
+        assert_eq!(arena.len(), ARENA_CHUNK_ROWS + 1);
+        let before = arena.capacity();
+        {
+            let guard = arena.read_guard();
+            let chunks: Vec<_> = guard.chunks().collect();
+            assert_eq!(chunks.len(), 2);
+            assert!(chunks[0].is_frozen());
+            assert!(!chunks[1].is_frozen());
+            assert_eq!(chunks[0].slot_count(), ARENA_CHUNK_ROWS);
+            assert_eq!(guard.get_meta(first).unwrap().row_id, 0);
+            assert_eq!(
+                guard.get_meta(next).unwrap().row_id,
+                ARENA_CHUNK_ROWS as i64
             );
         }
-        assert_eq!(arena.len(), 5);
-
-        // Clear slots 1 and 3 (0-indexed)
-        arena.clear_at(1);
-        arena.clear_at(3);
-
-        // Arena len is still 5 (slots are cleared but not removed)
-        assert_eq!(arena.len(), 5);
-
-        // Verify cleared slots have row_id = 0
-        {
-            let guard = arena.read_guard();
-            assert_eq!(guard.meta()[1].row_id, 0);
-            assert_eq!(guard.meta()[3].row_id, 0);
+        for begin in (0..ARENA_CHUNK_ROWS).step_by(2000) {
+            let identities: Vec<_> = (begin..(begin + 2000).min(ARENA_CHUNK_ROWS))
+                .map(|slot| {
+                    (
+                        ArenaId::from_parts(first.chunk_id(), slot).unwrap(),
+                        slot as i64,
+                        1,
+                    )
+                })
+                .collect();
+            assert_eq!(arena.clear_batch(&identities), identities.len());
         }
-
-        // Insert new rows - should reuse cleared slots (3 then 1, LIFO order)
-        let idx1 = arena.insert(10, 200, &[Value::Integer(10), Value::text("new1")]);
-        let idx2 = arena.insert(11, 200, &[Value::Integer(11), Value::text("new2")]);
-
-        // Slots should be reused, not appended
-        assert_eq!(arena.len(), 5); // Still 5, slots were reused
-
-        // Verify indices are the cleared slots (LIFO: 3 was pushed last, so popped first)
-        assert_eq!(idx1, 3);
-        assert_eq!(idx2, 1);
-
-        // Verify the new data is in the reused slots
-        {
-            let guard = arena.read_guard();
-            assert_eq!(guard.meta()[3].row_id, 10);
-            assert_eq!(guard.meta()[1].row_id, 11);
-        }
-
-        // Insert one more - should append since free list is empty
-        let idx3 = arena.insert(12, 200, &[Value::Integer(12), Value::text("new3")]);
-        assert_eq!(idx3, 5); // New slot at end
-        assert_eq!(arena.len(), 6);
+        let after = arena.capacity();
+        assert!(after.metadata_bytes < before.metadata_bytes / 100);
+        assert!(after.payload_slots_bytes < before.payload_slots_bytes / 100);
+        assert_eq!(arena.len(), 1);
+        assert!(arena.get_arc(first).is_none());
+        assert!(arena.get_arc(next).is_some());
+        assert_eq!(arena.bytes(), row_bytes(&data));
     }
 
     #[test]
-    fn test_arena_clear_batch_free_list() {
+    fn active_reuse_and_stale_clears_preserve_identity_and_bytes() {
         let arena = RowArena::new();
+        let zero = arena.insert_arc(0, 1, payload(0), None).unwrap();
+        let one = arena.insert_arc(1, 1, payload(1), None).unwrap();
+        let two = arena.insert_arc(2, 1, payload(2), None).unwrap();
+        assert!(!arena.clear_at(one, 7, 1));
+        assert!(!arena.clear_at(one, 1, 2));
+        assert!(arena.clear_at(one, 1, 1));
+        assert!(!arena.clear_at(one, 1, 1));
+        assert_eq!(arena.clear_batch(&[(two, 2, 1), (two, 2, 1)]), 1);
+        let replacement = arena.insert_arc(9, 2, payload(9), None).unwrap();
+        assert_eq!(replacement, two);
+        assert!(!arena.clear_at(two, 2, 1));
+        assert_eq!(arena.len(), 2);
+        assert_eq!(arena.bytes(), row_bytes(&payload(0)) * 2);
+        assert!(arena
+            .update_at(replacement, 9, 3, payload(99), lsn(30))
+            .unwrap());
+        assert!(!arena.clear_at(replacement, 9, 2));
+        assert!(arena.mark_deleted(replacement, 9, 4, lsn(40)).unwrap());
+        assert!(!arena.clear_at(replacement, 9, 3));
+        assert_eq!(
+            arena
+                .get_meta_and_arc(replacement)
+                .unwrap()
+                .0
+                .mutation_txn_id(),
+            4
+        );
+        assert!(arena.clear_at(replacement, 9, 4));
+        assert!(arena.clear_at(zero, 0, 1));
+        assert_eq!(arena.bytes(), 0);
+        assert_eq!(arena.slot_count(), 0);
+        assert_eq!(arena.capacity().metadata_bytes, 0);
+        let later = arena.insert_arc(0, 5, payload(0), None).unwrap();
+        assert_ne!(later.chunk_id(), zero.chunk_id());
+        assert!(!arena.clear_at(zero, 0, 1));
+        assert!(arena.insert_arc(1, 0, payload(1), None).is_err());
+        assert_eq!(arena.len(), 1);
+    }
 
-        // Insert 10 rows
-        for i in 0..10 {
-            arena.insert(i, 100, &[Value::Integer(i)]);
+    #[test]
+    fn freezing_is_lazy_and_never_reuses_captured_slots() {
+        let arena = RowArena::with_capacity(usize::MAX);
+        let empty_capacity = arena.capacity();
+        assert_eq!(empty_capacity.directory_bytes, 0);
+        assert_eq!(empty_capacity.metadata_bytes, 0);
+        assert_eq!(arena.freeze_active().unwrap(), None);
+        assert_eq!(arena.capacity(), empty_capacity);
+        let first = arena.insert_arc(99, 1, payload(99), None).unwrap();
+        let hole = arena.insert_arc(-2, 1, payload(-2), None).unwrap();
+        assert!(arena.clear_at(hole, -2, 1));
+        assert_eq!(arena.inner.read().free_head, Some(hole.slot() as u32));
+        assert_eq!(arena.capacity().free_list_bytes, 0);
+        let row_capacity = arena.capacity().metadata_bytes;
+        assert_eq!(
+            row_capacity,
+            ARENA_CHUNK_ROWS * std::mem::size_of::<ArenaRowMeta>()
+        );
+        assert_eq!(arena.freeze_active().unwrap(), Some(first.chunk_id()));
+        assert_eq!(arena.capacity().free_list_bytes, 0);
+        assert_eq!(arena.inner.read().free_head, None);
+        assert_eq!(arena.capacity().metadata_bytes, row_capacity);
+        assert!(arena.update_at(first, 99, 2, payload(100), None).unwrap());
+        let next = arena.insert_arc(0, 2, payload(0), None).unwrap();
+        assert_ne!(next.chunk_id(), first.chunk_id());
+        assert_eq!(next.slot(), 0);
+        assert!(arena.get_arc(hole).is_none());
+        assert!(arena.clear_at(first, 99, 2));
+        arena.clear_all();
+        assert_eq!(arena.capacity().metadata_bytes, 0);
+        let after_clear = arena.insert_arc(0, 3, payload(0), None).unwrap();
+        assert!(after_clear.chunk_id() > next.chunk_id());
+    }
+
+    #[test]
+    fn lsn_minima_follow_updates_delete_and_undo_across_leaves() {
+        let arena = RowArena::new();
+        let mut ids = Vec::new();
+        let data = payload(1);
+        for slot in 0..=LSN_LEAF_ROWS {
+            let source = match slot {
+                0 => lsn(10),
+                1 => lsn(20),
+                LSN_LEAF_ROWS => lsn(30),
+                _ => None,
+            };
+            ids.push(
+                arena
+                    .insert_arc(slot as i64, 1, data.clone(), source)
+                    .unwrap(),
+            );
         }
-        assert_eq!(arena.len(), 10);
+        let chunk = ids[0].chunk_id();
+        arena.freeze_active().unwrap();
+        let pin = arena.pin_chunk_lsn(chunk).unwrap().unwrap();
+        assert_eq!(arena.first_lsn(), lsn(10));
+        arena
+            .update_at(ids[0], 0, 2, data.clone(), lsn(100))
+            .unwrap();
+        arena.mark_deleted(ids[1], 1, 2, lsn(200)).unwrap();
+        // Published changes raise the row minimum, but cannot release old WAL.
+        assert_eq!(
+            arena.read_guard().chunks().next().unwrap().row_first_lsn(),
+            lsn(30)
+        );
+        assert_eq!(arena.first_lsn(), lsn(10));
+        arena
+            .update_at(ids[0], 0, 1, data.clone(), lsn(10))
+            .unwrap();
+        arena
+            .update_at(ids[1], 1, 1, data.clone(), lsn(20))
+            .unwrap();
+        drop(pin);
+        assert_eq!(arena.first_lsn(), lsn(10));
+        assert!(arena.clear_at(ids[0], 0, 1));
+        assert_eq!(arena.first_lsn(), lsn(20));
+        assert!(arena.clear_at(ids[1], 1, 1));
+        assert_eq!(arena.first_lsn(), lsn(30));
+        // A lower value in an already allocated leaf updates the path directly.
+        arena.update_at(ids[5], 5, 3, data, lsn(5)).unwrap();
+        assert_eq!(arena.first_lsn(), lsn(5));
+        assert_eq!(
+            arena.capacity().lsn_tree_bytes,
+            4 * std::mem::size_of::<Option<NonZeroU64>>()
+        );
+    }
 
-        // Clear slots 2, 4, 6, 8 in batch
-        let cleared = arena.clear_batch(&[2, 4, 6, 8]);
-        assert_eq!(cleared, 4);
-        assert_eq!(arena.len(), 10); // Still 10, slots cleared but not removed
+    #[test]
+    fn receipts_outlive_empty_chunks_and_release_only_their_own_pin() {
+        let arena = RowArena::new();
+        let id = arena.insert_arc(1, 1, payload(1), lsn(10)).unwrap();
+        let pin = arena.pin_chunk_lsn(id.chunk_id()).unwrap().unwrap();
+        let later = arena
+            .pin_lsn(id.chunk_id(), NonZeroU64::new(20).unwrap())
+            .unwrap();
+        assert!(arena.clear_at(id, 1, 1));
+        assert_eq!(arena.capacity().metadata_bytes, 0);
+        assert_eq!(arena.capacity().lsn_tree_bytes, 0);
+        assert_eq!(arena.chunk_first_lsn(id.chunk_id()), lsn(10));
+        arena.clear_all();
+        assert_eq!(arena.first_lsn(), lsn(10));
+        drop(pin);
+        assert_eq!(arena.first_lsn(), lsn(20));
+        assert!(arena.pin_chunk_lsn(id.chunk_id()).unwrap().is_none());
+        let copied = arena
+            .pin_lsn(id.chunk_id(), NonZeroU64::new(20).unwrap())
+            .unwrap();
+        drop(later);
+        assert_eq!(arena.first_lsn(), lsn(20));
+        drop(copied);
+        assert_eq!(arena.first_lsn(), None);
+        assert!(arena.pin_chunk_lsn(id.chunk_id()).unwrap().is_none());
+    }
 
-        // Insert 4 new rows - should reuse all 4 cleared slots
-        let mut new_indices = Vec::new();
-        for i in 100..104 {
-            new_indices.push(arena.insert(i, 200, &[Value::Integer(i)]));
+    #[test]
+    fn overlapping_publications_do_not_inherit_predecessor_receipts() {
+        let arena = RowArena::new();
+        let id = arena.insert_arc(1, 1, payload(1), lsn(10)).unwrap();
+        let first = arena.pin_chunk_lsn(id.chunk_id()).unwrap().unwrap();
+        arena.update_at(id, 1, 2, payload(2), lsn(20)).unwrap();
+        let second = arena.pin_chunk_lsn(id.chunk_id()).unwrap().unwrap();
+        arena.update_at(id, 1, 3, payload(3), lsn(30)).unwrap();
+        assert_eq!(arena.first_lsn(), lsn(10));
+        drop(first);
+        assert_eq!(arena.first_lsn(), lsn(20));
+        let third = arena.pin_chunk_lsn(id.chunk_id()).unwrap().unwrap();
+        drop(second);
+        assert_eq!(arena.first_lsn(), lsn(30));
+        drop(third);
+        assert_eq!(arena.first_lsn(), lsn(30));
+    }
+
+    #[test]
+    fn indexed_receipt_heaps_release_arbitrary_tokens_across_chunks() {
+        let arena = RowArena::new();
+        let initial_capacity = arena.capacity().receipt_bytes;
+        let mut pins = Vec::new();
+        for value in 0..512 {
+            // Exercise both a large same-chunk heap and one inline pin per chunk.
+            let chunk = ChunkId::new(if value < 256 { 0 } else { value - 255 }).unwrap();
+            let lsn = NonZeroU64::new((value * 137) % 512 + 1).unwrap();
+            pins.push((chunk, lsn, Some(arena.pin_lsn(chunk, lsn).unwrap())));
         }
+        for ordinal in 0..512 {
+            let index = (ordinal * 37) % 512;
+            let chunk = pins[index].0;
+            drop(pins[index].2.take());
+            let global = pins
+                .iter()
+                .filter(|(_, _, pin)| pin.is_some())
+                .map(|(_, lsn, _)| *lsn)
+                .min();
+            let local = pins
+                .iter()
+                .filter(|(id, _, pin)| *id == chunk && pin.is_some())
+                .map(|(_, lsn, _)| *lsn)
+                .min();
+            assert_eq!(arena.first_lsn(), global);
+            assert_eq!(arena.chunk_first_lsn(chunk), local);
+        }
+        assert_eq!(arena.capacity().receipt_bytes, initial_capacity);
+        let next_token = arena.receipts.lock().next_token;
+        let id = ChunkId::new(0).unwrap();
+        let pin = arena.pin_lsn(id, NonZeroU64::new(1).unwrap()).unwrap();
+        assert!(pin.token > next_token);
+        arena.receipts.lock().next_token = u64::MAX;
+        let capacity = arena.capacity();
+        assert!(arena.pin_lsn(id, NonZeroU64::new(2).unwrap()).is_err());
+        assert_eq!(arena.first_lsn(), lsn(1));
+        assert_eq!(arena.capacity(), capacity);
+    }
 
-        // Should still be 10 (all slots reused)
-        assert_eq!(arena.len(), 10);
-
-        // Verify all new indices are from cleared slots (8, 6, 4, 2 in LIFO order)
-        assert!(new_indices.iter().all(|&idx| [2, 4, 6, 8].contains(&idx)));
+    #[test]
+    fn sparse_read_cache_and_iteration_validate_real_chunk_addresses() {
+        let arena = RowArena::new();
+        let first = arena.insert_arc(99, 1, payload(99), None).unwrap();
+        arena.freeze_active().unwrap();
+        let removed = arena.insert_arc(-2, 1, payload(-2), None).unwrap();
+        arena.freeze_active().unwrap();
+        let last = arena.insert_arc(0, 1, payload(0), None).unwrap();
+        assert!(arena.clear_at(removed, -2, 1));
+        let guard = arena.read_guard();
+        let mut cache = usize::MAX;
+        assert_eq!(
+            guard.get_entry_cached(first, &mut cache).unwrap().0.row_id,
+            99
+        );
+        assert_eq!(cache, 0);
+        assert_eq!(
+            guard.get_entry_cached(last, &mut cache).unwrap().0.row_id,
+            0
+        );
+        assert_eq!(cache, 1);
+        assert!(guard.get_entry_cached(removed, &mut cache).is_none());
+        assert_eq!(
+            guard.get_entry_cached(first, &mut cache).unwrap().0.row_id,
+            99
+        );
+        assert_eq!(
+            guard
+                .iter()
+                .map(|(id, meta, _)| (id, meta.row_id))
+                .collect::<Vec<_>>(),
+            vec![(first, 99), (last, 0)]
+        );
+        let shared = guard.get(first).unwrap().clone();
+        drop(guard);
+        arena.clear_all();
+        assert_eq!(shared.as_ref(), &[Value::Integer(99)]);
     }
 }

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -19,7 +19,6 @@
 
 use crate::common::{CompactArc, I64Map, SmartString, StringMap};
 use rustc_hash::{FxHashMap, FxHashSet};
-use smallvec::SmallVec;
 use std::borrow::Cow;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
@@ -56,12 +55,12 @@ use crate::storage::mvcc::{
 use crate::storage::traits::{Engine, Index, Table, Transaction};
 
 /// Type alias for a single table entry in the transaction version store
-type TxnTableEntry = (SmartString, Arc<RwLock<TransactionVersionStore>>);
+type TxnTableEntry = (SmartString, CompactArc<RwLock<TransactionVersionStore>>);
 
 /// Type alias for the transaction version store map
 /// Structured as txn_id -> [(table_name, store)] for efficient lookup per transaction
 /// Uses SmallVec<[T; 2]> since most transactions access 1-2 tables, avoiding heap allocation
-type TxnVersionStoreMap = I64Map<SmallVec<[TxnTableEntry; 2]>>;
+type TxnVersionStoreMap = I64Map<super::accounting::RetainedSmallVec<[TxnTableEntry; 2]>>;
 
 /// Helper to get registry as the visibility checker type expected by VersionStore.
 /// In production: returns concrete Arc<TransactionRegistry> (zero-cost, inlined).
@@ -442,12 +441,21 @@ pub struct MemoryStat {
     pub chain_entries: usize,
     pub volume_bytes: usize,
     pub admission_waits: u64,
+    /// Allocation lifetime counters. `hot_bytes` above retains its legacy
+    /// committed-slot scope for admission until the pressure seal is enabled.
+    pub retained_hot_bytes: usize,
+    pub conservative_hot_bytes: usize,
+    pub pending_hot_bytes: usize,
+    pub accounted_hot_bytes: usize,
+    pub peak_accounted_hot_bytes: usize,
 }
 
 /// MVCC Storage Engine
 ///
 /// Provides multi-version concurrency control with snapshot isolation.
 pub struct MVCCEngine {
+    txn_map_pools: CompactArc<super::version_store::TxnMapPools>,
+    memory: crate::common::memory::MemoryAccount,
     /// Database path (empty for in-memory)
     path: String,
     /// Configuration
@@ -465,7 +473,7 @@ pub struct MVCCEngine {
     execution_failed: Arc<AtomicBool>,
     /// Cache of transaction version stores per (txn_id, table_name) for proper commit/rollback
     /// (Arc-wrapped for safe sharing with transactions)
-    txn_version_stores: Arc<RwLock<TxnVersionStoreMap>>,
+    txn_version_stores: CompactArc<RwLock<TxnVersionStoreMap>>,
     /// View definitions (Arc for cheap cloning on lookup)
     views: RwLock<FxHashMap<String, Arc<ViewDefinition>>>,
     /// Persistence manager for WAL and snapshot operations (Arc-wrapped for safe sharing)
@@ -542,6 +550,7 @@ fn get_or_create_segment_manager(
     >,
     persistence: &Option<PersistenceManager>,
     table_name: &str,
+    memory: &crate::common::memory::MemoryAccount,
 ) -> Arc<crate::storage::volume::manifest::SegmentManager> {
     // Fast path: read lock (common case during WAL replay — manager already exists)
     {
@@ -555,8 +564,10 @@ fn get_or_create_segment_manager(
     mgrs.entry(table_name.to_string())
         .or_insert_with(|| {
             let vol_dir = persistence.as_ref().map(|pm| pm.path().join("volumes"));
-            Arc::new(crate::storage::volume::manifest::SegmentManager::new(
-                table_name, vol_dir,
+            Arc::new(crate::storage::volume::manifest::SegmentManager::new_in(
+                table_name,
+                vol_dir,
+                memory.child(),
             ))
         })
         .clone()
@@ -581,7 +592,11 @@ impl MVCCEngine {
             None
         };
 
+        let memory = crate::common::memory::MemoryAccount::new();
+        let txn_map_pools = super::version_store::TxnMapPools::new_in(&memory);
         Self {
+            txn_map_pools,
+            memory: memory.clone(),
             path: if path.is_empty() {
                 "memory://".to_string()
             } else {
@@ -590,10 +605,10 @@ impl MVCCEngine {
             config: RwLock::new(config),
             schemas: Arc::new(RwLock::new(FxHashMap::default())),
             version_stores: Arc::new(RwLock::new(FxHashMap::default())),
-            registry: Arc::new(TransactionRegistry::new()),
+            registry: Arc::new(TransactionRegistry::new_in(&memory)),
             open: AtomicBool::new(false),
             execution_failed: Arc::new(AtomicBool::new(false)),
-            txn_version_stores: Arc::new(RwLock::new(I64Map::new())),
+            txn_version_stores: CompactArc::new_in(RwLock::new(I64Map::new_in(&memory)), &memory),
             views: RwLock::new(FxHashMap::default()),
             persistence: Arc::new(persistence),
             loading_from_disk: Arc::new(AtomicBool::new(false)),
@@ -1106,24 +1121,34 @@ impl MVCCEngine {
         let table_name_lower = schema.table_name_lower.clone();
 
         // Create the version store
-        let version_store = Arc::new(VersionStore::with_visibility_checker(
+        let version_store = Arc::new(VersionStore::with_capacity_and_pools(
             schema.table_name.clone(),
             schema.clone(),
-            registry_as_visibility_checker(&self.registry),
+            Some(registry_as_visibility_checker(&self.registry)),
+            0,
+            self.memory.child(),
+            self.txn_map_pools.clone(),
         ));
 
         // Register virtual PkIndex for INTEGER PRIMARY KEY
         register_pk_index(&schema, &version_store)?;
 
-        // Load all rows from the snapshot
+        // Load all rows from the snapshot; stop on the first arena failure.
+        let mut apply_error = None;
         reader.for_each(|row_id, mut version| {
             // Snapshot versions have txn_id = -1, we need to use the recovery txn_id
             version.txn_id = super::RECOVERY_TRANSACTION_ID;
 
             // Apply to version store
-            version_store.apply_recovered_version(row_id, version);
+            if let Err(error) = version_store.apply_recovered_version(row_id, version) {
+                apply_error = Some(error);
+                return false;
+            }
             true
         })?;
+        if let Some(error) = apply_error {
+            return Err(error);
+        }
 
         // Store the schema and version store
         {
@@ -1167,10 +1192,13 @@ impl MVCCEngine {
             let table_name_lower = schema.table_name_lower.clone();
 
             // Create empty version store (hot buffer for WAL data only)
-            let version_store = Arc::new(VersionStore::with_visibility_checker(
+            let version_store = Arc::new(VersionStore::with_capacity_and_pools(
                 schema.table_name.clone(),
                 schema.clone(),
-                registry_as_visibility_checker(&self.registry),
+                Some(registry_as_visibility_checker(&self.registry)),
+                0,
+                self.memory.child(),
+                self.txn_map_pools.clone(),
             ));
             register_pk_index(&schema, &version_store)?;
 
@@ -1208,10 +1236,13 @@ impl MVCCEngine {
         let table_name_lower = schema.table_name_lower.clone();
 
         // Create an empty version store (hot buffer for WAL data only)
-        let version_store = Arc::new(VersionStore::with_visibility_checker(
+        let version_store = Arc::new(VersionStore::with_capacity_and_pools(
             schema.table_name.clone(),
             schema.clone(),
-            registry_as_visibility_checker(&self.registry),
+            Some(registry_as_visibility_checker(&self.registry)),
+            0,
+            self.memory.child(),
+            self.txn_map_pools.clone(),
         ));
         register_pk_index(&schema, &version_store)?;
 
@@ -1619,10 +1650,13 @@ impl MVCCEngine {
                 // Deserialize schema from entry data
                 if let Ok(schema) = self.deserialize_schema(&entry.data) {
                     // Create the table (version store)
-                    let version_store = Arc::new(VersionStore::with_visibility_checker(
+                    let version_store = Arc::new(VersionStore::with_capacity_and_pools(
                         schema.table_name.clone(),
                         schema.clone(),
-                        registry_as_visibility_checker(&self.registry),
+                        Some(registry_as_visibility_checker(&self.registry)),
+                        0,
+                        self.memory.child(),
+                        self.txn_map_pools.clone(),
                     ));
 
                     // Register virtual PkIndex for INTEGER PRIMARY KEY
@@ -1771,14 +1805,22 @@ impl MVCCEngine {
                             // in the cumulative skip set at scan time). No tombstone
                             // needed here — the hot version IS the dedup mechanism.
                             if let Ok(store) = self.get_version_store(&table_name) {
-                                store.apply_recovered_version(entry.row_id, row_version);
+                                store.apply_recovered_version_with_lsn(
+                                    entry.row_id,
+                                    row_version,
+                                    std::num::NonZeroU64::new(entry.lsn),
+                                )?;
                             }
                         }
                         // else: sealed INSERT, volume has authoritative data → skip
                     } else {
                         // Row not in any volume: standard hot insert
                         if let Ok(store) = self.get_version_store(&table_name) {
-                            store.apply_recovered_version(entry.row_id, row_version);
+                            store.apply_recovered_version_with_lsn(
+                                entry.row_id,
+                                row_version,
+                                std::num::NonZeroU64::new(entry.lsn),
+                            )?;
                         }
                     }
                 }
@@ -1787,7 +1829,11 @@ impl MVCCEngine {
                 // For deletes, mark the row as deleted in the hot store.
                 let table_name = entry.table_name.to_lowercase();
                 if let Ok(store) = self.get_version_store(&table_name) {
-                    store.mark_deleted(entry.row_id, entry.txn_id);
+                    store.mark_deleted_with_lsn(
+                        entry.row_id,
+                        entry.txn_id,
+                        std::num::NonZeroU64::new(entry.lsn),
+                    )?;
                 }
                 // If the deleted row_id lives in a cold segment, add a tombstone
                 // so it is excluded from scans and point lookups.
@@ -2196,6 +2242,7 @@ impl MVCCEngine {
             *file_lock = None;
         }
 
+        self.txn_map_pools.trim();
         Ok(())
     }
 
@@ -2290,14 +2337,38 @@ impl MVCCEngine {
                 .collect()
         };
         let mut result = Vec::with_capacity(stores.len() + 1);
+        let engine_memory = self.memory.snapshot();
         let mut total = MemoryStat {
+            retained_hot_bytes: engine_memory.retained_bytes,
+            conservative_hot_bytes: engine_memory.conservative_bytes,
+            pending_hot_bytes: engine_memory.pending_bytes,
+            accounted_hot_bytes: engine_memory.accounted_bytes,
+            peak_accounted_hot_bytes: engine_memory.peak_accounted_bytes,
             table_name: "*".to_string(),
             admission_waits: self.hot_limits.admission_waits.load(Ordering::Relaxed),
             ..Default::default()
         };
         for (name, store) in stores {
             let (arena_slots, arena_capacity_bytes) = store.arena_footprint();
+            let memory = store.memory_account().snapshot();
+            let cold_writes = {
+                let Ok(managers) = self.segment_managers.read() else {
+                    panic!("segment manager catalog is poisoned while reading memory statistics");
+                };
+                managers
+                    .get(&name)
+                    .map(|manager| manager.hot_memory_account().snapshot())
+                    .unwrap_or_default()
+            };
             let stat = MemoryStat {
+                retained_hot_bytes: memory.retained_bytes + cold_writes.retained_bytes,
+                conservative_hot_bytes: memory.conservative_bytes + cold_writes.conservative_bytes,
+                pending_hot_bytes: memory.pending_bytes + cold_writes.pending_bytes,
+                accounted_hot_bytes: memory.accounted_bytes + cold_writes.accounted_bytes,
+                // Per-table component peaks form an upper bound; the '*' row
+                // uses the engine root's directly observed aggregate peak.
+                peak_accounted_hot_bytes: memory.peak_accounted_bytes
+                    + cold_writes.peak_accounted_bytes,
                 hot_rows: store.committed_row_count(),
                 hot_bytes: store.hot_bytes(),
                 arena_slots,
@@ -2772,10 +2843,13 @@ impl MVCCEngine {
         self.validate_schema(&schema)?;
 
         // Create version store for this table
-        let version_store = Arc::new(VersionStore::with_visibility_checker(
+        let version_store = Arc::new(VersionStore::with_capacity_and_pools(
             schema.table_name.clone(),
             schema.clone(),
-            registry_as_visibility_checker(&self.registry),
+            Some(registry_as_visibility_checker(&self.registry)),
+            0,
+            self.memory.child(),
+            self.txn_map_pools.clone(),
         ));
 
         // Register virtual PkIndex for INTEGER PRIMARY KEY
@@ -3056,7 +3130,12 @@ impl MVCCEngine {
         &self,
         table_name: &str,
     ) -> Arc<crate::storage::volume::manifest::SegmentManager> {
-        get_or_create_segment_manager(&self.segment_managers, &self.persistence, table_name)
+        get_or_create_segment_manager(
+            &self.segment_managers,
+            &self.persistence,
+            table_name,
+            &self.memory,
+        )
     }
 
     /// Clean up stale .dv files from disk left over by previous versions.
@@ -3184,9 +3263,10 @@ impl MVCCEngine {
             let table_name = entry.file_name().to_string_lossy().to_lowercase();
 
             // Try to load manifest from this table directory
-            match crate::storage::volume::manifest::SegmentManager::load_from_disk(
+            match crate::storage::volume::manifest::SegmentManager::load_from_disk_in(
                 &table_name,
                 &vol_dir,
+                self.memory.child(),
             ) {
                 Ok(Some(mgr)) => {
                     let lsn = mgr.manifest().checkpoint_lsn;
@@ -6874,6 +6954,8 @@ impl Drop for CleanupHandle {
 /// Holds Arc references to shared engine state, allowing safe access
 /// from transactions without raw pointers.
 struct EngineOperations {
+    txn_map_pools: CompactArc<super::version_store::TxnMapPools>,
+    memory: crate::common::memory::MemoryAccount,
     execution_failed: Arc<AtomicBool>,
     /// Shared reference to schemas (each schema is Arc-wrapped to avoid cloning on lookup)
     schemas: Arc<RwLock<FxHashMap<String, CompactArc<Schema>>>>,
@@ -6882,7 +6964,7 @@ struct EngineOperations {
     /// Shared reference to registry
     registry: Arc<TransactionRegistry>,
     /// Shared reference to transaction version stores cache
-    txn_version_stores: Arc<RwLock<TxnVersionStoreMap>>,
+    txn_version_stores: CompactArc<RwLock<TxnVersionStoreMap>>,
     /// Shared reference to persistence manager (optional)
     persistence: Arc<Option<PersistenceManager>>,
     /// Shared reference to loading_from_disk flag
@@ -6901,11 +6983,13 @@ struct EngineOperations {
 impl EngineOperations {
     fn new(engine: &MVCCEngine) -> Self {
         Self {
+            txn_map_pools: engine.txn_map_pools.clone(),
+            memory: engine.memory.clone(),
             execution_failed: Arc::clone(&engine.execution_failed),
             schemas: Arc::clone(&engine.schemas),
             version_stores: Arc::clone(&engine.version_stores),
             registry: Arc::clone(&engine.registry),
-            txn_version_stores: Arc::clone(&engine.txn_version_stores),
+            txn_version_stores: engine.txn_version_stores.clone(),
             persistence: Arc::clone(&engine.persistence),
             loading_from_disk: Arc::clone(&engine.loading_from_disk),
             segment_managers: Arc::clone(&engine.segment_managers),
@@ -6941,7 +7025,7 @@ impl EngineOperations {
     fn validate_pending_against_cold(
         &self,
         txn_id: i64,
-        txn_store: &Arc<RwLock<TransactionVersionStore>>,
+        txn_store: &CompactArc<RwLock<TransactionVersionStore>>,
         version_store: &Arc<VersionStore>,
         mgr: &Arc<crate::storage::volume::manifest::SegmentManager>,
     ) -> Result<()> {
@@ -7143,7 +7227,8 @@ impl EngineOperations {
                     WALOperationType::Insert
                 };
 
-                pm.record_dml_operation(txn_id, table_name, row_id, op, &version)?;
+                let lsn = pm.record_dml_operation(txn_id, table_name, row_id, op, &version)?;
+                table.record_source_lsn(row_id, lsn);
             }
         }
         Ok(())
@@ -7204,7 +7289,7 @@ impl TransactionEngineOperations for EngineOperations {
                 txn_tables
                     .iter()
                     .find(|(name, _)| name == &*table_name_lower)
-                    .map(|(_, cached)| Arc::clone(cached))
+                    .map(|(_, cached)| CompactArc::clone(cached))
             } else {
                 None
             };
@@ -7215,21 +7300,30 @@ impl TransactionEngineOperations for EngineOperations {
             } else {
                 // Upgrade to write lock and re-check (another thread may have inserted)
                 let mut cache = self.txn_version_stores().write().unwrap();
-                let txn_tables = cache.entry(txn_id).or_default();
+                let txn_tables = cache
+                    .entry(txn_id)
+                    .or_insert_with(super::accounting::RetainedSmallVec::new);
                 if let Some((_, cached)) = txn_tables
                     .iter()
                     .find(|(name, _)| name == &*table_name_lower)
                 {
-                    Arc::clone(cached)
+                    CompactArc::clone(cached)
                 } else {
-                    let new_store = Arc::new(RwLock::new(TransactionVersionStore::new(
-                        Arc::clone(&version_store),
-                        txn_id,
-                    )));
-                    txn_tables.push((
-                        table_name_lower.clone().into_owned().into(),
-                        Arc::clone(&new_store),
-                    ));
+                    let new_store = CompactArc::new_in(
+                        RwLock::new(TransactionVersionStore::new(
+                            Arc::clone(&version_store),
+                            txn_id,
+                        )),
+                        version_store.memory_account(),
+                    );
+                    txn_tables.push(
+                        (
+                            SmartString::from(table_name_lower.clone().into_owned())
+                                .into_hot(&self.memory),
+                            CompactArc::clone(&new_store),
+                        ),
+                        &self.memory,
+                    );
                     new_store
                 }
             }
@@ -7248,6 +7342,7 @@ impl TransactionEngineOperations for EngineOperations {
                 &self.segment_managers,
                 &self.persistence,
                 &table_name_lower,
+                &self.memory,
             )
         } else {
             let mgrs = self.segment_managers.read().unwrap();
@@ -7275,10 +7370,13 @@ impl TransactionEngineOperations for EngineOperations {
         let table_name = name.to_lowercase();
 
         // Create version store for this table (before acquiring locks)
-        let version_store = Arc::new(VersionStore::with_visibility_checker(
+        let version_store = Arc::new(VersionStore::with_capacity_and_pools(
             schema.table_name.clone(),
             schema.clone(),
-            registry_as_visibility_checker(&self.registry),
+            Some(registry_as_visibility_checker(&self.registry)),
+            0,
+            self.memory.child(),
+            self.txn_map_pools.clone(),
         ));
 
         // Register PkIndex if table has a primary key
@@ -7493,7 +7591,8 @@ impl TransactionEngineOperations for EngineOperations {
                         WALOperationType::Insert
                     };
 
-                    pm.record_dml_operation(txn_id, table_name, row_id, op, &version)?;
+                    let lsn = pm.record_dml_operation(txn_id, table_name, row_id, op, &version)?;
+                    table.record_source_lsn(row_id, lsn);
                 }
             }
         }
@@ -7561,7 +7660,7 @@ impl TransactionEngineOperations for EngineOperations {
                         let table = MVCCTable::new_with_shared_store(
                             txn_id,
                             Arc::clone(&version_store),
-                            Arc::clone(txn_store),
+                            CompactArc::clone(txn_store),
                         );
 
                         tables.push(Box::new(table) as Box<dyn Table>);
@@ -7725,7 +7824,7 @@ impl TransactionEngineOperations for EngineOperations {
                     stores.get(name.as_str()).map(|parent| {
                         (
                             name.clone(),
-                            Arc::clone(local),
+                            CompactArc::clone(local),
                             Arc::clone(parent),
                             managers.get(name.as_str()).cloned(),
                         )
@@ -7763,7 +7862,7 @@ impl TransactionEngineOperations for EngineOperations {
                     let table = MVCCTable::new_with_shared_store(
                         txn_id,
                         Arc::clone(parent),
-                        Arc::clone(local),
+                        CompactArc::clone(local),
                     );
                     self.record_table_to_wal(txn_id, &table)?;
                 }
@@ -7836,7 +7935,7 @@ impl TransactionEngineOperations for EngineOperations {
                     continue;
                 }
                 if let Some(version_store) = stores.get(table_name.as_str()) {
-                    hold.add(version_store, Arc::clone(txn_store));
+                    hold.add(version_store, CompactArc::clone(txn_store));
                 }
             }
         }
@@ -7875,14 +7974,14 @@ impl TransactionEngineOperations for EngineOperations {
         let touched: smallvec::SmallVec<
             [(
                 crate::common::SmartString,
-                Arc<RwLock<TransactionVersionStore>>,
+                CompactArc<RwLock<TransactionVersionStore>>,
             ); 4],
         > = cache
             .get(txn_id)
             .map(|tables| {
                 tables
                     .iter()
-                    .map(|(name, store)| (name.clone(), Arc::clone(store)))
+                    .map(|(name, store)| (name.clone(), CompactArc::clone(store)))
                     .collect()
             })
             .unwrap_or_default();

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -35,6 +35,7 @@
 //! ```
 //!
 
+pub(crate) mod accounting;
 pub mod arena;
 pub mod engine;
 pub mod file_lock;
@@ -58,6 +59,10 @@ pub use crate::storage::index::{
 };
 
 // Re-export main types
+pub use arena::{
+    ArenaCapacity, ArenaChunkRef, ArenaId, ArenaLsnPin, ArenaReadGuard, ArenaRowMeta, ChunkId,
+    RowArena, ARENA_CHUNK_MASK, ARENA_CHUNK_ROWS, ARENA_CHUNK_SHIFT,
+};
 pub use engine::{CleanupHandle, MVCCEngine};
 pub use persistence::{
     deserialize_row_version, deserialize_value, serialize_row_version, serialize_value,
@@ -74,8 +79,8 @@ pub use transaction::{
     MvccTransaction, SealFenceGuard, TransactionEngineOperations, TransactionState,
 };
 pub use version_store::{
-    clear_version_map_pools, AggregateOp, AggregateResult, RowIndex, RowVersion,
-    SealedIndexCleanup, TransactionVersionStore, VersionStore, VisibilityChecker, WriteSetEntry,
+    AggregateOp, AggregateResult, RowIndex, RowVersion, SealedIndexCleanup,
+    TransactionVersionStore, VersionStore, VisibilityChecker, WriteSetEntry,
 };
 pub use wal_manager::{
     CheckpointMetadata, WALEntry, WALManager, WALOperationType, DEFAULT_WAL_BUFFER_SIZE,

--- a/src/storage/mvcc/persistence.rs
+++ b/src/storage/mvcc/persistence.rs
@@ -486,9 +486,9 @@ impl PersistenceManager {
         row_id: i64,
         op: WALOperationType,
         version: &RowVersion,
-    ) -> Result<()> {
+    ) -> Result<Option<std::num::NonZeroU64>> {
         if !self.is_enabled() {
-            return Ok(());
+            return Ok(None);
         }
 
         let wal = self.wal.as_ref().ok_or(Error::WalNotInitialized)?;
@@ -498,8 +498,7 @@ impl PersistenceManager {
 
         let entry = WALEntry::new(txn_id, table_name.to_string(), row_id, op, data);
 
-        wal.append_entry(entry)?;
-        Ok(())
+        Ok(std::num::NonZeroU64::new(wal.append_entry(entry)?))
     }
 
     /// Record a transaction commit

--- a/src/storage/mvcc/registry.rs
+++ b/src/storage/mvcc/registry.rs
@@ -214,6 +214,8 @@ pub struct TransactionRegistry {
 
     /// Whether new transactions are being accepted.
     accepting: AtomicBool,
+    // The std::Arc control block is opaque; keep its allowance conservative.
+    _object_charge: Option<crate::common::memory::MemoryCharge>,
 }
 
 impl TransactionRegistry {
@@ -234,7 +236,20 @@ impl TransactionRegistry {
             override_count: AtomicUsize::new(0),
             active_txn_count: AtomicUsize::new(0),
             accepting: AtomicBool::new(true),
+            _object_charge: None,
         }
+    }
+
+    pub(crate) fn new_in(account: &crate::common::memory::MemoryAccount) -> Self {
+        let mut registry = Self::with_capacity(0);
+        registry.transactions = Mutex::new(I64Map::with_capacity_in(16, account));
+        registry.snapshot_seqs = Mutex::new(I64Map::new_in(account));
+        registry.isolation_overrides = Mutex::new(I64Map::new_in(account));
+        registry._object_charge = Some(crate::common::memory::MemoryCharge::conservative(
+            account,
+            std::mem::size_of::<Self>() + 4 * std::mem::size_of::<usize>(),
+        ));
+        registry
     }
 
     #[inline(always)]

--- a/src/storage/mvcc/streaming_result.rs
+++ b/src/storage/mvcc/streaming_result.rs
@@ -25,15 +25,14 @@
 
 use crate::common::CompactArc;
 use crate::core::{Row, Value};
-use crate::storage::mvcc::arena::ArenaReadGuard;
+use crate::storage::mvcc::arena::{ArenaId, ArenaReadGuard};
 
 /// Pre-computed visible row information for zero-copy iteration
 #[derive(Clone, Copy)]
 pub struct VisibleRowInfo {
     pub row_id: i64,
-    /// Arena index for rows in the arena, OR `arena_len + fallback_index` for
-    /// chain entries not in the arena (visible under snapshot isolation).
-    pub arena_idx: usize,
+    /// Stable arena address. None consumes the next historical fallback row.
+    pub arena_idx: Option<ArenaId>,
 }
 
 /// Zero-copy streaming result that yields references to arena data
@@ -42,18 +41,19 @@ pub struct VisibleRowInfo {
 /// allowing it to yield row references without any cloning.
 ///
 /// For rows whose visible version is a chain entry (not in the arena),
-/// the data is stored in `fallback_data` and referenced via indices
-/// starting at `arena_len`.
+/// the data is stored in `fallback_data` in the order of absent arena IDs.
+/// Sparse addresses never overlap the historical-row representation.
 pub struct StreamingResult<'a> {
     /// Unified arena guard (single lock for both data and metadata)
     arena_guard: ArenaReadGuard<'a>,
     /// Pre-sorted list of visible row indices
     visible_indices: Vec<VisibleRowInfo>,
     /// Fallback data for chain entries not in arena (snapshot isolation).
-    /// Indexed by `arena_idx - arena_len` when `arena_idx >= arena_len`.
+    /// Consumed sequentially for absent arena IDs.
     fallback_data: Vec<CompactArc<[Value]>>,
-    /// Length of the arena at construction time (boundary between arena and fallback)
-    arena_len: usize,
+    fallback_pos: usize,
+    /// Directory positions remain stable while the read guard is held.
+    chunk_cache: usize,
     /// Current position in visible_indices
     current_pos: usize,
     /// Column names
@@ -71,12 +71,12 @@ impl<'a> StreamingResult<'a> {
         visible_indices: Vec<VisibleRowInfo>,
         columns: Vec<String>,
     ) -> Self {
-        let arena_len = arena_guard.len();
         Self {
             arena_guard,
             visible_indices,
             fallback_data: Vec::new(),
-            arena_len,
+            fallback_pos: 0,
+            chunk_cache: usize::MAX,
             current_pos: 0,
             columns,
             current_row: Row::new(),
@@ -93,12 +93,12 @@ impl<'a> StreamingResult<'a> {
         fallback_data: Vec<CompactArc<[Value]>>,
         columns: Vec<String>,
     ) -> Self {
-        let arena_len = arena_guard.len();
         Self {
             arena_guard,
             visible_indices,
             fallback_data,
-            arena_len,
+            fallback_pos: 0,
+            chunk_cache: usize::MAX,
             current_pos: 0,
             columns,
             current_row: Row::new(),
@@ -119,33 +119,24 @@ impl<'a> StreamingResult<'a> {
     #[inline]
     #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> bool {
-        if self.current_pos < self.visible_indices.len() {
+        while self.current_pos < self.visible_indices.len() {
             let info = &self.visible_indices[self.current_pos];
-
-            if info.arena_idx < self.arena_len {
-                // Arena path: O(1) Arc clone - no data copying
-                if let Some(arc) = self.arena_guard.data().get(info.arena_idx) {
-                    self.current_row = Row::from_arc(CompactArc::clone(arc));
-                    self.current_arc = Some(CompactArc::clone(arc));
-                } else {
-                    self.current_arc = None;
-                }
-            } else {
-                // Fallback path: chain entry data stored in fallback_data
-                let fb_idx = info.arena_idx - self.arena_len;
-                if let Some(arc) = self.fallback_data.get(fb_idx) {
-                    self.current_row = Row::from_arc(CompactArc::clone(arc));
-                    self.current_arc = Some(CompactArc::clone(arc));
-                } else {
-                    self.current_arc = None;
-                }
-            }
-
             self.current_pos += 1;
-            true
-        } else {
-            false
+            if let Some(arc) = visible_row(
+                &self.arena_guard,
+                &self.fallback_data,
+                info,
+                &mut self.fallback_pos,
+                &mut self.chunk_cache,
+            ) {
+                self.current_row = Row::from_arc(CompactArc::clone(arc));
+                self.current_arc = Some(CompactArc::clone(arc));
+                return true;
+            }
         }
+        self.current_arc = None;
+        self.current_row = Row::new();
+        false
     }
 
     /// Get current row as Arc slice (for efficient access)
@@ -184,7 +175,10 @@ impl<'a> StreamingResult<'a> {
     /// Reset to beginning
     pub fn reset(&mut self) {
         self.current_pos = 0;
+        self.fallback_pos = 0;
+        self.chunk_cache = usize::MAX;
         self.current_arc = None;
+        self.current_row = Row::new();
     }
 
     /// Create an AggregationScanner for fast direct aggregations
@@ -193,64 +187,83 @@ impl<'a> StreamingResult<'a> {
     /// - Zero allocations during computation
     /// - Direct memory access to arena data
     /// - Single pass through visible rows
-    pub fn as_aggregation_scanner(&self) -> AggregationScanner<'_> {
+    pub fn as_aggregation_scanner(&self) -> AggregationScanner<'_, 'a> {
         AggregationScanner::new(
-            self.arena_guard.data(),
+            &self.arena_guard,
             &self.visible_indices,
             &self.fallback_data,
-            self.arena_len,
         )
     }
 }
 
-/// Fast aggregation helper that works directly on arena data
-///
-/// Enables aggregations in a single pass over contiguous memory with
-/// zero allocations during the scan. Supports both arena and fallback data.
-pub struct AggregationScanner<'a> {
-    arena_data: &'a [CompactArc<[Value]>],
-    visible_indices: &'a [VisibleRowInfo],
-    fallback_data: &'a [CompactArc<[Value]>],
-    arena_len: usize,
+/// Resolve one visible row without allocating or searching the directory again
+/// while successive handles refer to the same chunk.
+#[inline]
+fn visible_row<'a>(
+    arena: &'a ArenaReadGuard<'_>,
+    fallback: &'a [CompactArc<[Value]>],
+    info: &VisibleRowInfo,
+    fallback_pos: &mut usize,
+    chunk_cache: &mut usize,
+) -> Option<&'a CompactArc<[Value]>> {
+    match info.arena_idx {
+        Some(id) => arena
+            .get_entry_cached(id, chunk_cache)
+            .filter(|(meta, _)| meta.row_id == info.row_id)
+            .map(|(_, data)| data),
+        None => {
+            let data = fallback.get(*fallback_pos);
+            *fallback_pos += 1;
+            data
+        }
+    }
 }
 
-impl<'a> AggregationScanner<'a> {
+/// Allocation-free aggregation over stable arena addresses and historical rows.
+pub struct AggregationScanner<'a, 'arena> {
+    arena: &'a ArenaReadGuard<'arena>,
+    visible_indices: &'a [VisibleRowInfo],
+    fallback_data: &'a [CompactArc<[Value]>],
+}
+
+impl<'a, 'arena> AggregationScanner<'a, 'arena> {
     pub fn new(
-        arena_data: &'a [CompactArc<[Value]>],
+        arena: &'a ArenaReadGuard<'arena>,
         visible_indices: &'a [VisibleRowInfo],
         fallback_data: &'a [CompactArc<[Value]>],
-        arena_len: usize,
     ) -> Self {
         Self {
-            arena_data,
+            arena,
             visible_indices,
             fallback_data,
-            arena_len,
         }
     }
 
-    /// Get the row data for a given VisibleRowInfo (arena or fallback)
-    #[inline(always)]
-    fn get_row(&self, info: &VisibleRowInfo) -> Option<&CompactArc<[Value]>> {
-        if info.arena_idx < self.arena_len {
-            self.arena_data.get(info.arena_idx)
-        } else {
-            self.fallback_data.get(info.arena_idx - self.arena_len)
-        }
+    #[inline]
+    fn rows(&self) -> impl Iterator<Item = &CompactArc<[Value]>> {
+        let mut fallback_pos = 0;
+        let mut chunk_cache = usize::MAX;
+        self.visible_indices.iter().filter_map(move |info| {
+            visible_row(
+                self.arena,
+                self.fallback_data,
+                info,
+                &mut fallback_pos,
+                &mut chunk_cache,
+            )
+        })
     }
 
     /// Sum a column (for INTEGER/FLOAT columns)
     #[inline]
     pub fn sum_column(&self, col_idx: usize) -> f64 {
         let mut sum = 0.0f64;
-        for info in self.visible_indices {
-            if let Some(row) = self.get_row(info) {
-                if let Some(val) = row.get(col_idx) {
-                    match val {
-                        Value::Integer(i) => sum += *i as f64,
-                        Value::Float(f) => sum += *f,
-                        _ => {}
-                    }
+        for row in self.rows() {
+            if let Some(val) = row.get(col_idx) {
+                match val {
+                    Value::Integer(i) => sum += *i as f64,
+                    Value::Float(f) => sum += *f,
+                    _ => {}
                 }
             }
         }
@@ -260,19 +273,17 @@ impl<'a> AggregationScanner<'a> {
     /// Count rows
     #[inline]
     pub fn count(&self) -> usize {
-        self.visible_indices.len()
+        self.rows().count()
     }
 
     /// Count non-null values in a column
     #[inline]
     pub fn count_column(&self, col_idx: usize) -> usize {
         let mut count = 0;
-        for info in self.visible_indices {
-            if let Some(row) = self.get_row(info) {
-                if let Some(val) = row.get(col_idx) {
-                    if !val.is_null() {
-                        count += 1;
-                    }
+        for row in self.rows() {
+            if let Some(val) = row.get(col_idx) {
+                if !val.is_null() {
+                    count += 1;
                 }
             }
         }
@@ -282,17 +293,15 @@ impl<'a> AggregationScanner<'a> {
     /// Get min value in a column
     pub fn min_column(&self, col_idx: usize) -> Option<Value> {
         let mut min: Option<Value> = None;
-        for info in self.visible_indices {
-            if let Some(row) = self.get_row(info) {
-                if let Some(val) = row.get(col_idx) {
-                    if !val.is_null() {
-                        match &min {
-                            None => min = Some(val.clone()),
-                            Some(current) => {
-                                if let Ok(ord) = val.compare(current) {
-                                    if ord == std::cmp::Ordering::Less {
-                                        min = Some(val.clone());
-                                    }
+        for row in self.rows() {
+            if let Some(val) = row.get(col_idx) {
+                if !val.is_null() {
+                    match &min {
+                        None => min = Some(val.clone()),
+                        Some(current) => {
+                            if let Ok(ord) = val.compare(current) {
+                                if ord == std::cmp::Ordering::Less {
+                                    min = Some(val.clone());
                                 }
                             }
                         }
@@ -306,17 +315,15 @@ impl<'a> AggregationScanner<'a> {
     /// Get max value in a column
     pub fn max_column(&self, col_idx: usize) -> Option<Value> {
         let mut max: Option<Value> = None;
-        for info in self.visible_indices {
-            if let Some(row) = self.get_row(info) {
-                if let Some(val) = row.get(col_idx) {
-                    if !val.is_null() {
-                        match &max {
-                            None => max = Some(val.clone()),
-                            Some(current) => {
-                                if let Ok(ord) = val.compare(current) {
-                                    if ord == std::cmp::Ordering::Greater {
-                                        max = Some(val.clone());
-                                    }
+        for row in self.rows() {
+            if let Some(val) = row.get(col_idx) {
+                if !val.is_null() {
+                    match &max {
+                        None => max = Some(val.clone()),
+                        Some(current) => {
+                            if let Ok(ord) = val.compare(current) {
+                                if ord == std::cmp::Ordering::Greater {
+                                    max = Some(val.clone());
                                 }
                             }
                         }
@@ -332,33 +339,43 @@ impl<'a> AggregationScanner<'a> {
 mod tests {
     use super::*;
     use crate::core::types::DataType;
-    use crate::storage::mvcc::arena::RowArena;
+    use crate::storage::mvcc::arena::{ChunkId, RowArena};
+
+    fn first_chunk_slot(slot: usize) -> Option<ArenaId> {
+        Some(ArenaId::from_parts(ChunkId::new(0).unwrap(), slot).unwrap())
+    }
 
     #[test]
     fn test_aggregation_scanner() {
         // Create test data using RowArena
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Integer(1), Value::Float(10.0)]);
-        arena.insert(2, 1, &[Value::Integer(2), Value::Float(20.0)]);
-        arena.insert(3, 1, &[Value::Integer(3), Value::Float(30.0)]);
+        arena
+            .insert(1, 1, &[Value::Integer(1), Value::Float(10.0)], None)
+            .unwrap();
+        arena
+            .insert(2, 1, &[Value::Integer(2), Value::Float(20.0)], None)
+            .unwrap();
+        arena
+            .insert(3, 1, &[Value::Integer(3), Value::Float(30.0)], None)
+            .unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![
             VisibleRowInfo {
                 row_id: 1,
-                arena_idx: 0,
+                arena_idx: first_chunk_slot(0),
             },
             VisibleRowInfo {
                 row_id: 2,
-                arena_idx: 1,
+                arena_idx: first_chunk_slot(1),
             },
             VisibleRowInfo {
                 row_id: 3,
-                arena_idx: 2,
+                arena_idx: first_chunk_slot(2),
             },
         ];
 
-        let scanner = AggregationScanner::new(guard.data(), &visible, &[], guard.len());
+        let scanner = AggregationScanner::new(&guard, &visible, &[]);
 
         assert_eq!(scanner.count(), 3);
         assert_eq!(scanner.sum_column(0), 6.0); // 1 + 2 + 3
@@ -385,23 +402,29 @@ mod tests {
     #[test]
     fn test_streaming_result_iteration() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Integer(100), Value::Text("a".into())]);
-        arena.insert(2, 1, &[Value::Integer(200), Value::Text("b".into())]);
-        arena.insert(3, 1, &[Value::Integer(300), Value::Text("c".into())]);
+        arena
+            .insert(1, 1, &[Value::Integer(100), Value::Text("a".into())], None)
+            .unwrap();
+        arena
+            .insert(2, 1, &[Value::Integer(200), Value::Text("b".into())], None)
+            .unwrap();
+        arena
+            .insert(3, 1, &[Value::Integer(300), Value::Text("c".into())], None)
+            .unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![
             VisibleRowInfo {
                 row_id: 1,
-                arena_idx: 0,
+                arena_idx: first_chunk_slot(0),
             },
             VisibleRowInfo {
                 row_id: 2,
-                arena_idx: 1,
+                arena_idx: first_chunk_slot(1),
             },
             VisibleRowInfo {
                 row_id: 3,
-                arena_idx: 2,
+                arena_idx: first_chunk_slot(2),
             },
         ];
         let columns = vec!["id".to_string(), "name".to_string()];
@@ -440,18 +463,18 @@ mod tests {
     #[test]
     fn test_streaming_result_reset() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Integer(1)]);
-        arena.insert(2, 1, &[Value::Integer(2)]);
+        arena.insert(1, 1, &[Value::Integer(1)], None).unwrap();
+        arena.insert(2, 1, &[Value::Integer(2)], None).unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![
             VisibleRowInfo {
                 row_id: 1,
-                arena_idx: 0,
+                arena_idx: first_chunk_slot(0),
             },
             VisibleRowInfo {
                 row_id: 2,
-                arena_idx: 1,
+                arena_idx: first_chunk_slot(1),
             },
         ];
         let columns = vec!["id".to_string()];
@@ -477,12 +500,12 @@ mod tests {
     #[test]
     fn test_streaming_result_row_id_edge_cases() {
         let arena = RowArena::new();
-        arena.insert(100, 1, &[Value::Integer(1)]);
+        arena.insert(100, 1, &[Value::Integer(1)], None).unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![VisibleRowInfo {
             row_id: 100,
-            arena_idx: 0,
+            arena_idx: first_chunk_slot(0),
         }];
         let columns = vec!["id".to_string()];
 
@@ -504,23 +527,23 @@ mod tests {
     #[test]
     fn test_streaming_result_row_id_with_many_rows() {
         let arena = RowArena::new();
-        arena.insert(10, 1, &[Value::Integer(1)]);
-        arena.insert(20, 1, &[Value::Integer(2)]);
-        arena.insert(30, 1, &[Value::Integer(3)]);
+        arena.insert(10, 1, &[Value::Integer(1)], None).unwrap();
+        arena.insert(20, 1, &[Value::Integer(2)], None).unwrap();
+        arena.insert(30, 1, &[Value::Integer(3)], None).unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![
             VisibleRowInfo {
                 row_id: 10,
-                arena_idx: 0,
+                arena_idx: first_chunk_slot(0),
             },
             VisibleRowInfo {
                 row_id: 20,
-                arena_idx: 1,
+                arena_idx: first_chunk_slot(1),
             },
             VisibleRowInfo {
                 row_id: 30,
-                arena_idx: 2,
+                arena_idx: first_chunk_slot(2),
             },
         ];
         let columns = vec!["id".to_string()];
@@ -548,12 +571,14 @@ mod tests {
     #[test]
     fn test_streaming_result_row_slice_and_row() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Integer(42), Value::Float(3.5)]);
+        arena
+            .insert(1, 1, &[Value::Integer(42), Value::Float(3.5)], None)
+            .unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![VisibleRowInfo {
             row_id: 1,
-            arena_idx: 0,
+            arena_idx: first_chunk_slot(0),
         }];
         let columns = vec!["num".to_string(), "val".to_string()];
 
@@ -577,20 +602,21 @@ mod tests {
     #[test]
     fn test_streaming_result_invalid_arena_index() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Integer(1)]);
+        arena.insert(1, 1, &[Value::Integer(1)], None).unwrap();
 
         let guard = arena.read_guard();
         // Invalid arena_idx (999 doesn't exist)
         let visible = vec![VisibleRowInfo {
             row_id: 1,
-            arena_idx: 999,
+            arena_idx: first_chunk_slot(999),
         }];
         let columns = vec!["id".to_string()];
 
         let mut result = StreamingResult::new(guard, visible, columns);
 
-        // Should still advance but current_arc will be None
-        assert!(result.next());
+        // Missing addresses never produce a phantom empty row.
+        assert!(!result.next());
+        assert_eq!(result.remaining(), 0);
         assert!(result.current_arc.is_none());
         assert!(result.row_arc_slice().is_none());
     }
@@ -598,18 +624,18 @@ mod tests {
     #[test]
     fn test_streaming_result_as_aggregation_scanner() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Integer(10)]);
-        arena.insert(2, 1, &[Value::Integer(20)]);
+        arena.insert(1, 1, &[Value::Integer(10)], None).unwrap();
+        arena.insert(2, 1, &[Value::Integer(20)], None).unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![
             VisibleRowInfo {
                 row_id: 1,
-                arena_idx: 0,
+                arena_idx: first_chunk_slot(0),
             },
             VisibleRowInfo {
                 row_id: 2,
-                arena_idx: 1,
+                arena_idx: first_chunk_slot(1),
             },
         ];
         let columns = vec!["value".to_string()];
@@ -627,7 +653,7 @@ mod tests {
         let guard = arena.read_guard();
         let visible: Vec<VisibleRowInfo> = vec![];
 
-        let scanner = AggregationScanner::new(guard.data(), &visible, &[], guard.len());
+        let scanner = AggregationScanner::new(&guard, &visible, &[]);
 
         assert_eq!(scanner.count(), 0);
         assert_eq!(scanner.sum_column(0), 0.0);
@@ -639,27 +665,43 @@ mod tests {
     #[test]
     fn test_aggregation_scanner_with_nulls() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Integer(10), Value::Null(DataType::Integer)]);
-        arena.insert(2, 1, &[Value::Null(DataType::Integer), Value::Integer(20)]);
-        arena.insert(3, 1, &[Value::Integer(30), Value::Integer(30)]);
+        arena
+            .insert(
+                1,
+                1,
+                &[Value::Integer(10), Value::Null(DataType::Integer)],
+                None,
+            )
+            .unwrap();
+        arena
+            .insert(
+                2,
+                1,
+                &[Value::Null(DataType::Integer), Value::Integer(20)],
+                None,
+            )
+            .unwrap();
+        arena
+            .insert(3, 1, &[Value::Integer(30), Value::Integer(30)], None)
+            .unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![
             VisibleRowInfo {
                 row_id: 1,
-                arena_idx: 0,
+                arena_idx: first_chunk_slot(0),
             },
             VisibleRowInfo {
                 row_id: 2,
-                arena_idx: 1,
+                arena_idx: first_chunk_slot(1),
             },
             VisibleRowInfo {
                 row_id: 3,
-                arena_idx: 2,
+                arena_idx: first_chunk_slot(2),
             },
         ];
 
-        let scanner = AggregationScanner::new(guard.data(), &visible, &[], guard.len());
+        let scanner = AggregationScanner::new(&guard, &visible, &[]);
 
         // count() returns all visible rows
         assert_eq!(scanner.count(), 3);
@@ -676,27 +718,33 @@ mod tests {
     #[test]
     fn test_aggregation_scanner_all_nulls() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Null(DataType::Integer)]);
-        arena.insert(2, 1, &[Value::Null(DataType::Integer)]);
-        arena.insert(3, 1, &[Value::Null(DataType::Integer)]);
+        arena
+            .insert(1, 1, &[Value::Null(DataType::Integer)], None)
+            .unwrap();
+        arena
+            .insert(2, 1, &[Value::Null(DataType::Integer)], None)
+            .unwrap();
+        arena
+            .insert(3, 1, &[Value::Null(DataType::Integer)], None)
+            .unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![
             VisibleRowInfo {
                 row_id: 1,
-                arena_idx: 0,
+                arena_idx: first_chunk_slot(0),
             },
             VisibleRowInfo {
                 row_id: 2,
-                arena_idx: 1,
+                arena_idx: first_chunk_slot(1),
             },
             VisibleRowInfo {
                 row_id: 3,
-                arena_idx: 2,
+                arena_idx: first_chunk_slot(2),
             },
         ];
 
-        let scanner = AggregationScanner::new(guard.data(), &visible, &[], guard.len());
+        let scanner = AggregationScanner::new(&guard, &visible, &[]);
 
         assert_eq!(scanner.count(), 3);
         assert_eq!(scanner.count_column(0), 0);
@@ -708,32 +756,34 @@ mod tests {
     #[test]
     fn test_aggregation_scanner_min_max() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Integer(50)]);
-        arena.insert(2, 1, &[Value::Integer(10)]);
-        arena.insert(3, 1, &[Value::Integer(30)]);
-        arena.insert(4, 1, &[Value::Null(DataType::Integer)]);
+        arena.insert(1, 1, &[Value::Integer(50)], None).unwrap();
+        arena.insert(2, 1, &[Value::Integer(10)], None).unwrap();
+        arena.insert(3, 1, &[Value::Integer(30)], None).unwrap();
+        arena
+            .insert(4, 1, &[Value::Null(DataType::Integer)], None)
+            .unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![
             VisibleRowInfo {
                 row_id: 1,
-                arena_idx: 0,
+                arena_idx: first_chunk_slot(0),
             },
             VisibleRowInfo {
                 row_id: 2,
-                arena_idx: 1,
+                arena_idx: first_chunk_slot(1),
             },
             VisibleRowInfo {
                 row_id: 3,
-                arena_idx: 2,
+                arena_idx: first_chunk_slot(2),
             },
             VisibleRowInfo {
                 row_id: 4,
-                arena_idx: 3,
+                arena_idx: first_chunk_slot(3),
             },
         ];
 
-        let scanner = AggregationScanner::new(guard.data(), &visible, &[], guard.len());
+        let scanner = AggregationScanner::new(&guard, &visible, &[]);
 
         assert_eq!(scanner.min_column(0), Some(Value::Integer(10)));
         assert_eq!(scanner.max_column(0), Some(Value::Integer(50)));
@@ -742,27 +792,27 @@ mod tests {
     #[test]
     fn test_aggregation_scanner_min_max_floats() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Float(3.15)]);
-        arena.insert(2, 1, &[Value::Float(2.72)]);
-        arena.insert(3, 1, &[Value::Float(1.42)]);
+        arena.insert(1, 1, &[Value::Float(3.15)], None).unwrap();
+        arena.insert(2, 1, &[Value::Float(2.72)], None).unwrap();
+        arena.insert(3, 1, &[Value::Float(1.42)], None).unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![
             VisibleRowInfo {
                 row_id: 1,
-                arena_idx: 0,
+                arena_idx: first_chunk_slot(0),
             },
             VisibleRowInfo {
                 row_id: 2,
-                arena_idx: 1,
+                arena_idx: first_chunk_slot(1),
             },
             VisibleRowInfo {
                 row_id: 3,
-                arena_idx: 2,
+                arena_idx: first_chunk_slot(2),
             },
         ];
 
-        let scanner = AggregationScanner::new(guard.data(), &visible, &[], guard.len());
+        let scanner = AggregationScanner::new(&guard, &visible, &[]);
 
         assert_eq!(scanner.min_column(0), Some(Value::Float(1.42)));
         assert_eq!(scanner.max_column(0), Some(Value::Float(3.15)));
@@ -771,27 +821,33 @@ mod tests {
     #[test]
     fn test_aggregation_scanner_min_max_text() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Text("banana".into())]);
-        arena.insert(2, 1, &[Value::Text("apple".into())]);
-        arena.insert(3, 1, &[Value::Text("cherry".into())]);
+        arena
+            .insert(1, 1, &[Value::Text("banana".into())], None)
+            .unwrap();
+        arena
+            .insert(2, 1, &[Value::Text("apple".into())], None)
+            .unwrap();
+        arena
+            .insert(3, 1, &[Value::Text("cherry".into())], None)
+            .unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![
             VisibleRowInfo {
                 row_id: 1,
-                arena_idx: 0,
+                arena_idx: first_chunk_slot(0),
             },
             VisibleRowInfo {
                 row_id: 2,
-                arena_idx: 1,
+                arena_idx: first_chunk_slot(1),
             },
             VisibleRowInfo {
                 row_id: 3,
-                arena_idx: 2,
+                arena_idx: first_chunk_slot(2),
             },
         ];
 
-        let scanner = AggregationScanner::new(guard.data(), &visible, &[], guard.len());
+        let scanner = AggregationScanner::new(&guard, &visible, &[]);
 
         assert_eq!(scanner.min_column(0), Some(Value::Text("apple".into())));
         assert_eq!(scanner.max_column(0), Some(Value::Text("cherry".into())));
@@ -800,27 +856,29 @@ mod tests {
     #[test]
     fn test_aggregation_scanner_sum_non_numeric() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Text("hello".into())]);
-        arena.insert(2, 1, &[Value::Boolean(true)]);
-        arena.insert(3, 1, &[Value::Integer(10)]);
+        arena
+            .insert(1, 1, &[Value::Text("hello".into())], None)
+            .unwrap();
+        arena.insert(2, 1, &[Value::Boolean(true)], None).unwrap();
+        arena.insert(3, 1, &[Value::Integer(10)], None).unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![
             VisibleRowInfo {
                 row_id: 1,
-                arena_idx: 0,
+                arena_idx: first_chunk_slot(0),
             },
             VisibleRowInfo {
                 row_id: 2,
-                arena_idx: 1,
+                arena_idx: first_chunk_slot(1),
             },
             VisibleRowInfo {
                 row_id: 3,
-                arena_idx: 2,
+                arena_idx: first_chunk_slot(2),
             },
         ];
 
-        let scanner = AggregationScanner::new(guard.data(), &visible, &[], guard.len());
+        let scanner = AggregationScanner::new(&guard, &visible, &[]);
 
         // sum_column only sums Integer and Float, ignores others
         assert_eq!(scanner.sum_column(0), 10.0);
@@ -829,27 +887,27 @@ mod tests {
     #[test]
     fn test_aggregation_scanner_mixed_numeric() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Integer(10)]);
-        arena.insert(2, 1, &[Value::Float(20.5)]);
-        arena.insert(3, 1, &[Value::Integer(30)]);
+        arena.insert(1, 1, &[Value::Integer(10)], None).unwrap();
+        arena.insert(2, 1, &[Value::Float(20.5)], None).unwrap();
+        arena.insert(3, 1, &[Value::Integer(30)], None).unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![
             VisibleRowInfo {
                 row_id: 1,
-                arena_idx: 0,
+                arena_idx: first_chunk_slot(0),
             },
             VisibleRowInfo {
                 row_id: 2,
-                arena_idx: 1,
+                arena_idx: first_chunk_slot(1),
             },
             VisibleRowInfo {
                 row_id: 3,
-                arena_idx: 2,
+                arena_idx: first_chunk_slot(2),
             },
         ];
 
-        let scanner = AggregationScanner::new(guard.data(), &visible, &[], guard.len());
+        let scanner = AggregationScanner::new(&guard, &visible, &[]);
 
         assert_eq!(scanner.sum_column(0), 60.5);
     }
@@ -857,15 +915,15 @@ mod tests {
     #[test]
     fn test_aggregation_scanner_invalid_column() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Integer(10)]);
+        arena.insert(1, 1, &[Value::Integer(10)], None).unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![VisibleRowInfo {
             row_id: 1,
-            arena_idx: 0,
+            arena_idx: first_chunk_slot(0),
         }];
 
-        let scanner = AggregationScanner::new(guard.data(), &visible, &[], guard.len());
+        let scanner = AggregationScanner::new(&guard, &visible, &[]);
 
         // Column 99 doesn't exist
         assert_eq!(scanner.sum_column(99), 0.0);
@@ -877,56 +935,156 @@ mod tests {
     #[test]
     fn test_aggregation_scanner_invalid_arena_index() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Integer(10)]);
+        arena.insert(1, 1, &[Value::Integer(10)], None).unwrap();
 
         let guard = arena.read_guard();
         // Include an invalid arena index
         let visible = vec![
             VisibleRowInfo {
                 row_id: 1,
-                arena_idx: 0,
+                arena_idx: first_chunk_slot(0),
             },
             VisibleRowInfo {
                 row_id: 2,
-                arena_idx: 999,
+                arena_idx: first_chunk_slot(999),
             }, // Invalid
         ];
 
-        let scanner = AggregationScanner::new(guard.data(), &visible, &[], guard.len());
+        let scanner = AggregationScanner::new(&guard, &visible, &[]);
 
-        // Should gracefully skip invalid indices
-        assert_eq!(scanner.count(), 2);
+        // Every aggregation skips absent addresses, including COUNT(*).
+        assert_eq!(scanner.count(), 1);
         assert_eq!(scanner.sum_column(0), 10.0); // Only valid row counted
         assert_eq!(scanner.count_column(0), 1); // Only valid row counted
     }
 
     #[test]
     fn test_visible_row_info_clone_copy() {
+        assert_eq!(std::mem::size_of::<VisibleRowInfo>(), 16);
         let info = VisibleRowInfo {
             row_id: 42,
-            arena_idx: 5,
+            arena_idx: first_chunk_slot(5),
         };
 
         // Test Copy trait
         let copied = info;
         assert_eq!(copied.row_id, 42);
-        assert_eq!(copied.arena_idx, 5);
+        assert_eq!(copied.arena_idx, first_chunk_slot(5));
 
         // Test Clone trait (use Clone::clone to avoid clone_on_copy warning)
         let cloned = Clone::clone(&info);
         assert_eq!(cloned.row_id, 42);
-        assert_eq!(cloned.arena_idx, 5);
+        assert_eq!(cloned.arena_idx, first_chunk_slot(5));
+    }
+
+    #[test]
+    fn stale_address_cannot_read_the_replacement_rows_payload() {
+        let arena = RowArena::new();
+        let anchor = arena.insert(99, 1, &[Value::Integer(99)], None).unwrap();
+        let old = arena.insert(1, 1, &[Value::Integer(11)], None).unwrap();
+        assert!(arena.clear_at(old, 1, 1));
+        let replacement = arena.insert(2, 2, &[Value::Integer(222)], None).unwrap();
+        assert_eq!(replacement, old, "active slot was actually reused");
+        let visible = vec![
+            VisibleRowInfo {
+                row_id: 1,
+                arena_idx: Some(old),
+            },
+            VisibleRowInfo {
+                row_id: 2,
+                arena_idx: Some(replacement),
+            },
+            VisibleRowInfo {
+                row_id: 99,
+                arena_idx: Some(anchor),
+            },
+        ];
+        let mut result = StreamingResult::new(arena.read_guard(), visible, vec!["value".into()]);
+        let scanner = result.as_aggregation_scanner();
+        assert_eq!(scanner.count(), 2);
+        assert_eq!(scanner.sum_column(0), 321.0);
+        assert!(result.next());
+        assert_eq!(result.row_id(), 2);
+        assert_eq!(result.get(0), Some(&Value::Integer(222)));
+        assert!(result.next());
+        assert_eq!(result.row_id(), 99);
+        assert!(!result.next());
+    }
+
+    #[test]
+    fn historical_rows_keep_sequence_across_chunk_holes_and_reset() {
+        let arena = RowArena::new();
+        let left = arena.insert(10, 1, &[Value::Integer(10)], None).unwrap();
+        arena.freeze_active().unwrap();
+        let hole = arena.insert(20, 1, &[Value::Integer(20)], None).unwrap();
+        arena.freeze_active().unwrap();
+        let right = arena.insert(30, 1, &[Value::Integer(30)], None).unwrap();
+        assert!(arena.clear_at(hole, 20, 1));
+        let visible = vec![
+            VisibleRowInfo {
+                row_id: 5,
+                arena_idx: None,
+            },
+            VisibleRowInfo {
+                row_id: 10,
+                arena_idx: Some(left),
+            },
+            VisibleRowInfo {
+                row_id: 20,
+                arena_idx: Some(hole),
+            },
+            VisibleRowInfo {
+                row_id: 25,
+                arena_idx: None,
+            },
+            VisibleRowInfo {
+                row_id: 30,
+                arena_idx: Some(right),
+            },
+            VisibleRowInfo {
+                row_id: 40,
+                arena_idx: None,
+            },
+        ];
+        let fallback = [50, 250, 400].map(|value| CompactArc::from(vec![Value::Integer(value)]));
+        let mut result = StreamingResult::new_with_fallback(
+            arena.read_guard(),
+            visible,
+            fallback.to_vec(),
+            vec!["value".into()],
+        );
+        assert!(result.next());
+        assert!(result.next());
+        // Aggregations have independent fallback/cached-chunk cursors even
+        // when called after partial streaming or a previous aggregation.
+        let scanner = result.as_aggregation_scanner();
+        assert_eq!(scanner.count(), 5);
+        assert_eq!(scanner.sum_column(0), 740.0);
+        assert_eq!(scanner.count_column(0), 5);
+        assert_eq!(scanner.min_column(0), Some(Value::Integer(10)));
+        assert_eq!(scanner.max_column(0), Some(Value::Integer(400)));
+        assert_eq!(scanner.sum_column(0), 740.0);
+        for _ in 0..2 {
+            result.reset();
+            let mut actual = Vec::new();
+            while result.next() {
+                actual.push((result.row_id(), result.get(0).cloned().unwrap()));
+            }
+            let expected = [(5, 50), (10, 10), (25, 250), (30, 30), (40, 400)]
+                .map(|(row, value)| (row, Value::Integer(value)));
+            assert_eq!(actual, expected);
+        }
     }
 
     #[test]
     fn test_streaming_result_single_row() {
         let arena = RowArena::new();
-        arena.insert(1, 1, &[Value::Integer(42)]);
+        arena.insert(1, 1, &[Value::Integer(42)], None).unwrap();
 
         let guard = arena.read_guard();
         let visible = vec![VisibleRowInfo {
             row_id: 1,
-            arena_idx: 0,
+            arena_idx: first_chunk_slot(0),
         }];
         let columns = vec!["value".to_string()];
 

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -39,7 +39,7 @@ pub struct MVCCTable {
     /// Reference to the version store
     version_store: Arc<VersionStore>,
     /// Transaction-local version store (shared between multiple MVCCTable instances for same txn+table)
-    txn_versions: Arc<RwLock<TransactionVersionStore>>,
+    txn_versions: CompactArc<RwLock<TransactionVersionStore>>,
     /// Cached schema for returning references (Arc clone from version_store - O(1) instead of cloning)
     cached_schema: CompactArc<Schema>,
 }
@@ -82,10 +82,12 @@ impl MVCCTable {
     ) -> Self {
         // CompactArc clone - O(1) reference count increment, not full schema clone
         let cached_schema = version_store.schema().clone();
+        let txn_versions =
+            CompactArc::new_in(RwLock::new(txn_versions), version_store.memory_account());
         Self {
             txn_id,
             version_store,
-            txn_versions: Arc::new(RwLock::new(txn_versions)),
+            txn_versions,
             cached_schema,
         }
     }
@@ -95,7 +97,7 @@ impl MVCCTable {
     pub fn new_with_shared_store(
         txn_id: i64,
         version_store: Arc<VersionStore>,
-        txn_versions: Arc<RwLock<TransactionVersionStore>>,
+        txn_versions: CompactArc<RwLock<TransactionVersionStore>>,
     ) -> Self {
         // CompactArc clone - O(1) reference count increment, not full schema clone
         let cached_schema = version_store.schema().clone();
@@ -118,7 +120,7 @@ impl MVCCTable {
     }
 
     /// Returns a reference to the shared transaction version store
-    pub fn txn_versions(&self) -> &Arc<RwLock<TransactionVersionStore>> {
+    pub fn txn_versions(&self) -> &CompactArc<RwLock<TransactionVersionStore>> {
         &self.txn_versions
     }
 
@@ -3208,6 +3210,13 @@ impl Table for MVCCTable {
         self.txn_versions.read().unwrap().has_local_changes()
     }
 
+    fn record_source_lsn(&self, row_id: i64, lsn: Option<std::num::NonZeroU64>) {
+        let Ok(mut versions) = self.txn_versions.write() else {
+            panic!("transaction store is poisoned while recording its source LSN");
+        };
+        versions.record_source_lsn(row_id, lsn);
+    }
+
     fn get_pending_versions(&self) -> Vec<(i64, Row, bool, i64)> {
         let txn_versions = self.txn_versions.read().unwrap();
         txn_versions
@@ -3349,7 +3358,7 @@ impl Table for MVCCTable {
         let expected_rows = self.version_store.row_count();
 
         // Create the appropriate index type with capacity hint
-        let index: Arc<dyn Index> = match chosen_type {
+        let mut index: Arc<dyn Index> = match chosen_type {
             IndexType::Hash => Arc::new(HashIndex::new(
                 name.to_string(),
                 self.name().to_string(),
@@ -3450,6 +3459,8 @@ impl Table for MVCCTable {
                 Arc::new(hnsw)
             }
         };
+
+        self.version_store.attach_index_memory(&mut index)?;
 
         // Populate the index with existing data using batch_slice for better performance
         // Collect all entries first, then add in a single batch operation
@@ -3598,7 +3609,8 @@ impl Table for MVCCTable {
             metric,
         );
         hnsw.set_unique(is_unique);
-        let index: Arc<dyn Index> = Arc::new(hnsw);
+        let mut index: Arc<dyn Index> = Arc::new(hnsw);
+        self.version_store.attach_index_memory(&mut index)?;
 
         // Populate with existing data
         let mut entries: Vec<(i64, Vec<Value>)> = Vec::new();
@@ -3807,7 +3819,7 @@ impl Table for MVCCTable {
 
         // Create the btree index with capacity hint
         let expected_rows = self.version_store.row_count();
-        let index = BTreeIndex::new(
+        let mut index = BTreeIndex::new(
             index_name.clone(),
             self.name().to_string(),
             col.id as i32,
@@ -3816,6 +3828,8 @@ impl Table for MVCCTable {
             is_unique,
             expected_rows,
         );
+
+        index.attach_memory_account(self.version_store.memory_account())?;
 
         // Populate the index with existing data using batch_slice
         let mut entries: Vec<(i64, Vec<Value>)> = Vec::new();
@@ -3922,7 +3936,7 @@ impl Table for MVCCTable {
 
         // Create the multi-column index with capacity hint
         let expected_rows = self.version_store.row_count();
-        let index = MultiColumnIndex::new(
+        let mut index = MultiColumnIndex::new(
             name.to_string(),
             self.name().to_string(),
             column_names,
@@ -3931,6 +3945,8 @@ impl Table for MVCCTable {
             is_unique,
             expected_rows,
         );
+
+        index.attach_memory_account(self.version_store.memory_account())?;
 
         // Populate the index with existing data using batch_slice
         let mut entries: Vec<(i64, Vec<Value>)> = Vec::new();

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -27,7 +27,7 @@
 //!
 
 use std::fmt;
-use std::num::{NonZeroU64, NonZeroUsize};
+use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -36,13 +36,13 @@ use parking_lot::{Mutex, RwLock};
 use crate::common::SmartString;
 
 use crate::common::i64_map::{f64_from_key, key_from_f64};
-use crate::common::{
-    new_cow_btree_map, new_i64_map, new_i64_map_with_capacity, CompactArc, CowBTreeMap, I64Map,
-};
+use crate::common::{CompactArc, CowBTreeMap, I64Map};
 use crate::core::types::DataType;
 use crate::core::{Error, Row, RowVec, Schema, Value};
 use crate::storage::expression::CompiledFilter;
-use crate::storage::mvcc::arena::RowArena;
+use crate::storage::index::accounted_map::{HashEntry, TrackedHash};
+use crate::storage::mvcc::accounting::RetainedSmallVec;
+use crate::storage::mvcc::arena::{ArenaId, RowArena};
 use crate::storage::mvcc::get_fast_timestamp;
 #[cfg(not(test))]
 use crate::storage::mvcc::registry::TransactionRegistry;
@@ -194,16 +194,14 @@ impl fmt::Display for RowVersion {
 /// Uses Arc for the prev pointer to enable O(1) cloning of the chain
 ///
 /// # Memory Optimization
-/// - `arena_idx`: Uses `Option<NonZeroU64>` (8 bytes) instead of `Option<usize>` (16 bytes)
-///   Stored as `idx + 1` to enable niche optimization (0 = None)
+/// Stable optional arena addresses occupy one word, including on sparse chunks.
 struct VersionChainEntry {
     /// Current version
     version: RowVersion,
     /// Previous version in the chain (Arc allows cheap cloning)
-    prev: Option<Arc<VersionChainEntry>>,
-    /// Index into the arena for zero-copy access (None if data not in arena)
-    /// Stored as `idx + 1` to enable niche optimization (NonZeroU64)
-    arena_idx: Option<NonZeroU64>,
+    prev: Option<CompactArc<VersionChainEntry>>,
+    /// Stable arena address, absent for historical payloads outside the arena.
+    arena_idx: Option<ArenaId>,
 }
 
 /// Count the depth of a version chain by traversing prev pointers.
@@ -217,34 +215,6 @@ fn count_chain_depth(entry: &VersionChainEntry) -> usize {
         current = &prev.prev;
     }
     depth
-}
-
-/// Convert arena index (usize) to compact representation (Option<NonZeroU64>)
-/// Stores `idx + 1` so that 0 can represent None via niche optimization
-#[inline(always)]
-fn pack_arena_idx(idx: usize) -> Option<NonZeroU64> {
-    // idx + 1 is always > 0, supports full usize range on 64-bit systems
-    NonZeroU64::new((idx as u64).saturating_add(1))
-}
-
-/// Convert compact arena index back to usize
-/// Returns None if the stored value was None
-#[inline(always)]
-fn unpack_arena_idx(packed: Option<NonZeroU64>) -> Option<usize> {
-    packed.map(|nz| (nz.get() - 1) as usize)
-}
-
-/// Convert Option<usize> to Option<NonZeroUsize> for RowIndex
-/// Stores `idx + 1` so that 0 can represent None via niche optimization
-#[inline(always)]
-fn pack_row_arena_idx(idx: Option<usize>) -> Option<NonZeroUsize> {
-    idx.and_then(|i| NonZeroUsize::new(i.wrapping_add(1)))
-}
-
-/// Convert Option<NonZeroUsize> back to Option<usize> for RowIndex
-#[inline(always)]
-fn unpack_row_arena_idx(packed: Option<NonZeroUsize>) -> Option<usize> {
-    packed.map(|nz| nz.get().wrapping_sub(1))
 }
 
 /// Tracks write operations with the version read for conflict detection
@@ -269,67 +239,91 @@ pub struct WriteSetEntry {
 // With pooling, maps are returned to the pool on Drop and reused by the next
 // transaction, reducing allocation churn by ~99% for bulk insert workloads.
 
-/// Maximum number of maps to keep in each pool.
-/// Prevents unbounded memory growth while allowing reasonable reuse.
+/// Count and byte bounds limit idle capacity independently of future admission.
 const MAP_POOL_MAX_SIZE: usize = 64;
-
-/// Global pool for VersionList maps (local_versions in TransactionVersionStore)
-static VERSION_LIST_MAP_POOL: Mutex<Vec<I64Map<VersionList>>> = Mutex::new(Vec::new());
-
-/// Global pool for WriteSetEntry maps (write_set in TransactionVersionStore)
-static WRITE_SET_MAP_POOL: Mutex<Vec<I64Map<WriteSetEntry>>> = Mutex::new(Vec::new());
-
-/// Get a VersionList map from pool or create a new one
-#[inline]
-fn get_version_list_map() -> I64Map<VersionList> {
-    if let Some(map) = VERSION_LIST_MAP_POOL.lock().pop() {
-        map
-    } else {
-        new_i64_map_with_capacity(TX_VERSION_MAP_INITIAL_CAPACITY)
-    }
-}
-
-/// Get a WriteSetEntry map from pool or create a new one
-#[inline]
-fn get_write_set_map() -> I64Map<WriteSetEntry> {
-    if let Some(map) = WRITE_SET_MAP_POOL.lock().pop() {
-        map
-    } else {
-        new_i64_map_with_capacity(TX_VERSION_MAP_INITIAL_CAPACITY)
-    }
-}
-
-/// Return a VersionList map to the pool for reuse
-#[inline]
-fn return_version_list_map(mut map: I64Map<VersionList>) {
-    map.clear();
-    let mut pool = VERSION_LIST_MAP_POOL.lock();
-    if pool.len() < MAP_POOL_MAX_SIZE {
-        pool.push(map);
-    }
-    // If pool is full, map is dropped (deallocated)
-}
-
-/// Return a WriteSetEntry map to the pool for reuse
-#[inline]
-fn return_write_set_map(mut map: I64Map<WriteSetEntry>) {
-    map.clear();
-    let mut pool = WRITE_SET_MAP_POOL.lock();
-    if pool.len() < MAP_POOL_MAX_SIZE {
-        pool.push(map);
-    }
-    // If pool is full, map is dropped (deallocated)
-}
-
-/// Clear the transaction version map pools.
-/// Call this when dropping the database to release pooled memory.
-pub fn clear_version_map_pools() {
-    VERSION_LIST_MAP_POOL.lock().clear();
-    WRITE_SET_MAP_POOL.lock().clear();
-}
-
-/// Capacity hint for transaction version maps - used by pool functions
+const MAP_POOL_MAX_BYTES: usize = 1 << 20;
 const TX_VERSION_MAP_INITIAL_CAPACITY: usize = 16;
+
+struct IdleMapPool<V> {
+    maps: Vec<I64Map<V>>,
+    idle_bytes: usize,
+    // Drop the physical vector before releasing its capacity charge.
+    charge: crate::common::memory::MemoryCharge,
+}
+
+impl<V> IdleMapPool<V> {
+    fn new(account: &crate::common::memory::MemoryAccount) -> Self {
+        Self {
+            maps: Vec::new(),
+            idle_bytes: 0,
+            charge: crate::common::memory::MemoryCharge::new(account, 0),
+        }
+    }
+
+    fn take(&mut self) -> I64Map<V> {
+        if let Some(map) = self.maps.pop() {
+            self.idle_bytes -= map.allocation_size();
+            map
+        } else {
+            I64Map::with_capacity_in(TX_VERSION_MAP_INITIAL_CAPACITY, self.charge.account())
+        }
+    }
+
+    fn put(&mut self, map: I64Map<V>) -> Option<I64Map<V>> {
+        debug_assert!(map.is_empty());
+        let bytes = map.allocation_size();
+        if self.maps.len() == MAP_POOL_MAX_SIZE
+            || bytes > MAP_POOL_MAX_BYTES.saturating_sub(self.idle_bytes)
+        {
+            return Some(map);
+        }
+        if self.maps.len() == self.maps.capacity() {
+            let capacity = (self.maps.capacity().max(2) * 2).min(MAP_POOL_MAX_SIZE);
+            let replacement = Vec::with_capacity(capacity);
+            let new_charge = crate::common::memory::MemoryCharge::new(
+                self.charge.account(),
+                replacement.capacity() * std::mem::size_of::<I64Map<V>>(),
+            );
+            let old = std::mem::replace(&mut self.maps, replacement);
+            let old_charge = std::mem::replace(&mut self.charge, new_charge);
+            self.maps.extend(old);
+            drop(old_charge);
+        }
+        self.idle_bytes += bytes;
+        self.maps.push(map);
+        None
+    }
+
+    fn trim(&mut self) {
+        self.maps = Vec::new();
+        self.idle_bytes = 0;
+        self.charge.resize(0);
+    }
+}
+
+/// Reuse belongs to one engine. Maps retain their charge while checked out,
+/// idle, or held by a transaction after the engine handle is closed.
+pub(crate) struct TxnMapPools {
+    versions: Mutex<IdleMapPool<VersionList>>,
+    writes: Mutex<IdleMapPool<WriteSetEntry>>,
+}
+
+impl TxnMapPools {
+    pub(crate) fn new_in(memory: &crate::common::memory::MemoryAccount) -> CompactArc<Self> {
+        CompactArc::new_in(
+            Self {
+                versions: Mutex::new(IdleMapPool::new(memory)),
+                writes: Mutex::new(IdleMapPool::new(memory)),
+            },
+            memory,
+        )
+    }
+
+    pub(crate) fn trim(&self) {
+        self.versions.lock().trim();
+        self.writes.lock().trim();
+    }
+}
 
 /// Lightweight row index for deferred materialization
 ///
@@ -342,31 +336,26 @@ const TX_VERSION_MAP_INITIAL_CAPACITY: usize = 16;
 /// - New: Get 100K indices, filter to 50K, limit to 10, clone 10 (10 allocations)
 ///
 /// # Memory Optimization
-/// Uses `Option<NonZeroUsize>` (8 bytes) instead of `Option<usize>` (16 bytes)
-/// for arena_idx, reducing struct size from 24 to 16 bytes (33% smaller).
+/// An optional stable arena address preserves the 16-byte deferred row handle.
 #[derive(Clone, Copy, Debug)]
 pub struct RowIndex {
     /// Row ID
     pub row_id: i64,
-    /// Arena index (None if row data is not in arena, must clone from version)
-    /// Stored as `idx + 1` to enable niche optimization (0 = None)
-    arena_idx: Option<NonZeroUsize>,
+    /// None means the payload must be resolved from its visible version.
+    arena_idx: Option<ArenaId>,
 }
 
 impl RowIndex {
     /// Create a new RowIndex with the given row_id and arena index
     #[inline(always)]
-    pub fn new(row_id: i64, arena_idx: Option<usize>) -> Self {
-        Self {
-            row_id,
-            arena_idx: pack_row_arena_idx(arena_idx),
-        }
+    pub fn new(row_id: i64, arena_idx: Option<ArenaId>) -> Self {
+        Self { row_id, arena_idx }
     }
 
-    /// Get the arena index (unpacked to Option<usize>)
+    /// Get the stable arena address.
     #[inline(always)]
-    pub fn arena_idx(&self) -> Option<usize> {
-        unpack_row_arena_idx(self.arena_idx)
+    pub fn arena_idx(&self) -> Option<ArenaId> {
+        self.arena_idx
     }
 }
 
@@ -479,14 +468,14 @@ impl Drop for PublishGuard {
 #[derive(Default)]
 pub struct PublishHold {
     guards: Vec<PublishGuard>,
-    stores: Vec<Arc<std::sync::RwLock<TransactionVersionStore>>>,
+    stores: Vec<CompactArc<std::sync::RwLock<TransactionVersionStore>>>,
 }
 
 impl PublishHold {
     pub fn add(
         &mut self,
         version_store: &Arc<VersionStore>,
-        txn_store: Arc<std::sync::RwLock<TransactionVersionStore>>,
+        txn_store: CompactArc<std::sync::RwLock<TransactionVersionStore>>,
     ) {
         self.guards.push(version_store.begin_publish());
         self.stores.push(txn_store);
@@ -517,12 +506,99 @@ impl PublishHold {
     }
 }
 
-/// The index entries a commit added and removed for one index, kept until
-/// the commit is visible or undone
+/// A complete inverse is retained before either index mutation is attempted.
+/// Batch methods may fail after changing a prefix, so progress records an
+/// attempted set, not a count of calls that returned success.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum IndexUndoProgress {
+    Prepared,
+    RemovingOld,
+    AddingNew,
+}
+
 struct IndexUndo {
     index: Arc<dyn Index>,
     added: Vec<(i64, Vec<Value>)>,
     removed: Vec<(i64, Vec<Value>)>,
+    progress: IndexUndoProgress,
+    _charge: crate::common::memory::MemoryCharge,
+}
+
+impl IndexUndo {
+    fn buffer_bytes(added: &Vec<(i64, Vec<Value>)>, removed: &Vec<(i64, Vec<Value>)>) -> usize {
+        (added.capacity() + removed.capacity()) * std::mem::size_of::<(i64, Vec<Value>)>()
+            + added
+                .iter()
+                .chain(removed)
+                .map(|(_, values)| values.capacity() * std::mem::size_of::<Value>())
+                .sum::<usize>()
+    }
+
+    fn new(
+        index: Arc<dyn Index>,
+        added: Vec<(i64, Vec<Value>)>,
+        removed: Vec<(i64, Vec<Value>)>,
+        account: &crate::common::memory::MemoryAccount,
+    ) -> Self {
+        let bytes = Self::buffer_bytes(&added, &removed);
+        Self {
+            index,
+            added,
+            removed,
+            progress: IndexUndoProgress::Prepared,
+            _charge: crate::common::memory::MemoryCharge::new(account, bytes),
+        }
+    }
+
+    fn change(index: &dyn Index, entries: &[(i64, Vec<Value>)], add: bool) -> Result<(), Error> {
+        if let [(row_id, values)] = entries {
+            return if add {
+                index.add(values, *row_id, *row_id)
+            } else {
+                index.remove(values, *row_id, *row_id)
+            };
+        }
+        let batch: Vec<(i64, &[Value])> = entries
+            .iter()
+            .map(|(row_id, values)| (*row_id, values.as_slice()))
+            .collect();
+        if add {
+            index.add_batch_slice(&batch)
+        } else {
+            index.remove_batch_slice(&batch)
+        }
+    }
+
+    fn apply(&mut self) -> Result<(), Error> {
+        if !self.removed.is_empty() {
+            self.progress = IndexUndoProgress::RemovingOld;
+            Self::change(self.index.as_ref(), &self.removed, false)?;
+        }
+        if !self.added.is_empty() {
+            self.progress = IndexUndoProgress::AddingNew;
+            Self::change(self.index.as_ref(), &self.added, true)?;
+        }
+        Ok(())
+    }
+
+    fn undo(&mut self) -> Result<(), Error> {
+        // Remove attempted additions before restoring old keys, including UNIQUE swaps and batch retries.
+        if self.progress == IndexUndoProgress::AddingNew {
+            Self::change(self.index.as_ref(), &self.added, false)?;
+            self.progress = IndexUndoProgress::RemovingOld;
+            self.added.clear();
+            self._charge
+                .resize(Self::buffer_bytes(&self.added, &self.removed));
+        }
+        if self.progress == IndexUndoProgress::RemovingOld && !self.removed.is_empty() {
+            Self::change(self.index.as_ref(), &self.removed, true)?;
+            self.removed.clear();
+            self._charge
+                .resize(Self::buffer_bytes(&self.added, &self.removed));
+        }
+        self.progress = IndexUndoProgress::Prepared;
+        Ok(())
+    }
 }
 
 /// VersionStore tracks the latest committed version of each row for a table
@@ -539,6 +615,8 @@ struct IndexUndo {
 /// - Returning slices instead of clones during iteration
 /// - Eliminating per-row allocation overhead
 pub struct VersionStore {
+    pools: CompactArc<TxnMapPools>,
+    memory: crate::common::memory::MemoryAccount,
     /// Row versions indexed by row ID (CowBTree for O(1) snapshot cloning)
     versions: CowBTreeMap<VersionChainEntry>,
     /// The name of the table this store belongs to (SmartString inlines up to 15 bytes)
@@ -579,10 +657,11 @@ pub struct VersionStore {
     upsert_mutex: Arc<parking_lot::Mutex<()>>,
     /// Commits between their index updates and their versions being visible
     publishing: AtomicUsize,
-    publication_keys: Mutex<ahash::AHashMap<PublicationKey, i64>>,
+    publication_keys: Mutex<PublicationOwners>,
     index_catalog: Arc<AtomicUsize>,
     /// Publishes completed
     publish_epoch: AtomicU64,
+    _object_charge: crate::common::memory::MemoryCharge,
 }
 
 impl VersionStore {
@@ -591,69 +670,77 @@ impl VersionStore {
         Self::with_capacity(table_name, schema, None, 0)
     }
 
-    /// Creates a new version store with pre-allocated capacity
-    ///
-    /// Pre-allocating capacity avoids hash map resizing during bulk inserts.
-    /// Use this when the expected row count is known (e.g., during recovery).
-    #[cfg(not(test))]
+    /// Standalone stores get an independent accounting root; engine stores
+    /// use a child of their engine's root through `with_capacity_in`.
     pub fn with_capacity(
         table_name: impl Into<SmartString>,
         schema: Schema,
-        checker: Option<Arc<TransactionRegistry>>,
+        #[cfg(not(test))] checker: Option<Arc<TransactionRegistry>>,
+        #[cfg(test)] checker: Option<Arc<dyn VisibilityChecker>>,
         expected_rows: usize,
     ) -> Self {
-        let versions = new_cow_btree_map();
-
-        Self {
-            versions,
-            table_name: table_name.into(),
-            schema: RwLock::new(CompactArc::new(schema)),
-            indexes: RwLock::new(FxHashMap::default()),
-            closed: AtomicBool::new(false),
-            auto_increment_counter: AtomicI64::new(0),
-            uncommitted_writes: RwLock::new(new_i64_map()),
-            visibility_checker: checker,
-            arena: RowArena::with_capacity(expected_rows),
-            zone_maps: RwLock::new(None),
-            max_version_history: 10, // Default: keep up to 10 previous versions
-            committed_row_count: AtomicUsize::new(0),
-            upsert_mutex: Arc::new(parking_lot::Mutex::new(())),
-            publishing: AtomicUsize::new(0),
-            publication_keys: Mutex::new(ahash::AHashMap::new()),
-            index_catalog: Arc::new(AtomicUsize::new(0)),
-            publish_epoch: AtomicU64::new(0),
-        }
+        Self::with_capacity_in(
+            table_name,
+            schema,
+            checker,
+            expected_rows,
+            crate::common::memory::MemoryAccount::new(),
+        )
     }
 
-    /// Creates a new version store with pre-allocated capacity (test version)
-    #[cfg(test)]
-    pub fn with_capacity(
+    pub(crate) fn with_capacity_in(
         table_name: impl Into<SmartString>,
         schema: Schema,
-        checker: Option<Arc<dyn VisibilityChecker>>,
+        #[cfg(not(test))] checker: Option<Arc<TransactionRegistry>>,
+        #[cfg(test)] checker: Option<Arc<dyn VisibilityChecker>>,
         expected_rows: usize,
+        memory: crate::common::memory::MemoryAccount,
     ) -> Self {
-        let versions = new_cow_btree_map();
+        let pools = TxnMapPools::new_in(&memory);
+        Self::with_capacity_and_pools(table_name, schema, checker, expected_rows, memory, pools)
+    }
 
+    pub(crate) fn with_capacity_and_pools(
+        table_name: impl Into<SmartString>,
+        schema: Schema,
+        #[cfg(not(test))] checker: Option<Arc<TransactionRegistry>>,
+        #[cfg(test)] checker: Option<Arc<dyn VisibilityChecker>>,
+        expected_rows: usize,
+        memory: crate::common::memory::MemoryAccount,
+        pools: CompactArc<TxnMapPools>,
+    ) -> Self {
+        let versions = RwLock::new(crate::common::CowBTree::new_in(memory.clone()));
+        let mut publication_keys = PublicationOwners::default();
+        publication_keys.attach(&memory);
         Self {
+            pools,
             versions,
-            table_name: table_name.into(),
-            schema: RwLock::new(CompactArc::new(schema)),
+            table_name: table_name.into().into_hot(&memory),
+            schema: RwLock::new(CompactArc::new_in(schema, &memory)),
             indexes: RwLock::new(FxHashMap::default()),
             closed: AtomicBool::new(false),
             auto_increment_counter: AtomicI64::new(0),
-            uncommitted_writes: RwLock::new(new_i64_map()),
+            uncommitted_writes: RwLock::new(I64Map::new_in(&memory)),
             visibility_checker: checker,
-            arena: RowArena::with_capacity(expected_rows),
+            arena: RowArena::with_account(expected_rows, &memory),
             zone_maps: RwLock::new(None),
             max_version_history: 10,
             committed_row_count: AtomicUsize::new(0),
             upsert_mutex: Arc::new(parking_lot::Mutex::new(())),
             publishing: AtomicUsize::new(0),
-            publication_keys: Mutex::new(ahash::AHashMap::new()),
+            publication_keys: Mutex::new(publication_keys),
             index_catalog: Arc::new(AtomicUsize::new(0)),
             publish_epoch: AtomicU64::new(0),
+            _object_charge: crate::common::memory::MemoryCharge::conservative(
+                &memory,
+                std::mem::size_of::<Self>() + 12 * std::mem::size_of::<usize>(),
+            ),
+            memory,
         }
+    }
+
+    pub(crate) fn memory_account(&self) -> &crate::common::memory::MemoryAccount {
+        &self.memory
     }
 
     /// Sets the maximum version history limit per row
@@ -773,438 +860,146 @@ impl VersionStore {
         self.auto_increment_counter.load(Ordering::Acquire)
     }
 
-    /// Adds a new version for a row
-    pub fn add_version(&self, row_id: i64, version: RowVersion) {
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
-
-        let is_new_version_deleted = version.deleted_at_txn_id != 0;
-
-        // Use write lock for the entire operation (MVCC single-writer semantics)
-        let mut versions = self.versions.write();
-
-        // Use entry API to avoid double traversal
-        match versions.entry(row_id) {
-            crate::common::cow_btree::Entry::Occupied(mut occupied) => {
-                // Extract existing data from the entry
-                let existing = occupied.get();
-                let existing_arena_idx = existing.arena_idx;
-                let was_deleted = existing.version.deleted_at_txn_id != 0;
-
-                // Update committed row count based on delete state transitions
-                if was_deleted && !is_new_version_deleted {
-                    // Row was deleted, now being re-inserted -> increment
-                    self.committed_row_count.fetch_add(1, Ordering::Relaxed);
-                } else if !was_deleted && is_new_version_deleted {
-                    // Row was visible, now being deleted -> decrement
-                    self.committed_row_count.fetch_sub(1, Ordering::Relaxed);
-                }
-
-                // O(k) chain management - depth computed by traversal
-                // When limit exceeded: drop old chain AND reuse arena slot
-                let existing_depth = count_chain_depth(existing);
-                let new_depth = existing_depth + 1;
-                let can_reuse_arena =
-                    self.max_version_history > 0 && new_depth > self.max_version_history;
-
-                // Only clone existing version data when needed:
-                // 1. For delete operations that need to preserve data
-                // 2. When keeping version history (not pruning)
-                let mut new_version = version;
-                if new_version.deleted_at_txn_id != 0 && new_version.data.is_empty() {
-                    // For deletes, preserve data from current version
-                    new_version.data = existing.version.data.clone();
-                }
-
-                // Store in arena (only for non-deleted versions)
-                // OPTIMIZATION: Always reuse arena slot - historical data is in prev_chain
-                let arena_idx = if new_version.deleted_at_txn_id == 0 {
-                    // Convert Row to Arc once (takes ownership, no copy if already Arc)
-                    let arc_data = std::mem::take(&mut new_version.data).into_arc();
-
-                    // Always reuse existing arena slot if available
-                    // Historical versions are stored in prev_chain.version.data
-                    let idx = if let Some(old_idx) = unpack_arena_idx(existing_arena_idx) {
-                        // Reuse the arena slot - prevents unbounded growth
-                        self.arena.update_at(
-                            old_idx,
-                            row_id,
-                            new_version.txn_id,
-                            CompactArc::clone(&arc_data),
-                        );
-                        old_idx
-                    } else {
-                        // No existing slot (shouldn't happen for updates), append
-                        self.arena.insert_arc(
-                            row_id,
-                            new_version.txn_id,
-                            CompactArc::clone(&arc_data),
-                        )
-                    };
-
-                    // Reuse the Arc for the version's data - enables O(1) clone on read
-                    new_version.data = Row::from_arc(arc_data);
-
-                    pack_arena_idx(idx)
-                } else {
-                    // Deleted version - mark arena as deleted for visibility
-                    if let Some(old_arena_idx) = unpack_arena_idx(existing_arena_idx) {
-                        self.arena.mark_deleted(old_arena_idx, new_version.txn_id);
-                    }
-                    existing_arena_idx
-                };
-
-                // Build version chain entry
-                // When limit exceeded: drop entire history (no prev_chain allocation)
-                // When under limit: create prev_chain with existing version
-                let final_prev = if can_reuse_arena {
-                    // Exceeded limit - drop all history, no allocation
-                    None
-                } else {
-                    // Under limit - clone existing version and create chain
-                    let existing_version = existing.version.clone();
-                    let existing_prev = existing.prev.clone();
-                    Some(Arc::new(VersionChainEntry {
-                        version: existing_version,
-                        prev: existing_prev,
-                        // Historical versions don't use arena (slot reused by new HEAD)
-                        arena_idx: None,
-                    }))
-                };
-
-                let new_entry = VersionChainEntry {
-                    version: new_version,
-                    prev: final_prev,
-                    arena_idx,
-                };
-
-                // Replace entry in-place (no additional tree traversal)
-                occupied.insert(new_entry);
-            }
-            crate::common::cow_btree::Entry::Vacant(vacant) => {
-                // First version for this row - store in arena
-                // OPTIMIZATION: Convert Row to Arc once, then just clone Arc (no data copy)
-                let (arena_idx, final_version) = if version.deleted_at_txn_id == 0 {
-                    // New non-deleted row -> increment counter
-                    self.committed_row_count.fetch_add(1, Ordering::Relaxed);
-
-                    let mut v = version;
-                    // Convert Row to Arc once (takes ownership, no copy if already Arc)
-                    let arc_data = std::mem::take(&mut v.data).into_arc();
-                    // Insert Arc into arena (just Arc::clone, no data copy)
-                    let idx = self
-                        .arena
-                        .insert_arc(row_id, v.txn_id, CompactArc::clone(&arc_data));
-                    // Create version with Arc-backed data for O(1) clone
-                    v.data = Row::from_arc(arc_data);
-                    (pack_arena_idx(idx), v)
-                } else {
-                    (None, version)
-                };
-
-                let new_entry = VersionChainEntry {
-                    version: final_version,
-                    prev: None,
-                    arena_idx,
-                };
-
-                // Insert into vacant slot (no additional traversal)
-                vacant.insert(new_entry);
-            }
-        }
+    /// Publish one version without a WAL source (in-memory or legacy recovery).
+    pub fn add_version(&self, row_id: i64, version: RowVersion) -> Result<(), Error> {
+        self.add_version_with_lsn(row_id, version, None)
     }
 
-    /// Adds multiple versions in batch - used by commit
-    ///
-    /// Updates both the version store and the arena atomically per row.
-    /// Arena updates are O(1) per row (just an insert), so this is efficient.
-    /// Row arena index updates are batched under a single lock acquisition.
-    /// Version data uses Arc-backed storage for O(1) clones on read.
     #[inline]
-    pub fn add_versions_batch(&self, batch: Vec<(i64, RowVersion)>) {
-        if self.closed.load(Ordering::Acquire) || batch.is_empty() {
-            return;
+    pub fn add_version_with_lsn(
+        &self,
+        row_id: i64,
+        version: RowVersion,
+        source_lsn: Option<NonZeroU64>,
+    ) -> Result<(), Error> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(Error::internal("version store is closed"));
         }
+        self.add_version_locked(&mut self.versions.write(), row_id, version, source_lsn)
+    }
 
-        // Use write lock for the entire batch operation (MVCC single-writer semantics)
+    /// Each successful row is counted immediately, including a partial batch
+    /// that fails. Transaction publication retains the complete undo journal.
+    #[inline]
+    pub fn add_versions_batch(&self, batch: Vec<(i64, RowVersion)>) -> Result<(), Error> {
+        self.add_versions_with_lsns(batch.into_iter().map(|(id, version)| (id, version, None)))
+    }
+
+    fn add_versions_with_lsns(
+        &self,
+        batch: impl IntoIterator<Item = (i64, RowVersion, Option<NonZeroU64>)>,
+    ) -> Result<(), Error> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(Error::internal("version store is closed"));
+        }
         let mut versions = self.versions.write();
+        for (row_id, version, source_lsn) in batch {
+            self.add_version_locked(&mut versions, row_id, version, source_lsn)?;
+        }
+        Ok(())
+    }
 
-        // Track row count delta: positive for inserts, negative for deletes
-        let mut count_delta: isize = 0;
+    #[inline]
+    pub fn add_version_single(&self, row_id: i64, version: RowVersion) -> Result<(), Error> {
+        self.add_version_with_lsn(row_id, version, None)
+    }
 
-        for (row_id, version) in batch {
-            let is_new_version_deleted = version.deleted_at_txn_id != 0;
-
-            // Use entry API to avoid double traversal
-            match versions.entry(row_id) {
-                crate::common::cow_btree::Entry::Occupied(mut occupied) => {
-                    // Extract existing data from the entry
-                    let existing = occupied.get();
-                    let existing_arena_idx = existing.arena_idx;
-                    let was_deleted = existing.version.deleted_at_txn_id != 0;
-
-                    // Track row count changes based on delete state transitions
-                    if was_deleted && !is_new_version_deleted {
-                        count_delta += 1; // Row re-inserted
-                    } else if !was_deleted && is_new_version_deleted {
-                        count_delta -= 1; // Row deleted
-                    }
-
-                    // O(k) chain management - depth computed by traversal
-                    // When limit exceeded: drop old chain AND reuse arena slot
-                    let existing_depth = count_chain_depth(existing);
-                    let new_depth = existing_depth + 1;
-                    let can_reuse_arena =
-                        self.max_version_history > 0 && new_depth > self.max_version_history;
-
-                    // Only clone existing version data when needed:
-                    // 1. For delete operations that need to preserve data
-                    // 2. When keeping version history (not pruning)
-                    let mut new_version = version;
-                    if new_version.deleted_at_txn_id != 0 && new_version.data.is_empty() {
-                        // For deletes, preserve data from current version
-                        new_version.data = existing.version.data.clone();
-                    }
-
-                    // Update arena with Arc reuse for O(1) clones on read
-                    // OPTIMIZATION: Always reuse arena slot - historical data is in prev_chain
-                    let arena_idx = if new_version.deleted_at_txn_id == 0 {
-                        // Convert Row to Arc once (takes ownership, no copy if already Arc)
-                        let arc_data = std::mem::take(&mut new_version.data).into_arc();
-
-                        // Always reuse existing arena slot if available
-                        // Historical versions are stored in prev_chain.version.data
-                        let idx = if let Some(old_idx) = unpack_arena_idx(existing_arena_idx) {
-                            // Reuse the arena slot - prevents unbounded growth
-                            self.arena.update_at(
-                                old_idx,
-                                row_id,
-                                new_version.txn_id,
-                                CompactArc::clone(&arc_data),
-                            );
-                            old_idx
-                        } else {
-                            // No existing slot (shouldn't happen for updates), append
-                            self.arena.insert_arc(
-                                row_id,
-                                new_version.txn_id,
-                                CompactArc::clone(&arc_data),
-                            )
-                        };
-
-                        // Reuse the Arc for the version's data
-                        new_version.data = Row::from_arc(arc_data);
-
-                        pack_arena_idx(idx)
-                    } else {
-                        // Deleted version - mark arena as deleted for visibility
-                        if let Some(old_arena_idx) = unpack_arena_idx(existing_arena_idx) {
-                            self.arena.mark_deleted(old_arena_idx, new_version.txn_id);
+    #[inline]
+    fn add_version_locked(
+        &self,
+        versions: &mut crate::common::CowBTree<VersionChainEntry>,
+        row_id: i64,
+        mut version: RowVersion,
+        source_lsn: Option<NonZeroU64>,
+    ) -> Result<(), Error> {
+        version.data = version.data.into_hot(&self.memory);
+        let new_live = !version.is_deleted();
+        let old_live;
+        match versions.entry(row_id) {
+            crate::common::cow_btree::Entry::Occupied(mut occupied) => {
+                let existing = occupied.get();
+                old_live = !existing.version.is_deleted();
+                if !new_live && version.data.is_empty() {
+                    version.data = existing.version.data.clone();
+                }
+                let arena_idx = if new_live {
+                    let data = std::mem::take(&mut version.data).into_arc();
+                    let id = if let Some(id) = existing.arena_idx {
+                        if !self.arena.update_at(
+                            id,
+                            row_id,
+                            version.txn_id,
+                            data.clone(),
+                            source_lsn,
+                        )? {
+                            return Err(Error::internal("published arena row identity changed"));
                         }
-                        existing_arena_idx
-                    };
-
-                    // Build version chain entry
-                    // When limit exceeded: drop entire history (no prev_chain allocation)
-                    // When under limit: create prev_chain with existing version
-                    let final_prev = if can_reuse_arena {
-                        // Exceeded limit - drop all history, no allocation
-                        None
+                        id
                     } else {
-                        // Under limit - clone existing version and create chain
-                        let existing_version = existing.version.clone();
-                        let existing_prev = existing.prev.clone();
-                        Some(Arc::new(VersionChainEntry {
-                            version: existing_version,
-                            prev: existing_prev,
-                            // Historical versions don't use arena (slot reused by new HEAD)
-                            arena_idx: None,
-                        }))
+                        self.arena
+                            .insert_arc(row_id, version.txn_id, data.clone(), source_lsn)?
                     };
-
-                    let new_entry = VersionChainEntry {
-                        version: new_version,
-                        prev: final_prev,
-                        arena_idx,
-                    };
-
-                    // Replace entry in-place (no additional tree traversal)
-                    occupied.insert(new_entry);
-                }
-                crate::common::cow_btree::Entry::Vacant(vacant) => {
-                    // First version for this row - store in arena with Arc reuse
-                    // OPTIMIZATION: Convert Row to Arc once, then just clone Arc (no data copy)
-                    let (arena_idx, final_version) = if version.deleted_at_txn_id == 0 {
-                        // New non-deleted row -> will increment counter
-                        count_delta += 1;
-
-                        let mut v = version;
-                        // Convert Row to Arc once (takes ownership, no copy if already Arc)
-                        let arc_data = std::mem::take(&mut v.data).into_arc();
-                        // Insert Arc into arena (just Arc::clone, no data copy)
-                        let idx =
-                            self.arena
-                                .insert_arc(row_id, v.txn_id, CompactArc::clone(&arc_data));
-                        // Create version with Arc-backed data for O(1) clone
-                        v.data = Row::from_arc(arc_data);
-                        (pack_arena_idx(idx), v)
-                    } else {
-                        (None, version)
-                    };
-
-                    let new_entry = VersionChainEntry {
-                        version: final_version,
-                        prev: None,
-                        arena_idx,
-                    };
-
-                    // Insert into vacant slot (no additional traversal)
-                    vacant.insert(new_entry);
-                }
-            }
-        }
-
-        // Apply count delta in a single atomic operation
-        if count_delta > 0 {
-            self.committed_row_count
-                .fetch_add(count_delta as usize, Ordering::Relaxed);
-        } else if count_delta < 0 {
-            self.committed_row_count
-                .fetch_sub((-count_delta) as usize, Ordering::Relaxed);
-        }
-    }
-
-    /// Add a single version to the store (optimized for auto-commit single-row inserts)
-    ///
-    /// This avoids Vec allocation for the common single-row commit case.
-    #[inline]
-    pub fn add_version_single(&self, row_id: i64, version: RowVersion) {
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
-
-        let is_new_version_deleted = version.deleted_at_txn_id != 0;
-        let mut versions = self.versions.write();
-
-        match versions.entry(row_id) {
-            crate::common::cow_btree::Entry::Occupied(mut occupied) => {
-                // Extract existing data from the entry
-                let existing = occupied.get();
-                let existing_arena_idx = existing.arena_idx;
-                let was_deleted = existing.version.deleted_at_txn_id != 0;
-
-                // Update committed row count based on delete state transitions
-                if was_deleted && !is_new_version_deleted {
-                    // Row was deleted, now being re-inserted -> increment
-                    self.committed_row_count.fetch_add(1, Ordering::Relaxed);
-                } else if !was_deleted && is_new_version_deleted {
-                    // Row was visible, now being deleted -> decrement
-                    self.committed_row_count.fetch_sub(1, Ordering::Relaxed);
-                }
-
-                // O(k) chain management - depth computed by traversal
-                // When limit exceeded: drop old chain AND reuse arena slot
-                let existing_depth = count_chain_depth(existing);
-                let new_depth = existing_depth + 1;
-                let can_reuse_arena =
-                    self.max_version_history > 0 && new_depth > self.max_version_history;
-
-                // Only clone existing version data when needed:
-                // 1. For delete operations that need to preserve data
-                // 2. When keeping version history (not pruning)
-                let mut new_version = version;
-                if new_version.deleted_at_txn_id != 0 && new_version.data.is_empty() {
-                    // For deletes, preserve data from current version
-                    new_version.data = existing.version.data.clone();
-                }
-
-                // OPTIMIZATION: Always reuse arena slot - historical data is in prev_chain
-                let arena_idx = if new_version.deleted_at_txn_id == 0 {
-                    let arc_data = std::mem::take(&mut new_version.data).into_arc();
-
-                    // Always reuse existing arena slot if available
-                    // Historical versions are stored in prev_chain.version.data
-                    let idx = if let Some(old_idx) = unpack_arena_idx(existing_arena_idx) {
-                        // Reuse the arena slot - prevents unbounded growth
-                        self.arena.update_at(
-                            old_idx,
-                            row_id,
-                            new_version.txn_id,
-                            CompactArc::clone(&arc_data),
-                        );
-                        old_idx
-                    } else {
-                        // No existing slot (shouldn't happen for updates), append
-                        self.arena.insert_arc(
-                            row_id,
-                            new_version.txn_id,
-                            CompactArc::clone(&arc_data),
-                        )
-                    };
-
-                    new_version.data = Row::from_arc(arc_data);
-
-                    pack_arena_idx(idx)
+                    version.data = Row::from_arc(data);
+                    Some(id)
                 } else {
-                    // Deleted version - mark arena as deleted for visibility
-                    if let Some(old_arena_idx) = unpack_arena_idx(existing_arena_idx) {
-                        self.arena.mark_deleted(old_arena_idx, new_version.txn_id);
+                    if let Some(id) = existing.arena_idx {
+                        if !self.arena.mark_deleted(
+                            id,
+                            row_id,
+                            version.deleted_at_txn_id,
+                            source_lsn,
+                        )? {
+                            return Err(Error::internal("deleted arena row identity changed"));
+                        }
                     }
-                    existing_arena_idx
+                    existing.arena_idx
                 };
-
-                // Build version chain entry
-                // When limit exceeded: drop entire history (no prev_chain allocation)
-                // When under limit: create prev_chain with existing version
-                let final_prev = if can_reuse_arena {
-                    // Exceeded limit - drop all history, no allocation
+                let prev = if self.max_version_history > 0
+                    && count_chain_depth(existing) + 1 > self.max_version_history
+                {
                     None
                 } else {
-                    // Under limit - clone existing version and create chain
-                    let existing_version = existing.version.clone();
-                    let existing_prev = existing.prev.clone();
-                    Some(Arc::new(VersionChainEntry {
-                        version: existing_version,
-                        prev: existing_prev,
-                        // Historical versions don't use arena (slot reused by new HEAD)
-                        arena_idx: None,
-                    }))
+                    Some(CompactArc::new_in(
+                        VersionChainEntry {
+                            version: existing.version.clone(),
+                            prev: existing.prev.clone(),
+                            arena_idx: None,
+                        },
+                        &self.memory,
+                    ))
                 };
-
-                let new_entry = VersionChainEntry {
-                    version: new_version,
-                    prev: final_prev,
+                occupied.insert(VersionChainEntry {
+                    version,
+                    prev,
                     arena_idx,
-                };
-
-                occupied.insert(new_entry);
+                });
             }
             crate::common::cow_btree::Entry::Vacant(vacant) => {
-                let (arena_idx, final_version) = if version.deleted_at_txn_id == 0 {
-                    // New non-deleted row -> increment counter
-                    self.committed_row_count.fetch_add(1, Ordering::Relaxed);
-
-                    let mut v = version;
-                    let arc_data = std::mem::take(&mut v.data).into_arc();
-                    let idx = self
-                        .arena
-                        .insert_arc(row_id, v.txn_id, CompactArc::clone(&arc_data));
-                    v.data = Row::from_arc(arc_data);
-                    (pack_arena_idx(idx), v)
+                old_live = false;
+                let arena_idx = if new_live {
+                    let data = std::mem::take(&mut version.data).into_arc();
+                    let id =
+                        self.arena
+                            .insert_arc(row_id, version.txn_id, data.clone(), source_lsn)?;
+                    version.data = Row::from_arc(data);
+                    Some(id)
                 } else {
-                    (None, version)
+                    None
                 };
-
-                let new_entry = VersionChainEntry {
-                    version: final_version,
+                vacant.insert(VersionChainEntry {
+                    version,
                     prev: None,
                     arena_idx,
-                };
-
-                vacant.insert(new_entry);
+                });
             }
         }
+        // Fallible arena work precedes both the tree change and its row count.
+        if new_live && !old_live {
+            self.committed_row_count.fetch_add(1, Ordering::Relaxed);
+        } else if old_live && !new_live {
+            self.committed_row_count.fetch_sub(1, Ordering::Relaxed);
+        }
+        Ok(())
     }
 
     /// Quick check if a row might exist
@@ -1230,18 +1025,16 @@ impl VersionStore {
         // Arena guard is acquired and dropped here to avoid lock ordering inversion
         // with the commit path (which holds versions.write → arena.write).
         if row_id > 0 {
-            let probe_idx = (row_id - 1) as usize;
             let arena_guard = self.arena.read_guard();
-            let arena_meta = arena_guard.meta();
-            if probe_idx < arena_meta.len() {
-                let meta = arena_meta[probe_idx];
+            let probe = ArenaId::from_nonzero(NonZeroU64::new(row_id as u64)?);
+            if let Some((meta, probe_data)) = arena_guard.get_entry(probe) {
                 if meta.row_id == row_id && checker.is_visible(meta.txn_id, txn_id) {
                     if meta.deleted_at_txn_id != 0
                         && checker.is_visible(meta.deleted_at_txn_id, txn_id)
                     {
                         return None;
                     }
-                    let data = Row::from_arc(CompactArc::clone(&arena_guard.data()[probe_idx]));
+                    let data = Row::from_arc(CompactArc::clone(probe_data));
                     return Some(RowVersion {
                         txn_id: meta.txn_id,
                         deleted_at_txn_id: meta.deleted_at_txn_id,
@@ -1270,16 +1063,7 @@ impl VersionStore {
                 return None;
             }
             // Use arena data via chain.arena_idx for O(1) Arc clone
-            let row = if let Some(idx) = unpack_arena_idx(chain.arena_idx) {
-                let arena_guard = self.arena.read_guard();
-                if let Some(arc_row) = arena_guard.data().get(idx) {
-                    Row::from_arc(CompactArc::clone(arc_row))
-                } else {
-                    chain.version.data.clone()
-                }
-            } else {
-                chain.version.data.clone()
-            };
+            let row = chain.version.data.clone();
             return Some(RowVersion {
                 txn_id: head_txn_id,
                 deleted_at_txn_id: head_deleted_at,
@@ -1321,14 +1105,12 @@ impl VersionStore {
         // Lock ordering: versions first, then arena (matches commit path)
         let versions = self.versions.read();
         let arena_guard = self.arena.read_guard();
-        let arena_meta = arena_guard.meta();
 
         for &row_id in row_ids {
             // Speculative arena probe: O(1) for auto-increment PKs
-            if row_id > 0 {
-                let probe_idx = (row_id - 1) as usize;
-                if probe_idx < arena_meta.len() {
-                    let meta = arena_meta[probe_idx];
+            if let Some(encoded) = NonZeroU64::new(row_id as u64).filter(|_| row_id > 0) {
+                let probe = ArenaId::from_nonzero(encoded);
+                if let Some((meta, _)) = arena_guard.get_entry(probe) {
                     if meta.row_id == row_id && checker.is_visible(meta.txn_id, txn_id) {
                         if meta.deleted_at_txn_id == 0
                             || !checker.is_visible(meta.deleted_at_txn_id, txn_id)
@@ -1389,12 +1171,10 @@ impl VersionStore {
         // Lock ordering: versions first, then arena (matches commit path)
         let versions = self.versions.read();
         let arena_guard = self.arena.read_guard();
-        let arena_meta = arena_guard.meta();
-        let arena_data = arena_guard.data();
 
         // Fast path: if both arena and version tree are empty, no rows can match.
         // This avoids iterating millions of phantom row_ids from volume-populated indexes.
-        if arena_meta.is_empty() && versions.is_empty() {
+        if arena_guard.is_empty() && versions.is_empty() {
             return RowVec::new();
         }
 
@@ -1403,15 +1183,14 @@ impl VersionStore {
 
         for &row_id in row_ids {
             // Speculative arena probe: O(1) for auto-increment PKs
-            if row_id > 0 {
-                let probe_idx = (row_id - 1) as usize;
-                if probe_idx < arena_meta.len() {
-                    let meta = arena_meta[probe_idx];
+            if let Some(encoded) = NonZeroU64::new(row_id as u64).filter(|_| row_id > 0) {
+                let probe = ArenaId::from_nonzero(encoded);
+                if let Some((meta, probe_data)) = arena_guard.get_entry(probe) {
                     if meta.row_id == row_id && checker.is_visible(meta.txn_id, txn_id) {
                         if meta.deleted_at_txn_id == 0
                             || !checker.is_visible(meta.deleted_at_txn_id, txn_id)
                         {
-                            let row = Row::from_arc(CompactArc::clone(&arena_data[probe_idx]));
+                            let row = Row::from_arc(CompactArc::clone(probe_data));
                             results.push((row_id, row));
                         }
                         continue; // Skip CowBTree lookup
@@ -1426,15 +1205,7 @@ impl VersionStore {
 
                 if checker.is_visible(head_txn_id, txn_id) {
                     if head_deleted_at == 0 || !checker.is_visible(head_deleted_at, txn_id) {
-                        let row = if let Some(idx) = unpack_arena_idx(chain.arena_idx) {
-                            if let Some(arc_row) = arena_data.get(idx) {
-                                Row::from_arc(CompactArc::clone(arc_row))
-                            } else {
-                                chain.version.data.clone()
-                            }
-                        } else {
-                            chain.version.data.clone()
-                        };
+                        let row = chain.version.data.clone();
                         results.push((row_id, row));
                     }
                     continue;
@@ -1448,15 +1219,7 @@ impl VersionStore {
                         if e.version.deleted_at_txn_id == 0
                             || !checker.is_visible(e.version.deleted_at_txn_id, txn_id)
                         {
-                            let row = if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                                if let Some(arc_row) = arena_data.get(idx) {
-                                    Row::from_arc(CompactArc::clone(arc_row))
-                                } else {
-                                    e.version.data.clone()
-                                }
-                            } else {
-                                e.version.data.clone()
-                            };
+                            let row = e.version.data.clone();
                             results.push((row_id, row));
                         }
                         break;
@@ -1493,20 +1256,17 @@ impl VersionStore {
         // Lock ordering: versions first, then arena (matches commit path)
         let versions = self.versions.read();
         let arena_guard = self.arena.read_guard();
-        let arena_meta = arena_guard.meta();
-        let arena_data = arena_guard.data();
 
         for &row_id in row_ids {
             // Speculative arena probe: O(1) for auto-increment PKs
-            if row_id > 0 {
-                let probe_idx = (row_id - 1) as usize;
-                if probe_idx < arena_meta.len() {
-                    let meta = arena_meta[probe_idx];
+            if let Some(encoded) = NonZeroU64::new(row_id as u64).filter(|_| row_id > 0) {
+                let probe = ArenaId::from_nonzero(encoded);
+                if let Some((meta, probe_data)) = arena_guard.get_entry(probe) {
                     if meta.row_id == row_id && checker.is_visible(meta.txn_id, txn_id) {
                         if meta.deleted_at_txn_id == 0
                             || !checker.is_visible(meta.deleted_at_txn_id, txn_id)
                         {
-                            let row = Row::from_arc(CompactArc::clone(&arena_data[probe_idx]));
+                            let row = Row::from_arc(CompactArc::clone(probe_data));
                             if !callback(row_id, row) {
                                 return;
                             }
@@ -1523,15 +1283,7 @@ impl VersionStore {
 
                 if checker.is_visible(head_txn_id, txn_id) {
                     if head_deleted_at == 0 || !checker.is_visible(head_deleted_at, txn_id) {
-                        let row = if let Some(idx) = unpack_arena_idx(chain.arena_idx) {
-                            if let Some(arc_row) = arena_data.get(idx) {
-                                Row::from_arc(CompactArc::clone(arc_row))
-                            } else {
-                                chain.version.data.clone()
-                            }
-                        } else {
-                            chain.version.data.clone()
-                        };
+                        let row = chain.version.data.clone();
                         if !callback(row_id, row) {
                             return;
                         }
@@ -1547,15 +1299,7 @@ impl VersionStore {
                         if e.version.deleted_at_txn_id == 0
                             || !checker.is_visible(e.version.deleted_at_txn_id, txn_id)
                         {
-                            let row = if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                                if let Some(arc_row) = arena_data.get(idx) {
-                                    Row::from_arc(CompactArc::clone(arc_row))
-                                } else {
-                                    e.version.data.clone()
-                                }
-                            } else {
-                                e.version.data.clone()
-                            };
+                            let row = e.version.data.clone();
                             if !callback(row_id, row) {
                                 return;
                             }
@@ -1596,7 +1340,6 @@ impl VersionStore {
         // Clone CowBTree for parallel path (O(1) Arc clone of root node)
         let versions = self.versions.read().clone();
         let arena_guard = self.arena.read_guard();
-        let arena_meta = arena_guard.meta();
 
         #[cfg(feature = "parallel")]
         if row_ids.len() >= PARALLEL_THRESHOLD {
@@ -1606,10 +1349,10 @@ impl VersionStore {
                     let mut chunk_count = 0;
                     for &row_id in chunk {
                         // Speculative arena probe: O(1) for auto-increment PKs
-                        if row_id > 0 {
-                            let probe_idx = (row_id - 1) as usize;
-                            if probe_idx < arena_meta.len() {
-                                let meta = arena_meta[probe_idx];
+                        if let Some(encoded) = NonZeroU64::new(row_id as u64).filter(|_| row_id > 0)
+                        {
+                            let probe = ArenaId::from_nonzero(encoded);
+                            if let Some((meta, _)) = arena_guard.get_entry(probe) {
                                 if meta.row_id == row_id && checker.is_visible(meta.txn_id, txn_id)
                                 {
                                     if meta.deleted_at_txn_id == 0
@@ -1660,10 +1403,9 @@ impl VersionStore {
         let mut count = 0;
         for &row_id in row_ids {
             // Speculative arena probe: O(1) for auto-increment PKs
-            if row_id > 0 {
-                let probe_idx = (row_id - 1) as usize;
-                if probe_idx < arena_meta.len() {
-                    let meta = arena_meta[probe_idx];
+            if let Some(encoded) = NonZeroU64::new(row_id as u64).filter(|_| row_id > 0) {
+                let probe = ArenaId::from_nonzero(encoded);
+                if let Some((meta, _)) = arena_guard.get_entry(probe) {
                     if meta.row_id == row_id && checker.is_visible(meta.txn_id, txn_id) {
                         if meta.deleted_at_txn_id == 0
                             || !checker.is_visible(meta.deleted_at_txn_id, txn_id)
@@ -1735,18 +1477,9 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock for O(1) Arc clones
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Helper: get row from arena (O(1)) or version (O(n) clone)
-        let get_row = |entry: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(entry.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            entry.version.data.clone()
-        };
+        let get_row = |entry: &VersionChainEntry| -> Row { entry.version.data.clone() };
         for &row_id in row_ids {
             if let Some(chain) = versions.get(row_id) {
                 // FAST PATH: Check HEAD version first - O(1) for common case
@@ -1905,12 +1638,12 @@ impl VersionStore {
             let uncommitted_empty = self.uncommitted_writes.read().is_empty();
             if uncommitted_empty && !checker.needs_snapshot_isolation(txn_id) {
                 let arena_guard = self.arena.read_guard();
-                let arena_meta = arena_guard.meta();
+
                 let arena_len = arena_guard.len();
 
                 if arena_len > 0 {
                     let mut visible_row_ids = Vec::with_capacity(arena_len);
-                    for meta in arena_meta {
+                    for (_, meta, _) in arena_guard.iter() {
                         if meta.txn_id != 0
                             && meta.deleted_at_txn_id == 0
                             && checker.is_visible(meta.txn_id, txn_id)
@@ -1979,12 +1712,12 @@ impl VersionStore {
             let uncommitted_empty = self.uncommitted_writes.read().is_empty();
             if uncommitted_empty && !checker.needs_snapshot_isolation(txn_id) {
                 let arena_guard = self.arena.read_guard();
-                let arena_meta = arena_guard.meta();
+
                 let arena_len = arena_guard.len();
 
                 if arena_len > 0 {
                     let mut count = 0usize;
-                    for meta in arena_meta {
+                    for (_, meta, _) in arena_guard.iter() {
                         if meta.txn_id != 0
                             && meta.deleted_at_txn_id == 0
                             && checker.is_visible(meta.txn_id, txn_id)
@@ -2246,18 +1979,9 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock for O(1) Arc clones
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Helper: get row from arena (O(1)) or version (O(n) clone)
-        let get_row = |entry: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(entry.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            entry.version.data.clone()
-        };
+        let get_row = |entry: &VersionChainEntry| -> Row { entry.version.data.clone() };
         let mut results = RowVec::with_capacity(versions.len());
 
         for (&row_id, chain) in versions.iter() {
@@ -2313,18 +2037,9 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock ONCE for the entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
+        let get_row_data = |e: &VersionChainEntry| -> Row { e.version.data.clone() };
 
         // Single-pass: read directly from arena during visibility check
         let mut result = RowVec::with_capacity(versions.len());
@@ -2382,18 +2097,9 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock ONCE for the entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
+        let get_row_data = |e: &VersionChainEntry| -> Row { e.version.data.clone() };
 
         // Single-pass: read directly from arena during visibility check
 
@@ -2462,18 +2168,9 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock ONCE for the entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
+        let get_row_data = |e: &VersionChainEntry| -> Row { e.version.data.clone() };
 
         // Single-pass: read directly from arena during visibility check
         let mut result: Vec<(i64, Row, RowVersion)> = Vec::with_capacity(versions.len());
@@ -2547,8 +2244,6 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock ONCE for the entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Single-pass: read, filter, and collect in one loop
         let mut result: Vec<(i64, Row, RowVersion)> = Vec::with_capacity(versions.len() / 4);
@@ -2562,8 +2257,8 @@ impl VersionStore {
                 // HEAD is visible - check if deleted
                 if head_deleted_at == 0 || !checker.is_visible(head_deleted_at, txn_id) {
                     // Try arena path first (zero-copy filter check using matches_arc_slice)
-                    if let Some(idx) = unpack_arena_idx(chain.arena_idx) {
-                        if let Some(arc_row) = arena_data.get(idx) {
+                    if chain.arena_idx.is_some() {
+                        if let Some(arc_row) = chain.version.data.as_arc() {
                             // Filter directly on Arc slice - no Row allocation for non-matching rows
                             if compiled_filter.matches_arc_slice(arc_row.as_ref()) {
                                 let mut version_copy = chain.version.clone();
@@ -2596,8 +2291,8 @@ impl VersionStore {
                 if checker.is_visible(version_txn_id, txn_id) {
                     if deleted_at_txn_id == 0 || !checker.is_visible(deleted_at_txn_id, txn_id) {
                         // Try arena path first (zero-copy filter check using matches_arc_slice)
-                        if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                            if let Some(arc_row) = arena_data.get(idx) {
+                        if e.arena_idx.is_some() {
+                            if let Some(arc_row) = e.version.data.as_arc() {
                                 // Filter directly on Arc slice - no Row allocation for non-matching rows
                                 if compiled_filter.matches_arc_slice(arc_row.as_ref()) {
                                     let mut version_copy = e.version.clone();
@@ -2645,18 +2340,9 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock ONCE for the entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
+        let get_row_data = |e: &VersionChainEntry| -> Row { e.version.data.clone() };
 
         // Single-pass: read directly from arena during visibility check
         let mut result = RowVec::with_capacity(versions.len());
@@ -2718,18 +2404,9 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock ONCE for the entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
+        let get_row_data = |e: &VersionChainEntry| -> Row { e.version.data.clone() };
 
         // Collect with early termination
         // A user-supplied limit can be i64::MAX; only pre-allocate what
@@ -2878,18 +2555,9 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock ONCE for this batch
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
+        let get_row_data = |e: &VersionChainEntry| -> Row { e.version.data.clone() };
 
         // Use range for efficient cursor-based iteration
         let mut result = RowVec::with_capacity(batch_size);
@@ -2982,18 +2650,9 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock ONCE for this batch
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
+        let get_row_data = |e: &VersionChainEntry| -> Row { e.version.data.clone() };
 
         // Use range for efficient cursor-based iteration
         buffer.reserve(batch_size);
@@ -3085,18 +2744,9 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock ONCE for this entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Helper to get row data from an entry
-        let get_row_from_entry = |entry: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(entry.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            entry.version.data.clone()
-        };
+        let get_row_from_entry = |entry: &VersionChainEntry| -> Row { entry.version.data.clone() };
 
         // Collect with offset/limit
         // Cap capacity to avoid overflow when limit is usize::MAX
@@ -3192,8 +2842,6 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock ONCE for this entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Helper to find visible version and get row data
         let find_visible_row = |chain: &VersionChainEntry| -> Option<Row> {
@@ -3208,15 +2856,7 @@ impl VersionStore {
                     }
 
                     // Read row data from arena or version
-                    let row_data = if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                        if let Some(arc_row) = arena_data.get(idx) {
-                            Row::from_arc(CompactArc::clone(arc_row))
-                        } else {
-                            e.version.data.clone()
-                        }
-                    } else {
-                        e.version.data.clone()
-                    };
+                    let row_data = e.version.data.clone();
                     return Some(row_data);
                 }
                 current = e.prev.as_ref().map(|b| b.as_ref());
@@ -3297,8 +2937,6 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock ONCE
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Single-pass: read, filter, and collect in one loop
         let mut result = RowVec::with_capacity(versions.len() / 4);
@@ -3317,8 +2955,8 @@ impl VersionStore {
 
                     // OPTIMIZATION: Filter BEFORE cloning to avoid allocation for non-matching rows
                     // Try arena path first (zero-copy filter check using matches_arc_slice)
-                    if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                        if let Some(arc_row) = arena_data.get(idx) {
+                    if e.arena_idx.is_some() {
+                        if let Some(arc_row) = e.version.data.as_arc() {
                             // Filter directly on Arc slice - no Row allocation for non-matching rows
                             if compiled_filter.matches_arc_slice(arc_row.as_ref()) {
                                 result.push((row_id, Row::from_arc(CompactArc::clone(arc_row))));
@@ -3366,8 +3004,6 @@ impl VersionStore {
         drop(schema);
 
         let versions = self.versions.read().clone();
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         for (&row_id, chain) in versions.iter() {
             let mut current: Option<&VersionChainEntry> = Some(chain);
@@ -3381,8 +3017,8 @@ impl VersionStore {
                         break;
                     }
 
-                    if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                        if let Some(arc_row) = arena_data.get(idx) {
+                    if e.arena_idx.is_some() {
+                        if let Some(arc_row) = e.version.data.as_arc() {
                             if compiled_filter.matches_arc_slice(arc_row.as_ref()) {
                                 let row = Row::from_arc(CompactArc::clone(arc_row));
                                 if !callback(row_id, row) {
@@ -3440,8 +3076,6 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         // Pre-acquire arena lock ONCE
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         // Collect with offset/limit and early termination
         // A user-supplied limit can be i64::MAX; only pre-allocate what
@@ -3463,8 +3097,8 @@ impl VersionStore {
 
                     // OPTIMIZATION: Filter BEFORE cloning to avoid allocation for non-matching rows
                     // Try arena path first (zero-copy filter check using matches_arc_slice)
-                    if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                        if let Some(arc_row) = arena_data.get(idx) {
+                    if e.arena_idx.is_some() {
+                        if let Some(arc_row) = e.version.data.as_arc() {
                             // Filter directly on Arc slice - no Row allocation for non-matching rows
                             if compiled_filter.matches_arc_slice(arc_row.as_ref()) {
                                 if skipped < offset {
@@ -3543,13 +3177,13 @@ impl VersionStore {
 
             // Get arena metadata for fast path detection
             let arena_guard = self.arena.read_guard();
-            let arena_meta = arena_guard.meta();
+
             let arena_len = arena_guard.len();
 
             if uncommitted_empty && arena_len > 0 && !checker.needs_snapshot_isolation(txn_id) {
                 let mut indices: Vec<RowIndex> = Vec::with_capacity(arena_len);
 
-                for (idx, meta) in arena_meta.iter().enumerate() {
+                for (idx, meta, _) in arena_guard.iter() {
                     if meta.txn_id != 0
                         && meta.deleted_at_txn_id == 0
                         && checker.is_visible(meta.txn_id, txn_id)
@@ -3581,7 +3215,7 @@ impl VersionStore {
                         if deleted_at_txn_id == 0 || !checker.is_visible(deleted_at_txn_id, txn_id)
                         {
                             // Found visible, non-deleted version
-                            indices.push(RowIndex::new(row_id, unpack_arena_idx(e.arena_idx)));
+                            indices.push(RowIndex::new(row_id, e.arena_idx));
                         }
                         break;
                     }
@@ -3610,13 +3244,13 @@ impl VersionStore {
             let uncommitted_empty = self.uncommitted_writes.read().is_empty();
 
             let arena_guard = self.arena.read_guard();
-            let arena_meta = arena_guard.meta();
+
             let arena_len = arena_guard.len();
 
             if uncommitted_empty && arena_len > 0 && !checker.needs_snapshot_isolation(txn_id) {
                 let mut indices: Vec<RowIndex> = Vec::with_capacity(arena_len);
 
-                for (idx, meta) in arena_meta.iter().enumerate() {
+                for (idx, meta, _) in arena_guard.iter() {
                     if meta.txn_id != 0
                         && meta.deleted_at_txn_id == 0
                         && checker.is_visible(meta.txn_id, txn_id)
@@ -3646,7 +3280,7 @@ impl VersionStore {
                     if checker.is_visible(version_txn_id, txn_id) {
                         if deleted_at_txn_id == 0 || !checker.is_visible(deleted_at_txn_id, txn_id)
                         {
-                            indices.push(RowIndex::new(row_id, unpack_arena_idx(e.arena_idx)));
+                            indices.push(RowIndex::new(row_id, e.arena_idx));
                         }
                         break;
                     }
@@ -3677,16 +3311,18 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
-        let arena_len = arena_guard.len();
 
         let mut result = RowVec::with_capacity(indices.len());
 
         for idx in indices {
             if let Some(arena_idx) = idx.arena_idx() {
                 // Fast path: get from arena
-                if arena_idx < arena_len {
-                    if let Some(arc_row) = arena_data.get(arena_idx) {
+                {
+                    if let Some(arc_row) = arena_guard
+                        .get_entry(arena_idx)
+                        .filter(|(meta, _)| meta.row_id == idx.row_id)
+                        .map(|(_, data)| data)
+                    {
                         result.push((idx.row_id, Row::from_arc(CompactArc::clone(arc_row))));
                         continue;
                     }
@@ -3715,8 +3351,12 @@ impl VersionStore {
     pub fn materialize_row(&self, idx: &RowIndex) -> Option<(i64, Row)> {
         if let Some(arena_idx) = idx.arena_idx() {
             let arena_guard = self.arena.read_guard();
-            let arena_data = arena_guard.data();
-            if let Some(arc_row) = arena_data.get(arena_idx) {
+
+            if let Some(arc_row) = arena_guard
+                .get_entry(arena_idx)
+                .filter(|(meta, _)| meta.row_id == idx.row_id)
+                .map(|(_, data)| data)
+            {
                 return Some((idx.row_id, Row::from_arc(CompactArc::clone(arc_row))));
             }
         }
@@ -3742,8 +3382,12 @@ impl VersionStore {
     pub fn get_column_value(&self, idx: &RowIndex, col_idx: usize) -> Option<Value> {
         if let Some(arena_idx) = idx.arena_idx() {
             let arena_guard = self.arena.read_guard();
-            let arena_data = arena_guard.data();
-            if let Some(arc_row) = arena_data.get(arena_idx) {
+
+            if let Some(arc_row) = arena_guard
+                .get_entry(arena_idx)
+                .filter(|(meta, _)| meta.row_id == idx.row_id)
+                .map(|(_, data)| data)
+            {
                 return arc_row.get(col_idx).cloned();
             }
         }
@@ -3772,14 +3416,17 @@ impl VersionStore {
         let versions = self.versions.read().clone();
 
         let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
-        let arena_len = arena_guard.len();
+
         indices
             .iter()
             .map(|idx| {
                 if let Some(arena_idx) = idx.arena_idx() {
-                    if arena_idx < arena_len {
-                        if let Some(arc_row) = arena_data.get(arena_idx) {
+                    {
+                        if let Some(arc_row) = arena_guard
+                            .get_entry(arena_idx)
+                            .filter(|(meta, _)| meta.row_id == idx.row_id)
+                            .map(|(_, data)| data)
+                        {
                             return arc_row.get(col_idx).cloned();
                         }
                     }
@@ -3837,20 +3484,17 @@ impl VersionStore {
         let uncommitted_empty = self.uncommitted_writes.read().is_empty();
         if uncommitted_empty && !checker.needs_snapshot_isolation(txn_id) {
             let arena_guard = self.arena.read_guard();
-            let arena_meta = arena_guard.meta();
-            let arena_data = arena_guard.data();
+
             let arena_len = arena_guard.len();
 
             if arena_len > 0 {
                 paired = Vec::with_capacity(arena_len);
-                for (idx, meta) in arena_meta.iter().enumerate() {
+                for (idx, meta, arena_row) in arena_guard.iter() {
                     if meta.txn_id != 0
                         && meta.deleted_at_txn_id == 0
                         && checker.is_visible(meta.txn_id, txn_id)
                     {
-                        let sort_val = arena_data
-                            .get(idx)
-                            .and_then(|row| row.get(sort_col_idx).cloned());
+                        let sort_val = arena_row.get(sort_col_idx).cloned();
                         paired.push((RowIndex::new(meta.row_id, Some(idx)), sort_val));
                     }
                 }
@@ -3893,7 +3537,6 @@ impl VersionStore {
         // deferred materialization would lose track of which version was visible.
         let versions = self.versions.read().clone();
         let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         let mut materialized: Vec<(i64, Row, Option<Value>)> = Vec::with_capacity(versions.len());
 
@@ -3904,15 +3547,7 @@ impl VersionStore {
                     if e.version.deleted_at_txn_id == 0
                         || !checker.is_visible(e.version.deleted_at_txn_id, txn_id)
                     {
-                        let row = if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                            if let Some(arc_row) = arena_data.get(idx) {
-                                Row::from_arc(CompactArc::clone(arc_row))
-                            } else {
-                                e.version.data.clone()
-                            }
-                        } else {
-                            e.version.data.clone()
-                        };
+                        let row = e.version.data.clone();
                         let sort_val = row.get(sort_col_idx).cloned();
                         materialized.push((row_id, row, sort_val));
                     }
@@ -4013,8 +3648,7 @@ impl VersionStore {
 
         {
             let arena_guard = self.arena.read_guard();
-            let arena_meta = arena_guard.meta();
-            let arena_data = arena_guard.data();
+
             let arena_len = arena_guard.len();
 
             if uncommitted_empty && arena_len > 0 && !checker.needs_snapshot_isolation(txn_id) {
@@ -4024,9 +3658,7 @@ impl VersionStore {
                 let mut last_txn_id: i64 = 0;
                 let mut last_visible: bool = false;
 
-                let mut idx = 0;
-                while idx < arena_len {
-                    let meta = &arena_meta[idx];
+                for (_, meta, arena_row) in arena_guard.iter() {
                     if meta.txn_id != 0 && meta.deleted_at_txn_id == 0 {
                         // Check visibility with cache
                         let version_txn_id = meta.txn_id;
@@ -4040,12 +3672,11 @@ impl VersionStore {
                         };
 
                         if is_vis {
-                            if let Some(val) = arena_data[idx].get(col_idx) {
+                            if let Some(val) = arena_row.get(col_idx) {
                                 accumulate_sum(&mut int_sum, &mut float_sum, &mut count, val);
                             }
                         }
                     }
-                    idx += 1;
                 }
                 return (int_sum as f64 + float_sum, count);
             }
@@ -4124,8 +3755,7 @@ impl VersionStore {
 
         {
             let arena_guard = self.arena.read_guard();
-            let arena_meta = arena_guard.meta();
-            let arena_data = arena_guard.data();
+
             let arena_len = arena_guard.len();
 
             if uncommitted_empty && arena_len > 0 && !checker.needs_snapshot_isolation(txn_id) {
@@ -4133,9 +3763,7 @@ impl VersionStore {
                 let mut last_txn_id: i64 = 0;
                 let mut last_visible: bool = false;
 
-                let mut idx = 0;
-                while idx < arena_len {
-                    let meta = &arena_meta[idx];
+                for (_, meta, arena_row) in arena_guard.iter() {
                     if meta.txn_id != 0 && meta.deleted_at_txn_id == 0 {
                         let version_txn_id = meta.txn_id;
                         let is_vis = if version_txn_id == last_txn_id {
@@ -4148,12 +3776,11 @@ impl VersionStore {
                         };
 
                         if is_vis {
-                            if let Some(val) = arena_data[idx].get(col_idx) {
+                            if let Some(val) = arena_row.get(col_idx) {
                                 update_min(&mut min_val, val);
                             }
                         }
                     }
-                    idx += 1;
                 }
                 return min_val;
             }
@@ -4231,8 +3858,7 @@ impl VersionStore {
 
         {
             let arena_guard = self.arena.read_guard();
-            let arena_meta = arena_guard.meta();
-            let arena_data = arena_guard.data();
+
             let arena_len = arena_guard.len();
 
             if uncommitted_empty && arena_len > 0 && !checker.needs_snapshot_isolation(txn_id) {
@@ -4240,9 +3866,7 @@ impl VersionStore {
                 let mut last_txn_id: i64 = 0;
                 let mut last_visible: bool = false;
 
-                let mut idx = 0;
-                while idx < arena_len {
-                    let meta = &arena_meta[idx];
+                for (_, meta, arena_row) in arena_guard.iter() {
                     if meta.txn_id != 0 && meta.deleted_at_txn_id == 0 {
                         let version_txn_id = meta.txn_id;
                         let is_vis = if version_txn_id == last_txn_id {
@@ -4255,12 +3879,11 @@ impl VersionStore {
                         };
 
                         if is_vis {
-                            if let Some(val) = arena_data[idx].get(col_idx) {
+                            if let Some(val) = arena_row.get(col_idx) {
                                 update_max(&mut max_val, val);
                             }
                         }
                     }
-                    idx += 1;
                 }
                 return max_val;
             }
@@ -4424,19 +4047,16 @@ impl VersionStore {
         let uncommitted_empty = self.uncommitted_writes.read().is_empty();
         if uncommitted_empty && !checker.needs_snapshot_isolation(txn_id) {
             let arena_guard = self.arena.read_guard();
-            let arena_meta = arena_guard.meta();
-            let arena_data = arena_guard.data();
+
             let arena_len = arena_guard.len();
 
             if arena_len > 0 {
-                for (idx, meta) in arena_meta.iter().enumerate() {
+                for (_, meta, arena_row) in arena_guard.iter() {
                     if meta.txn_id != 0
                         && meta.deleted_at_txn_id == 0
                         && checker.is_visible(meta.txn_id, txn_id)
                     {
-                        if let Some(arc_row) = arena_data.get(idx) {
-                            accumulate_from!(arc_row, results, aggregates);
-                        }
+                        accumulate_from!(arena_row, results, aggregates);
                     }
                 }
 
@@ -4457,10 +4077,8 @@ impl VersionStore {
             }
         }
 
-        // SLOW PATH: CowBTree iteration with arena data retrieval
+        // The captured tree owns the exact visible version's payload.
         let versions = self.versions.read().clone();
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
 
         for chain in versions.values() {
             let mut current: Option<&VersionChainEntry> = Some(chain);
@@ -4469,8 +4087,8 @@ impl VersionStore {
                     if e.version.deleted_at_txn_id == 0
                         || !checker.is_visible(e.version.deleted_at_txn_id, txn_id)
                     {
-                        if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                            if let Some(arc_row) = arena_data.get(idx) {
+                        if e.arena_idx.is_some() {
+                            if let Some(arc_row) = e.version.data.as_arc() {
                                 accumulate_from!(arc_row, results, aggregates);
                             } else {
                                 accumulate_from!(e.version.data, results, aggregates);
@@ -4558,7 +4176,7 @@ impl VersionStore {
                 // Fast path: scan arena directly, skip version map iteration
                 let mut visible_indices: Vec<VisibleRowInfo> = Vec::with_capacity(arena_len);
 
-                for (idx, meta) in arena_guard.meta().iter().enumerate() {
+                for (idx, meta, _) in arena_guard.iter() {
                     // Check visibility and deleted status
                     if meta.txn_id != 0
                         && meta.deleted_at_txn_id == 0
@@ -4566,7 +4184,7 @@ impl VersionStore {
                     {
                         visible_indices.push(VisibleRowInfo {
                             row_id: meta.row_id,
-                            arena_idx: idx,
+                            arena_idx: Some(idx),
                         });
                     }
                 }
@@ -4593,31 +4211,15 @@ impl VersionStore {
                     if checker.is_visible(version_txn_id, txn_id) {
                         if deleted_at_txn_id == 0 || !checker.is_visible(deleted_at_txn_id, txn_id)
                         {
-                            // Found visible, non-deleted version
-                            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                                if idx < arena_len {
-                                    visible_indices.push(VisibleRowInfo {
-                                        row_id,
-                                        arena_idx: idx,
-                                    });
-                                } else {
-                                    // Arena index out of bounds — use fallback
-                                    let fb_idx = arena_len + fallback_data.len();
-                                    fallback_data.push(e.version.data.clone().into_arc());
-                                    visible_indices.push(VisibleRowInfo {
-                                        row_id,
-                                        arena_idx: fb_idx,
-                                    });
-                                }
-                            } else {
-                                // Chain entry without arena index — store data in fallback
-                                let fb_idx = arena_len + fallback_data.len();
+                            let arena_idx = e.arena_idx.filter(|&id| {
+                                arena_guard.get_meta(id).is_some_and(|meta| {
+                                    meta.row_id == row_id && meta.txn_id == version_txn_id
+                                })
+                            });
+                            if arena_idx.is_none() {
                                 fallback_data.push(e.version.data.clone().into_arc());
-                                visible_indices.push(VisibleRowInfo {
-                                    row_id,
-                                    arena_idx: fb_idx,
-                                });
                             }
+                            visible_indices.push(VisibleRowInfo { row_id, arena_idx });
                         }
                         break;
                     }
@@ -4749,7 +4351,7 @@ impl VersionStore {
     pub(crate) fn add_index_under_build(
         &self,
         name: String,
-        index: Arc<dyn Index>,
+        mut index: Arc<dyn Index>,
         build: &IndexCatalogLease,
     ) -> Result<(), Error> {
         if !build.exclusive || !Arc::ptr_eq(&build.state, &self.index_catalog) {
@@ -4757,8 +4359,45 @@ impl VersionStore {
                 "index build lease belongs to another catalog",
             ));
         }
+        self.attach_index_memory(&mut index)?;
         self.indexes.write().insert(name, index);
         Ok(())
+    }
+
+    pub(crate) fn attach_index_memory(&self, index: &mut Arc<dyn Index>) -> Result<(), Error> {
+        if let Some(account) = index.memory_account() {
+            return if account.same_engine(&self.memory) {
+                Ok(())
+            } else {
+                Err(Error::internal("index belongs to another memory account"))
+            };
+        }
+        Arc::get_mut(index)
+            .ok_or_else(|| Error::internal("attach index memory before sharing its handle"))?
+            .attach_memory_account(&self.memory)
+    }
+
+    fn release_publication_keys(&self, keys: &[PublicationKey], txn_id: i64) {
+        if keys.is_empty() {
+            return;
+        }
+        let retired = {
+            let mut owners = self.publication_keys.lock();
+            for key in keys {
+                if owners.get(key) == Some(&txn_id) {
+                    owners.remove(key);
+                }
+            }
+            // Release oversized empty ownership tables left by exceptional bulk statements.
+            if owners.is_empty() && owners.allocation_size() > 64 * 1024 {
+                let mut replacement = PublicationOwners::default();
+                replacement.attach(&self.memory);
+                Some(std::mem::replace(&mut *owners, replacement))
+            } else {
+                None
+            }
+        };
+        drop(retired);
     }
 
     /// Add an already-built index during initialization or recovery.
@@ -4975,7 +4614,16 @@ impl VersionStore {
     /// the version is skipped to avoid duplicate entries in the version chain. This can
     /// occur when snapshot and WAL both contain the same committed data due to race
     /// conditions during snapshot creation.
-    pub fn apply_recovered_version(&self, row_id: i64, version: RowVersion) {
+    pub fn apply_recovered_version(&self, row_id: i64, version: RowVersion) -> Result<(), Error> {
+        self.apply_recovered_version_with_lsn(row_id, version, None)
+    }
+
+    pub fn apply_recovered_version_with_lsn(
+        &self,
+        row_id: i64,
+        version: RowVersion,
+        source_lsn: Option<NonZeroU64>,
+    ) -> Result<(), Error> {
         let is_deleted = version.is_deleted();
         let row_data = version.data.clone();
 
@@ -4994,13 +4642,13 @@ impl VersionStore {
                     if row_id > 0 {
                         self.set_auto_increment_counter(row_id);
                     }
-                    return;
+                    return Ok(());
                 }
             }
         }
 
         // Add the version to the store
-        self.add_version(row_id, version);
+        self.add_version_with_lsn(row_id, version, source_lsn)?;
 
         // Update auto_increment counter if this row_id is higher
         // This ensures the counter is restored to at least the max seen row_id
@@ -5035,13 +4683,23 @@ impl VersionStore {
                 }
             }
         }
+        Ok(())
     }
 
     /// Mark a row as deleted during WAL replay
     ///
     /// This creates a deleted version for the row during recovery.
     /// Also removes the row from any existing indexes.
-    pub fn mark_deleted(&self, row_id: i64, txn_id: i64) {
+    pub fn mark_deleted(&self, row_id: i64, txn_id: i64) -> Result<(), Error> {
+        self.mark_deleted_with_lsn(row_id, txn_id, None)
+    }
+
+    pub fn mark_deleted_with_lsn(
+        &self,
+        row_id: i64,
+        txn_id: i64,
+        source_lsn: Option<NonZeroU64>,
+    ) -> Result<(), Error> {
         // Get the old row data for index removal BEFORE creating the deleted version
         let old_row = self
             .get_visible_version(row_id, txn_id)
@@ -5057,7 +4715,7 @@ impl VersionStore {
                 .map(|d| d.as_nanos() as i64)
                 .unwrap_or(0),
         };
-        self.add_version(row_id, deleted_version);
+        self.add_version_with_lsn(row_id, deleted_version, source_lsn)?;
 
         // Remove from indexes using old row data
         if let Some(old_data) = old_row {
@@ -5086,6 +4744,7 @@ impl VersionStore {
                 }
             }
         }
+        Ok(())
     }
 
     /// Drop an index by name (alias for remove_index)
@@ -5157,7 +4816,7 @@ impl VersionStore {
                 .unwrap_or(crate::core::DataType::Null);
 
             // Create index based on stored index_type
-            let index: Arc<dyn crate::storage::Index> = match meta.index_type {
+            let mut index: Arc<dyn crate::storage::Index> = match meta.index_type {
                 IndexType::Hash => {
                     let idx = HashIndex::new(
                         meta.name.clone(),
@@ -5237,17 +4896,20 @@ impl VersionStore {
 
                     // Try loading saved HNSW graph from snapshot file
                     if let Some(graph_path) = hnsw_graph_path {
-                        if let Ok(Some(mut loaded)) = crate::storage::index::HnswIndex::load_graph(
-                            graph_path,
-                            meta.name.clone(),
-                            meta.table_name.clone(),
-                            column_name.clone(),
-                            column_id,
-                            dims,
-                            m,
-                            ef_construction,
-                            ef_search,
-                        ) {
+                        if let Ok(Some(mut loaded)) =
+                            crate::storage::index::HnswIndex::load_graph_in(
+                                graph_path,
+                                meta.name.clone(),
+                                meta.table_name.clone(),
+                                column_name.clone(),
+                                column_id,
+                                dims,
+                                m,
+                                ef_construction,
+                                ef_search,
+                                &self.memory,
+                            )
+                        {
                             loaded.set_unique(meta.is_unique);
                             Arc::new(loaded)
                         } else {
@@ -5289,6 +4951,8 @@ impl VersionStore {
                 }
             };
 
+            self.attach_index_memory(&mut index)?;
+
             // Populate the index with existing data unless deferred
             // Uses batch_slice for better performance
             if !skip_population {
@@ -5315,7 +4979,7 @@ impl VersionStore {
             self.add_index(meta.name.clone(), index)?;
         } else {
             // Multi-column index: use MultiColumnIndex
-            let index = crate::storage::index::MultiColumnIndex::new(
+            let mut index = crate::storage::index::MultiColumnIndex::new(
                 meta.name.clone(),
                 meta.table_name.clone(),
                 meta.column_names.clone(),
@@ -5325,6 +4989,7 @@ impl VersionStore {
                 expected_rows,
             );
 
+            index.attach_memory_account(&self.memory)?;
             let index = Arc::new(index);
 
             // Populate the index with existing data unless deferred
@@ -5562,7 +5227,7 @@ impl VersionStore {
         const SUB_BATCH_SIZE: usize = 2_000;
         let mut removed_ids: Vec<i64> = Vec::with_capacity(row_ids.len());
         let mut skipped_ids: Vec<i64> = Vec::new();
-        let mut arena_indices_to_clear: Vec<usize> = Vec::new();
+        let mut arena_indices_to_clear: Vec<(ArenaId, i64, i64)> = Vec::new();
 
         for chunk in row_ids.chunks(SUB_BATCH_SIZE) {
             let uncommitted = self.uncommitted_writes.read();
@@ -5586,8 +5251,8 @@ impl VersionStore {
                         skipped_ids.push(row_id);
                         continue;
                     }
-                    if let Some(idx) = unpack_arena_idx(entry.arena_idx) {
-                        arena_indices_to_clear.push(idx);
+                    if let Some(idx) = entry.arena_idx {
+                        arena_indices_to_clear.push((idx, row_id, entry.version.txn_id));
                     }
                     versions.remove(row_id);
                     removed_ids.push(row_id);
@@ -5739,8 +5404,12 @@ impl VersionStore {
                         {
                             continue;
                         }
-                        if let Some(idx) = unpack_arena_idx(entry.arena_idx) {
-                            actual_arena_indices.push(idx);
+                        if let Some(idx) = entry.arena_idx {
+                            actual_arena_indices.push((
+                                idx,
+                                row_id,
+                                entry.version.deleted_at_txn_id,
+                            ));
                         }
                         live.remove(row_id);
                         actually_deleted.push(row_id);
@@ -5888,7 +5557,7 @@ impl VersionStore {
                 };
 
                 // Collect previous versions from the LIVE entry
-                let mut prev_versions: Vec<Arc<VersionChainEntry>> = Vec::new();
+                let mut prev_versions: Vec<CompactArc<VersionChainEntry>> = Vec::new();
                 let mut current = chain_entry.prev.as_ref();
                 while let Some(prev_entry) = current {
                     prev_versions.push(prev_entry.clone());
@@ -5942,11 +5611,11 @@ impl VersionStore {
                             prev_versions.into_iter().take(keep_count).collect();
 
                         // Build chain from oldest to newest (reversed)
-                        let mut new_prev: Option<Arc<VersionChainEntry>> = None;
+                        let mut new_prev: Option<CompactArc<VersionChainEntry>> = None;
                         for entry in kept_versions.into_iter().rev() {
                             let mut cloned = (*entry).clone();
                             cloned.prev = new_prev;
-                            new_prev = Some(Arc::new(cloned));
+                            new_prev = Some(CompactArc::new_in(cloned, &self.memory));
                         }
                         modified_entry.prev = new_prev;
                     }
@@ -6161,8 +5830,6 @@ impl VersionStore {
 
         // Pre-acquire arena lock ONCE
         let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
-        let arena_meta = arena_guard.meta();
 
         // Helper to update accumulators
         #[inline(always)]
@@ -6299,7 +5966,7 @@ impl VersionStore {
             // Only used for String/other types that can't be mapped to i64
             let mut other_groups: GroupKeyMap<u32> = GroupKeyMap::default();
 
-            for (idx, meta) in arena_meta.iter().enumerate() {
+            for (_, meta, arena_row) in arena_guard.iter() {
                 // Visibility check (standard pattern: check creation, then deletion)
                 if meta.txn_id == 0 || !checker.is_visible(meta.txn_id, txn_id) {
                     continue;
@@ -6309,10 +5976,7 @@ impl VersionStore {
                     continue;
                 }
 
-                let row_data = match arena_data.get(idx) {
-                    Some(data) => data,
-                    None => continue,
-                };
+                let row_data = arena_row;
 
                 let row_slice = row_data.as_ref();
                 let val = if col_idx < row_slice.len() {
@@ -6461,7 +6125,7 @@ impl VersionStore {
         // SLOW PATH: Multi-column GROUP BY (currently not used from try_storage_aggregation)
         let mut groups: GroupKeyMap<Vec<Accum>> = GroupKeyMap::default();
 
-        for (idx, meta) in arena_meta.iter().enumerate() {
+        for (_, meta, arena_row) in arena_guard.iter() {
             // Visibility check (standard pattern: check creation, then deletion)
             if meta.txn_id == 0 || !checker.is_visible(meta.txn_id, txn_id) {
                 continue;
@@ -6470,10 +6134,7 @@ impl VersionStore {
                 continue;
             }
 
-            let row_data = match arena_data.get(idx) {
-                Some(data) => data,
-                None => continue,
-            };
+            let row_data = arena_row;
             let row_slice = row_data.as_ref();
 
             let key_values: Vec<CompactArc<Value>> = group_by_indices
@@ -6541,20 +6202,21 @@ struct LocalMutationUndo {
 
 /// Reservations protect removed UNIQUE keys as well as additions until undo
 /// is no longer possible. Arc clones share the projected key allocation.
-type PublicationKey = (usize, Arc<[Value]>);
+type PublicationKey = (usize, CompactArc<[Value]>);
+type PublicationOwners = TrackedHash<PublicationKey, i64, ahash::RandomState>;
 
 /// Called with the ownership mutex held. A conflicting key leaves every
 /// reservation unchanged, including the common single-key INSERT case.
 #[inline]
 fn try_reserve_publication_keys(
-    owners: &mut AHashMap<PublicationKey, i64>,
+    owners: &mut PublicationOwners,
     keys: &[PublicationKey],
     txn_id: i64,
 ) -> bool {
     if let [key] = keys {
         return match owners.entry(key.clone()) {
-            std::collections::hash_map::Entry::Occupied(entry) => *entry.get() == txn_id,
-            std::collections::hash_map::Entry::Vacant(entry) => {
+            HashEntry::Occupied(entry) => *entry.get() == txn_id,
+            HashEntry::Vacant(entry) => {
                 entry.insert(txn_id);
                 true
             }
@@ -6613,14 +6275,72 @@ impl Drop for IndexCatalogLease {
     }
 }
 
-#[derive(Default)]
+type PublicationRowUndo = (
+    i64,
+    Option<VersionChainEntry>,
+    Option<super::arena::ArenaRowMeta>,
+);
+
 struct TransactionMutation {
-    statement_undo: SmallVec<[LocalMutationUndo; 1]>,
-    publication_undo: SmallVec<[(i64, Option<VersionChainEntry>); 1]>,
+    index_undo: Mutex<RetainedSmallVec<[IndexUndo; 0]>>,
+    statement_undo: RetainedSmallVec<[LocalMutationUndo; 1]>,
+    publication_undo: RetainedSmallVec<[PublicationRowUndo; 1]>,
+    undo_lsn_pins: RetainedSmallVec<[super::arena::ArenaLsnPin; 1]>,
+    source_lsns: RetainedSmallVec<[(i64, NonZeroU64); 1]>,
     publication_applied: bool,
-    reserved_keys: SmallVec<[PublicationKey; 2]>,
-    reserved_indexes: SmallVec<[Arc<dyn Index>; 4]>,
+    reserved_keys: RetainedSmallVec<[PublicationKey; 2]>,
+    reserved_indexes: RetainedSmallVec<[Arc<dyn Index>; 4]>,
     index_catalog_lease: Option<IndexCatalogLease>,
+    // One aggregate token per writing transaction, never one per row.
+    history_charge: crate::common::memory::MemoryCharge,
+}
+
+impl TransactionMutation {
+    fn new(account: &crate::common::memory::MemoryAccount) -> Self {
+        Self {
+            index_undo: Mutex::new(RetainedSmallVec::new()),
+            statement_undo: RetainedSmallVec::new(),
+            publication_undo: RetainedSmallVec::new(),
+            undo_lsn_pins: RetainedSmallVec::new(),
+            source_lsns: RetainedSmallVec::new(),
+            publication_applied: false,
+            reserved_keys: RetainedSmallVec::new(),
+            reserved_indexes: RetainedSmallVec::new(),
+            index_catalog_lease: None,
+            history_charge: crate::common::memory::MemoryCharge::new(account, 0),
+        }
+    }
+}
+
+/// A unique handle keeps read-only transactions at one optional pointer while
+/// the allocation header accounts for the write-side state through deallocation.
+struct TransactionMutationOwner(CompactArc<TransactionMutation>);
+
+impl TransactionMutationOwner {
+    fn new(account: &crate::common::memory::MemoryAccount) -> Self {
+        Self(CompactArc::new_in(
+            TransactionMutation::new(account),
+            account,
+        ))
+    }
+}
+
+impl std::ops::Deref for TransactionMutationOwner {
+    type Target = TransactionMutation;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for TransactionMutationOwner {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // This private wrapper never clones or exposes its outer handle.
+        let Some(mutation) = CompactArc::get_mut(&mut self.0) else {
+            unreachable!("unique transaction mutation owner");
+        };
+        mutation
+    }
 }
 
 /// Transaction-local version store for uncommitted changes
@@ -6637,10 +6357,8 @@ pub struct TransactionVersionStore {
     /// Write set for conflict detection
     /// Lazily allocated on first write to avoid allocation overhead for read-only queries
     write_set: Option<I64Map<WriteSetEntry>>,
-    /// Index updates applied by commit, until the commit is visible or undone
-    index_undo: Mutex<Vec<IndexUndo>>,
     /// Read-only table handles pay one pointer, not inline write-side buffers.
-    mutation: Option<Box<TransactionMutation>>,
+    mutation: Option<TransactionMutationOwner>,
 }
 
 impl TransactionVersionStore {
@@ -6656,7 +6374,6 @@ impl TransactionVersionStore {
             parent_store,
             txn_id,
             write_set: None,
-            index_undo: Mutex::new(Vec::new()),
             mutation: None,
         }
     }
@@ -6681,9 +6398,9 @@ impl TransactionVersionStore {
                 .is_some_and(|w| w.contains_key(row_id)),
         };
         self.mutation
-            .get_or_insert_with(|| Box::new(TransactionMutation::default()))
+            .get_or_insert_with(|| TransactionMutationOwner::new(&self.parent_store.memory))
             .statement_undo
-            .push(undo);
+            .push(undo, &self.parent_store.memory);
     }
 
     pub fn finish_statement(&mut self, checkpoint: usize, success: bool) {
@@ -6691,10 +6408,22 @@ impl TransactionVersionStore {
             return;
         };
         if !success {
-            for undo in mutation.statement_undo.drain(..).skip(checkpoint).rev() {
+            while mutation.statement_undo.len() > checkpoint {
+                let Some(undo) = mutation.statement_undo.pop() else {
+                    unreachable!("statement journal remains above checkpoint");
+                };
                 if let Some(local) = self.local_versions.as_mut() {
                     if undo.versions_len == 0 {
-                        local.remove(undo.row_id);
+                        if let Some(history) = local.remove(undo.row_id) {
+                            let bytes = if history.spilled() {
+                                history.capacity() * std::mem::size_of::<RowVersion>()
+                            } else {
+                                0
+                            };
+                            drop(history);
+                            let charge = &mut mutation.history_charge;
+                            charge.resize(charge.bytes() - bytes);
+                        }
                     } else if let Some(versions) = local.get_mut(undo.row_id) {
                         versions.truncate(undo.versions_len);
                     }
@@ -6713,24 +6442,13 @@ impl TransactionVersionStore {
 
     /// Takes back the index updates of this transaction's commit, in reverse
     pub fn undo_index_updates(&self) -> Result<(), Error> {
-        let undo: Vec<IndexUndo> = std::mem::take(&mut *self.index_undo.lock());
-        for entry in undo.iter().rev() {
-            if !entry.added.is_empty() {
-                let batch: Vec<(i64, &[Value])> = entry
-                    .added
-                    .iter()
-                    .map(|(row_id, values)| (*row_id, values.as_slice()))
-                    .collect();
-                entry.index.remove_batch_slice(&batch)?;
-            }
-            if !entry.removed.is_empty() {
-                let batch: Vec<(i64, &[Value])> = entry
-                    .removed
-                    .iter()
-                    .map(|(row_id, values)| (*row_id, values.as_slice()))
-                    .collect();
-                entry.index.add_batch_slice(&batch)?;
-            }
+        let Some(mutation) = self.mutation.as_ref() else {
+            return Ok(());
+        };
+        let mut undo = mutation.index_undo.lock();
+        while let Some(entry) = undo.last_mut() {
+            entry.undo()?;
+            undo.pop();
         }
         Ok(())
     }
@@ -6754,14 +6472,42 @@ impl TransactionVersionStore {
     /// Uses pooled maps when available to reduce allocation overhead.
     #[inline]
     fn ensure_local_versions(&mut self) -> &mut I64Map<VersionList> {
-        self.local_versions.get_or_insert_with(get_version_list_map)
+        self.local_versions
+            .get_or_insert_with(|| self.parent_store.pools.versions.lock().take())
     }
 
     /// Ensures write_set map is allocated, returning a mutable reference.
     /// Uses pooled maps when available to reduce allocation overhead.
     #[inline]
     fn ensure_write_set(&mut self) -> &mut I64Map<WriteSetEntry> {
-        self.write_set.get_or_insert_with(get_write_set_map)
+        self.write_set
+            .get_or_insert_with(|| self.parent_store.pools.writes.lock().take())
+    }
+
+    fn append_local_version(
+        history: &mut VersionList,
+        mutation: &mut Option<TransactionMutationOwner>,
+        version: RowVersion,
+    ) {
+        let Some(mutation) = mutation else {
+            unreachable!("local history requires its recorded mutation owner");
+        };
+        let charge = &mut mutation.history_charge;
+        if history.len() == history.capacity() {
+            let old_bytes = if history.spilled() {
+                history.capacity() * std::mem::size_of::<RowVersion>()
+            } else {
+                0
+            };
+            let replacement = VersionList::with_capacity(history.capacity() * 2);
+            let new_bytes = replacement.capacity() * std::mem::size_of::<RowVersion>();
+            // Keep both buffers charged during the move and release the old buffer before its charge.
+            charge.resize(charge.bytes() + new_bytes);
+            let old = std::mem::replace(history, replacement);
+            history.extend(old);
+            charge.resize(charge.bytes() - old_bytes);
+        }
+        history.push(version);
     }
 
     /// Put adds or updates a row in the transaction's local store
@@ -6770,7 +6516,7 @@ impl TransactionVersionStore {
         // Convert to Shared (Arc) storage immediately for efficient Arc sharing:
         // - get_arc() will return cheap Arc clones (no value cloning)
         // - into_arc() at commit time returns the existing Arc (no clone)
-        let data = Row::from_arc(data.into_arc());
+        let data = data.into_hot(&self.parent_store.memory);
 
         // Get timestamp once at the start (avoids calling SystemTime::now() inside RowVersion::new)
         let timestamp = get_fast_timestamp();
@@ -6782,17 +6528,14 @@ impl TransactionVersionStore {
         }
 
         // Check if we already have a local version for this row
-        let has_local = self
+        let history = self
             .local_versions
-            .as_ref()
-            .is_some_and(|lv| lv.contains_key(row_id));
+            .as_mut()
+            .and_then(|local| local.get_mut(row_id));
 
-        if has_local {
+        if let Some(history) = history {
             // Already have local version - just append
-            self.ensure_local_versions()
-                .get_mut(row_id)
-                .unwrap()
-                .push(rv);
+            Self::append_local_version(history, &mut self.mutation, rv);
         } else {
             // New row - need to check write-set and parent store
             let needs_write_set_entry = self
@@ -6850,12 +6593,12 @@ impl TransactionVersionStore {
         &mut self,
         row_id: i64,
         data: Row,
-        original_version: RowVersion,
+        mut original_version: RowVersion,
         is_delete: bool,
     ) -> Result<(), Error> {
         self.record_local_mutation(row_id);
         // Convert to Shared (Arc) storage immediately for efficient Arc sharing
-        let data = Row::from_arc(data.into_arc());
+        let data = data.into_hot(&self.parent_store.memory);
 
         // Get timestamp once at the start (avoids calling SystemTime::now() inside RowVersion::new)
         let timestamp = get_fast_timestamp();
@@ -6867,17 +6610,14 @@ impl TransactionVersionStore {
         }
 
         // Check if we already have a local version for this row
-        let has_local = self
+        let history = self
             .local_versions
-            .as_ref()
-            .is_some_and(|lv| lv.contains_key(row_id));
+            .as_mut()
+            .and_then(|local| local.get_mut(row_id));
 
-        if has_local {
+        if let Some(history) = history {
             // Already have local version - just append
-            self.ensure_local_versions()
-                .get_mut(row_id)
-                .unwrap()
-                .push(rv);
+            Self::append_local_version(history, &mut self.mutation, rv);
         } else {
             // Track in write-set using the pre-fetched original version
             let needs_write_set_entry = self
@@ -6893,6 +6633,7 @@ impl TransactionVersionStore {
                     .map(|c| c.get_current_sequence())
                     .unwrap_or(0);
 
+                original_version.data = original_version.data.into_hot(&self.parent_store.memory);
                 self.ensure_write_set().insert(
                     row_id,
                     WriteSetEntry {
@@ -6923,19 +6664,23 @@ impl TransactionVersionStore {
     ) -> Result<(), Error> {
         let now = get_fast_timestamp();
 
-        for (row_id, data, original_version) in rows {
+        for (row_id, data, mut original_version) in rows {
             self.record_local_mutation(row_id);
             // Convert to Shared (Arc) storage immediately for efficient Arc sharing
-            let data = Row::from_arc(data.into_arc());
+            let data = data.into_hot(&self.parent_store.memory);
 
             // Create the new row version with pre-computed timestamp (avoids wasteful
             // get_fast_timestamp() call inside RowVersion::new that would be overwritten)
             let rv = RowVersion::new_with_timestamp(self.txn_id, data, now);
 
             // Check if already in local versions (already processed in this transaction)
-            if let Some(versions) = self.ensure_local_versions().get_mut(row_id) {
+            if let Some(history) = self
+                .local_versions
+                .as_mut()
+                .and_then(|local| local.get_mut(row_id))
+            {
                 // Append new version to history
-                versions.push(rv);
+                Self::append_local_version(history, &mut self.mutation, rv);
                 continue;
             }
 
@@ -6955,6 +6700,7 @@ impl TransactionVersionStore {
                     .as_ref()
                     .map(|c| c.get_current_sequence())
                     .unwrap_or(0);
+                original_version.data = original_version.data.into_hot(&self.parent_store.memory);
                 self.ensure_write_set().insert(
                     row_id,
                     WriteSetEntry {
@@ -7026,15 +6772,22 @@ impl TransactionVersionStore {
             }
 
             // Create deleted row version with pre-computed timestamp
-            let mut rv = RowVersion::new_with_timestamp(self.txn_id, data, timestamp);
+            let mut rv = RowVersion::new_with_timestamp(
+                self.txn_id,
+                data.into_hot(&self.parent_store.memory),
+                timestamp,
+            );
             rv.deleted_at_txn_id = self.txn_id;
 
             // Append to version history for this row
-            let local_versions = self.ensure_local_versions();
-            if let Some(versions) = local_versions.get_mut(row_id) {
-                versions.push(rv);
+            if let Some(history) = self
+                .local_versions
+                .as_mut()
+                .and_then(|local| local.get_mut(row_id))
+            {
+                Self::append_local_version(history, &mut self.mutation, rv);
             } else {
-                local_versions.insert(row_id, smallvec![rv]);
+                self.ensure_local_versions().insert(row_id, smallvec![rv]);
             }
         }
         Ok(())
@@ -7052,15 +6805,23 @@ impl TransactionVersionStore {
         // Get timestamp once for all rows in the batch
         let timestamp = get_fast_timestamp();
 
-        for (row_id, data, original_version) in rows {
+        for (row_id, data, mut original_version) in rows {
             self.record_local_mutation(row_id);
             // Create deleted row version with pre-computed timestamp
-            let mut rv = RowVersion::new_with_timestamp(self.txn_id, data, timestamp);
+            let mut rv = RowVersion::new_with_timestamp(
+                self.txn_id,
+                data.into_hot(&self.parent_store.memory),
+                timestamp,
+            );
             rv.deleted_at_txn_id = self.txn_id;
 
             // Check if already in local versions (already processed in this transaction)
-            if let Some(versions) = self.ensure_local_versions().get_mut(row_id) {
-                versions.push(rv);
+            if let Some(history) = self
+                .local_versions
+                .as_mut()
+                .and_then(|local| local.get_mut(row_id))
+            {
+                Self::append_local_version(history, &mut self.mutation, rv);
                 continue;
             }
 
@@ -7078,6 +6839,7 @@ impl TransactionVersionStore {
                     .map(|c| c.get_current_sequence())
                     .unwrap_or(0);
 
+                original_version.data = original_version.data.into_hot(&self.parent_store.memory);
                 self.ensure_write_set().insert(
                     row_id,
                     WriteSetEntry {
@@ -7280,6 +7042,15 @@ impl TransactionVersionStore {
 
     /// Prepares row and UNIQUE-key ownership and captures only changed heads.
     /// The engine prepares every table before applying any of them.
+    pub fn record_source_lsn(&mut self, row_id: i64, source_lsn: Option<NonZeroU64>) {
+        if let Some(lsn) = source_lsn {
+            self.mutation
+                .get_or_insert_with(|| TransactionMutationOwner::new(&self.parent_store.memory))
+                .source_lsns
+                .push((row_id, lsn), &self.parent_store.memory);
+        }
+    }
+
     pub fn prepare_publication(&mut self) -> Result<(), Error> {
         if self.mutation.is_none() {
             return Ok(());
@@ -7295,7 +7066,7 @@ impl TransactionVersionStore {
             }
         }
         self.detect_conflicts_safe()?;
-        let mut keys: SmallVec<[PublicationKey; 2]> = SmallVec::new();
+        let mut keys = RetainedSmallVec::<[PublicationKey; 2]>::new();
         let indexes = self.parent_store.get_all_indexes();
         for index in &indexes {
             if !index.is_unique() || index.index_type() == crate::core::IndexType::PrimaryKey {
@@ -7317,28 +7088,22 @@ impl TransactionVersionStore {
                     .into_iter()
                     .chain((!version.is_deleted()).then_some(&version.data))
                 {
-                    let values: Arc<[Value]> = index
-                        .column_ids()
-                        .iter()
-                        .map(|&id| {
+                    let values = CompactArc::from_exact_iter_in(
+                        index.column_ids().iter().map(|&id| {
                             row.get(id as usize)
                                 .cloned()
                                 .unwrap_or_else(Value::null_unknown)
-                        })
-                        .collect();
+                                .into_hot(&self.parent_store.memory)
+                        }),
+                        &self.parent_store.memory,
+                    );
                     if values.iter().any(Value::is_null) {
                         continue;
                     }
-                    keys.push((identity, values));
+                    keys.push((identity, values), &self.parent_store.memory);
                 }
             }
         }
-        let undo = {
-            let versions = self.parent_store.versions.read();
-            self.iter_local()
-                .map(|(row_id, _)| (row_id, versions.get(row_id).cloned()))
-                .collect()
-        };
         let mutation = self
             .mutation
             .as_mut()
@@ -7351,9 +7116,63 @@ impl TransactionVersionStore {
                 ));
             }
         }
+        // Install ownership undo before arena validation or pin allocation can fail.
         mutation.reserved_keys = keys;
-        mutation.reserved_indexes = indexes;
+        mutation.reserved_indexes =
+            RetainedSmallVec::from_inner(indexes, &self.parent_store.memory);
+        let versions = self.parent_store.versions.read();
+        let mut undo = RetainedSmallVec::<[_; 1]>::new();
+        undo.extend(
+            self.local_versions
+                .as_ref()
+                .into_iter()
+                .flat_map(|local| local.iter())
+                .filter(|(_, history)| !history.is_empty())
+                .map(|(row_id, _)| (row_id, versions.get(row_id).cloned(), None)),
+            &self.parent_store.memory,
+        );
+        let mut chunks: SmallVec<[_; 1]> = SmallVec::new();
+        if undo
+            .iter()
+            .any(|(_, entry, _)| entry.as_ref().is_some_and(|e| e.arena_idx.is_some()))
+        {
+            let arena = self.parent_store.arena.read_guard();
+            for (row_id, previous, saved_meta) in &mut undo {
+                if let Some(id) = previous.as_ref().and_then(|entry| entry.arena_idx) {
+                    let meta = arena
+                        .get_meta(id)
+                        .filter(|meta| {
+                            meta.row_id == *row_id
+                                && previous.as_ref().is_some_and(|entry| {
+                                    meta.mutation_txn_id()
+                                        == if entry.version.is_deleted() {
+                                            entry.version.deleted_at_txn_id
+                                        } else {
+                                            entry.version.txn_id
+                                        }
+                                })
+                        })
+                        .ok_or_else(|| Error::internal("publication undo lost its arena row"))?;
+                    *saved_meta = Some(*meta);
+                    if meta.source_lsn.is_some() {
+                        chunks.push(id.chunk_id());
+                    }
+                }
+            }
+        }
+        chunks.sort_unstable();
+        chunks.dedup();
+        let mut pins = RetainedSmallVec::<[_; 1]>::new();
+        for chunk in chunks {
+            if let Some(pin) = self.parent_store.arena.pin_chunk_lsn(chunk)? {
+                pins.push(pin, &self.parent_store.memory);
+            }
+        }
         mutation.publication_undo = undo;
+        mutation.undo_lsn_pins = pins;
+        mutation
+            .source_lsns
+            .sort_unstable_by_key(|&(row_id, lsn)| (row_id, lsn));
         Ok(())
     }
 
@@ -7377,24 +7196,27 @@ impl TransactionVersionStore {
             .mutation
             .as_mut()
             .ok_or_else(|| Error::internal("cold reservation before prepare"))?;
-        let mut keys: SmallVec<[PublicationKey; 2]> = SmallVec::new();
+        let mut keys = RetainedSmallVec::<[PublicationKey; 2]>::new();
         for index in &mutation.reserved_indexes {
             if !index.is_unique() || index.index_type() == crate::core::IndexType::PrimaryKey {
                 continue;
             }
-            let values: Arc<[Value]> = index
-                .column_ids()
-                .iter()
-                .map(|&id| {
+            let values = CompactArc::from_exact_iter_in(
+                index.column_ids().iter().map(|&id| {
                     row.get(id as usize)
                         .cloned()
                         .unwrap_or_else(Value::null_unknown)
-                })
-                .collect();
+                        .into_hot(&self.parent_store.memory)
+                }),
+                &self.parent_store.memory,
+            );
             if values.iter().any(Value::is_null) {
                 continue;
             }
-            keys.push((Arc::as_ptr(index) as *const () as usize, values));
+            keys.push(
+                (Arc::as_ptr(index) as *const () as usize, values),
+                &self.parent_store.memory,
+            );
         }
         if keys.is_empty() {
             return Ok(());
@@ -7405,7 +7227,9 @@ impl TransactionVersionStore {
                 "write conflict: cold unique key is being published",
             ));
         }
-        mutation.reserved_keys.extend(keys);
+        mutation
+            .reserved_keys
+            .extend(keys, &self.parent_store.memory);
         Ok(())
     }
 
@@ -7421,72 +7245,98 @@ impl TransactionVersionStore {
         let Some(local) = self.local_versions.as_ref() else {
             return Ok(());
         };
+        let source_lsns = self
+            .mutation
+            .as_ref()
+            .map_or(&[][..], |m| m.source_lsns.as_slice());
+        let source_lsn = |row_id| {
+            let end = source_lsns.partition_point(|&(id, _)| id <= row_id);
+            end.checked_sub(1)
+                .and_then(|i| (source_lsns[i].0 == row_id).then_some(source_lsns[i].1))
+        };
         if local.len() == 1 {
             if let Some((row_id, versions)) = local.iter().next() {
                 if let Some(version) = versions.last() {
-                    self.parent_store
-                        .add_version_single(row_id, version.clone());
+                    self.parent_store.add_version_with_lsn(
+                        row_id,
+                        version.clone(),
+                        source_lsn(row_id),
+                    )?;
                 }
             }
         } else {
             let mut batch: Vec<_> = local
                 .iter()
                 .filter_map(|(row_id, versions)| {
-                    versions.last().map(|version| (row_id, version.clone()))
+                    versions
+                        .last()
+                        .map(|version| (row_id, version.clone(), source_lsn(row_id)))
                 })
                 .collect();
-            batch.sort_unstable_by_key(|(row_id, _)| *row_id);
-            self.parent_store.add_versions_batch(batch);
+            batch.sort_unstable_by_key(|(row_id, _, _)| *row_id);
+            self.parent_store.add_versions_with_lsns(batch)?;
         }
         Ok(())
     }
 
     pub fn finish_publication(&mut self, committed: bool) -> Result<(), Error> {
+        if !committed {
+            self.undo_index_updates()?;
+        }
         let Some(mut mutation) = self.mutation.take() else {
             return Ok(());
         };
-        if !committed {
-            if let Err(error) = self.undo_index_updates() {
-                self.mutation = Some(mutation);
-                return Err(error);
-            }
-            if mutation.publication_applied {
-                let mut versions = self.parent_store.versions.write();
-                for (row_id, previous) in mutation.publication_undo.drain(..) {
+        if !committed && mutation.publication_applied {
+            let mut versions = self.parent_store.versions.write();
+            let restore_result = (|| -> Result<(), Error> {
+                while let Some((row_id, previous, saved_meta)) =
+                    mutation.publication_undo.last().cloned()
+                {
                     let Some(current) = versions
                         .get(row_id)
                         .filter(|entry| entry.version.txn_id == self.txn_id)
                     else {
+                        mutation.publication_undo.pop();
                         continue;
                     };
                     let current_live = !current.version.is_deleted();
-                    let current_slot = unpack_arena_idx(current.arena_idx);
+                    let current_slot = current.arena_idx;
                     let previous_live = previous
                         .as_ref()
                         .is_some_and(|entry| !entry.version.is_deleted());
-                    let previous_slot = previous
-                        .as_ref()
-                        .and_then(|entry| unpack_arena_idx(entry.arena_idx));
-                    if let Some(slot) = current_slot.filter(|slot| Some(*slot) != previous_slot) {
-                        self.parent_store.arena.clear_at(slot);
-                    }
+                    let previous_slot = previous.as_ref().and_then(|entry| entry.arena_idx);
                     if let Some(entry) = previous {
                         if let Some(slot) = previous_slot {
-                            self.parent_store.arena.update_at(
+                            if !self.parent_store.arena.update_at(
                                 slot,
                                 row_id,
-                                entry.version.txn_id,
+                                saved_meta.map_or(entry.version.txn_id, |meta| meta.txn_id),
                                 entry.version.data.clone().into_arc(),
-                            );
-                            if entry.version.is_deleted() {
-                                self.parent_store
-                                    .arena
-                                    .mark_deleted(slot, entry.version.deleted_at_txn_id);
+                                saved_meta.and_then(|meta| meta.source_lsn),
+                            )? {
+                                return Err(Error::internal(
+                                    "publication undo lost its arena slot",
+                                ));
+                            }
+                            if entry.version.is_deleted()
+                                && !self.parent_store.arena.mark_deleted(
+                                    slot,
+                                    row_id,
+                                    entry.version.deleted_at_txn_id,
+                                    saved_meta.and_then(|meta| meta.source_lsn),
+                                )?
+                            {
+                                return Err(Error::internal(
+                                    "publication undo lost its deleted arena slot",
+                                ));
                             }
                         }
                         versions.insert(row_id, entry);
                     } else {
                         versions.remove(row_id);
+                    }
+                    if let Some(slot) = current_slot.filter(|slot| Some(*slot) != previous_slot) {
+                        self.parent_store.arena.clear_at(slot, row_id, self.txn_id);
                     }
                     if current_live && !previous_live {
                         self.parent_store
@@ -7497,20 +7347,25 @@ impl TransactionVersionStore {
                             .committed_row_count
                             .fetch_add(1, Ordering::Relaxed);
                     }
+                    mutation.publication_undo.pop();
                 }
+                Ok(())
+            })();
+            drop(versions);
+            if let Err(error) = restore_result {
+                // Retain claims and receipt pins while incomplete undo still requires recovery.
+                self.mutation = Some(mutation);
+                return Err(error);
             }
         }
         mutation.publication_undo.clear();
+        // Previous row minima are covered by restored rows or a terminal commit.
+        mutation.undo_lsn_pins.clear();
         mutation.publication_applied = false;
-        self.index_undo.lock().clear();
-        if !mutation.reserved_keys.is_empty() {
-            let mut owners = self.parent_store.publication_keys.lock();
-            for key in mutation.reserved_keys.drain(..) {
-                if owners.get(&key) == Some(&self.txn_id) {
-                    owners.remove(&key);
-                }
-            }
-        }
+        mutation.index_undo.lock().clear();
+        self.parent_store
+            .release_publication_keys(&mutation.reserved_keys, self.txn_id);
+        mutation.reserved_keys.clear();
         mutation.reserved_indexes.clear();
         self.release_all_claims();
         // Drain only after the outcome and any undo. Besides dropping values,
@@ -7522,6 +7377,7 @@ impl TransactionVersionStore {
         if let Some(local) = self.local_versions.as_mut() {
             drop(local.drain());
         }
+        mutation.history_charge.resize(0);
         mutation.statement_undo.clear();
         Ok(())
     }
@@ -7552,11 +7408,15 @@ impl TransactionVersionStore {
         if indexes.is_empty() {
             return Ok(());
         }
+        let mutation = self
+            .mutation
+            .as_ref()
+            .ok_or_else(|| Error::internal("index publication mutation is missing"))?;
 
         // FAST PATH: Single-row commit (most common case for auto-commit INSERT/UPDATE/DELETE)
         // Uses SmallVec to avoid heap allocation for 1-2 column indexes
         if local_versions.len() == 1 {
-            return self.update_indexes_single_row(indexes);
+            return self.update_indexes_single_row(indexes, local_versions, mutation);
         }
 
         // BATCH PATH: Multi-row commit
@@ -7762,282 +7622,95 @@ impl TransactionVersionStore {
             }
         }
 
-        // PHASE 2: All validations passed - now modify all indexes
-        // Track modifications for rollback if a later index fails (race condition protection)
-        // Between Phase 1 validation and Phase 2 modification, another transaction could commit,
-        // causing a unique constraint violation that wasn't detected in Phase 1.
-        let mut completed_removals: Vec<usize> = Vec::new();
-        let mut completed_additions: Vec<usize> = Vec::new();
-
-        for (idx, index) in indexes.iter().enumerate() {
-            // Remove old entries first (for UPDATE correctness)
-            if !remove_batches[idx].is_empty() {
-                let batch: Vec<(i64, &[crate::core::Value])> = remove_batches[idx]
-                    .iter()
-                    .map(|(row_id, values)| (*row_id, values.as_slice()))
-                    .collect();
-                // Note: remove_batch_slice can fail (e.g., I/O error), but typically succeeds
-                if index.remove_batch_slice(&batch).is_ok() {
-                    completed_removals.push(idx);
-                }
-            }
-
-            // Add new entries
-            if !add_batches[idx].is_empty() {
-                let batch: Vec<(i64, &[crate::core::Value])> = add_batches[idx]
-                    .iter()
-                    .map(|(row_id, values)| (*row_id, values.as_slice()))
-                    .collect();
-
-                if let Err(e) = index.add_batch_slice(&batch) {
-                    // ROLLBACK: A later index failed - undo all previous modifications
-                    // This prevents index corruption where indexes point to uncommitted rows
-
-                    // 1. Remove additions we made to earlier indexes
-                    for &rollback_idx in &completed_additions {
-                        let rollback_batch: Vec<(i64, &[crate::core::Value])> = add_batches
-                            [rollback_idx]
-                            .iter()
-                            .map(|(row_id, values)| (*row_id, values.as_slice()))
-                            .collect();
-                        let _ = indexes[rollback_idx].remove_batch_slice(&rollback_batch);
-                    }
-
-                    // 2. Re-add removals we made to earlier indexes
-                    for &rollback_idx in &completed_removals {
-                        let rollback_batch: Vec<(i64, &[crate::core::Value])> = remove_batches
-                            [rollback_idx]
-                            .iter()
-                            .map(|(row_id, values)| (*row_id, values.as_slice()))
-                            .collect();
-                        // Rollback additions - ignore errors as we're in error recovery
-                        let _ = indexes[rollback_idx].add_batch_slice(&rollback_batch);
-                    }
-
-                    return Err(e);
-                }
-                completed_additions.push(idx);
-            }
-        }
-
-        let mut undo = self.index_undo.lock();
+        // Install the complete inverse before any index mutation so a failed prefix can be retried.
+        let mut undo = mutation.index_undo.lock();
+        let start = undo.len();
         for (idx, index) in indexes.iter().enumerate() {
             if add_batches[idx].is_empty() && remove_batches[idx].is_empty() {
                 continue;
             }
-            undo.push(IndexUndo {
-                index: Arc::clone(index),
-                added: std::mem::take(&mut add_batches[idx]),
-                removed: std::mem::take(&mut remove_batches[idx]),
-            });
+            undo.push(
+                IndexUndo::new(
+                    Arc::clone(index),
+                    std::mem::take(&mut add_batches[idx]),
+                    std::mem::take(&mut remove_batches[idx]),
+                    &self.parent_store.memory,
+                ),
+                &self.parent_store.memory,
+            );
         }
-
+        for entry in &mut undo[start..] {
+            entry.apply()?;
+        }
         Ok(())
     }
 
-    /// Fast path for single-row index updates
-    ///
-    /// Uses SmallVec to avoid heap allocation for indexes with 1-2 columns (most common case).
-    /// Applies changes immediately without batching overhead.
-    fn update_indexes_single_row(&self, indexes: &[Arc<dyn Index>]) -> Result<(), Error> {
-        let local_versions = self.local_versions.as_ref().unwrap();
-
-        // Get the single row entry
+    /// The single-row path builds the same owned key buffers needed for undo,
+    /// installs them first, and calls the scalar index APIs without batch views.
+    fn update_indexes_single_row(
+        &self,
+        indexes: &[Arc<dyn Index>],
+        local_versions: &I64Map<VersionList>,
+        mutation: &TransactionMutation,
+    ) -> Result<(), Error> {
         let Some((row_id, versions)) = local_versions.iter().next() else {
             return Ok(());
         };
-
         let Some(new_version) = versions.last() else {
             return Ok(());
         };
-
-        let is_deleted = new_version.is_deleted();
-        let new_row = &new_version.data;
-
-        // Get old version from write_set (if exists)
-        let old_row: Option<&Row> = self
+        let old_row = self
             .write_set
             .as_ref()
             .and_then(|ws| ws.get(row_id))
             .and_then(|entry| entry.read_version.as_ref())
-            .map(|rv| &rv.data);
-
-        // Track what we've done for rollback on error
-        let mut completed_ops: SmallVec<[(usize, bool); 4]> = SmallVec::new(); // (index_idx, is_add)
-
-        for (idx, index) in indexes.iter().enumerate() {
-            let column_ids = index.column_ids();
-            if column_ids.is_empty() {
+            .map(|version| &version.data);
+        let new_row = &new_version.data;
+        let mut undo = mutation.index_undo.lock();
+        let start = undo.len();
+        for index in indexes {
+            let columns = index.column_ids();
+            if columns.is_empty()
+                || (!new_version.is_deleted()
+                    && old_row.is_some_and(|old| {
+                        columns
+                            .iter()
+                            .all(|&id| old.get(id as usize) == new_row.get(id as usize))
+                    }))
+            {
                 continue;
             }
-
-            // OPTIMIZATION: For UPDATEs, check if any indexed column changed BEFORE allocating
-            if let Some(old_r) = old_row {
-                if !is_deleted {
-                    // UPDATE case: check if indexed columns differ (no allocation)
-                    let any_changed = column_ids.iter().any(|&col_id| {
-                        let col_idx = col_id as usize;
-                        old_r.get(col_idx) != new_row.get(col_idx)
-                    });
-
-                    if !any_changed {
-                        // Indexed columns unchanged - skip this index entirely
-                        continue;
-                    }
-
-                    // Values differ - collect and update using SmallVec (stack allocation for 1-2 cols)
-                    let old_values: SmallVec<[Value; 2]> = column_ids
-                        .iter()
-                        .map(|&col_id| {
-                            old_r
-                                .get(col_id as usize)
-                                .cloned()
-                                .unwrap_or(Value::Null(DataType::Null))
-                        })
-                        .collect();
-
-                    let new_values: SmallVec<[Value; 2]> = column_ids
-                        .iter()
-                        .map(|&col_id| {
-                            new_row
-                                .get(col_id as usize)
-                                .cloned()
-                                .unwrap_or(Value::Null(DataType::Null))
-                        })
-                        .collect();
-
-                    // Remove old, add new
-                    let _ = index.remove(&old_values, row_id, row_id);
-                    completed_ops.push((idx, false)); // false = removal
-
-                    if let Err(e) = index.add(&new_values, row_id, row_id) {
-                        // Rollback: re-add the old value we removed
-                        let _ = index.add(&old_values, row_id, row_id);
-                        // Rollback previous indexes
-                        self.rollback_single_row_ops(
-                            &completed_ops,
-                            indexes,
-                            row_id,
-                            old_row,
-                            new_row,
-                        );
-                        return Err(e);
-                    }
-                    completed_ops.push((idx, true)); // true = addition
-                    continue;
-                }
-            }
-
-            if is_deleted {
-                // DELETE: remove from index
-                let source_row = old_row.unwrap_or(new_row);
-                let values_to_remove: SmallVec<[Value; 2]> = column_ids
+            let project = |row: &Row| {
+                columns
                     .iter()
-                    .map(|&col_id| {
-                        source_row
-                            .get(col_id as usize)
+                    .map(|&id| {
+                        row.get(id as usize)
                             .cloned()
-                            .unwrap_or(Value::Null(DataType::Null))
+                            .unwrap_or_else(Value::null_unknown)
                     })
-                    .collect();
-                let _ = index.remove(&values_to_remove, row_id, row_id);
-                completed_ops.push((idx, false));
-            } else {
-                // INSERT: add values to index
-                let new_values: SmallVec<[Value; 2]> = column_ids
-                    .iter()
-                    .map(|&col_id| {
-                        new_row
-                            .get(col_id as usize)
-                            .cloned()
-                            .unwrap_or(Value::Null(DataType::Null))
-                    })
-                    .collect();
-
-                if let Err(e) = index.add(&new_values, row_id, row_id) {
-                    // Rollback previous indexes
-                    self.rollback_single_row_ops(&completed_ops, indexes, row_id, old_row, new_row);
-                    return Err(e);
-                }
-                completed_ops.push((idx, true));
-            }
-        }
-
-        let mut undo = self.index_undo.lock();
-        for &(idx, is_add) in completed_ops.iter() {
-            let index = &indexes[idx];
-            let source = if is_add {
-                new_row
-            } else {
-                old_row.unwrap_or(new_row)
+                    .collect()
             };
-            let values: Vec<Value> = index
-                .column_ids()
-                .iter()
-                .map(|&col_id| {
-                    source
-                        .get(col_id as usize)
-                        .cloned()
-                        .unwrap_or(Value::Null(DataType::Null))
-                })
-                .collect();
-            let entry = vec![(row_id, values)];
-            let (added, removed) = if is_add {
-                (entry, Vec::new())
+            let added = if new_version.is_deleted() {
+                Vec::new()
             } else {
-                (Vec::new(), entry)
+                vec![(row_id, project(new_row))]
             };
-            undo.push(IndexUndo {
-                index: Arc::clone(index),
-                added,
-                removed,
-            });
+            let removed = if new_version.is_deleted() {
+                vec![(row_id, project(old_row.unwrap_or(new_row)))]
+            } else if let Some(old) = old_row {
+                vec![(row_id, project(old))]
+            } else {
+                Vec::new()
+            };
+            undo.push(
+                IndexUndo::new(Arc::clone(index), added, removed, &self.parent_store.memory),
+                &self.parent_store.memory,
+            );
         }
-
+        for entry in &mut undo[start..] {
+            entry.apply()?;
+        }
         Ok(())
-    }
-
-    /// Rollback helper for single-row operations
-    #[inline]
-    fn rollback_single_row_ops(
-        &self,
-        completed_ops: &[(usize, bool)],
-        indexes: &[Arc<dyn Index>],
-        row_id: i64,
-        old_row: Option<&Row>,
-        new_row: &Row,
-    ) {
-        for &(idx, is_add) in completed_ops.iter().rev() {
-            let index = &indexes[idx];
-            let column_ids = index.column_ids();
-
-            if is_add {
-                // We added new values - remove them
-                let values: SmallVec<[Value; 2]> = column_ids
-                    .iter()
-                    .map(|&col_id| {
-                        new_row
-                            .get(col_id as usize)
-                            .cloned()
-                            .unwrap_or(Value::Null(DataType::Null))
-                    })
-                    .collect();
-                let _ = index.remove(&values, row_id, row_id);
-            } else {
-                // We removed old values - re-add them
-                let source = old_row.unwrap_or(new_row);
-                let values: SmallVec<[Value; 2]> = column_ids
-                    .iter()
-                    .map(|&col_id| {
-                        source
-                            .get(col_id as usize)
-                            .cloned()
-                            .unwrap_or(Value::Null(DataType::Null))
-                    })
-                    .collect();
-                let _ = index.add(&values, row_id, row_id);
-            }
-        }
     }
 
     /// Rollback - discard local changes and release claims
@@ -8070,7 +7743,19 @@ impl TransactionVersionStore {
 
         // Remove rows with no remaining versions and release their claims
         for row_id in &rows_to_remove_completely {
-            local_versions.remove(*row_id);
+            if let Some(history) = local_versions.remove(*row_id) {
+                let bytes = if history.spilled() {
+                    history.capacity() * std::mem::size_of::<RowVersion>()
+                } else {
+                    0
+                };
+                drop(history);
+                let Some(mutation) = self.mutation.as_mut() else {
+                    unreachable!("rollback history requires its mutation owner");
+                };
+                let charge = &mut mutation.history_charge;
+                charge.resize(charge.bytes() - bytes);
+            }
             self.parent_store.release_row_claim(*row_id, self.txn_id);
             if let Some(write_set) = self.write_set.as_mut() {
                 write_set.remove(*row_id);
@@ -8145,14 +7830,8 @@ impl TransactionVersionStore {
 impl Drop for TransactionVersionStore {
     fn drop(&mut self) {
         if let Some(mutation) = &self.mutation {
-            if !mutation.reserved_keys.is_empty() {
-                let mut owners = self.parent_store.publication_keys.lock();
-                for key in &mutation.reserved_keys {
-                    if owners.get(key) == Some(&self.txn_id) {
-                        owners.remove(key);
-                    }
-                }
-            }
+            self.parent_store
+                .release_publication_keys(&mutation.reserved_keys, self.txn_id);
         }
         // Release any row claims still held by this transaction.
         // This is a safety net for cases where drop happens without explicit
@@ -8164,11 +7843,19 @@ impl Drop for TransactionVersionStore {
         // Return maps to the pool for reuse by future transactions.
         // This reduces allocation overhead from ~5.5KB per transaction to near zero
         // for bulk insert workloads where many short-lived transactions are created.
-        if let Some(map) = self.local_versions.take() {
-            return_version_list_map(map);
+        if let Some(mut map) = self.local_versions.take() {
+            if !map.is_empty() {
+                map.clear();
+            }
+            let rejected = self.parent_store.pools.versions.lock().put(map);
+            drop(rejected);
         }
-        if let Some(map) = self.write_set.take() {
-            return_write_set_map(map);
+        if let Some(mut map) = self.write_set.take() {
+            if !map.is_empty() {
+                map.clear();
+            }
+            let rejected = self.parent_store.pools.writes.lock().put(map);
+            drop(rejected);
         }
     }
 }
@@ -8193,6 +7880,7 @@ impl fmt::Debug for TransactionVersionStore {
 mod tests {
     use super::*;
     use crate::core::Value;
+    use crate::storage::mvcc::arena::{ChunkId, ARENA_CHUNK_MASK, ARENA_CHUNK_SHIFT};
     use std::sync::atomic::AtomicI64;
 
     /// Simple visibility checker for testing
@@ -8382,7 +8070,7 @@ mod tests {
         let row = Row::from(vec![Value::from(42)]);
         let version = RowVersion::new(1, row);
 
-        store.add_version(100, version);
+        store.add_version(100, version).unwrap();
 
         // Transaction 2 should see version from transaction 1
         let visible = store.get_visible_version(100, 2);
@@ -8399,7 +8087,7 @@ mod tests {
         // Add version from transaction 5
         let row = Row::from(vec![Value::from(42)]);
         let version = RowVersion::new(5, row);
-        store.add_version(100, version);
+        store.add_version(100, version).unwrap();
 
         // Transaction 3 should NOT see version from transaction 5
         let visible = store.get_visible_version(100, 3);
@@ -8423,11 +8111,11 @@ mod tests {
         // Add version from transaction 1
         let row = Row::from(vec![Value::from(42)]);
         let version = RowVersion::new(1, row.clone());
-        store.add_version(100, version);
+        store.add_version(100, version).unwrap();
 
         // Delete in transaction 2
         let deleted_version = RowVersion::new_deleted(2, row);
-        store.add_version(100, deleted_version);
+        store.add_version(100, deleted_version).unwrap();
 
         // Transaction 1 should still see the row (delete not visible)
         let visible = store.get_visible_version(100, 1);
@@ -8443,9 +8131,13 @@ mod tests {
         let store = VersionStore::new("test_table".to_string(), test_schema());
 
         let row = Row::from(vec![Value::from(1)]);
-        store.add_version(100, RowVersion::new(1, row.clone()));
-        store.add_version(200, RowVersion::new(1, row.clone()));
-        store.add_version(300, RowVersion::new(1, row));
+        store
+            .add_version(100, RowVersion::new(1, row.clone()))
+            .unwrap();
+        store
+            .add_version(200, RowVersion::new(1, row.clone()))
+            .unwrap();
+        store.add_version(300, RowVersion::new(1, row)).unwrap();
 
         let row_ids = store.get_all_row_ids();
         assert_eq!(row_ids.len(), 3);
@@ -8462,9 +8154,9 @@ mod tests {
         store.close();
         assert!(store.is_closed());
 
-        // Operations should be no-ops when closed
+        // Closed stores reject publication without changing their contents.
         let row = Row::from(vec![Value::from(1)]);
-        store.add_version(100, RowVersion::new(1, row));
+        assert!(store.add_version(100, RowVersion::new(1, row)).is_err());
         assert_eq!(store.row_count(), 0);
     }
 
@@ -8560,7 +8252,7 @@ mod tests {
         for txn_id in 1..=5 {
             let row = Row::from(vec![Value::from(txn_id)]);
             let version = RowVersion::new(txn_id, row);
-            store.add_version(row_id, version);
+            store.add_version(row_id, version).unwrap();
         }
 
         // After 5 versions with limit 3:
@@ -8596,7 +8288,7 @@ mod tests {
         for txn_id in 1..=20 {
             let row = Row::from(vec![Value::from(txn_id)]);
             let version = RowVersion::new(txn_id, row);
-            store.add_version(row_id, version);
+            store.add_version(row_id, version).unwrap();
         }
 
         // Verify chain is bounded (between 2 and limit+1)
@@ -8633,7 +8325,7 @@ mod tests {
         for txn_id in 1..=15 {
             let row = Row::from(vec![Value::from(txn_id)]);
             let version = RowVersion::new(txn_id, row);
-            store.add_version(row_id, version);
+            store.add_version(row_id, version).unwrap();
         }
 
         // Count chain length - should be 15 (unlimited)
@@ -8665,7 +8357,7 @@ mod tests {
         for txn_id in 1..=3 {
             let row = Row::from(vec![Value::from(txn_id)]);
             let version = RowVersion::new(txn_id, row);
-            store.add_version(row_id, version);
+            store.add_version(row_id, version).unwrap();
         }
 
         // Now add more via batch - each will trigger drop when exceeding limit
@@ -8676,7 +8368,7 @@ mod tests {
             })
             .collect();
 
-        store.add_versions_batch(batch);
+        store.add_versions_batch(batch).unwrap();
 
         // Verify chain is bounded (at most limit+1)
         // Chain can be as short as 1 right after pruning (when new_depth > limit)
@@ -8763,12 +8455,13 @@ mod tests {
 
     #[test]
     fn test_row_index() {
-        let idx = RowIndex::new(100, Some(5));
+        let address = ArenaId::from_parts(ChunkId::new(7).unwrap(), 5).unwrap();
+        let idx = RowIndex::new(100, Some(address));
 
         // Test Copy trait
         let copied = idx;
         assert_eq!(copied.row_id, 100);
-        assert_eq!(copied.arena_idx(), Some(5));
+        assert_eq!(copied.arena_idx(), Some(address));
 
         // Test Clone trait (use Clone::clone to avoid clone_on_copy warning)
         let cloned = Clone::clone(&idx);
@@ -8831,7 +8524,7 @@ mod tests {
         // Add a row
         let row = Row::from(vec![Value::from(42)]);
         let version = RowVersion::new(1, row);
-        store.add_version(100, version);
+        store.add_version(100, version).unwrap();
 
         // Row exists
         assert!(store.quick_check_row_existence(100));
@@ -8848,7 +8541,7 @@ mod tests {
         for i in 1..=5 {
             let row = Row::from(vec![Value::from(i * 10)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         // Batch query
@@ -8868,7 +8561,7 @@ mod tests {
         for i in 1..=5 {
             let row = Row::from(vec![Value::from(i)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         let count = store.count_visible_versions_batch(&[1, 2, 3, 99, 100], 2);
@@ -8887,7 +8580,7 @@ mod tests {
         for i in 1..=10 {
             let row = Row::from(vec![Value::from(i)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         assert_eq!(store.count_visible_rows(2), 10);
@@ -8902,10 +8595,10 @@ mod tests {
         // Add a row
         let row = Row::from(vec![Value::from(42)]);
         let version = RowVersion::new(1, row);
-        store.add_version(100, version);
+        store.add_version(100, version).unwrap();
 
         // Mark it deleted
-        store.mark_deleted(100, 2);
+        store.mark_deleted(100, 2).unwrap();
 
         // Transaction 1 should still see it
         assert!(store.get_visible_version(100, 1).is_some());
@@ -8914,7 +8607,7 @@ mod tests {
         assert!(store.get_visible_version(100, 3).is_none());
 
         // Mark non-existent row as deleted (no-op)
-        store.mark_deleted(999, 2);
+        store.mark_deleted(999, 2).unwrap();
     }
 
     #[test]
@@ -8927,7 +8620,7 @@ mod tests {
         for i in 1..=20 {
             let row = Row::from(vec![Value::from(i)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         // Get with limit (txn_id, limit, offset)
@@ -8948,12 +8641,12 @@ mod tests {
         // Add version from transaction 5
         let row = Row::from(vec![Value::from(100)]);
         let version = RowVersion::new(5, row);
-        store.add_version(1, version);
+        store.add_version(1, version).unwrap();
 
         // Add updated version from transaction 10
         let row2 = Row::from(vec![Value::from(200)]);
         let version2 = RowVersion::new(10, row2);
-        store.add_version(1, version2);
+        store.add_version(1, version2).unwrap();
 
         // AS OF transaction 7 should see the first version
         let result = store.get_visible_version_as_of_transaction(1, 7);
@@ -8985,12 +8678,12 @@ mod tests {
         // Add version with specific timestamp
         let row = Row::from(vec![Value::from(100)]);
         let version = RowVersion::new_with_timestamp(1, row, 1000);
-        store.add_version(1, version);
+        store.add_version(1, version).unwrap();
 
         // Add version with later timestamp
         let row2 = Row::from(vec![Value::from(200)]);
         let version2 = RowVersion::new_with_timestamp(2, row2, 2000);
-        store.add_version(1, version2);
+        store.add_version(1, version2).unwrap();
 
         // AS OF timestamp 1500 should see first version
         let result = store.get_visible_version_as_of_timestamp(1, 1500);
@@ -9017,7 +8710,7 @@ mod tests {
         for i in 1..=5 {
             let row = Row::from(vec![Value::from(i * 10)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         let (sum, count) = store.sum_column(2, 0);
@@ -9036,7 +8729,7 @@ mod tests {
         for (i, v) in values.iter().enumerate() {
             let row = Row::from(vec![Value::from(*v)]);
             let version = RowVersion::new(1, row);
-            store.add_version((i + 1) as i64, version);
+            store.add_version((i + 1) as i64, version).unwrap();
         }
 
         let (sum, count) = store.sum_column(2, 0);
@@ -9054,7 +8747,7 @@ mod tests {
         for i in [30, 10, 50, 20, 40] {
             let row = Row::from(vec![Value::from(i)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         let min = store.min_column(2, 0);
@@ -9085,7 +8778,7 @@ mod tests {
         for i in 1..=5 {
             let row = Row::from(vec![Value::from(i * 10)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         // Compute multiple aggregates at once
@@ -9144,7 +8837,7 @@ mod tests {
         for i in 1..=3 {
             let row = Row::from(vec![Value::from(i * 10)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         let mut stream = store.stream_visible_rows(2);
@@ -9238,7 +8931,7 @@ mod tests {
         for i in 1..=5 {
             let row = Row::from(vec![Value::from(i)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         let indices = store.get_visible_row_indices(2);
@@ -9258,7 +8951,7 @@ mod tests {
         // Add a row with multiple columns
         let row = Row::from(vec![Value::from(42), Value::from("test")]);
         let version = RowVersion::new(1, row);
-        store.add_version(1, version);
+        store.add_version(1, version).unwrap();
 
         let indices = store.get_visible_row_indices(2);
         assert_eq!(indices.len(), 1);
@@ -9282,7 +8975,7 @@ mod tests {
         // Apply a recovered version
         let row = Row::from(vec![Value::from(42)]);
         let version = RowVersion::new(1, row);
-        store.apply_recovered_version(100, version);
+        store.apply_recovered_version(100, version).unwrap();
 
         assert_eq!(store.row_count(), 1);
         assert!(store.quick_check_row_existence(100));
@@ -9315,7 +9008,7 @@ mod tests {
         // Verify it works with the new checker
         let row = Row::from(vec![Value::from(42)]);
         let version = RowVersion::new(1, row);
-        store.add_version(100, version);
+        store.add_version(100, version).unwrap();
 
         let visible = store.get_visible_version(100, 2);
         assert!(visible.is_some());
@@ -9333,7 +9026,7 @@ mod tests {
         // Add a row first
         let row = Row::from(vec![Value::from(42)]);
         let version = RowVersion::new(1, row);
-        store.add_version(100, version);
+        store.add_version(100, version).unwrap();
 
         // Start a new transaction and update
         let mut tvs = TransactionVersionStore::new(Arc::clone(&store), 2);
@@ -9369,7 +9062,7 @@ mod tests {
         // Add a row first
         let row = Row::from(vec![Value::from(42)]);
         let version = RowVersion::new(1, row);
-        store.add_version(100, version);
+        store.add_version(100, version).unwrap();
 
         // Start a new transaction and delete
         let mut tvs = TransactionVersionStore::new(Arc::clone(&store), 2);
@@ -9400,7 +9093,7 @@ mod tests {
         for i in 1..=5 {
             let row = Row::from(vec![Value::from(i * 10)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         let rows = store.get_all_visible_rows(2);
@@ -9429,7 +9122,7 @@ mod tests {
         for i in 1..=5 {
             let row = Row::from(vec![Value::from(i)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         let row_ids = store.get_all_visible_row_ids(2);
@@ -9448,7 +9141,7 @@ mod tests {
         for i in [5, 3, 1, 4, 2] {
             let row = Row::from(vec![Value::from(i * 10)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         // Get rows in ascending PK order
@@ -9497,10 +9190,560 @@ mod tests {
         for i in 1..=10 {
             let row = Row::from(vec![Value::from(i)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         assert_eq!(store.count_visible(2), 10);
+    }
+
+    #[test]
+    fn saved_row_index_rejects_reused_slot_for_single_and_batch_reads() {
+        let store = VersionStore::with_visibility_checker(
+            "saved_index",
+            test_schema(),
+            Arc::new(ReadCommittedChecker),
+        );
+        store
+            .add_version(99, RowVersion::new(1, Row::from(vec![99.into()])))
+            .unwrap();
+        store
+            .add_version(1, RowVersion::new(1, Row::from(vec![11.into()])))
+            .unwrap();
+        let indices = store.get_visible_row_indices(1);
+        let saved = *indices.iter().find(|index| index.row_id == 1).unwrap();
+        let anchor = *indices.iter().find(|index| index.row_id == 99).unwrap();
+        store.mark_deleted(1, 2).unwrap();
+        assert_eq!(store.cleanup_deleted_rows(std::time::Duration::ZERO), 1);
+        store
+            .add_version(2, RowVersion::new(3, Row::from(vec![222.into()])))
+            .unwrap();
+        let replacement = store
+            .get_visible_row_indices(3)
+            .into_iter()
+            .find(|index| index.row_id == 2)
+            .unwrap();
+        assert_eq!(
+            replacement.arena_idx(),
+            saved.arena_idx(),
+            "the saved slot was actually reused"
+        );
+        assert!(store.materialize_row(&saved).is_none());
+        assert_eq!(store.get_column_value(&saved, 0), None);
+        assert_eq!(
+            store.get_column_values_batch(&[saved, anchor], 0),
+            vec![None, Some(99.into())]
+        );
+        let rows = store.materialize_rows(&[saved, anchor]);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, 99);
+
+        // The old address still names row 2; row 1 is now resolved by its tree
+        // identity rather than accidentally materializing row 2's payload.
+        store
+            .add_version(1, RowVersion::new(4, Row::from(vec![1111.into()])))
+            .unwrap();
+        assert_eq!(
+            store.materialize_row(&saved).unwrap().1.get(0),
+            Some(&1111.into())
+        );
+        assert_eq!(store.get_column_value(&saved, 0), Some(1111.into()));
+        assert_eq!(
+            store.get_column_values_batch(&[saved, replacement], 0),
+            vec![Some(1111.into()), Some(222.into())]
+        );
+        let rows = store.materialize_rows(&[saved, replacement]);
+        assert_eq!(rows[0].1.get(0), Some(&1111.into()));
+        assert_eq!(rows[1].1.get(0), Some(&222.into()));
+    }
+
+    #[test]
+    fn arbitrary_primary_keys_survive_frozen_chunks_and_directory_holes() {
+        let store = VersionStore::with_visibility_checker(
+            "sparse_chunks",
+            test_schema(),
+            Arc::new(ReadCommittedChecker),
+        );
+        for row_id in [100, 0, -4, 7] {
+            store
+                .add_version(
+                    row_id,
+                    RowVersion::new(1, Row::from(vec![(row_id * 10).into()])),
+                )
+                .unwrap();
+        }
+        store.arena.freeze_active().unwrap();
+        store
+            .add_version(999, RowVersion::new(1, Row::from(vec![9990.into()])))
+            .unwrap();
+        let removed = store
+            .get_visible_row_indices(1)
+            .into_iter()
+            .find(|index| index.row_id == 999)
+            .unwrap();
+        store.arena.freeze_active().unwrap();
+        store
+            .add_version(2, RowVersion::new(1, Row::from(vec![20.into()])))
+            .unwrap();
+        store.mark_deleted(999, 2).unwrap();
+        assert_eq!(store.cleanup_deleted_rows(std::time::Duration::ZERO), 1);
+        assert!(store.arena.get_arc(removed.arena_idx().unwrap()).is_none());
+        let chunks: Vec<_> = store
+            .arena
+            .read_guard()
+            .chunks()
+            .map(|chunk| chunk.id().get())
+            .collect();
+        assert_eq!(chunks, vec![0, 2]);
+        let expected = [-4, 0, 2, 7, 100];
+        for row_id in expected {
+            assert_eq!(
+                store.get_visible_version(row_id, 3).unwrap().data.get(0),
+                Some(&(row_id * 10).into())
+            );
+        }
+        let indices = store.get_visible_row_indices(3);
+        assert_eq!(
+            indices.iter().map(|index| index.row_id).collect::<Vec<_>>(),
+            expected
+        );
+        let rows = store.materialize_rows(&indices);
+        assert_eq!(
+            rows.iter().map(|(row_id, _)| *row_id).collect::<Vec<_>>(),
+            expected
+        );
+        for (row_id, row) in rows {
+            assert_eq!(row.get(0), Some(&(row_id * 10).into()));
+        }
+    }
+
+    #[test]
+    fn captured_tree_keeps_payload_charges_after_arena_and_table_drop() {
+        let root = crate::common::memory::MemoryAccount::new();
+        let empty = root.snapshot().accounted_bytes;
+        let store =
+            VersionStore::with_capacity_in("retained_tree", test_schema(), None, 0, root.child());
+        store
+            .add_version(
+                1,
+                RowVersion::new(
+                    1,
+                    Row::from(vec![Value::Text("retained payload ".repeat(256).into())]),
+                ),
+            )
+            .unwrap();
+        let captured = store.versions.read().clone();
+        store.arena.freeze_active().unwrap();
+        store.arena.clear_all();
+        store.versions.write().clear();
+        drop(store);
+        assert!(root.snapshot().retained_bytes > 4096);
+        assert!(matches!(
+            captured.get(1).unwrap().version.data.get(0),
+            Some(Value::Text(_))
+        ));
+        drop(captured);
+        assert_eq!(root.snapshot().accounted_bytes, empty);
+    }
+
+    #[test]
+    fn local_history_spills_remain_charged_after_truncation_until_buffer_release() {
+        let root = crate::common::memory::MemoryAccount::new();
+        let empty = root.snapshot().accounted_bytes;
+        let store = Arc::new(VersionStore::with_capacity_in(
+            "history_memory",
+            test_schema(),
+            None,
+            0,
+            root.child(),
+        ));
+        let mut transaction = TransactionVersionStore::new(store.clone(), 1);
+        transaction
+            .put(1, Row::from(vec![1.into()]), false)
+            .unwrap();
+        transaction.finish_statement(0, true);
+        assert_eq!(
+            transaction
+                .mutation
+                .as_ref()
+                .unwrap()
+                .history_charge
+                .bytes(),
+            0
+        );
+        let checkpoint = transaction.statement_checkpoint();
+        for value in 2..=17 {
+            transaction
+                .put(1, Row::from(vec![value.into()]), false)
+                .unwrap();
+        }
+        let capacity = transaction
+            .local_versions
+            .as_ref()
+            .unwrap()
+            .get(1)
+            .unwrap()
+            .capacity();
+        let spilled_bytes = capacity * std::mem::size_of::<RowVersion>();
+        assert!(capacity >= 17);
+        assert_eq!(
+            transaction
+                .mutation
+                .as_ref()
+                .unwrap()
+                .history_charge
+                .bytes(),
+            spilled_bytes
+        );
+        transaction.finish_statement(checkpoint, false);
+        assert_eq!(
+            transaction
+                .local_versions
+                .as_ref()
+                .unwrap()
+                .get(1)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            transaction
+                .mutation
+                .as_ref()
+                .unwrap()
+                .history_charge
+                .bytes(),
+            spilled_bytes,
+            "truncation preserves the physical history buffer"
+        );
+
+        for value in 1..=4 {
+            transaction
+                .put(2, Row::from(vec![value.into()]), false)
+                .unwrap();
+        }
+        let second_bytes = transaction
+            .local_versions
+            .as_ref()
+            .unwrap()
+            .get(2)
+            .unwrap()
+            .capacity()
+            * std::mem::size_of::<RowVersion>();
+        assert_eq!(
+            transaction
+                .mutation
+                .as_ref()
+                .unwrap()
+                .history_charge
+                .bytes(),
+            spilled_bytes + second_bytes
+        );
+        transaction.rollback_to_timestamp(0);
+        assert!(transaction.local_versions.as_ref().unwrap().is_empty());
+        assert_eq!(
+            transaction
+                .mutation
+                .as_ref()
+                .unwrap()
+                .history_charge
+                .bytes(),
+            0
+        );
+        drop(transaction);
+        drop(store);
+        assert_eq!(root.snapshot().accounted_bytes, empty);
+    }
+
+    #[test]
+    fn idle_publication_table_releases_bulk_capacity_after_last_owner() {
+        let store = VersionStore::new("publication_capacity", test_schema());
+        let mut keys = RetainedSmallVec::<[PublicationKey; 2]>::new();
+        keys.extend(
+            (0..4096).map(|value| {
+                (
+                    0,
+                    CompactArc::from_slice_in(&[Value::Integer(value)], &store.memory),
+                )
+            }),
+            &store.memory,
+        );
+        {
+            let mut owners = store.publication_keys.lock();
+            assert!(try_reserve_publication_keys(&mut owners, &keys, 1));
+            assert!(owners.allocation_size() > 64 * 1024);
+        }
+        store.release_publication_keys(&keys[..4095], 1);
+        assert!(store.publication_keys.lock().allocation_size() > 64 * 1024);
+        store.release_publication_keys(&keys[4095..], 1);
+        assert_eq!(store.publication_keys.lock().allocation_size(), 0);
+    }
+
+    #[test]
+    fn publication_undo_preserves_receipts_and_claims_until_failed_restore_can_retry() {
+        let store = Arc::new(VersionStore::with_visibility_checker(
+            "undo_retry",
+            test_schema(),
+            Arc::new(ReadCommittedChecker),
+        ));
+        for row_id in [1, 2] {
+            store
+                .add_version_with_lsn(
+                    row_id,
+                    RowVersion::new(1, Row::from(vec![Value::Integer(row_id)])),
+                    NonZeroU64::new(10 + row_id as u64 - 1),
+                )
+                .unwrap();
+        }
+        let slot = store.versions.read().get(1).unwrap().arena_idx.unwrap();
+        let before = store.arena.get_meta_and_arc(slot).unwrap().0;
+        let mut transaction = TransactionVersionStore::new(store.clone(), 2);
+        transaction
+            .put(1, Row::from(vec![100.into()]), false)
+            .unwrap();
+        transaction.record_source_lsn(1, NonZeroU64::new(20));
+        transaction.prepare_publication().unwrap();
+        transaction.apply_prepared_publication().unwrap();
+        let published = store
+            .versions
+            .read()
+            .get(1)
+            .unwrap()
+            .version
+            .data
+            .clone()
+            .into_arc();
+        assert!(store.arena.clear_at(slot, 1, 2));
+        let occupied = store
+            .arena
+            .insert_arc(999, 7, Row::new().into_arc(), NonZeroU64::new(70))
+            .unwrap();
+        assert_eq!(occupied, slot);
+
+        assert!(transaction.finish_publication(false).is_err());
+        let mutation = transaction.mutation.as_ref().unwrap();
+        assert_eq!(mutation.publication_undo.len(), 1);
+        assert_eq!(mutation.undo_lsn_pins.len(), 1);
+        assert!(mutation.index_catalog_lease.is_some());
+        assert_eq!(store.uncommitted_writes.read().get(1), Some(&2));
+        assert_eq!(store.versions.read().get(1).unwrap().version.txn_id, 2);
+        assert_eq!(store.committed_row_count(), 2);
+        assert_eq!(store.arena.first_lsn(), NonZeroU64::new(10));
+
+        assert!(store.arena.clear_at(slot, 999, 7));
+        assert_eq!(
+            store
+                .arena
+                .insert_arc(1, 2, published, NonZeroU64::new(20))
+                .unwrap(),
+            slot
+        );
+        transaction.finish_publication(false).unwrap();
+        assert_eq!(store.arena.get_meta_and_arc(slot).unwrap().0, before);
+        assert_eq!(
+            store.versions.read().get(1).unwrap().version.data.get(0),
+            Some(&Value::Integer(1))
+        );
+        assert_eq!(store.committed_row_count(), 2);
+        assert!(!store.uncommitted_writes.read().contains_key(1));
+        assert!(transaction.mutation.is_none());
+    }
+
+    #[test]
+    fn deleted_creator_and_mutator_can_differ_during_reinsert_undo() {
+        let store = Arc::new(VersionStore::with_visibility_checker(
+            "deleted_identity",
+            test_schema(),
+            Arc::new(ReadCommittedChecker),
+        ));
+        let row = Row::from(vec![10.into()]);
+        store
+            .add_version_with_lsn(1, RowVersion::new(1, row.clone()), NonZeroU64::new(10))
+            .unwrap();
+        let mut deleted = RowVersion::new(1, row);
+        deleted.deleted_at_txn_id = 2;
+        store
+            .add_version_with_lsn(1, deleted, NonZeroU64::new(20))
+            .unwrap();
+        let slot = store.versions.read().get(1).unwrap().arena_idx.unwrap();
+        let before = store.arena.get_meta_and_arc(slot).unwrap().0;
+        assert_eq!(before.txn_id, 1);
+        assert_eq!(before.mutation_txn_id(), 2);
+        let mut transaction = TransactionVersionStore::new(store.clone(), 3);
+        transaction
+            .put(1, Row::from(vec![30.into()]), false)
+            .unwrap();
+        transaction.prepare_publication().unwrap();
+        transaction.apply_prepared_publication().unwrap();
+        transaction.finish_publication(false).unwrap();
+        assert_eq!(store.arena.get_meta_and_arc(slot).unwrap().0, before);
+        assert_eq!(store.committed_row_count(), 0);
+    }
+
+    #[test]
+    fn idle_map_pools_preserve_engine_ownership_and_bound_count_and_bytes() {
+        use crate::common::memory::MemoryAccount;
+        let first = MemoryAccount::new();
+        let second = MemoryAccount::new();
+        let mut a = IdleMapPool::<u64>::new(&first);
+        let mut b = IdleMapPool::<u64>::new(&second);
+        let map_a = a.take();
+        let map_b = b.take();
+        let held_bytes = map_b.allocation_size();
+        assert!(a.put(map_a).is_none());
+        a.trim();
+        assert_eq!(first.snapshot().retained_bytes, 0);
+        assert_eq!(second.snapshot().retained_bytes, held_bytes);
+        b.trim();
+        drop(b);
+        assert_eq!(second.snapshot().retained_bytes, held_bytes);
+        drop(map_b);
+        assert_eq!(second.snapshot().retained_bytes, 0);
+
+        for _ in 0..MAP_POOL_MAX_SIZE {
+            let map = I64Map::with_capacity_in(16, &first);
+            assert!(a.put(map).is_none());
+        }
+        assert_eq!(a.maps.len(), MAP_POOL_MAX_SIZE);
+        assert_eq!(
+            a.idle_bytes,
+            a.maps.iter().map(I64Map::allocation_size).sum::<usize>()
+        );
+        let excess = I64Map::with_capacity_in(16, &first);
+        assert!(a.put(excess).is_some());
+        a.trim();
+        let oversized = I64Map::with_capacity_in(MAP_POOL_MAX_BYTES / 8, &first);
+        assert!(oversized.allocation_size() > MAP_POOL_MAX_BYTES);
+        assert!(a.put(oversized).is_some());
+        assert!(a.maps.is_empty());
+        assert_eq!(first.snapshot().retained_bytes, 0);
+    }
+
+    #[test]
+    fn publication_abort_restores_mutation_lsns_and_minima_in_two_chunks() {
+        let store = Arc::new(VersionStore::with_visibility_checker(
+            "lsn_undo",
+            test_schema(),
+            Arc::new(ReadCommittedChecker),
+        ));
+        store
+            .add_version_with_lsn(
+                1,
+                RowVersion::new(1, Row::from(vec![10.into()])),
+                NonZeroU64::new(10),
+            )
+            .unwrap();
+        store.arena.freeze_active().unwrap();
+        store
+            .apply_recovered_version_with_lsn(
+                2,
+                RowVersion::new(1, Row::from(vec![20.into()])),
+                NonZeroU64::new(20),
+            )
+            .unwrap();
+        let first = store.versions.read().get(1).unwrap().arena_idx.unwrap();
+        let second = store.versions.read().get(2).unwrap().arena_idx.unwrap();
+        assert_ne!(first.chunk_id(), second.chunk_id());
+        let first_before = store.arena.get_meta_and_arc(first).unwrap().0;
+        let second_before = store.arena.get_meta_and_arc(second).unwrap().0;
+        let mut transaction = TransactionVersionStore::new(Arc::clone(&store), 2);
+        transaction
+            .put(1, Row::from(vec![100.into()]), false)
+            .unwrap();
+        transaction.put(2, Row::new(), true).unwrap();
+        transaction.record_source_lsn(1, NonZeroU64::new(90));
+        transaction.record_source_lsn(1, NonZeroU64::new(100));
+        transaction.record_source_lsn(2, NonZeroU64::new(200));
+        transaction.prepare_publication().unwrap();
+        transaction.apply_prepared_publication().unwrap();
+        let first_after = store.arena.get_meta_and_arc(first).unwrap().0;
+        let second_after = store.arena.get_meta_and_arc(second).unwrap().0;
+        assert_eq!(first_after.source_lsn, NonZeroU64::new(100));
+        assert_eq!(second_after.source_lsn, NonZeroU64::new(200));
+        assert!(second_after.is_deleted());
+        assert_eq!(
+            store.arena.chunk_first_lsn(first.chunk_id()),
+            NonZeroU64::new(10)
+        );
+        assert_eq!(
+            store.arena.chunk_first_lsn(second.chunk_id()),
+            NonZeroU64::new(20)
+        );
+        transaction.finish_publication(false).unwrap();
+        assert_eq!(store.arena.get_meta_and_arc(first).unwrap().0, first_before);
+        assert_eq!(
+            store.arena.get_meta_and_arc(second).unwrap().0,
+            second_before
+        );
+        assert_eq!(store.arena.first_lsn(), NonZeroU64::new(10));
+        assert_eq!(store.committed_row_count(), 2);
+
+        // The successful path releases old pins after publication. A subsequent
+        // recovered DELETE also replaces the mutation's source LSN.
+        let mut committed = TransactionVersionStore::new(Arc::clone(&store), 3);
+        committed
+            .put(1, Row::from(vec![300.into()]), false)
+            .unwrap();
+        committed.record_source_lsn(1, NonZeroU64::new(300));
+        committed.commit().unwrap();
+        assert_eq!(
+            store.arena.chunk_first_lsn(first.chunk_id()),
+            NonZeroU64::new(300)
+        );
+        store
+            .mark_deleted_with_lsn(2, 4, NonZeroU64::new(400))
+            .unwrap();
+        assert_eq!(
+            store.arena.get_meta_and_arc(second).unwrap().0.source_lsn,
+            NonZeroU64::new(400)
+        );
+        assert_eq!(store.arena.first_lsn(), NonZeroU64::new(300));
+    }
+
+    #[test]
+    fn failed_arena_validation_releases_prepared_unique_key_owners() {
+        use crate::storage::index::HashIndex;
+        let schema = SchemaBuilder::new("failed_prepare")
+            .column("id", DataType::Integer, false, true)
+            .column("u", DataType::Integer, false, false)
+            .build();
+        let store = Arc::new(VersionStore::with_visibility_checker(
+            "failed_prepare",
+            schema,
+            Arc::new(ReadCommittedChecker),
+        ));
+        store
+            .add_index(
+                "u".into(),
+                Arc::new(HashIndex::new(
+                    "u".into(),
+                    "failed_prepare".into(),
+                    vec!["u".into()],
+                    vec![1],
+                    vec![DataType::Integer],
+                    true,
+                    0,
+                )),
+            )
+            .unwrap();
+        let mut seed = TransactionVersionStore::new(Arc::clone(&store), 1);
+        seed.put(1, Row::from(vec![1.into(), 10.into()]), false)
+            .unwrap();
+        seed.commit().unwrap();
+        let mut failed = TransactionVersionStore::new(Arc::clone(&store), 2);
+        failed
+            .put(1, Row::from(vec![1.into(), 20.into()]), false)
+            .unwrap();
+        // Fault injection: its version remains, but the arena identity vanished
+        // before the new fallible prepare validation/pinning step.
+        let address = store.versions.read().get(1).unwrap().arena_idx.unwrap();
+        assert!(store.arena.clear_at(address, 1, 1));
+        assert!(failed.prepare_publication().is_err());
+        failed.finish_publication(false).unwrap();
+        assert!(store.publication_keys.lock().is_empty());
+        let mut next = TransactionVersionStore::new(Arc::clone(&store), 3);
+        next.put(2, Row::from(vec![2.into(), 20.into()]), false)
+            .unwrap();
+        next.commit().unwrap();
     }
 
     #[test]
@@ -9512,7 +9755,7 @@ mod tests {
         // Add a row
         let row = Row::from(vec![Value::from(42)]);
         let version = RowVersion::new(1, row);
-        store.add_version(100, version);
+        store.add_version(100, version).unwrap();
 
         let indices = store.get_visible_row_indices(2);
         assert_eq!(indices.len(), 1);
@@ -9544,7 +9787,7 @@ mod tests {
         for i in 1..=10 {
             let row = Row::from(vec![Value::from(i)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         // Delete all rows in transaction 2
@@ -9552,7 +9795,7 @@ mod tests {
             let row = Row::from(vec![Value::from(i)]);
             let mut version = RowVersion::new(1, row);
             version.deleted_at_txn_id = 2;
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         // Cleanup with 0 retention (immediate)
@@ -9578,11 +9821,11 @@ mod tests {
         // Add and delete a row
         let row = Row::from(vec![Value::from(1)]);
         let version = RowVersion::new(1, row.clone());
-        store.add_version(1, version);
+        store.add_version(1, version).unwrap();
 
         let mut deleted_version = RowVersion::new(1, row);
         deleted_version.deleted_at_txn_id = 2;
-        store.add_version(1, deleted_version);
+        store.add_version(1, deleted_version).unwrap();
 
         // Cleanup with very long retention - should not clean
         let cleaned = store.cleanup_deleted_rows(std::time::Duration::from_secs(3600));
@@ -9606,7 +9849,7 @@ mod tests {
         for i in 1..=5 {
             let row = Row::from(vec![Value::from(i)]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         // Delete rows 1, 3, 5
@@ -9614,7 +9857,7 @@ mod tests {
             let row = Row::from(vec![Value::from(i)]);
             let mut version = RowVersion::new(1, row);
             version.deleted_at_txn_id = 2;
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         // Cleanup
@@ -9638,7 +9881,7 @@ mod tests {
         for i in 1..=5 {
             let row = Row::from(vec![Value::from(i), Value::text(format!("data_{}", i))]);
             let version = RowVersion::new(1, row);
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         // Record initial arena length
@@ -9650,26 +9893,22 @@ mod tests {
             let row = Row::from(vec![Value::from(i), Value::text(format!("data_{}", i))]);
             let mut version = RowVersion::new(1, row);
             version.deleted_at_txn_id = 2;
-            store.add_version(i, version);
+            store.add_version(i, version).unwrap();
         }
 
         // Cleanup
         let cleaned = store.cleanup_deleted_rows(std::time::Duration::from_secs(0));
         assert_eq!(cleaned, 5);
 
-        // Arena slots should be cleared (data replaced with empty)
-        // The slots remain but data is released
+        // The final occupied row releases the whole chunk allocation.
         let guard = store.arena.read_guard();
-        for i in 0..5 {
-            // Cleared slots have row_id = 0
-            assert_eq!(guard.meta()[i].row_id, 0, "Slot {} should be cleared", i);
-            // Data should be empty
-            assert!(
-                guard.data()[i].is_empty(),
-                "Slot {} data should be empty",
-                i
-            );
-        }
+        assert_eq!(guard.len(), 0);
+        assert_eq!(guard.chunks().count(), 0);
+        assert_eq!(guard.slot_count(), 0);
+        drop(guard);
+        assert_eq!(store.arena.capacity().metadata_bytes, 0);
+        assert_eq!(store.arena.capacity().payload_slots_bytes, 0);
+        assert_eq!(store.arena.bytes(), 0);
     }
 
     #[test]
@@ -9684,13 +9923,13 @@ mod tests {
         // Tx 1: insert row_id=100
         let row = Row::from(vec![Value::from(42)]);
         let version = RowVersion::new(1, row);
-        store.add_version(100, version);
+        store.add_version(100, version).unwrap();
 
         // Tx 2: delete row_id=100
         let row = Row::from(vec![Value::from(42)]);
         let mut deleted = RowVersion::new(1, row);
         deleted.deleted_at_txn_id = 2;
-        store.add_version(100, deleted);
+        store.add_version(100, deleted).unwrap();
 
         // Simulate the cleanup's first pass: snapshot and identify row for deletion
         assert!(store.versions.read().get(100).unwrap().version.is_deleted());
@@ -9698,7 +9937,7 @@ mod tests {
         // Now, BEFORE cleanup's removal pass, tx 3 re-inserts a live version at row_id=100
         let row = Row::from(vec![Value::from(99)]);
         let live_version = RowVersion::new(3, row);
-        store.add_version(100, live_version);
+        store.add_version(100, live_version).unwrap();
 
         // The row should now be live (not deleted)
         assert!(!store.versions.read().get(100).unwrap().version.is_deleted());
@@ -9730,19 +9969,19 @@ mod tests {
         // Insert and delete rows 1..=4
         for i in 1..=4 {
             let row = Row::from(vec![Value::from(i)]);
-            store.add_version(i, RowVersion::new(1, row));
+            store.add_version(i, RowVersion::new(1, row)).unwrap();
         }
         for i in 1..=4 {
             let row = Row::from(vec![Value::from(i)]);
             let mut del = RowVersion::new(1, row);
             del.deleted_at_txn_id = 2;
-            store.add_version(i, del);
+            store.add_version(i, del).unwrap();
         }
 
         // Re-insert rows 2 and 4 with new values (simulating concurrent commit)
         for &i in &[2, 4] {
             let row = Row::from(vec![Value::from(i * 100)]);
-            store.add_version(i, RowVersion::new(3, row));
+            store.add_version(i, RowVersion::new(3, row)).unwrap();
         }
 
         // Cleanup should only remove rows 1 and 3 (still deleted)
@@ -9781,14 +10020,16 @@ mod tests {
 
         // Tx 1: insert row_id=1 with value=100, row_id=2 with value=200
         let row1 = Row::from(vec![Value::from(100)]);
-        store.add_version(1, RowVersion::new(1, row1));
+        store.add_version(1, RowVersion::new(1, row1)).unwrap();
         let row2 = Row::from(vec![Value::from(200)]);
-        store.add_version(2, RowVersion::new(1, row2));
+        store.add_version(2, RowVersion::new(1, row2)).unwrap();
 
         // Tx 3: update row_id=1 with new value=999
         // This creates a version chain: HEAD(txn=3, val=999) -> prev(txn=1, val=100)
         let updated_row = Row::from(vec![Value::from(999)]);
-        store.add_version(1, RowVersion::new(3, updated_row));
+        store
+            .add_version(1, RowVersion::new(3, updated_row))
+            .unwrap();
 
         // Viewer txn_id=2: sees txn<=2, so sees txn=1 but NOT txn=3
         // Expected: row_id=1 should have value=100, row_id=2 should have value=200
@@ -9830,13 +10071,15 @@ mod tests {
 
         // Tx 1: insert row_id=1 with value=100, row_id=2 with value=200
         let row1 = Row::from(vec![Value::from(100)]);
-        store.add_version(1, RowVersion::new(1, row1));
+        store.add_version(1, RowVersion::new(1, row1)).unwrap();
         let row2 = Row::from(vec![Value::from(200)]);
-        store.add_version(2, RowVersion::new(1, row2));
+        store.add_version(2, RowVersion::new(1, row2)).unwrap();
 
         // Tx 3: update row_id=1 with new value=999
         let updated_row = Row::from(vec![Value::from(999)]);
-        store.add_version(1, RowVersion::new(3, updated_row));
+        store
+            .add_version(1, RowVersion::new(3, updated_row))
+            .unwrap();
 
         // Viewer txn_id=2: sees txn<=2
         // Sort by column 0, ascending — row_id=1 (val=100) should come first
@@ -9865,40 +10108,22 @@ mod tests {
     }
 
     #[test]
-    fn test_pack_arena_idx_no_overflow() {
-        // Verify that NonZeroU64 handles all valid indices correctly without overflow
-
-        // Case 1: Small index
-        let small = 100usize;
-        let packed = pack_arena_idx(small);
-        assert!(packed.is_some());
-        assert_eq!(unpack_arena_idx(packed), Some(small));
-
-        // Case 2: Max u32 value (previously caused issues with NonZeroU32)
-        let max_u32 = u32::MAX as usize;
-        let packed_u32 = pack_arena_idx(max_u32);
-        assert!(packed_u32.is_some());
-        assert_eq!(unpack_arena_idx(packed_u32), Some(max_u32));
-
-        // Case 3: Beyond u32::MAX (previously caused corruption with NonZeroU32)
-        let beyond_u32 = u32::MAX as usize + 1;
-        let packed_beyond = pack_arena_idx(beyond_u32);
-        assert!(packed_beyond.is_some());
-        assert_eq!(unpack_arena_idx(packed_beyond), Some(beyond_u32)); // Now correct!
-
-        // Case 4: Large index (5 billion - would have corrupted with u32)
-        let large = 5_000_000_000usize;
-        let packed_large = pack_arena_idx(large);
-        assert!(packed_large.is_some());
-        assert_eq!(unpack_arena_idx(packed_large), Some(large)); // Now correct!
-
-        // Case 5: Zero index
-        let zero = 0usize;
-        let packed_zero = pack_arena_idx(zero);
-        assert!(packed_zero.is_some());
-        assert_eq!(unpack_arena_idx(packed_zero), Some(zero));
-
-        assert_eq!(unpack_arena_idx(None), None);
+    fn row_index_keeps_high_chunk_bits_and_the_optional_handle_niche() {
+        for raw in [
+            0,
+            100,
+            u64::from(u32::MAX),
+            u64::from(u32::MAX) + 1,
+            5_000_000_000,
+            u64::MAX - 1,
+        ] {
+            let chunk = ChunkId::new(raw >> ARENA_CHUNK_SHIFT).unwrap();
+            let address = ArenaId::from_parts(chunk, (raw & ARENA_CHUNK_MASK) as usize).unwrap();
+            let index = RowIndex::new(0, Some(address));
+            assert_eq!(index.arena_idx().unwrap().as_nonzero().get(), raw + 1);
+        }
+        assert!(RowIndex::new(0, None).arena_idx().is_none());
+        assert_eq!(std::mem::size_of::<RowIndex>(), 16);
     }
 
     #[test]
@@ -10037,10 +10262,10 @@ mod tests {
 
     #[test]
     fn publication_key_conflict_preserves_free_prefix_and_existing_owners() {
-        let free_key: PublicationKey = (1, Arc::from([Value::Integer(30)]));
-        let conflicting_key: PublicationKey = (1, Arc::from([Value::Integer(10)]));
-        let unrelated_key: PublicationKey = (2, Arc::from([Value::Integer(10)]));
-        let mut owners = AHashMap::new();
+        let free_key: PublicationKey = (1, CompactArc::from_slice(&[Value::Integer(30)]));
+        let conflicting_key: PublicationKey = (1, CompactArc::from_slice(&[Value::Integer(10)]));
+        let unrelated_key: PublicationKey = (2, CompactArc::from_slice(&[Value::Integer(10)]));
+        let mut owners = PublicationOwners::default();
         owners.insert(conflicting_key.clone(), 10);
         owners.insert(unrelated_key.clone(), 30);
         let before = owners.clone();
@@ -10052,19 +10277,19 @@ mod tests {
             &[free_key.clone(), conflicting_key.clone()],
             20,
         ));
-        assert_eq!(owners, before);
+        assert_eq!(&*owners, &before);
         assert!(!try_reserve_publication_keys(
             &mut owners,
             std::slice::from_ref(&conflicting_key),
             20,
         ));
-        assert_eq!(owners, before);
+        assert_eq!(&*owners, &before);
         assert!(try_reserve_publication_keys(
             &mut owners,
             std::slice::from_ref(&conflicting_key),
             10,
         ));
-        assert_eq!(owners, before);
+        assert_eq!(&*owners, &before);
         assert!(try_reserve_publication_keys(
             &mut owners,
             std::slice::from_ref(&free_key),
@@ -10072,7 +10297,7 @@ mod tests {
         ));
         let mut expected = before;
         expected.insert(free_key, 20);
-        assert_eq!(owners, expected);
+        assert_eq!(&*owners, &expected);
     }
 
     #[test]
@@ -10087,7 +10312,7 @@ mod tests {
             schema,
             Arc::new(TestVisibilityChecker::new()),
         ));
-        let index = Arc::new(HashIndex::new(
+        let mut index: Arc<dyn Index> = Arc::new(HashIndex::new(
             "idx_u".into(),
             "reserved_keys".into(),
             vec!["u".into()],
@@ -10096,6 +10321,7 @@ mod tests {
             true,
             0,
         ));
+        store.attach_index_memory(&mut index).unwrap();
         store.add_index("idx_u".into(), index.clone()).unwrap();
         let mut seed = TransactionVersionStore::new(Arc::clone(&store), 1);
         seed.put(1, Row::from(vec![1.into(), 10.into()]), false)
@@ -10247,7 +10473,7 @@ mod tests {
         // Setup: 10 committed rows
         for i in 1..=10 {
             let row = Row::from(vec![Value::from(i)]);
-            store.add_version(i, RowVersion::new(1, row));
+            store.add_version(i, RowVersion::new(1, row)).unwrap();
         }
         assert_eq!(store.committed_row_count.load(Ordering::Relaxed), 10);
 
@@ -10282,7 +10508,7 @@ mod tests {
         // Insert fresh data for next round
         for i in 1..=5 {
             let row = Row::from(vec![Value::from(i)]);
-            store.add_version(i, RowVersion::new(1, row));
+            store.add_version(i, RowVersion::new(1, row)).unwrap();
         }
         // Force committed_row_count to reflect the 5 rows
         store.committed_row_count.store(5, Ordering::Relaxed);
@@ -10315,6 +10541,387 @@ mod tests {
         } else {
             // Claim was first — truncate correctly rejected
             assert!(claim_result.is_ok());
+        }
+    }
+}
+
+#[cfg(test)]
+mod index_publication_tests {
+    use super::*;
+    use crate::core::{IndexEntry, IndexType, Operator, RowIdVec};
+    use crate::storage::expression::Expression;
+    use crate::storage::index::hnsw::HnswDistanceMetric;
+    use crate::storage::index::{
+        BTreeIndex, BitmapIndex, HashIndex, HnswIndex, MultiColumnIndex, PkIndex,
+    };
+
+    /// Errors happen after a requested prefix has really changed the native
+    /// index. A retry therefore tests partial mutation, not just validation.
+    struct FaultIndex {
+        inner: Box<dyn Index>,
+        fail: Arc<Mutex<Option<(bool, usize)>>>,
+    }
+    impl FaultIndex {
+        fn change(&self, entries: &[(i64, &[Value])], add: bool) -> Result<(), Error> {
+            let fault = {
+                let mut fault = self.fail.lock();
+                if fault
+                    .as_ref()
+                    .is_some_and(|&(operation, _)| operation == add)
+                {
+                    fault.take()
+                } else {
+                    None
+                }
+            };
+            let changed =
+                &entries[..fault.map_or(entries.len(), |(_, count)| count.min(entries.len()))];
+            if add {
+                self.inner.add_batch_slice(changed)?;
+            } else {
+                self.inner.remove_batch_slice(changed)?;
+            }
+            if fault.is_some() {
+                Err(Error::internal("injected error after index mutation"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+    impl Index for FaultIndex {
+        fn name(&self) -> &str {
+            self.inner.name()
+        }
+        fn table_name(&self) -> &str {
+            self.inner.table_name()
+        }
+        fn build(&mut self) -> Result<(), Error> {
+            self.inner.build()
+        }
+        fn add(&self, values: &[Value], row: i64, _: i64) -> Result<(), Error> {
+            self.change(&[(row, values)], true)
+        }
+        fn remove(&self, values: &[Value], row: i64, _: i64) -> Result<(), Error> {
+            self.change(&[(row, values)], false)
+        }
+        fn add_batch(&self, entries: &I64Map<Vec<Value>>) -> Result<(), Error> {
+            let entries: Vec<_> = entries
+                .iter()
+                .map(|(row, values)| (row, values.as_slice()))
+                .collect();
+            self.change(&entries, true)
+        }
+        fn remove_batch(&self, entries: &I64Map<Vec<Value>>) -> Result<(), Error> {
+            let entries: Vec<_> = entries
+                .iter()
+                .map(|(row, values)| (row, values.as_slice()))
+                .collect();
+            self.change(&entries, false)
+        }
+        fn add_batch_slice(&self, entries: &[(i64, &[Value])]) -> Result<(), Error> {
+            self.change(entries, true)
+        }
+        fn remove_batch_slice(&self, entries: &[(i64, &[Value])]) -> Result<(), Error> {
+            self.change(entries, false)
+        }
+        fn column_ids(&self) -> &[i32] {
+            self.inner.column_ids()
+        }
+        fn column_names(&self) -> &[String] {
+            self.inner.column_names()
+        }
+        fn data_types(&self) -> &[DataType] {
+            self.inner.data_types()
+        }
+        fn index_type(&self) -> IndexType {
+            self.inner.index_type()
+        }
+        fn is_unique(&self) -> bool {
+            self.inner.is_unique()
+        }
+        fn find(&self, values: &[Value]) -> Result<Vec<IndexEntry>, Error> {
+            self.inner.find(values)
+        }
+        fn find_range(
+            &self,
+            min: &[Value],
+            max: &[Value],
+            a: bool,
+            b: bool,
+        ) -> Result<Vec<IndexEntry>, Error> {
+            self.inner.find_range(min, max, a, b)
+        }
+        fn find_with_operator(
+            &self,
+            op: Operator,
+            values: &[Value],
+        ) -> Result<Vec<IndexEntry>, Error> {
+            self.inner.find_with_operator(op, values)
+        }
+        fn get_filtered_row_ids(&self, expr: &dyn Expression) -> RowIdVec {
+            self.inner.get_filtered_row_ids(expr)
+        }
+        fn cleanup(&self) -> Result<(), Error> {
+            self.inner.cleanup()
+        }
+        fn get_distinct_count_excluding_null(&self) -> Option<usize> {
+            self.inner.get_distinct_count_excluding_null()
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self.inner.as_any()
+        }
+        fn close(&mut self) -> Result<(), Error> {
+            self.inner.close()
+        }
+    }
+
+    fn native(family: usize, name: &str) -> Box<dyn Index> {
+        native_with_unique(family, name, true)
+    }
+
+    fn native_with_unique(family: usize, name: &str, unique: bool) -> Box<dyn Index> {
+        match family {
+            0 => Box::new(PkIndex::new(name.into(), "t".into(), 0, "v".into())),
+            1 => Box::new(BTreeIndex::new(
+                name.into(),
+                "t".into(),
+                0,
+                "v".into(),
+                DataType::Integer,
+                unique,
+                0,
+            )),
+            2 => Box::new(HashIndex::new(
+                name.into(),
+                "t".into(),
+                vec!["v".into()],
+                vec![0],
+                vec![DataType::Integer],
+                unique,
+                0,
+            )),
+            3 => Box::new(MultiColumnIndex::new(
+                name.into(),
+                "t".into(),
+                vec!["v".into()],
+                vec![0],
+                vec![DataType::Integer],
+                unique,
+                0,
+            )),
+            4 => Box::new(BitmapIndex::new(
+                name.into(),
+                "t".into(),
+                vec!["v".into()],
+                vec![0],
+                vec![DataType::Integer],
+                unique,
+                0,
+            )),
+            _ => {
+                let mut index = HnswIndex::new(
+                    name.into(),
+                    "t".into(),
+                    "v".into(),
+                    0,
+                    2,
+                    8,
+                    24,
+                    24,
+                    HnswDistanceMetric::L2,
+                );
+                index.set_unique(unique);
+                Box::new(index)
+            }
+        }
+    }
+
+    fn key(family: usize, value: i64) -> Vec<Value> {
+        if family == 5 {
+            vec![Value::vector(vec![value as f32, 1.0])]
+        } else {
+            vec![Value::Integer(value)]
+        }
+    }
+
+    fn assert_keys(index: &dyn Index, expected: &[(i64, Vec<Value>)]) {
+        for (row, values) in expected {
+            if let Some(hnsw) = index.as_any().downcast_ref::<HnswIndex>() {
+                assert_eq!(hnsw.find_exact_duplicate(&values[0], -1, None), Some(*row));
+            } else {
+                assert_eq!(index.get_row_ids_equal(values).as_slice(), &[*row]);
+            }
+        }
+    }
+
+    #[test]
+    fn every_native_family_retries_partial_forward_and_inverse_batches() {
+        for family in 0..6 {
+            // PK represents membership, so its update replaces a set of IDs.
+            // Other UNIQUE families swap the values of the same three rows.
+            let old: Vec<_> = (1..=3).map(|row| (row, key(family, row))).collect();
+            let new: Vec<_> = (1..=3)
+                .map(|row| {
+                    if family == 0 {
+                        (row + 10, key(family, row + 10))
+                    } else {
+                        (row, key(family, row % 3 + 1))
+                    }
+                })
+                .collect();
+            for fail_add in [false, true] {
+                let account = crate::common::memory::MemoryAccount::new();
+                let inner = native(family, "fault");
+                for (row, values) in &old {
+                    inner.add(values, *row, *row).unwrap();
+                }
+                let fault = Arc::new(Mutex::new(Some((fail_add, 1))));
+                let index: Arc<dyn Index> = Arc::new(FaultIndex {
+                    inner,
+                    fail: fault.clone(),
+                });
+                let mut undo = IndexUndo::new(index.clone(), new.clone(), old.clone(), &account);
+                assert!(undo.apply().is_err());
+                // Fail removal of the partially added set, or restoration of
+                // the partially removed set, after its first native mutation.
+                *fault.lock() = Some((!fail_add, 1));
+                assert!(undo.undo().is_err());
+                assert!(undo.progress != IndexUndoProgress::Prepared);
+                if fail_add {
+                    // Next retry finishes removing all new keys but restoring
+                    // old keys also fails after a prefix. Keep that phase only.
+                    *fault.lock() = Some((true, 1));
+                    assert!(undo.undo().is_err());
+                    assert!(undo.added.is_empty());
+                    assert_eq!(
+                        undo._charge.bytes(),
+                        IndexUndo::buffer_bytes(&undo.added, &undo.removed)
+                    );
+                }
+                undo.undo().unwrap();
+                assert_keys(index.as_ref(), &old);
+                if family == 0 {
+                    for (row, values) in &new {
+                        assert!(
+                            index.get_row_ids_equal(values).is_empty(),
+                            "unexpected PK {row}"
+                        );
+                    }
+                }
+                // A terminal inverse is a no-op, including HNSW tombstones,
+                // uniqueness maps, reverse maps and distinct-key counters.
+                undo.undo().unwrap();
+                assert_keys(index.as_ref(), &old);
+                index.cleanup().unwrap();
+                assert_keys(index.as_ref(), &old);
+                if let Some(distinct) = index.get_distinct_count_excluding_null() {
+                    assert_eq!(distinct, 3);
+                }
+                drop(undo);
+                assert_eq!(account.snapshot().retained_bytes, 0);
+            }
+        }
+    }
+
+    #[test]
+    fn journals_precede_single_and_multi_row_mutations_and_survive_errors() {
+        for rows in [1, 3] {
+            let parent = Arc::new(VersionStore::new(
+                "journal",
+                crate::core::SchemaBuilder::new("journal")
+                    .column("v", DataType::Integer, false, false)
+                    .build(),
+            ));
+            let mut transaction = TransactionVersionStore::new(parent, 20);
+            let first: Arc<dyn Index> = Arc::from(native(1, "a_first"));
+            let last = native(1, "z_failing");
+            for row in 1..=rows {
+                let old = key(1, row);
+                first.add(&old, row, row).unwrap();
+                last.add(&old, row, row).unwrap();
+                transaction
+                    .put_with_original(
+                        row,
+                        Row::from(key(1, row + 10)),
+                        RowVersion::new(1, Row::from(old)),
+                        false,
+                    )
+                    .unwrap();
+            }
+            let fault = Arc::new(Mutex::new(Some((true, 1))));
+            let last: Arc<dyn Index> = Arc::new(FaultIndex {
+                inner: last,
+                fail: fault.clone(),
+            });
+            let indexes = [first, last];
+            assert!(transaction.update_indexes_on_commit(&indexes).is_err());
+            assert_eq!(
+                transaction
+                    .mutation
+                    .as_ref()
+                    .unwrap()
+                    .index_undo
+                    .lock()
+                    .len(),
+                2
+            );
+            *fault.lock() = Some((false, 1));
+            assert!(transaction.undo_index_updates().is_err());
+            assert_eq!(
+                transaction
+                    .mutation
+                    .as_ref()
+                    .unwrap()
+                    .index_undo
+                    .lock()
+                    .len(),
+                2
+            );
+            transaction.undo_index_updates().unwrap();
+            assert!(transaction
+                .mutation
+                .as_ref()
+                .unwrap()
+                .index_undo
+                .lock()
+                .is_empty());
+            let old: Vec<_> = (1..=rows).map(|row| (row, key(1, row))).collect();
+            for index in indexes {
+                assert_keys(index.as_ref(), &old);
+            }
+        }
+    }
+
+    #[test]
+    fn partial_undo_preserves_nonunique_duplicate_postings_and_reverse_maps() {
+        for family in 1..5 {
+            let account = crate::common::memory::MemoryAccount::new();
+            let inner = native_with_unique(family, "duplicates", false);
+            let old: Vec<_> = (1..=3).map(|row| (row, key(family, 7))).collect();
+            let new: Vec<_> = (1..=3).map(|row| (row, key(family, 9))).collect();
+            for (row, values) in &old {
+                inner.add(values, *row, *row).unwrap();
+            }
+            let fault = Arc::new(Mutex::new(Some((true, 1))));
+            let index: Arc<dyn Index> = Arc::new(FaultIndex {
+                inner,
+                fail: fault.clone(),
+            });
+            let mut undo = IndexUndo::new(index.clone(), new, old, &account);
+            assert!(undo.apply().is_err());
+            *fault.lock() = Some((false, 1));
+            assert!(undo.undo().is_err());
+            *fault.lock() = Some((true, 1));
+            assert!(undo.undo().is_err());
+            undo.undo().unwrap();
+            undo.undo().unwrap();
+            assert_eq!(
+                index.get_row_ids_equal(&key(family, 7)).as_slice(),
+                &[1, 2, 3]
+            );
+            assert!(index.get_row_ids_equal(&key(family, 9)).is_empty());
+            index.remove(&key(family, 7), 2, 2).unwrap();
+            assert_eq!(index.get_row_ids_equal(&key(family, 7)).as_slice(), &[1, 3]);
         }
     }
 }

--- a/src/storage/traits/index_trait.rs
+++ b/src/storage/traits/index_trait.rs
@@ -15,7 +15,7 @@
 //! Index trait for database indexes
 //!
 
-use crate::common::I64Map;
+use crate::common::{I64Map, MemoryAccount};
 use crate::core::{DataType, IndexEntry, IndexType, Operator, Result, RowIdVec, Value};
 use crate::storage::expression::Expression;
 
@@ -30,6 +30,21 @@ use crate::storage::expression::Expression;
 /// - **Bitmap**: For low-cardinality columns (< 5% unique values)
 /// - **BTree**: For range queries and ordered access
 pub trait Index: Send + Sync {
+    /// Attach an exclusively owned index before publication. Normal factories
+    /// attach while empty, before hot or cold population. Public prebuilt indexes
+    /// and deserialized graphs may perform one startup-only adoption traversal;
+    /// ordinary DML never attaches or reparents an index.
+    /// Implementations retain their origin until the final allocation owner drops.
+    fn attach_memory_account(&mut self, _account: &MemoryAccount) -> Result<()> {
+        Err(crate::core::Error::internal(
+            "index does not support memory accounting",
+        ))
+    }
+
+    fn memory_account(&self) -> Option<&MemoryAccount> {
+        None
+    }
+
     /// Returns the name of the index
     fn name(&self) -> &str;
 

--- a/src/storage/traits/table.rs
+++ b/src/storage/traits/table.rs
@@ -618,6 +618,9 @@ pub trait Table: Send + Sync {
         Vec::new() // Default implementation returns empty - override in concrete tables
     }
 
+    /// Retain the actual appended row record until transaction publication.
+    fn record_source_lsn(&self, _row_id: i64, _lsn: Option<std::num::NonZeroU64>) {}
+
     // ---- Index Operations ----
 
     /// Creates an index on the table

--- a/src/storage/volume/manifest.rs
+++ b/src/storage/volume/manifest.rs
@@ -575,8 +575,42 @@ fn compute_visibility_bitmaps(
     }
 }
 
-type PendingTombstoneUndo = FxHashMap<i64, Vec<(i64, Option<i64>)>>;
-type PublishedTombstoneUndo = FxHashMap<i64, (u64, Vec<(i64, Option<u64>)>)>;
+use crate::common::memory::{MemoryAccount, MemoryCharge};
+use crate::storage::index::accounted_map::{HashEntry, HeapBytes, PrivateHeap, TrackedHash};
+use crate::storage::mvcc::accounting::RetainedSmallVec;
+
+type HotTxnMap<V> = TrackedHash<i64, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
+type PendingJournal = RetainedSmallVec<[(i64, Option<i64>); 0]>;
+type PublishedJournal = RetainedSmallVec<[(i64, Option<u64>); 0]>;
+type PendingTombstoneUndo = HotTxnMap<PendingJournal>;
+type PublishedTombstoneUndo = HotTxnMap<(u64, PublishedJournal)>;
+
+// These nested containers carry their own capacity owner when moved out of a
+// transaction map; the enclosing map must not release or count that charge.
+impl PrivateHeap for PendingJournal {
+    const HAS_HEAP: bool = false;
+    fn private_heap(&self) -> HeapBytes {
+        HeapBytes::default()
+    }
+}
+impl PrivateHeap for PublishedJournal {
+    const HAS_HEAP: bool = false;
+    fn private_heap(&self) -> HeapBytes {
+        HeapBytes::default()
+    }
+}
+impl PrivateHeap for crate::common::I64Map<i64> {
+    const HAS_HEAP: bool = false;
+    fn private_heap(&self) -> HeapBytes {
+        HeapBytes::default()
+    }
+}
+
+fn hot_txn_map<V: PrivateHeap>(account: &MemoryAccount) -> HotTxnMap<V> {
+    let mut map = HotTxnMap::default();
+    map.attach(account);
+    map
+}
 
 /// Per-table segment manager.
 ///
@@ -643,7 +677,7 @@ pub struct SegmentManager {
     /// access to SegmentedTable state.
     /// Each row_id carries the timestamp it was tombstoned at, so a savepoint
     /// rollback can discard the tombstones made after the savepoint.
-    pending_txn_tombstones: RwLock<FxHashMap<i64, FxHashMap<i64, i64>>>,
+    pending_txn_tombstones: RwLock<HotTxnMap<crate::common::I64Map<i64>>>,
     pending_tombstone_undo: RwLock<PendingTombstoneUndo>,
     published_tombstone_undo: RwLock<PublishedTombstoneUndo>,
     // Unique constraint checks use per-volume hash indices (on FrozenVolume).
@@ -668,18 +702,28 @@ pub struct SegmentManager {
     seal_generation: std::sync::atomic::AtomicU64,
     /// Per-txn seal generation at INSERT time. Small map — only active
     /// transactions with pending inserts on this table.
-    txn_seal_gens: parking_lot::Mutex<rustc_hash::FxHashMap<i64, u64>>,
+    txn_seal_gens: parking_lot::Mutex<HotTxnMap<u64>>,
     /// Number of rows currently being sealed (exist in both hot and cold).
     /// Set to N before register_segment, cleared after remove_sealed_rows.
     /// Subtracted from row_count() to prevent double-counting during the seal window.
     seal_overlap_count: std::sync::atomic::AtomicUsize,
+    hot_memory: MemoryAccount,
+    _hot_object_charge: MemoryCharge,
 }
 
 impl SegmentManager {
     /// Create a new segment manager for a table.
     pub fn new(table_name: &str, volume_dir: Option<PathBuf>) -> Self {
+        Self::new_in(table_name, volume_dir, MemoryAccount::new())
+    }
+
+    pub(crate) fn new_in(
+        table_name: &str,
+        volume_dir: Option<PathBuf>,
+        memory: MemoryAccount,
+    ) -> Self {
         Self {
-            table_name: SmartString::from(table_name),
+            table_name: SmartString::from(table_name).into_hot(&memory),
             manifest: RwLock::new(TableManifest::new(table_name)),
             segments: RwLock::new(Arc::new(FxHashMap::default())),
             volume_dir,
@@ -688,24 +732,37 @@ impl SegmentManager {
             current_eviction_epoch: std::sync::atomic::AtomicU64::new(0),
             reloading: parking_lot::Mutex::new(()),
             tombstones: RwLock::new(Arc::new(FxHashMap::default())),
-            pending_txn_tombstones: RwLock::new(FxHashMap::default()),
-            pending_tombstone_undo: RwLock::new(FxHashMap::default()),
-            published_tombstone_undo: RwLock::new(FxHashMap::default()),
+            pending_txn_tombstones: RwLock::new(hot_txn_map(&memory)),
+            pending_tombstone_undo: RwLock::new(hot_txn_map(&memory)),
+            published_tombstone_undo: RwLock::new(hot_txn_map(&memory)),
             cached_deduped_count: std::sync::atomic::AtomicU64::new(u64::MAX),
             seal_fence: RwLock::new(()),
             visibility_seen: parking_lot::Mutex::new(rustc_hash::FxHashSet::default()),
             seal_generation: std::sync::atomic::AtomicU64::new(0),
-            txn_seal_gens: parking_lot::Mutex::new(rustc_hash::FxHashMap::default()),
+            txn_seal_gens: parking_lot::Mutex::new(hot_txn_map(&memory)),
             seal_overlap_count: std::sync::atomic::AtomicUsize::new(0),
+            _hot_object_charge: MemoryCharge::conservative(
+                &memory,
+                std::mem::size_of::<Self>() + 4 * std::mem::size_of::<usize>(),
+            ),
+            hot_memory: memory,
         }
     }
 
     /// Create from an existing manifest loaded from disk.
     pub fn from_manifest(manifest: TableManifest, volume_dir: Option<PathBuf>) -> Self {
+        Self::from_manifest_in(manifest, volume_dir, MemoryAccount::new())
+    }
+
+    pub(crate) fn from_manifest_in(
+        manifest: TableManifest,
+        volume_dir: Option<PathBuf>,
+        memory: MemoryAccount,
+    ) -> Self {
         let table_name = manifest.table_name.clone();
         let tombstone_map: FxHashMap<i64, u64> = manifest.tombstones.iter().copied().collect();
         Self {
-            table_name,
+            table_name: table_name.into_hot(&memory),
             manifest: RwLock::new(manifest),
             segments: RwLock::new(Arc::new(FxHashMap::default())),
             volume_dir,
@@ -714,21 +771,30 @@ impl SegmentManager {
             current_eviction_epoch: std::sync::atomic::AtomicU64::new(0),
             reloading: parking_lot::Mutex::new(()),
             tombstones: RwLock::new(Arc::new(tombstone_map)),
-            pending_txn_tombstones: RwLock::new(FxHashMap::default()),
-            pending_tombstone_undo: RwLock::new(FxHashMap::default()),
-            published_tombstone_undo: RwLock::new(FxHashMap::default()),
+            pending_txn_tombstones: RwLock::new(hot_txn_map(&memory)),
+            pending_tombstone_undo: RwLock::new(hot_txn_map(&memory)),
+            published_tombstone_undo: RwLock::new(hot_txn_map(&memory)),
             cached_deduped_count: std::sync::atomic::AtomicU64::new(u64::MAX),
             seal_fence: RwLock::new(()),
             visibility_seen: parking_lot::Mutex::new(rustc_hash::FxHashSet::default()),
             seal_generation: std::sync::atomic::AtomicU64::new(0),
-            txn_seal_gens: parking_lot::Mutex::new(rustc_hash::FxHashMap::default()),
+            txn_seal_gens: parking_lot::Mutex::new(hot_txn_map(&memory)),
             seal_overlap_count: std::sync::atomic::AtomicUsize::new(0),
+            _hot_object_charge: MemoryCharge::conservative(
+                &memory,
+                std::mem::size_of::<Self>() + 4 * std::mem::size_of::<usize>(),
+            ),
+            hot_memory: memory,
         }
     }
 
     /// Get the table name.
     pub fn table_name(&self) -> &str {
         &self.table_name
+    }
+
+    pub(crate) fn hot_memory_account(&self) -> &MemoryAccount {
+        &self.hot_memory
     }
 
     /// Ensure all volumes have column data before column access.
@@ -1669,7 +1735,7 @@ impl SegmentManager {
 
     /// Rename this segment manager's table (for ALTER TABLE RENAME).
     pub fn rename(&mut self, new_name: &str) {
-        self.table_name = SmartString::from(new_name);
+        self.table_name = SmartString::from(new_name).into_hot(&self.hot_memory);
         self.manifest.write().table_name = SmartString::from(new_name);
     }
 
@@ -1809,36 +1875,48 @@ impl SegmentManager {
     /// Called during DML (UPDATE/DELETE of cold rows).
     pub fn add_pending_tombstone(&self, txn_id: i64, row_id: i64) {
         let mut pending = self.pending_txn_tombstones.write();
-        let previous = pending
-            .entry(txn_id)
-            .or_default()
-            .insert(row_id, get_fast_timestamp());
-        self.pending_tombstone_undo
-            .write()
-            .entry(txn_id)
-            .or_default()
-            .push((row_id, previous));
+        let mut rows = match pending.entry(txn_id) {
+            HashEntry::Occupied(entry) => entry.into_mut(),
+            HashEntry::Vacant(entry) => {
+                entry.insert(crate::common::I64Map::new_in(&self.hot_memory))
+            }
+        };
+        let previous = rows.insert(row_id, get_fast_timestamp());
+        let mut undo = self.pending_tombstone_undo.write();
+        let mut journal = match undo.entry(txn_id) {
+            HashEntry::Occupied(entry) => entry.into_mut(),
+            HashEntry::Vacant(entry) => entry.insert(PendingJournal::new()),
+        };
+        journal.push((row_id, previous), &self.hot_memory);
     }
 
     pub fn pending_statement_checkpoint(&self, txn_id: i64) -> usize {
         self.pending_tombstone_undo
             .read()
             .get(&txn_id)
-            .map_or(0, Vec::len)
+            .map_or(0, |journal| journal.len())
     }
 
     pub fn finish_pending_statement(&self, txn_id: i64, checkpoint: usize, success: bool) {
         let mut pending = self.pending_txn_tombstones.write();
-        if let Some(journal) = self.pending_tombstone_undo.write().remove(&txn_id) {
+        if let Some(mut journal) = self.pending_tombstone_undo.write().remove_value(&txn_id) {
             if !success {
-                let rows = pending.entry(txn_id).or_default();
-                for (row_id, previous) in journal.into_iter().skip(checkpoint).rev() {
+                let mut rows = match pending.entry(txn_id) {
+                    HashEntry::Occupied(entry) => entry.into_mut(),
+                    HashEntry::Vacant(entry) => {
+                        entry.insert(crate::common::I64Map::new_in(&self.hot_memory))
+                    }
+                };
+                while journal.len() > checkpoint {
+                    let Some((row_id, previous)) = journal.pop() else {
+                        unreachable!("pending statement journal remains above checkpoint");
+                    };
                     match previous {
                         Some(timestamp) => {
                             rows.insert(row_id, timestamp);
                         }
                         None => {
-                            rows.remove(&row_id);
+                            rows.remove(row_id);
                         }
                     }
                 }
@@ -1853,10 +1931,12 @@ impl SegmentManager {
             return;
         };
         let committed = self.tombstones.read();
-        let undo = rows
-            .keys()
-            .map(|&row_id| (row_id, committed.get(&row_id).copied()))
-            .collect();
+        let mut undo = PublishedJournal::new();
+        undo.extend(
+            rows.keys()
+                .map(|row_id| (row_id, committed.get(&row_id).copied())),
+            &self.hot_memory,
+        );
         self.published_tombstone_undo
             .write()
             .insert(txn_id, (commit_seq, undo));
@@ -1867,7 +1947,8 @@ impl SegmentManager {
         if !success {
             self.rollback_pending_tombstones(txn_id);
         }
-        let Some((sequence, undo)) = self.published_tombstone_undo.write().remove(&txn_id) else {
+        let Some((sequence, undo)) = self.published_tombstone_undo.write().remove_value(&txn_id)
+        else {
             return;
         };
         if success {
@@ -1904,7 +1985,7 @@ impl SegmentManager {
         self.pending_txn_tombstones
             .read()
             .get(&txn_id)
-            .map(|set| set.keys().copied().collect())
+            .map(|set| set.keys().collect())
             .unwrap_or_default()
     }
 
@@ -1915,7 +1996,7 @@ impl SegmentManager {
         dest: &mut rustc_hash::FxHashSet<i64>,
     ) {
         if let Some(ids) = self.pending_txn_tombstones.read().get(&txn_id) {
-            for &id in ids.keys() {
+            for id in ids.keys() {
                 dest.insert(id);
             }
         }
@@ -1935,18 +2016,18 @@ impl SegmentManager {
         self.pending_txn_tombstones
             .read()
             .get(&txn_id)
-            .is_some_and(|set| set.contains_key(&row_id))
+            .is_some_and(|set| set.contains_key(row_id))
     }
 
     /// Commit pending tombstones: move from per-txn pending to shared tombstone set.
     /// The commit_seq is the transaction's commit sequence, used for snapshot
     /// isolation: older snapshots won't see these tombstones.
     pub fn commit_pending_tombstones(&self, txn_id: i64, commit_seq: u64) {
-        let pending = self.pending_txn_tombstones.write().remove(&txn_id);
+        let pending = self.pending_txn_tombstones.write().remove_value(&txn_id);
         self.pending_tombstone_undo.write().remove(&txn_id);
         if let Some(ids) = pending {
             if !ids.is_empty() {
-                let id_vec: Vec<i64> = ids.into_keys().collect();
+                let id_vec: Vec<i64> = ids.keys().collect();
                 self.add_tombstones(&id_vec, commit_seq);
             }
         }
@@ -1962,8 +2043,8 @@ impl SegmentManager {
     /// and return the row_ids discarded, so their row claims can be released.
     pub fn rollback_pending_tombstones_after(&self, txn_id: i64, timestamp: i64) -> Vec<i64> {
         let mut discarded = Vec::new();
-        if let Some(ids) = self.pending_txn_tombstones.write().get_mut(&txn_id) {
-            ids.retain(|&row_id, tombstoned_at| {
+        if let Some(mut ids) = self.pending_txn_tombstones.write().get_mut(&txn_id) {
+            ids.retain(|row_id, tombstoned_at| {
                 let keep = *tombstoned_at <= timestamp;
                 if !keep {
                     discarded.push(row_id);
@@ -2271,13 +2352,15 @@ impl SegmentManager {
     pub fn record_txn_seal_generation(&self, txn_id: i64) {
         let gen = self.seal_generation();
         let mut map = self.txn_seal_gens.lock();
-        map.entry(txn_id)
-            .and_modify(|existing| {
-                if gen < *existing {
-                    *existing = gen;
-                }
-            })
-            .or_insert(gen);
+        match map.entry(txn_id) {
+            HashEntry::Occupied(entry) => {
+                let mut existing = entry.into_mut();
+                *existing = (*existing).min(gen);
+            }
+            HashEntry::Vacant(entry) => {
+                entry.insert(gen);
+            }
+        }
     }
 
     /// Get the seal generation recorded for a transaction.
@@ -2455,6 +2538,14 @@ impl SegmentManager {
 
     /// Load manifest from disk.
     pub fn load_from_disk(table_name: &str, volume_dir: &Path) -> Result<Option<Self>> {
+        Self::load_from_disk_in(table_name, volume_dir, MemoryAccount::new())
+    }
+
+    pub(crate) fn load_from_disk_in(
+        table_name: &str,
+        volume_dir: &Path,
+        memory: MemoryAccount,
+    ) -> Result<Option<Self>> {
         let table_dir = volume_dir.join(table_name);
         let manifest_path = table_dir.join("manifest.bin");
 
@@ -2463,7 +2554,7 @@ impl SegmentManager {
         }
 
         let manifest = TableManifest::read_from_disk(&manifest_path)?;
-        let manager = Self::from_manifest(manifest, Some(volume_dir.to_path_buf()));
+        let manager = Self::from_manifest_in(manifest, Some(volume_dir.to_path_buf()), memory);
 
         Ok(Some(manager))
     }
@@ -3574,15 +3665,124 @@ mod publication_undo_tests {
     use super::*;
 
     #[test]
+    fn reopened_manager_keeps_pending_hot_bytes_in_its_engine_origin() {
+        let directory = tempfile::tempdir().unwrap();
+        let original = SegmentManager::new("reopened_memory", Some(directory.path().to_path_buf()));
+        original.persist().unwrap();
+        drop(original);
+
+        let engine = MemoryAccount::new();
+        let origin = engine.child();
+        let baseline = engine.snapshot().accounted_bytes;
+        let manager =
+            SegmentManager::load_from_disk_in("reopened_memory", directory.path(), origin.clone())
+                .unwrap()
+                .unwrap();
+        assert!(manager.hot_memory_account().same_origin(&origin));
+        let loaded = engine.snapshot().retained_bytes;
+        for row_id in 0..1024 {
+            manager.add_pending_tombstone(7, row_id);
+        }
+        manager.prepare_tombstone_publication(7, 10);
+        assert!(engine.snapshot().retained_bytes > loaded);
+        assert_eq!(
+            engine.snapshot().retained_bytes,
+            origin.snapshot().retained_bytes
+        );
+        assert_eq!(manager.pending_tombstone_count(7), 1024);
+        drop(manager);
+        assert_eq!(engine.snapshot().retained_bytes, 0);
+        assert_eq!(engine.snapshot().accounted_bytes, baseline);
+    }
+
+    #[test]
+    fn pending_tombstone_buffers_remain_charged_until_their_last_owner_drops() {
+        let root = MemoryAccount::new();
+        let empty = root.snapshot().accounted_bytes;
+        let manager = SegmentManager::new_in("pending_memory", None, root.child());
+        for row_id in 1..=1024 {
+            manager.add_pending_tombstone(7, row_id);
+        }
+        let checkpoint = manager.pending_statement_checkpoint(7);
+        let before_failed_statement = root.snapshot().retained_bytes;
+        manager.add_pending_tombstone(7, 1025);
+        manager.finish_pending_statement(7, checkpoint, false);
+        assert_eq!(manager.pending_tombstone_count(7), 1024);
+        assert!(!manager.is_pending_tombstone(7, 1025));
+        assert!(
+            root.snapshot().retained_bytes < before_failed_statement,
+            "the completed statement journal releases its physical buffer"
+        );
+
+        manager.prepare_tombstone_publication(7, 10);
+        let published_bytes = manager.published_tombstone_undo.read()[&7]
+            .1
+            .allocation_size();
+        assert!(published_bytes >= 1024 * std::mem::size_of::<(i64, Option<u64>)>());
+        manager.commit_pending_tombstones(7, 10);
+        assert!(
+            root.snapshot().retained_bytes >= published_bytes,
+            "published undo must remain charged through the commit outcome"
+        );
+        let before_finish = root.snapshot().retained_bytes;
+        manager.finish_tombstone_publication(7, true);
+        assert_eq!(
+            root.snapshot().retained_bytes + published_bytes,
+            before_finish
+        );
+
+        manager.add_pending_tombstone(8, 1);
+        let held_rows = manager
+            .pending_txn_tombstones
+            .write()
+            .remove_value(&8)
+            .unwrap();
+        let held_bytes = held_rows.allocation_size();
+        drop(manager);
+        assert_eq!(
+            root.snapshot().retained_bytes,
+            held_bytes,
+            "a moved row map retains its origin after the manager is dropped"
+        );
+        drop(held_rows);
+        assert_eq!(root.snapshot().accounted_bytes, empty);
+    }
+
+    #[test]
+    fn rollback_releases_pending_rows_and_journals_without_releasing_other_transactions() {
+        let root = MemoryAccount::new();
+        let empty = root.snapshot().accounted_bytes;
+        let manager = SegmentManager::new_in("rollback_memory", None, root.child());
+        for txn in [1, 2] {
+            for row_id in 0..128 {
+                manager.add_pending_tombstone(txn, row_id);
+            }
+            manager.record_txn_seal_generation(txn);
+        }
+        let before = root.snapshot().retained_bytes;
+        manager.rollback_pending_tombstones(1);
+        manager.clear_txn_seal_generation(1);
+        assert!(root.snapshot().retained_bytes < before);
+        assert_eq!(manager.pending_tombstone_count(1), 0);
+        assert_eq!(manager.pending_tombstone_count(2), 128);
+        assert_eq!(manager.get_txn_seal_generation(2), Some(0));
+        drop(manager);
+        assert_eq!(root.snapshot().accounted_bytes, empty);
+    }
+
+    #[test]
     fn failed_prepare_discards_pending_tombstones_without_an_undo_receipt() {
         let manager = SegmentManager::new("pending_undo", None);
         manager.add_pending_tombstone(7, 1);
         let checkpoint = manager.pending_statement_checkpoint(7);
-        let original = manager.pending_txn_tombstones.read()[&7][&1];
+        let original = *manager.pending_txn_tombstones.read()[&7].get(1).unwrap();
         manager.add_pending_tombstone(7, 1);
         manager.add_pending_tombstone(7, 2);
         manager.finish_pending_statement(7, checkpoint, false);
-        assert_eq!(manager.pending_txn_tombstones.read()[&7][&1], original);
+        assert_eq!(
+            *manager.pending_txn_tombstones.read()[&7].get(1).unwrap(),
+            original
+        );
         assert!(!manager.is_pending_tombstone(7, 2));
         // Failure before prepare_tombstone_publication creates any receipt.
         manager.finish_tombstone_publication(7, false);

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -3966,6 +3966,10 @@ impl Table for SegmentedTable {
         self.hot.has_local_changes() || self.segment_mgr.has_pending_tombstones(self.txn_id())
     }
 
+    fn record_source_lsn(&self, row_id: i64, lsn: Option<std::num::NonZeroU64>) {
+        self.hot.record_source_lsn(row_id, lsn);
+    }
+
     fn get_pending_versions(&self) -> Vec<(i64, Row, bool, i64)> {
         self.hot.get_pending_versions()
     }

--- a/tests/arena_slot_reuse_test.rs
+++ b/tests/arena_slot_reuse_test.rs
@@ -32,6 +32,53 @@
 
 use stoolap::Database;
 
+#[test]
+fn empty_arena_releases_capacity_after_sql_vacuum() {
+    let db = Database::open("memory://empty_arena_releases_capacity_after_sql_vacuum").unwrap();
+    db.execute("PRAGMA HOT_MAX_ROWS = 0", ()).unwrap();
+    db.execute(
+        "CREATE TABLE chunks (id INTEGER PRIMARY KEY, value INTEGER)",
+        (),
+    )
+    .unwrap();
+    let capacity = || {
+        db.query("PRAGMA MEMORY_STATS", ())
+            .unwrap()
+            .map(|row| row.unwrap())
+            .find(|row| row.get::<String>(0).unwrap() == "chunks")
+            .unwrap()
+            .get::<i64>(4)
+            .unwrap()
+    };
+    let initial = capacity();
+    let values = (1..=4000)
+        .map(|id| format!("({id},{id})"))
+        .collect::<Vec<_>>()
+        .join(",");
+    db.execute(&format!("INSERT INTO chunks VALUES {values}"), ())
+        .unwrap();
+    let populated = capacity();
+    assert!(populated > initial + 64_000);
+    db.execute("DELETE FROM chunks", ()).unwrap();
+    db.execute("VACUUM", ()).unwrap();
+    let empty = capacity();
+    assert!(
+        empty <= initial + 4096,
+        "arena kept {empty} of {populated} bytes"
+    );
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM chunks", ())
+            .unwrap(),
+        0
+    );
+    db.execute("INSERT INTO chunks VALUES (1, 77)", ()).unwrap();
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT value FROM chunks WHERE id = 1", ())
+            .unwrap(),
+        77
+    );
+}
+
 /// Test that AS OF queries return historical data after UPDATE
 ///
 /// This test verifies that snapshot isolation is preserved:

--- a/tests/hot_index_top_k_test.rs
+++ b/tests/hot_index_top_k_test.rs
@@ -401,6 +401,10 @@ struct StopAfterIndexAdd {
 }
 
 impl Index for StopAfterIndexAdd {
+    fn memory_account(&self) -> Option<&stoolap::common::MemoryAccount> {
+        self.inner.memory_account()
+    }
+
     fn name(&self) -> &str {
         self.inner.name()
     }

--- a/tests/phase1_review_reservation_test.rs
+++ b/tests/phase1_review_reservation_test.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::{Arc, RwLock};
+use stoolap::common::CompactArc;
 use stoolap::core::{DataType, Row, SchemaBuilder};
 use stoolap::storage::index::HashIndex;
 use stoolap::storage::mvcc::{
@@ -82,7 +83,7 @@ fn cold_deleted_unique_key_stays_reserved_until_terminal_outcome() {
         if evolved_schema {
             manager.invalidate_mappings(&schema);
         }
-        let first_local = Arc::new(RwLock::new(TransactionVersionStore::new(
+        let first_local = CompactArc::new(RwLock::new(TransactionVersionStore::new(
             parent.clone(),
             10,
         )));
@@ -116,7 +117,7 @@ fn cold_deleted_unique_key_stays_reserved_until_terminal_outcome() {
             .unwrap();
         manager.commit_pending_tombstones(10, 20);
         // T1 is paused immediately before recording COMMIT, matching engine ordering.
-        let second_local = Arc::new(RwLock::new(TransactionVersionStore::new(
+        let second_local = CompactArc::new(RwLock::new(TransactionVersionStore::new(
             parent.clone(),
             11,
         )));


### PR DESCRIPTION
I release empty hot arena chunks and charge retained hot allocations to their final owner. The source diff spans several thousand lines because arena identities, shared payload headers, transaction buffers and index owners must use the same lifetime accounting; a partial switch would release charges too early or count shared storage twice. Source line totals include inline unit tests.

I remove vendor/roaring and the root-only Cargo patch. Bitmap accounting now uses public APIs from the pinned upstream roaring 0.11.3 release. It keeps five usize counters per distinct indexed value (40 bytes on 64-bit targets), with no per-row or per-container side table. Point mutations inspect only the relevant prefixes. Stored data, container directories and B-tree structure are conservative upper bounds, not exact capacities. Empty bitmaps release their retained directory before their charge becomes zero. The version pin keeps the reviewed allocation-growth assumptions stable for downstream builds.

Arena IDs remain 8 bytes. Row metadata is 32 bytes per reserved slot, plus the 8-byte payload handle on 64-bit targets; payload capacity, LSN minima and chunk directories are accounted separately. The chunk limit is 262,144 slots and does not preallocate that many rows. This phase adds hot ownership accounting; it adds no cold-volume residency structure and enforces no engine hard limit.

| Added module | Engine caller |
|---|---|
| common/memory | Engine and table owners, DML payload adoption, PRAGMA MEMORY_STATS |
| storage/index/accounted_map | B-tree, hash, bitmap and composite index mutations and publication key reservations |
| storage/index/memory | Engine index factory and CREATE INDEX account attachment |
| storage/mvcc/accounting | Transaction undo, source LSNs, reservations and retained scratch buffers |

The public type audit follows all 23 added types to those production chains, including arena IDs/leases/capacity and transaction map pools. I removed the empty clear_version_map_pools export, unused active_chunk_id and the unused CompactArc string constructor wrapper. Arena accessors used only by unit tests are now compiled only for those tests. Raw measurements and temporary probes are outside the repository.

I ran the new SQL VACUUM capacity regression against the exact rewritten parent source (19ac00b0) in this checkout: it fails with all 131,072 arena bytes retained. The candidate passes. Strict all-target/all-feature Clippy passes, 2,166 targeted library/SQL tests pass (2 excluded), and 31 targeted tests with test-filedb pass. The default in-memory suite with test-failpoints passes: 5,432 tests, 3 excluded, one slow test, no leaked-process notices. The only later source edit completes the required Apache license comment; executable code is unchanged. I removed the obsolete vendor-only license checks and scan exclusion from CI, restoring the parent workflow. The old check fails on the deleted license file; the restored check and a fresh strict Clippy run pass locally.

Independent source review cleared the public bitmap bounds, allocation ownership and inherited cleanup. Newly introduced unwrap/expect calls were removed through existing references or checked errors. Explicit invariant and terminal poison panics preserve their prior failure behavior; this is not a panic-free claim.

The SQL regression proves empty arena capacity release, not total process heap release. Helper allocation tests establish only their component scope. Historical alternating-run latency/allocation comparisons are withdrawn and have not been reproduced. Bitmap no-op mutations still incur temporary accounting work; I have not measured its engine latency impact. RSS, whole-engine zero allocations and competitor performance are not established.

I keep this PR in draft until latency and allocation acceptance is reproduced under the current measurement protocol. Functional cleanup verification does not complete that performance gate.

| Diff category | Added | Removed |
|---|---:|---:|
| Source | 9,430 | 2,719 |
| Tests | 54 | 2 |
| Docs | 1 | 1 |
| Other | 1 | 1 |
