### PR TITLE
Keep hot and cold reads coherent across publication and file replacement

### DIFF
--- a/design/storage/progress.md
+++ b/design/storage/progress.md
@@ -9,7 +9,7 @@ with no engine caller does not count as an implemented phase.
 | 0 | Lifecycle contracts and validation rules | Design accepted | [#115](https://github.com/stoolap/stoolap/pull/115) |
 | 1 | Fallible cold access and statement rollback | Cleanup verified; SQL statement rollback proven against parent | [#116](https://github.com/stoolap/stoolap/pull/116) |
 | 2 | Releasable chunks and retained hot accounting | Cleanup verified; SQL arena release proven against parent; performance acceptance pending | [#117](https://github.com/stoolap/stoolap/pull/117) |
-| 3 | Coherent hot/cold reads | Draft; cleanup and final abort-publication correction remain | [#118](https://github.com/stoolap/stoolap/pull/118) |
+| 3 | Coherent hot/cold reads | Cleanup verified; cache freshness proven against parent; lifecycle and performance acceptance incomplete | [#118](https://github.com/stoolap/stoolap/pull/118) |
 | 4 | Bounded streaming seal | Incomplete; unintegrated V5 prototype withdrawn | [#119](https://github.com/stoolap/stoolap/pull/119) |
 | 5 | Durable lifecycle and pressure seal | Incomplete; unintegrated catalog and WAL prototypes withdrawn | [#120](https://github.com/stoolap/stoolap/pull/120) |
 | 6 | Paged residency and engine memory budgets | Frozen until phases 2 and 3 are clean; existing adapters are component work only | [#121](https://github.com/stoolap/stoolap/pull/121) |

--- a/src/common/cow_btree.rs
+++ b/src/common/cow_btree.rs
@@ -33,6 +33,7 @@
 //! - Memory: Shared nodes between snapshots
 
 use super::{CompactArc, MemoryAccount};
+use smallvec::SmallVec;
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::Bound;
@@ -1817,8 +1818,9 @@ enum InsertResult<V: Clone> {
 /// Iterator over chunks of a CowBTree (leaf slices)
 struct CowBTreeChunkIter<'a, V: Clone> {
     /// Stack of (node, next_child_index) for traversal
-    /// Only holds internal nodes.
-    stack: Vec<(&'a NodePtr<V>, usize)>,
+    /// Only holds internal nodes. Supported NodePath depths remain inline;
+    /// retain SmallVec fallback for compatibility with any deeper future tree.
+    stack: SmallVec<[(&'a NodePtr<V>, usize); MAX_TREE_DEPTH]>,
     /// Current leaf node being yielded (if any)
     current_leaf: Option<&'a NodePtr<V>>,
 }
@@ -1826,7 +1828,7 @@ struct CowBTreeChunkIter<'a, V: Clone> {
 impl<'a, V: Clone> CowBTreeChunkIter<'a, V> {
     fn new(root: Option<&'a NodePtr<V>>) -> Self {
         let mut iter = Self {
-            stack: Vec::new(),
+            stack: SmallVec::new(),
             current_leaf: None,
         };
         if let Some(root) = root {
@@ -1875,7 +1877,7 @@ impl<'a, V: Clone> Iterator for CowBTreeChunkIter<'a, V> {
 /// Range iterator over a CowBTree yielding chunks
 /// Optimized: Seeks directly to start bound and yields slices
 struct CowBTreeRangeChunkIter<'a, V: Clone, R> {
-    stack: Vec<(&'a NodePtr<V>, usize)>,
+    stack: SmallVec<[(&'a NodePtr<V>, usize); MAX_TREE_DEPTH]>,
     range: R,
     current_leaf: Option<&'a NodePtr<V>>,
     current_idx: usize,
@@ -1885,7 +1887,7 @@ struct CowBTreeRangeChunkIter<'a, V: Clone, R> {
 impl<'a, V: Clone, R: std::ops::RangeBounds<i64>> CowBTreeRangeChunkIter<'a, V, R> {
     fn new(root: Option<&'a NodePtr<V>>, range: R) -> Self {
         let mut iter = Self {
-            stack: Vec::new(),
+            stack: SmallVec::new(),
             range,
             current_leaf: None,
             current_idx: 0,
@@ -2047,7 +2049,7 @@ impl<V: Clone + std::fmt::Debug> std::fmt::Debug for CowBTree<V> {
 struct CowBTreeRevChunkIter<'a, V: Clone> {
     /// Stack of (node, next_child_plus_one) for reverse traversal.
     /// next_child_plus_one == 0 means no more children to visit at this level.
-    stack: Vec<(&'a NodePtr<V>, usize)>,
+    stack: smallvec::SmallVec<[(&'a NodePtr<V>, usize); MAX_TREE_DEPTH]>,
     /// Current leaf node being yielded
     current_leaf: Option<&'a NodePtr<V>>,
 }
@@ -2055,7 +2057,7 @@ struct CowBTreeRevChunkIter<'a, V: Clone> {
 impl<'a, V: Clone> CowBTreeRevChunkIter<'a, V> {
     fn new(root: Option<&'a NodePtr<V>>) -> Self {
         let mut iter = Self {
-            stack: Vec::new(),
+            stack: smallvec::SmallVec::new(),
             current_leaf: None,
         };
         if let Some(root) = root {
@@ -2107,7 +2109,7 @@ impl<'a, V: Clone> Iterator for CowBTreeRevChunkIter<'a, V> {
 /// Reverse range iterator over a CowBTree yielding chunks from end bound to start bound.
 /// Each chunk contains keys in ascending order; the consumer should reverse within each chunk.
 struct CowBTreeRevRangeChunkIter<'a, V: Clone, R> {
-    stack: Vec<(&'a NodePtr<V>, usize)>,
+    stack: smallvec::SmallVec<[(&'a NodePtr<V>, usize); MAX_TREE_DEPTH]>,
     range: R,
     current_leaf: Option<&'a NodePtr<V>>,
     /// End index (exclusive) within current leaf
@@ -2118,7 +2120,7 @@ struct CowBTreeRevRangeChunkIter<'a, V: Clone, R> {
 impl<'a, V: Clone, R: std::ops::RangeBounds<i64>> CowBTreeRevRangeChunkIter<'a, V, R> {
     fn new(root: Option<&'a NodePtr<V>>, range: R) -> Self {
         let mut iter = Self {
-            stack: Vec::new(),
+            stack: smallvec::SmallVec::new(),
             range,
             current_leaf: None,
             current_end_idx: 0,

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -6855,6 +6855,7 @@ impl Executor {
     pub(crate) fn try_fast_count_distinct_compiled(
         &self,
         stmt: &SelectStatement,
+        ctx: &ExecutionContext,
         compiled: &RwLock<CompiledExecution>,
     ) -> Option<Result<Box<dyn QueryResult>>> {
         // Caller (try_compiled_fast_paths) guarantees no explicit transaction
@@ -6875,7 +6876,7 @@ impl Executor {
                 CompiledExecution::CountDistinct(cd) => {
                     // Fast path: validate epoch and execute directly
                     if self.engine.schema_epoch() == cd.cached_epoch {
-                        return Some(self.execute_compiled_count_distinct(cd));
+                        return Some(self.execute_compiled_count_distinct(cd, ctx));
                     }
                     // Schema changed - fall through to recompile
                 }
@@ -6886,17 +6887,18 @@ impl Executor {
         }
 
         // First execution or schema changed - compile and cache (write lock)
-        self.compile_and_execute_count_distinct(stmt, compiled)
+        self.compile_and_execute_count_distinct(stmt, ctx, compiled)
     }
 
     /// Execute using pre-compiled COUNT(DISTINCT col) info
     fn execute_compiled_count_distinct(
         &self,
         cd: &CompiledCountDistinct,
+        ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
         // Get table and count distinct values directly
         let tx = self.engine.begin_transaction()?;
-        let table = tx.get_table(&cd.table_name)?;
+        let table = ctx.get_table(tx.as_ref(), &cd.table_name)?;
 
         let count = table
             .get_partition_count(&cd.column_name)?
@@ -6919,6 +6921,7 @@ impl Executor {
     fn compile_and_execute_count_distinct(
         &self,
         stmt: &SelectStatement,
+        ctx: &ExecutionContext,
         compiled: &RwLock<CompiledExecution>,
     ) -> Option<Result<Box<dyn QueryResult>>> {
         use crate::common::SmartString;
@@ -6936,7 +6939,7 @@ impl Executor {
             }
             CompiledExecution::CountDistinct(cd) => {
                 if self.engine.schema_epoch() == cd.cached_epoch {
-                    return Some(self.execute_compiled_count_distinct(cd));
+                    return Some(self.execute_compiled_count_distinct(cd, ctx));
                 }
                 // Schema changed, continue to recompile
             }
@@ -7066,7 +7069,7 @@ impl Executor {
             }
         };
 
-        let table = match tx.get_table(&table_name) {
+        let table = match ctx.get_table(tx.as_ref(), &table_name) {
             Ok(t) => t,
             Err(_) => {
                 *compiled_guard = CompiledExecution::NotOptimizable(self.engine.schema_epoch());
@@ -7126,6 +7129,7 @@ impl Executor {
     pub(crate) fn try_fast_count_star_compiled(
         &self,
         stmt: &SelectStatement,
+        ctx: &ExecutionContext,
         compiled: &RwLock<CompiledExecution>,
     ) -> Option<Result<Box<dyn QueryResult>>> {
         // Caller (try_compiled_fast_paths) guarantees no explicit transaction
@@ -7146,7 +7150,7 @@ impl Executor {
                 CompiledExecution::CountStar(cs) => {
                     // Fast path: validate epoch and execute directly
                     if self.engine.schema_epoch() == cs.cached_epoch {
-                        return Some(self.execute_compiled_count_star(cs));
+                        return Some(self.execute_compiled_count_star(cs, ctx));
                     }
                     // Schema changed - fall through to recompile
                 }
@@ -7157,17 +7161,18 @@ impl Executor {
         }
 
         // First execution or schema changed - compile and cache (write lock)
-        self.compile_and_execute_count_star(stmt, compiled)
+        self.compile_and_execute_count_star(stmt, ctx, compiled)
     }
 
     /// Execute using pre-compiled COUNT(*) info
     fn execute_compiled_count_star(
         &self,
         cs: &crate::executor::query_cache::CompiledCountStar,
+        ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
         // Get table and count rows directly
         let tx = self.engine.begin_transaction()?;
-        let table = tx.get_table(&cs.table_name)?;
+        let table = ctx.get_table(tx.as_ref(), &cs.table_name)?;
 
         let count = table.row_count()?;
 
@@ -7188,6 +7193,7 @@ impl Executor {
     fn compile_and_execute_count_star(
         &self,
         stmt: &SelectStatement,
+        ctx: &ExecutionContext,
         compiled: &RwLock<CompiledExecution>,
     ) -> Option<Result<Box<dyn QueryResult>>> {
         use crate::common::SmartString;
@@ -7206,7 +7212,7 @@ impl Executor {
             }
             CompiledExecution::CountStar(cs) => {
                 if self.engine.schema_epoch() == cs.cached_epoch {
-                    return Some(self.execute_compiled_count_star(cs));
+                    return Some(self.execute_compiled_count_star(cs, ctx));
                 }
                 // Schema changed, continue to recompile
             }
@@ -7378,7 +7384,7 @@ impl Executor {
             }
         };
 
-        let table = match tx.get_table(&table_name) {
+        let table = match ctx.get_table(tx.as_ref(), &table_name) {
             Ok(t) => t,
             Err(_) => {
                 *compiled_guard = CompiledExecution::NotOptimizable(self.engine.schema_epoch());

--- a/src/executor/context.rs
+++ b/src/executor/context.rs
@@ -667,6 +667,43 @@ pub fn cache_exists_correlation(
     result
 }
 
+thread_local! {
+    static DATA_CACHE_EPOCH: RefCell<Option<(usize, i64)>> = const { RefCell::new(None) };
+}
+
+/// Cached row/value data belongs to one immutable statement view. The copied
+/// identity retains no registry horizon or allocation while a thread is idle.
+/// Checking again during lazy/nested evaluation also handles two results
+/// consumed in alternating order on the same thread.
+pub(crate) fn ensure_statement_cache_epoch(ctx: &ExecutionContext) {
+    let Some(epoch) = ctx.read_epoch() else {
+        return;
+    };
+    let changed = DATA_CACHE_EPOCH.with(|current| {
+        let mut current = current.borrow_mut();
+        if *current == Some(epoch.cache_identity()) {
+            false
+        } else {
+            *current = Some(epoch.cache_identity());
+            true
+        }
+    });
+    if changed {
+        clear_scalar_subquery_cache();
+        clear_in_subquery_cache();
+        clear_semi_join_cache();
+        clear_batch_aggregate_cache();
+        clear_batch_aggregate_info_cache();
+        clear_exists_correlation_cache();
+        clear_exists_predicate_cache();
+        clear_exists_index_cache();
+        clear_exists_fetcher_cache();
+        clear_count_counter_cache();
+        clear_exists_schema_cache();
+        clear_exists_pred_key_cache();
+    }
+}
+
 /// Execution context for SQL queries
 ///
 /// The execution context carries state and configuration for query execution,
@@ -676,21 +713,44 @@ pub fn cache_exists_correlation(
 /// during correlated subquery processing where context is cloned per row.
 /// A transaction shared by every read of one statement
 #[derive(Clone)]
-pub struct StatementSnapshot(Arc<Mutex<Box<dyn crate::storage::traits::Transaction>>>);
+pub struct StatementSnapshot {
+    transaction: Arc<Mutex<Box<dyn crate::storage::traits::Transaction>>>,
+    epoch: Option<crate::storage::mvcc::registry::ReadEpoch>,
+}
 
 impl StatementSnapshot {
     pub fn new(transaction: Box<dyn crate::storage::traits::Transaction>) -> Self {
-        Self(Arc::new(Mutex::new(transaction)))
+        Self {
+            transaction: Arc::new(Mutex::new(transaction)),
+            epoch: None,
+        }
+    }
+
+    pub fn with_epoch(mut self, epoch: Option<crate::storage::mvcc::registry::ReadEpoch>) -> Self {
+        self.epoch = epoch;
+        self
     }
 
     pub fn get_table(
         &self,
         name: &str,
     ) -> crate::core::Result<Box<dyn crate::storage::traits::Table>> {
-        self.0
+        let transaction = self
+            .transaction
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .get_table(name)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.get_table_for_transaction(transaction.as_ref(), name)
+    }
+
+    pub(crate) fn get_table_for_transaction(
+        &self,
+        transaction: &dyn crate::storage::traits::Transaction,
+        name: &str,
+    ) -> crate::core::Result<Box<dyn crate::storage::traits::Table>> {
+        match &self.epoch {
+            Some(epoch) => transaction.get_table_in_epoch(name, epoch),
+            None => transaction.get_table(name),
+        }
     }
 }
 
@@ -736,6 +796,8 @@ pub struct ExecutionContext {
     /// One transaction for every fetch of a statement that has no explicit
     /// transaction, so its reads share a snapshot
     statement_snapshot: Option<StatementSnapshot>,
+    /// One registered lease shared by every read of this statement.
+    read_epoch: Option<crate::storage::mvcc::registry::ReadEpoch>,
 }
 
 /// Type alias for CTE data: (columns, rows) with Arc for zero-copy sharing
@@ -772,6 +834,7 @@ impl ExecutionContext {
             cte_data: None,
             transaction_id: None,
             statement_snapshot: None,
+            read_epoch: None,
         }
     }
 
@@ -933,6 +996,7 @@ impl ExecutionContext {
             cte_data: self.cte_data.clone(),
             transaction_id: self.transaction_id,
             statement_snapshot: self.statement_snapshot.clone(),
+            read_epoch: self.read_epoch.clone(),
         }
     }
 
@@ -954,6 +1018,7 @@ impl ExecutionContext {
             cte_data: self.cte_data.clone(),
             transaction_id: self.transaction_id,
             statement_snapshot: self.statement_snapshot.clone(),
+            read_epoch: self.read_epoch.clone(),
         }
     }
 
@@ -1000,6 +1065,7 @@ impl ExecutionContext {
             cte_data: self.cte_data.clone(),    // Arc clone = cheap
             transaction_id: self.transaction_id,
             statement_snapshot: self.statement_snapshot.clone(),
+            read_epoch: self.read_epoch.clone(),
         }
     }
 
@@ -1053,6 +1119,7 @@ impl ExecutionContext {
             cte_data: Some(cte_data),
             transaction_id: self.transaction_id,
             statement_snapshot: self.statement_snapshot.clone(),
+            read_epoch: self.read_epoch.clone(),
         }
     }
 
@@ -1068,6 +1135,29 @@ impl ExecutionContext {
 
     /// Create a new context with a transaction ID
     /// The statement-scoped snapshot, if the statement carries one
+    pub fn read_epoch(&self) -> Option<&crate::storage::mvcc::registry::ReadEpoch> {
+        self.read_epoch.as_ref()
+    }
+
+    pub fn with_read_epoch(&self, epoch: crate::storage::mvcc::registry::ReadEpoch) -> Self {
+        let mut ctx = self.clone();
+        ctx.read_epoch = Some(epoch);
+        ctx
+    }
+
+    /// Use this statement's visibility even when a helper opens a new table
+    /// handle or an autocommit storage transaction after the statement began.
+    pub(crate) fn get_table(
+        &self,
+        transaction: &dyn crate::storage::traits::Transaction,
+        name: &str,
+    ) -> crate::core::Result<Box<dyn crate::storage::traits::Table>> {
+        match &self.read_epoch {
+            Some(epoch) => transaction.get_table_in_epoch(name, epoch),
+            None => transaction.get_table(name),
+        }
+    }
+
     pub fn statement_snapshot(&self) -> Option<&StatementSnapshot> {
         self.statement_snapshot.as_ref()
     }
@@ -1095,6 +1185,7 @@ impl ExecutionContext {
             cte_data: self.cte_data.clone(),
             transaction_id: Some(txn_id),
             statement_snapshot: self.statement_snapshot.clone(),
+            read_epoch: self.read_epoch.clone(),
         }
     }
 

--- a/src/executor/copy.rs
+++ b/src/executor/copy.rs
@@ -112,7 +112,7 @@ impl Executor {
     pub(crate) fn execute_copy(
         &self,
         stmt: &CopyStatement,
-        _ctx: &ExecutionContext,
+        ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
         let table_name = &stmt.table_name.value_lower;
 
@@ -128,7 +128,7 @@ impl Executor {
 
         // Create a standalone auto-commit transaction
         let mut tx = self.engine.begin_transaction()?;
-        let mut table = tx.get_table(table_name)?;
+        let mut table = ctx.get_table(tx.as_ref(), table_name)?;
 
         // Pre-compute schema information
         let schema = table.schema();

--- a/src/executor/ddl.rs
+++ b/src/executor/ddl.rs
@@ -149,6 +149,7 @@ impl Executor {
         stmt: &CreateTableStatement,
         ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        let _logical_change = self.engine.begin_logical_mutation();
         let table_name = &stmt.table_name.value;
 
         // Check if table already exists
@@ -601,6 +602,7 @@ impl Executor {
         stmt: &DropTableStatement,
         _ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        let _logical_change = self.engine.begin_logical_mutation();
         let table_name = &stmt.table_name.value;
 
         // Check if table exists
@@ -649,6 +651,7 @@ impl Executor {
         stmt: &CreateIndexStatement,
         _ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        let _logical_change = self.engine.begin_logical_mutation();
         let table_name = &stmt.table_name.value;
         let index_name = &stmt.index_name.value;
 
@@ -875,6 +878,7 @@ impl Executor {
         stmt: &DropIndexStatement,
         _ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        let _logical_change = self.engine.begin_logical_mutation();
         let index_name = &stmt.index_name.value;
 
         // Get table name if specified
@@ -922,6 +926,7 @@ impl Executor {
         stmt: &AlterTableStatement,
         _ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        let _logical_change = self.engine.begin_logical_mutation();
         let table_name = &stmt.table_name.value;
 
         // Check if table exists
@@ -1129,6 +1134,7 @@ impl Executor {
         stmt: &CreateViewStatement,
         _ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        let _logical_change = self.engine.begin_logical_mutation();
         let view_name = &stmt.view_name.value;
 
         // Check if a table with the same name exists
@@ -1152,6 +1158,7 @@ impl Executor {
         stmt: &DropViewStatement,
         _ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
+        let _logical_change = self.engine.begin_logical_mutation();
         let view_name = &stmt.view_name.value;
 
         // Drop the view (engine handles if_exists logic)

--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -477,13 +477,13 @@ impl Executor {
             if let Some(ref mut tx_state) = *active_tx {
                 // Use the active transaction
                 // NOTE: table_name is already lowercase (value_lower from AST)
-                let table = tx_state.transaction.get_table(table_name)?;
+                let table = ctx.get_table(tx_state.transaction.as_ref(), table_name)?;
 
                 // Store a reference to this table for commit/rollback
                 if !tx_state.tables.contains_key(table_name.as_str()) {
                     tx_state.tables.insert(
                         table_name.to_string(),
-                        tx_state.transaction.get_table(table_name)?,
+                        ctx.get_table(tx_state.transaction.as_ref(), table_name)?,
                     );
                 }
 
@@ -491,7 +491,7 @@ impl Executor {
             } else {
                 // No active transaction - create a standalone transaction with auto-commit
                 let tx = self.engine.begin_transaction()?;
-                let table = tx.get_table(table_name)?;
+                let table = ctx.get_table(tx.as_ref(), table_name)?;
                 (table, true, Some(tx))
             };
 
@@ -883,6 +883,17 @@ impl Executor {
                 invalidate_in_subquery_cache_for_table(table_name);
             }
 
+            // Evaluate RETURNING while statement rollback can still restore mutations.
+            let mut returning_result = if let Some(column_names) = &schema_column_names_arc {
+                Some(self.build_returning_result(
+                    &stmt.returning,
+                    returning_rows,
+                    column_names,
+                    ctx,
+                )?)
+            } else {
+                None
+            };
             // Commit if this is a standalone (auto-commit) transaction
             if should_auto_commit {
                 if let Some(mut tx) = standalone_tx {
@@ -902,7 +913,14 @@ impl Executor {
                             if stmt.do_nothing {
                                 // DO NOTHING: returning 0 rows is the correct semantic
                                 rows_affected = 0;
-                                returning_rows.clear();
+                                if let Some(column_names) = &schema_column_names_arc {
+                                    returning_result = Some(self.build_returning_result(
+                                        &stmt.returning,
+                                        Vec::new(),
+                                        column_names,
+                                        ctx,
+                                    )?);
+                                }
                             } else {
                                 return Err(e);
                             }
@@ -913,13 +931,8 @@ impl Executor {
             }
 
             // Handle RETURNING clause for INSERT...SELECT
-            if has_returning {
-                return self.build_returning_result(
-                    &stmt.returning,
-                    returning_rows,
-                    schema_column_names_arc.as_ref().unwrap(),
-                    ctx,
-                );
+            if let Some(result) = returning_result {
+                return Ok(result);
             }
 
             return Ok(Box::new(ExecResult::with_rows_affected(rows_affected)));
@@ -1239,6 +1252,12 @@ impl Executor {
             invalidate_in_subquery_cache_for_table(table_name);
         }
 
+        // Evaluate RETURNING before durable commit while statement rollback remains available.
+        let mut returning_result = if let Some(column_names) = &schema_column_names_arc {
+            Some(self.build_returning_result(&stmt.returning, returning_rows, column_names, ctx)?)
+        } else {
+            None
+        };
         // Commit if this is a standalone (auto-commit) transaction
         if should_auto_commit {
             if let Some(mut tx) = standalone_tx {
@@ -1256,7 +1275,14 @@ impl Executor {
                         if stmt.do_nothing {
                             // DO NOTHING: returning 0 rows is the correct semantic
                             rows_affected = 0;
-                            returning_rows.clear();
+                            if let Some(column_names) = &schema_column_names_arc {
+                                returning_result = Some(self.build_returning_result(
+                                    &stmt.returning,
+                                    Vec::new(),
+                                    column_names,
+                                    ctx,
+                                )?);
+                            }
                         } else {
                             return Err(e);
                         }
@@ -1267,13 +1293,8 @@ impl Executor {
         }
 
         // Handle RETURNING clause
-        if has_returning {
-            return self.build_returning_result(
-                &stmt.returning,
-                returning_rows,
-                schema_column_names_arc.as_ref().unwrap(),
-                ctx,
-            );
+        if let Some(result) = returning_result {
+            return Ok(result);
         }
 
         Ok(Box::new(ExecResult::with_rows_affected(rows_affected)))
@@ -1324,13 +1345,13 @@ impl Executor {
         let (mut table, should_auto_commit, standalone_tx) =
             if let Some(ref mut tx_state) = *active_tx {
                 // Use the active transaction
-                let table = tx_state.transaction.get_table(table_name)?;
+                let table = ctx.get_table(tx_state.transaction.as_ref(), table_name)?;
 
                 // Store a reference to this table for commit/rollback
                 if !tx_state.tables.contains_key(table_name.as_str()) {
                     tx_state.tables.insert(
                         table_name.to_string(),
-                        tx_state.transaction.get_table(table_name)?,
+                        ctx.get_table(tx_state.transaction.as_ref(), table_name)?,
                     );
                 }
 
@@ -1338,7 +1359,7 @@ impl Executor {
             } else {
                 // No active transaction - create a standalone transaction with auto-commit
                 let tx = self.engine.begin_transaction()?;
-                let table = tx.get_table(table_name)?;
+                let table = ctx.get_table(tx.as_ref(), table_name)?;
                 (table, true, Some(tx))
             };
 
@@ -1700,6 +1721,21 @@ impl Executor {
             invalidate_in_subquery_cache_for_table(table_name);
         }
 
+        // All target reads are complete. Release its captured root before
+        // publication so this handle does not force hot-tree copy-on-write.
+        // The transaction owns staged changes; RETURNING owns its rows.
+        drop(table);
+
+        let returning_result = if has_returning {
+            Some(self.build_returning_result(
+                &stmt.returning,
+                returning_rows,
+                schema_column_names_arc.as_ref().unwrap(),
+                ctx,
+            )?)
+        } else {
+            None
+        };
         // Commit if this is a standalone (auto-commit) transaction
         if should_auto_commit {
             if let Some(mut tx) = standalone_tx {
@@ -1708,13 +1744,8 @@ impl Executor {
         }
 
         // Handle RETURNING clause
-        if has_returning {
-            return self.build_returning_result(
-                &stmt.returning,
-                returning_rows,
-                schema_column_names_arc.as_ref().unwrap(),
-                ctx,
-            );
+        if let Some(result) = returning_result {
+            return Ok(result);
         }
 
         Ok(Box::new(ExecResult::with_rows_affected(rows_affected)))
@@ -1785,13 +1816,13 @@ impl Executor {
             if let Some(ref mut tx_state) = *active_tx {
                 // Use the active transaction
                 // NOTE: table_name is already lowercase (value_lower from AST)
-                let table = tx_state.transaction.get_table(table_name)?;
+                let table = ctx.get_table(tx_state.transaction.as_ref(), table_name)?;
 
                 // Store a reference to this table for commit/rollback
                 if !tx_state.tables.contains_key(table_name.as_str()) {
                     tx_state.tables.insert(
                         table_name.to_string(),
-                        tx_state.transaction.get_table(table_name)?,
+                        ctx.get_table(tx_state.transaction.as_ref(), table_name)?,
                     );
                 }
 
@@ -1799,7 +1830,7 @@ impl Executor {
             } else {
                 // No active transaction - create a standalone transaction with auto-commit
                 let tx = self.engine.begin_transaction()?;
-                let table = tx.get_table(table_name)?;
+                let table = ctx.get_table(tx.as_ref(), table_name)?;
                 (table, true, Some(tx))
             };
 
@@ -2688,18 +2719,20 @@ impl Executor {
             invalidate_in_subquery_cache_for_table(table_name);
         }
 
-        // Commit if this is a standalone (auto-commit) transaction
+        let returning_result = if has_returning {
+            let rows = returning_rows.into_inner();
+            Some(self.build_returning_result(&stmt.returning, rows, &column_names, ctx)?)
+        } else {
+            None
+        };
+        // Commit only after fallible RETURNING projection has completed.
         if should_auto_commit {
-            // Commit the transaction - it will commit all tables via commit_all_tables()
             if let Some(mut tx) = standalone_tx {
                 tx.commit()?;
             }
         }
-
-        // Handle RETURNING clause
-        if has_returning {
-            let rows = returning_rows.into_inner();
-            return self.build_returning_result(&stmt.returning, rows, &column_names, ctx);
+        if let Some(result) = returning_result {
+            return Ok(result);
         }
 
         Ok(Box::new(ExecResult::with_rows_affected(
@@ -2775,13 +2808,13 @@ impl Executor {
             if let Some(ref mut tx_state) = *active_tx {
                 // Use the active transaction
                 // NOTE: table_name is already lowercase (value_lower from AST)
-                let table = tx_state.transaction.get_table(table_name)?;
+                let table = ctx.get_table(tx_state.transaction.as_ref(), table_name)?;
 
                 // Store a reference to this table for commit/rollback
                 if !tx_state.tables.contains_key(table_name.as_str()) {
                     tx_state.tables.insert(
                         table_name.to_string(),
-                        tx_state.transaction.get_table(table_name)?,
+                        ctx.get_table(tx_state.transaction.as_ref(), table_name)?,
                     );
                 }
 
@@ -2789,7 +2822,7 @@ impl Executor {
             } else {
                 // No active transaction - create a standalone transaction with auto-commit
                 let tx = self.engine.begin_transaction()?;
-                let table = tx.get_table(table_name)?;
+                let table = ctx.get_table(tx.as_ref(), table_name)?;
                 (table, true, Some(tx))
             };
 
@@ -3190,22 +3223,24 @@ impl Executor {
             invalidate_in_subquery_cache_for_table(table_name);
         }
 
-        // Commit if this is a standalone (auto-commit) transaction
-        if should_auto_commit {
-            // Commit the transaction - it will commit all tables via commit_all_tables()
-            if let Some(mut tx) = standalone_tx {
-                tx.commit()?;
-            }
-        }
-
-        // Handle RETURNING clause
-        if has_returning {
-            return self.build_returning_result(
+        let returning_result = if has_returning {
+            Some(self.build_returning_result(
                 &stmt.returning,
                 returning_rows,
                 &column_names_owned,
                 ctx,
-            );
+            )?)
+        } else {
+            None
+        };
+        // Commit only after fallible RETURNING projection has completed.
+        if should_auto_commit {
+            if let Some(mut tx) = standalone_tx {
+                tx.commit()?;
+            }
+        }
+        if let Some(result) = returning_result {
+            return Ok(result);
         }
 
         Ok(Box::new(ExecResult::with_rows_affected(
@@ -3227,7 +3262,7 @@ impl Executor {
     pub(crate) fn execute_truncate(
         &self,
         stmt: &TruncateStatement,
-        _ctx: &ExecutionContext,
+        ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
         // OPTIMIZATION: Use pre-computed lowercase name to avoid allocation per query
         let table_name = &stmt.table_name.value_lower;
@@ -3245,41 +3280,25 @@ impl Executor {
                 }
 
                 // Use the active transaction
-                let table = tx_state.transaction.get_table(table_name)?;
+                let table = ctx.get_table(tx_state.transaction.as_ref(), table_name)?;
 
-                // Register this table for commit/rollback
-                tx_state.tables.insert(
-                    table_name.to_string(),
-                    tx_state.transaction.get_table(table_name)?,
-                );
+                // Physical TRUNCATE is already committed by its coordinator;
+                // a redundant table handle would retain a second read lease.
 
                 (table, false, None)
             } else {
                 // No active transaction - create a standalone transaction with auto-commit
                 let tx = self.engine.begin_transaction()?;
-                let table = tx.get_table(table_name)?;
+                let table = ctx.get_table(tx.as_ref(), table_name)?;
                 (table, true, Some(tx))
             };
 
         // Drop the lock before doing work
         drop(active_tx);
 
-        // FK enforcement: block truncate if child tables reference this table
-        // Uses the table's transaction for visibility (sees uncommitted child deletes)
-        super::foreign_key::check_no_referencing_rows(
-            &self.engine,
-            table_name,
-            Some(table.txn_id()),
-        )?;
-
-        // Truncate all rows (fast path: drops storage directly)
-        // WAL is recorded AFTER success to prevent phantom records on failure.
-        // If a crash occurs between truncate and WAL write, recovery restores
-        // the pre-truncate state from the snapshot — the user simply retries.
+        // One operation validates all claims/read leases and allocates its
+        // replacement state before WAL. A WAL error leaves both layers intact.
         let rows_affected = table.truncate()?;
-
-        // Record TRUNCATE to WAL for persistence (only after successful truncate)
-        self.engine.record_truncate_table(table_name)?;
 
         // Invalidate semantic cache for this table BEFORE commit
         // CRITICAL: Must invalidate before commit to prevent stale data window
@@ -3898,7 +3917,10 @@ impl Executor {
             result_rows.push((row_id as i64, Row::from_values(row_values)));
         }
 
-        Ok(Box::new(ExecutorResult::new(result_columns, result_rows)))
+        let affected = result_rows.len() as i64;
+        let mut result = ExecutorResult::new(result_columns, result_rows);
+        result.set_rows_affected(affected);
+        Ok(Box::new(result))
     }
 
     /// Get a column name for a RETURNING expression
@@ -3926,6 +3948,108 @@ mod tests {
     use super::*;
     use crate::storage::mvcc::engine::MVCCEngine;
     use std::sync::Arc;
+
+    #[test]
+    fn prepared_insert_released_target_preserves_values_and_returning() {
+        let db = crate::api::Database::open_in_memory().unwrap();
+        db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER)", ())
+            .unwrap();
+        let insert = db.prepare("INSERT INTO t VALUES ($1, $2)").unwrap();
+        // Populate multiple tree nodes, then reuse the compiled plan.
+        for id in 1..=128i64 {
+            assert_eq!(insert.execute((id, id * 10)).unwrap(), 1);
+        }
+        let returning = db
+            .prepare("INSERT INTO t VALUES ($1, $2) RETURNING id, n + $3")
+            .unwrap();
+        for id in 129..=130i64 {
+            let mut rows = returning.query((id, id * 10, 7i64)).unwrap();
+            let row = rows.next().unwrap().unwrap();
+            assert_eq!(row.get::<i64>(0).unwrap(), id);
+            assert_eq!(row.get::<i64>(1).unwrap(), id * 10 + 7);
+            assert!(rows.next().is_none());
+        }
+        assert!(insert.execute((1i64, 999i64)).is_err());
+        assert_eq!(
+            db.query_one::<i64, _>("SELECT COUNT(*) FROM t", ())
+                .unwrap(),
+            130
+        );
+        assert_eq!(
+            db.query_one::<i64, _>("SELECT n FROM t WHERE id=1", ())
+                .unwrap(),
+            10
+        );
+    }
+
+    #[test]
+    fn prepared_insert_released_target_preserves_constraints_and_defaults() {
+        let db = crate::api::Database::open_in_memory().unwrap();
+        db.execute("CREATE TABLE parents (id INTEGER PRIMARY KEY)", ())
+            .unwrap();
+        db.execute("INSERT INTO parents VALUES (1)", ()).unwrap();
+        db.execute(
+            "CREATE TABLE children (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parents(id), n INTEGER CHECK (n >= 0), label TEXT DEFAULT 'new')",
+            (),
+        ).unwrap();
+        let insert = db
+            .prepare("INSERT INTO children (id, parent_id, n) VALUES ($1, $2, $3) RETURNING label")
+            .unwrap();
+        assert_eq!(
+            insert.query_one::<String, _>((1i64, 1i64, 4i64)).unwrap(),
+            "new"
+        );
+        assert!(insert.query((2i64, 99i64, 4i64)).is_err());
+        assert!(insert.query((3i64, 1i64, -1i64)).is_err());
+        assert_eq!(
+            insert.query_one::<String, _>((4i64, 1i64, 5i64)).unwrap(),
+            "new"
+        );
+        assert_eq!(
+            db.query_one::<i64, _>("SELECT COUNT(*) FROM children", ())
+                .unwrap(),
+            2
+        );
+    }
+
+    #[test]
+    fn prepared_insert_released_target_preserves_select_and_explicit_rollback() {
+        let db = crate::api::Database::open_in_memory().unwrap();
+        db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER)", ())
+            .unwrap();
+        db.execute("CREATE TABLE src (id INTEGER PRIMARY KEY, n INTEGER)", ())
+            .unwrap();
+        db.execute("INSERT INTO src VALUES (1, 10), (2, 20)", ())
+            .unwrap();
+        let insert = db
+            .prepare("INSERT INTO t SELECT id, n FROM src RETURNING id, n")
+            .unwrap();
+        let collect = || {
+            let mut rows = insert
+                .query(())
+                .unwrap()
+                .map(|row| {
+                    let row = row.unwrap();
+                    (row.get::<i64>(0).unwrap(), row.get::<i64>(1).unwrap())
+                })
+                .collect::<Vec<_>>();
+            rows.sort_unstable();
+            rows
+        };
+        assert_eq!(collect(), vec![(1, 10), (2, 20)]);
+        db.execute("DELETE FROM src", ()).unwrap();
+        db.execute("INSERT INTO src VALUES (3, 30), (4, 40)", ())
+            .unwrap();
+        db.execute("BEGIN", ()).unwrap();
+        assert_eq!(collect(), vec![(3, 30), (4, 40)]);
+        db.execute("ROLLBACK", ()).unwrap();
+        assert_eq!(
+            db.query_one::<i64, _>("SELECT COUNT(*) FROM t", ())
+                .unwrap(),
+            2
+        );
+        assert_eq!(collect(), vec![(3, 30), (4, 40)]);
+    }
 
     fn create_test_executor() -> Executor {
         let engine = MVCCEngine::in_memory();

--- a/src/executor/dml_fast_path.rs
+++ b/src/executor/dml_fast_path.rs
@@ -111,7 +111,7 @@ impl Executor {
                         // Fast path: extract PK value and execute
                         let pk_value =
                             self.extract_pk_value_from_source(&delete.pk_value_source, ctx)?;
-                        return Some(self.execute_compiled_pk_delete(delete, pk_value));
+                        return Some(self.execute_compiled_pk_delete(delete, pk_value, ctx));
                     }
                     // Epoch changed - fall through to recompile
                 }
@@ -282,6 +282,7 @@ impl Executor {
         &self,
         _stmt: &UpdateStatement,
         params: &[Value],
+        ctx: &ExecutionContext,
         compiled: &RwLock<CompiledExecution>,
     ) -> Option<Result<Box<dyn QueryResult>>> {
         // Try read lock first - check if already compiled
@@ -326,7 +327,7 @@ impl Executor {
                         pk_value,
                         updates,
                         &[],
-                        &ExecutionContext::new(),
+                        ctx,
                     ));
                 }
                 None // Epoch changed, use normal path
@@ -341,6 +342,7 @@ impl Executor {
         &self,
         _stmt: &DeleteStatement,
         params: &[Value],
+        ctx: &ExecutionContext,
         compiled: &RwLock<CompiledExecution>,
     ) -> Option<Result<Box<dyn QueryResult>>> {
         // Try read lock first - check if already compiled
@@ -362,6 +364,7 @@ impl Executor {
                         &pk_column_name,
                         &schema,
                         pk_value,
+                        ctx,
                     ));
                 }
                 None // Epoch changed, use normal path
@@ -390,7 +393,7 @@ impl Executor {
     ) -> Result<Box<dyn QueryResult>> {
         // Create auto-commit transaction
         let tx = self.engine.begin_transaction()?;
-        let mut table = tx.get_table(table_name)?;
+        let mut table = ctx.get_table(tx.as_ref(), table_name)?;
 
         // Build WHERE expression for PK lookup
         let mut pk_expr = ComparisonExpr::new(
@@ -466,10 +469,11 @@ impl Executor {
         pk_column_name: &str,
         schema: &CompactArc<Schema>,
         pk_value: i64,
+        ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
         // Create auto-commit transaction
         let tx = self.engine.begin_transaction()?;
-        let mut table = tx.get_table(table_name)?;
+        let mut table = ctx.get_table(tx.as_ref(), table_name)?;
 
         // Build WHERE expression for PK lookup
         let mut pk_expr = ComparisonExpr::new(
@@ -571,12 +575,14 @@ impl Executor {
         &self,
         compiled: &CompiledPkDelete,
         pk_value: i64,
+        ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
         self.execute_pk_delete_minimal(
             &compiled.table_name,
             &compiled.pk_column_name,
             &compiled.schema,
             pk_value,
+            ctx,
         )
     }
 
@@ -750,7 +756,7 @@ impl Executor {
             }
             CompiledExecution::PkDelete(delete) => {
                 let pk_value = self.extract_pk_value_from_source(&delete.pk_value_source, ctx)?;
-                return Some(self.execute_compiled_pk_delete(delete, pk_value));
+                return Some(self.execute_compiled_pk_delete(delete, pk_value, ctx));
             }
             CompiledExecution::NotOptimizable(_) | CompiledExecution::Unknown => {} // Epoch changed or first run - recompile
             _ => return None,
@@ -809,7 +815,7 @@ impl Executor {
         drop(compiled_guard);
 
         // Execute
-        Some(self.execute_compiled_pk_delete(&compiled_delete, pk_value))
+        Some(self.execute_compiled_pk_delete(&compiled_delete, pk_value, ctx))
     }
 
     /// Extract value source (literal or parameter) from expression

--- a/src/executor/explain.rs
+++ b/src/executor/explain.rs
@@ -939,6 +939,7 @@ impl Executor {
                 &join_type_upper,
                 left_alias.as_deref(),
                 right_alias.as_deref(),
+                None,
             );
 
             if let Some((_, strategy, _, _)) = inlj_info {
@@ -956,6 +957,7 @@ impl Executor {
                 &join_type_upper,
                 right_alias.as_deref(),
                 left_alias.as_deref(),
+                None,
             );
 
             if let Some((_, strategy, _, _)) = swapped_info {

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -219,12 +219,9 @@ impl Executor {
         all_columns: &[String],
         ctx: &ExecutionContext,
     ) -> Result<Option<(Box<dyn QueryResult>, CompactArc<Vec<String>>)>> {
-        // Get the ORDER BY column name
         let order_by = &stmt.order_by[0];
-        let column_name = match &order_by.expression {
-            Expression::Identifier(id) => id.value.clone(),
-            Expression::QualifiedIdentifier(qid) => qid.name.value.clone(),
-            _ => return Ok(None), // Can't optimize complex ORDER BY expressions
+        let Some(column_name) = Self::storage_order_column(stmt) else {
+            return Ok(None);
         };
 
         // Determine sort order
@@ -259,7 +256,7 @@ impl Executor {
 
         // Try to use index-ordered scan
         if let Some(rows) =
-            table.collect_rows_ordered_by_index(&column_name, ascending, limit, offset)?
+            table.collect_rows_ordered_by_index(column_name, ascending, limit, offset)?
         {
             // Project rows according to SELECT expressions
             let projected_rows = self.project_rows(&stmt.columns, rows, all_columns, ctx)?;
@@ -293,29 +290,9 @@ impl Executor {
         ctx: &ExecutionContext,
     ) -> Result<Option<(Box<dyn QueryResult>, CompactArc<Vec<String>>)>> {
         let order_by = &stmt.order_by[0];
-        let column_name = match &order_by.expression {
-            Expression::Identifier(id) => id.value.clone(),
-            Expression::QualifiedIdentifier(qid) => qid.name.value.clone(),
-            _ => return Ok(None),
+        let Some(column_name) = Self::storage_order_column(stmt) else {
+            return Ok(None);
         };
-        // The name may be a select-list alias for another expression; only a
-        // bare column under that alias still orders by the table column
-        for item in &stmt.columns {
-            if let Expression::Aliased(aliased) = item {
-                if aliased.alias.value.eq_ignore_ascii_case(&column_name) {
-                    let same_column = match &*aliased.expression {
-                        Expression::Identifier(id) => id.value.eq_ignore_ascii_case(&column_name),
-                        Expression::QualifiedIdentifier(qid) => {
-                            qid.name.value.eq_ignore_ascii_case(&column_name)
-                        }
-                        _ => false,
-                    };
-                    if !same_column {
-                        return Ok(None);
-                    }
-                }
-            }
-        }
         let ascending = order_by.ascending;
 
         let limit = match stmt.limit.as_ref().and_then(|e| {
@@ -336,7 +313,7 @@ impl Executor {
             None => 0,
         };
 
-        let Some(rows) = table.scan_top_k(storage_expr, &column_name, ascending, limit, offset)?
+        let Some(rows) = table.scan_top_k(storage_expr, column_name, ascending, limit, offset)?
         else {
             return Ok(None);
         };
@@ -347,6 +324,34 @@ impl Executor {
         let result =
             ExecutorResult::with_arc_columns(CompactArc::clone(&output_columns), projected_rows);
         Ok(Some((Box::new(result), output_columns)))
+    }
+
+    /// Storage ordering reads a table column before projection. A SELECT alias
+    /// can instead name an expression, even when it shadows a real column.
+    /// Both ordered collection and top-k must decline that case.
+    fn storage_order_column(stmt: &SelectStatement) -> Option<&str> {
+        let name = match &stmt.order_by.first()?.expression {
+            Expression::Identifier(id) => id.value.as_str(),
+            Expression::QualifiedIdentifier(id) => id.name.value.as_str(),
+            _ => return None,
+        };
+        for item in &stmt.columns {
+            if let Expression::Aliased(aliased) = item {
+                if aliased.alias.value.eq_ignore_ascii_case(name) {
+                    let same_column = match &*aliased.expression {
+                        Expression::Identifier(id) => id.value.eq_ignore_ascii_case(name),
+                        Expression::QualifiedIdentifier(id) => {
+                            id.name.value.eq_ignore_ascii_case(name)
+                        }
+                        _ => false,
+                    };
+                    if !same_column {
+                        return None;
+                    }
+                }
+            }
+        }
+        Some(name)
     }
 
     /// Keyset pagination optimization for PRIMARY KEY columns
@@ -372,10 +377,8 @@ impl Executor {
 
         // Get the ORDER BY column name - must be single column
         let order_by = &stmt.order_by[0];
-        let order_column = match &order_by.expression {
-            Expression::Identifier(id) => id.value.clone(),
-            Expression::QualifiedIdentifier(qid) => qid.name.value.clone(),
-            _ => return Ok(None),
+        let Some(order_column) = Self::storage_order_column(stmt) else {
+            return Ok(None);
         };
 
         // Must be ascending order (most common case for keyset pagination)

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -128,6 +128,7 @@ pub use parallel::{
 pub use planner::{
     ColumnStatsCache, QueryPlanner, RuntimeJoinAlgorithm, RuntimeJoinDecision, StatsHealth,
 };
+use query_cache::CompiledExecution;
 pub use query_cache::{CacheStats, CachedPlanRef, CachedQueryPlan, QueryCache, DEFAULT_CACHE_SIZE};
 pub use query_classification::clear_classification_cache;
 pub use result::{ColumnarResult, ExecResult, ExecutorResult};
@@ -357,19 +358,61 @@ impl Executor {
             return None; // Let normal path handle error
         }
 
-        // Try compiled fast paths based on statement type
-        match cached.statement.as_ref() {
+        // Unsupported statement kinds use normal dispatch. Do not register
+        // and immediately discard a read epoch on every prepared INSERT.
+        if !matches!(
+            cached.statement.as_ref(),
+            Statement::Select(_) | Statement::Update(_) | Statement::Delete(_)
+        ) {
+            return None;
+        }
+
+        // These borrowed-parameter helpers only consume an already compiled
+        // matching plan. Unknown/stale plans must return to normal dispatch,
+        // where compilation happens, without creating an unused epoch first.
+        {
+            let compiled = cached.compiled.read().ok()?;
+            let cached_epoch = match (cached.statement.as_ref(), &*compiled) {
+                (Statement::Select(_), CompiledExecution::PkLookup(plan)) => plan.cached_epoch,
+                (Statement::Update(_), CompiledExecution::PkUpdate(plan)) => plan.cached_epoch,
+                (Statement::Delete(_), CompiledExecution::PkDelete(plan)) => plan.cached_epoch,
+                _ => return None,
+            };
+            if self.engine.schema_epoch() != cached_epoch {
+                return None;
+            }
+        }
+
+        // The borrowed-parameter entry point bypasses normal dispatch, but
+        // still registers the same statement visibility boundary.
+        let mut ctx = ExecutionContext::new();
+        let epoch = match self.engine.capture_read_epoch() {
+            Ok(epoch) => epoch,
+            Err(error) => return Some(Err(error)),
+        };
+        if let Some(epoch) = &epoch {
+            ctx = ctx.with_read_epoch(epoch.clone());
+        }
+        let result = match cached.statement.as_ref() {
             Statement::Select(stmt) => {
-                self.try_fast_pk_lookup_with_params(stmt, params, &cached.compiled)
+                self.try_fast_pk_lookup_with_params(stmt, params, &ctx, &cached.compiled)
             }
             Statement::Update(stmt) => {
-                self.try_fast_pk_update_with_params(stmt, params, &cached.compiled)
+                self.try_fast_pk_update_with_params(stmt, params, &ctx, &cached.compiled)
             }
             Statement::Delete(stmt) => {
-                self.try_fast_pk_delete_with_params(stmt, params, &cached.compiled)
+                self.try_fast_pk_delete_with_params(stmt, params, &ctx, &cached.compiled)
             }
             _ => None,
-        }
+        };
+        result.map(|result| {
+            result.map(|result| match epoch {
+                Some(epoch) if !result.columns().is_empty() => {
+                    Box::new(result::EpochResult::new(result, epoch)) as Box<dyn QueryResult>
+                }
+                _ => result,
+            })
+        })
     }
 
     /// Execute a SQL query with named parameters
@@ -404,46 +447,7 @@ impl Executor {
         self.engine.check_health()?;
         // Try to get from cache
         if let Some(cached) = self.query_cache.get(sql) {
-            // Validate parameter count if query has parameters
-            if cached.has_params {
-                let provided = ctx.params().len();
-                if provided < cached.param_count {
-                    return Err(Error::internal(format!(
-                        "Query requires {} parameters but only {} provided",
-                        cached.param_count, provided
-                    )));
-                }
-            }
-
-            // INSERT handles the active transaction itself; dispatch before
-            // the txn-state capture so the hot prepared-INSERT path takes
-            // the transaction mutex only once.
-            if let Statement::Insert(stmt) = cached.statement.as_ref() {
-                return self.execute_insert_with_compiled_cache(stmt, ctx, &cached.compiled);
-            }
-
-            // Capture transaction state once for the rest of the statement:
-            // the probe battery and the ctx txn-id injection both need it,
-            // and repeated mutex acquisitions dominate the fixed cost of
-            // cached statements.
-            let active_txn_id = self.active_txn_id();
-
-            if let Some(result) = self.try_compiled_fast_paths(
-                cached.statement.as_ref(),
-                ctx,
-                &cached.compiled,
-                active_txn_id.is_some(),
-            ) {
-                return result;
-            }
-
-            // Execute the cached statement (standard path)
-            return self.execute_statement_inner(
-                &cached.statement,
-                ctx,
-                active_txn_id,
-                Some(&cached.classification),
-            );
+            return self.execute_with_cached_plan(&cached, ctx);
         }
 
         // Parse the query
@@ -462,28 +466,7 @@ impl Executor {
                 .query_cache
                 .put(sql, stmt_arc.clone(), has_params, param_count);
 
-            if let Statement::Insert(stmt) = stmt_arc.as_ref() {
-                return self.execute_insert_with_compiled_cache(stmt, ctx, &cached_plan.compiled);
-            }
-
-            let active_txn_id = self.active_txn_id();
-
-            if let Some(result) = self.try_compiled_fast_paths(
-                stmt_arc.as_ref(),
-                ctx,
-                &cached_plan.compiled,
-                active_txn_id.is_some(),
-            ) {
-                return result;
-            }
-
-            // Execute directly from the Arc (no clone needed)
-            return self.execute_statement_inner(
-                &stmt_arc,
-                ctx,
-                active_txn_id,
-                Some(&cached_plan.classification),
-            );
+            return self.execute_with_cached_plan(&cached_plan, ctx);
         }
 
         self.execute_program_with_context(&program, ctx)
@@ -518,10 +501,10 @@ impl Executor {
                 if let Some(result) = self.try_fast_pk_lookup_compiled(stmt, ctx, compiled) {
                     return Some(result);
                 }
-                if let Some(result) = self.try_fast_count_distinct_compiled(stmt, compiled) {
+                if let Some(result) = self.try_fast_count_distinct_compiled(stmt, ctx, compiled) {
                     return Some(result);
                 }
-                self.try_fast_count_star_compiled(stmt, compiled)
+                self.try_fast_count_star_compiled(stmt, ctx, compiled)
             }
             Statement::Update(stmt) if !in_txn => {
                 self.try_fast_pk_update_compiled(stmt, ctx, compiled)
@@ -531,6 +514,39 @@ impl Executor {
             }
             _ => None,
         }
+    }
+
+    pub(crate) fn fetch_rows_in_context(
+        &self,
+        table_name: &str,
+        row_ids: &[i64],
+        ctx: &ExecutionContext,
+    ) -> Result<crate::core::RowVec> {
+        let table = self.table_in_context(table_name, ctx)?;
+        table.fetch_rows_by_ids(
+            row_ids,
+            &crate::storage::expression::logical::ConstBoolExpr::true_expr(),
+        )
+    }
+
+    pub(crate) fn table_in_context(
+        &self,
+        name: &str,
+        ctx: &ExecutionContext,
+    ) -> Result<Box<dyn Table>> {
+        let active = self
+            .active_transaction
+            .lock()
+            .map_err(|_| Error::internal("active transaction lock is poisoned"))?;
+        if let Some(tx) = active.as_ref() {
+            return ctx.get_table(tx.transaction.as_ref(), name);
+        }
+        drop(active);
+        if let Some(snapshot) = ctx.statement_snapshot() {
+            return snapshot.get_table(name);
+        }
+        let tx = self.engine.begin_transaction()?;
+        ctx.get_table(tx.as_ref(), name)
     }
 
     /// Get the query cache
@@ -601,7 +617,68 @@ impl Executor {
         statement: &Statement,
         ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
-        self.execute_statement_inner(statement, ctx, self.active_txn_id(), None)
+        self.with_statement_epoch(statement, ctx, |ctx| {
+            self.execute_statement_inner(statement, ctx, self.active_txn_id(), None)
+        })
+    }
+
+    /// Capture exactly once before any compiled or regular read. Context
+    /// clones used for nested queries share this lease; each top-level call
+    /// starts with its caller's unmodified context.
+    fn with_statement_epoch<F>(
+        &self,
+        statement: &Statement,
+        ctx: &ExecutionContext,
+        action: F,
+    ) -> Result<Box<dyn QueryResult>>
+    where
+        F: FnOnce(&ExecutionContext) -> Result<Box<dyn QueryResult>>,
+    {
+        if matches!(
+            statement,
+            Statement::Begin(_)
+                | Statement::Commit(_)
+                | Statement::Rollback(_)
+                | Statement::Savepoint(_)
+                | Statement::ReleaseSavepoint(_)
+                | Statement::Truncate(_)
+        ) {
+            return action(ctx);
+        }
+        if let Some(epoch) = ctx.read_epoch() {
+            let result = action(ctx)?;
+            return if ctx.query_depth == 0 && !result.columns().is_empty() {
+                Ok(Box::new(result::EpochResult::new(result, epoch.clone())))
+            } else {
+                Ok(result)
+            };
+        }
+        let (epoch, txn_id) = {
+            let active = self
+                .active_transaction
+                .lock()
+                .map_err(|_| Error::internal("active transaction lock is poisoned"))?;
+            match active.as_ref() {
+                Some(tx) => (
+                    tx.transaction.capture_read_epoch()?,
+                    Some(tx.transaction.id()),
+                ),
+                None => (self.engine.capture_read_epoch()?, None),
+            }
+        };
+        let Some(epoch) = epoch else {
+            return action(ctx);
+        };
+        let mut statement_ctx = ctx.with_read_epoch(epoch.clone());
+        if let Some(txn_id) = txn_id {
+            statement_ctx.set_transaction_id(txn_id as u64);
+        }
+        let result = action(&statement_ctx)?;
+        if result.columns().is_empty() {
+            Ok(result)
+        } else {
+            Ok(Box::new(result::EpochResult::new(result, epoch)))
+        }
     }
 
     /// Execute a single statement with pre-captured transaction state.
@@ -745,9 +822,7 @@ impl Executor {
         &self,
         isolation: crate::core::IsolationLevel,
     ) -> Result<Box<dyn Transaction>> {
-        let mut tx = self.engine.begin_transaction()?;
-        let _ = tx.set_isolation_level(isolation);
-        Ok(tx)
+        self.engine.begin_transaction_with_level(isolation)
     }
 
     /// Get or create a cached plan for a SQL statement.
@@ -782,6 +857,16 @@ impl Executor {
     /// here on every execution, avoiding normalize + hash + RwLock read
     /// per call.
     pub fn execute_with_cached_plan(
+        &self,
+        plan: &CachedPlanRef,
+        ctx: &ExecutionContext,
+    ) -> Result<Box<dyn QueryResult>> {
+        self.with_statement_epoch(&plan.statement, ctx, |ctx| {
+            self.execute_cached_plan_inner(plan, ctx)
+        })
+    }
+
+    fn execute_cached_plan_inner(
         &self,
         plan: &CachedPlanRef,
         ctx: &ExecutionContext,
@@ -988,6 +1073,257 @@ mod tests {
         let engine = MVCCEngine::in_memory();
         engine.open_engine().unwrap();
         Executor::new(Arc::new(engine))
+    }
+
+    fn epoch_statement() -> Statement {
+        Parser::new("SELECT 1")
+            .parse_program()
+            .unwrap()
+            .statements
+            .remove(0)
+    }
+
+    #[test]
+    fn statement_epoch_is_shared_by_nested_and_derived_contexts() {
+        let executor = create_test_executor();
+        let registry = executor.engine.registry();
+        let statement = epoch_statement();
+        executor
+            .with_statement_epoch(&statement, &ExecutionContext::new(), |ctx| {
+                let epoch = ctx.read_epoch().unwrap();
+                let (writer, _) = registry.begin_transaction();
+                registry.complete_commit(writer);
+                assert!(!epoch.is_visible(writer));
+                for nested in [
+                    ctx.with_incremented_query_depth(),
+                    ctx.with_incremented_view_depth(),
+                    ctx.with_transaction_id(99),
+                ] {
+                    executor.with_statement_epoch(&statement, &nested, |nested| {
+                        assert!(epoch.same_epoch(nested.read_epoch().unwrap()));
+                        assert!(!nested.read_epoch().unwrap().is_visible(writer));
+                        Ok(Box::new(ExecResult::empty()))
+                    })?;
+                }
+                Ok(Box::new(ExecResult::empty()))
+            })
+            .unwrap();
+        assert_eq!(registry.oldest_retention_horizon(), None);
+    }
+
+    #[test]
+    fn statement_epoch_refreshes_rc_and_preserves_si_begin() {
+        for isolation in [
+            crate::IsolationLevel::ReadCommitted,
+            crate::IsolationLevel::SnapshotIsolation,
+        ] {
+            let executor = create_test_executor();
+            let registry = executor.engine.registry();
+            let transaction = executor
+                .begin_transaction_with_isolation(isolation)
+                .unwrap();
+            let txn_id = transaction.id();
+            executor.install_transaction(transaction);
+            let statement = epoch_statement();
+            let mut first_cutoff = 0;
+            executor
+                .with_statement_epoch(&statement, &ExecutionContext::new(), |ctx| {
+                    first_cutoff = ctx.read_epoch().unwrap().cutoff();
+                    assert_eq!(ctx.transaction_id(), Some(txn_id as u64));
+                    Ok(Box::new(ExecResult::empty()))
+                })
+                .unwrap();
+            let (writer, _) = registry.begin_transaction();
+            registry.complete_commit(writer);
+            executor
+                .with_statement_epoch(&statement, &ExecutionContext::new(), |ctx| {
+                    let epoch = ctx.read_epoch().unwrap();
+                    if isolation == crate::IsolationLevel::ReadCommitted {
+                        assert!(epoch.cutoff() > first_cutoff);
+                        assert!(epoch.is_visible(writer));
+                    } else {
+                        assert_eq!(epoch.cutoff(), first_cutoff);
+                        assert!(!epoch.is_visible(writer));
+                    }
+                    Ok(Box::new(ExecResult::empty()))
+                })
+                .unwrap();
+            executor.execute("ROLLBACK").unwrap();
+            assert_eq!(registry.oldest_retention_horizon(), None);
+        }
+    }
+
+    #[test]
+    fn borrowed_fast_path_rejects_insert_before_epoch_registration() {
+        let executor = create_test_executor();
+        executor
+            .execute("CREATE TABLE epoch_insert (id INTEGER PRIMARY KEY)")
+            .unwrap();
+        let sql = "INSERT INTO epoch_insert VALUES ($1)";
+        executor
+            .execute_with_params(sql, smallvec::smallvec![Value::Integer(1)])
+            .unwrap();
+        let registry = executor.engine.registry();
+        let before = registry.capture_read_epoch().cache_identity().1;
+        assert!(executor
+            .try_fast_path_with_params(sql, &[Value::Integer(2)])
+            .is_none());
+        let after = registry.capture_read_epoch().cache_identity().1;
+        assert_eq!(
+            after,
+            before + 1,
+            "a rejected dispatch must not register an epoch"
+        );
+        assert_eq!(registry.oldest_retention_horizon(), None);
+
+        // The supported compiled SELECT still captures exactly one statement
+        // epoch. Its independent read transaction also registers a begin slot.
+        let select = "SELECT * FROM epoch_insert WHERE id = $1";
+        executor
+            .execute_with_params(select, smallvec::smallvec![Value::Integer(1)])
+            .unwrap();
+        let before_select = registry.capture_read_epoch().cache_identity().1;
+        let mut result = executor
+            .try_fast_path_with_params(select, &[Value::Integer(1)])
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            registry.capture_read_epoch().cache_identity().1,
+            before_select + 3,
+            "compiled lookup must share one statement lease plus its transaction begin slot"
+        );
+        assert!(registry.has_retention_obligations());
+        assert!(result.next());
+        assert_eq!(result.row().get(0), Some(&Value::Integer(1)));
+        result.close().unwrap();
+        assert!(!registry.has_retention_obligations());
+    }
+
+    #[test]
+    fn borrowed_compiled_preflight_preserves_normal_compilation_and_schema_refresh() {
+        let executor = create_test_executor();
+        executor
+            .execute("CREATE TABLE epoch_lookup (id INTEGER PRIMARY KEY, n INTEGER)")
+            .unwrap();
+        executor
+            .execute("INSERT INTO epoch_lookup VALUES (1, 10)")
+            .unwrap();
+        let registry = executor.engine.registry();
+        let query = "SELECT * FROM epoch_lookup WHERE id = $1";
+        executor
+            .execute_with_params(query, smallvec::smallvec![Value::Integer(1)])
+            .unwrap();
+        let cached = executor.query_cache.get(query).unwrap();
+        for state in [
+            CompiledExecution::Unknown,
+            CompiledExecution::NotOptimizable(executor.engine.schema_epoch()),
+        ] {
+            *cached.compiled.write().unwrap() = state;
+            let before = registry.capture_read_epoch().cache_identity().1;
+            assert!(executor
+                .try_fast_path_with_params(query, &[Value::Integer(1)])
+                .is_none());
+            assert_eq!(registry.capture_read_epoch().cache_identity().1, before + 1);
+            let mut result = executor
+                .execute_with_params(query, smallvec::smallvec![Value::Integer(1)])
+                .unwrap();
+            assert!(result.next());
+            assert_eq!(result.row().get(1), Some(&Value::Integer(10)));
+            result.close().unwrap();
+        }
+        // Unknown compilation still populates the shared slot; a later schema
+        // change routes through normal recompilation instead of getting stuck.
+        *cached.compiled.write().unwrap() = CompiledExecution::Unknown;
+        executor
+            .execute_with_params(query, smallvec::smallvec![Value::Integer(1)])
+            .unwrap();
+        assert!(matches!(
+            &*cached.compiled.read().unwrap(),
+            CompiledExecution::PkLookup(_)
+        ));
+        executor
+            .execute("ALTER TABLE epoch_lookup ADD COLUMN extra INTEGER DEFAULT 7")
+            .unwrap();
+        let before = registry.capture_read_epoch().cache_identity().1;
+        assert!(executor
+            .try_fast_path_with_params(query, &[Value::Integer(1)])
+            .is_none());
+        assert_eq!(registry.capture_read_epoch().cache_identity().1, before + 1);
+        let mut result = executor
+            .execute_with_params(query, smallvec::smallvec![Value::Integer(1)])
+            .unwrap();
+        assert!(result.next());
+        assert_eq!(result.row().get(2), Some(&Value::Integer(7)));
+        result.close().unwrap();
+        assert!(executor
+            .try_fast_path_with_params(query, &[Value::Integer(1)])
+            .is_some());
+        assert!(!registry.has_retention_obligations());
+    }
+
+    #[test]
+    fn statement_result_retains_epoch_until_drop_or_close() {
+        let executor = create_test_executor();
+        let registry = executor.engine.registry();
+        let mut result = executor.execute("SELECT 1").unwrap();
+        assert!(registry.oldest_retention_horizon().is_some());
+        assert!(result.next());
+        assert_eq!(result.row().get(0), Some(&Value::Integer(1)));
+        result.close().unwrap();
+        assert_eq!(registry.oldest_retention_horizon(), None);
+        assert!(!result.next());
+        let result = executor.execute("SELECT 2").unwrap();
+        assert!(registry.oldest_retention_horizon().is_some());
+        drop(result);
+        assert_eq!(registry.oldest_retention_horizon(), None);
+    }
+
+    #[test]
+    fn statement_epoch_error_releases_lease() {
+        let executor = create_test_executor();
+        let registry = executor.engine.registry();
+        let error =
+            executor.with_statement_epoch(&epoch_statement(), &ExecutionContext::new(), |_ctx| {
+                Err(Error::internal("statement failed"))
+            });
+        assert!(error.is_err());
+        assert_eq!(registry.oldest_retention_horizon(), None);
+    }
+
+    #[test]
+    fn statement_cache_epoch_separates_engines_without_pinning_horizons() {
+        use super::context::{
+            cache_scalar_subquery, ensure_statement_cache_epoch, get_cached_scalar_subquery,
+        };
+        let first = crate::storage::mvcc::TransactionRegistry::new();
+        let second = crate::storage::mvcc::TransactionRegistry::new();
+        let first_ctx = ExecutionContext::new().with_read_epoch(first.capture_read_epoch());
+        let second_ctx = ExecutionContext::new().with_read_epoch(second.capture_read_epoch());
+        ensure_statement_cache_epoch(&first_ctx);
+        cache_scalar_subquery(
+            "same key".into(),
+            smallvec::SmallVec::new(),
+            Value::Integer(1),
+        );
+        ensure_statement_cache_epoch(&first_ctx.with_incremented_query_depth());
+        assert_eq!(
+            get_cached_scalar_subquery("same key"),
+            Some(Value::Integer(1))
+        );
+        ensure_statement_cache_epoch(&second_ctx);
+        assert_eq!(get_cached_scalar_subquery("same key"), None);
+        cache_scalar_subquery(
+            "same key".into(),
+            smallvec::SmallVec::new(),
+            Value::Integer(2),
+        );
+        // Resuming an older lazy query must not consume the newer query's memo.
+        ensure_statement_cache_epoch(&first_ctx);
+        assert_eq!(get_cached_scalar_subquery("same key"), None);
+        drop(first_ctx);
+        drop(second_ctx);
+        assert_eq!(first.oldest_retention_horizon(), None);
+        assert_eq!(second.oldest_retention_horizon(), None);
     }
 
     #[test]

--- a/src/executor/pk_fast_path.rs
+++ b/src/executor/pk_fast_path.rs
@@ -114,7 +114,7 @@ impl Executor {
         let lookup_info = self.extract_pk_lookup_info(table_name, where_clause, ctx)?;
 
         // Execute the fast-path lookup
-        Some(self.execute_pk_lookup(lookup_info))
+        Some(self.execute_pk_lookup(lookup_info, ctx))
     }
 
     /// Extract PK lookup information from a WHERE clause
@@ -269,16 +269,18 @@ impl Executor {
     }
 
     /// Execute the fast-path PK lookup using Engine::fetch_rows_by_ids
-    fn execute_pk_lookup(&self, info: PkLookupInfo) -> Result<Box<dyn QueryResult>> {
+    fn execute_pk_lookup(
+        &self,
+        info: PkLookupInfo,
+        ctx: &ExecutionContext,
+    ) -> Result<Box<dyn QueryResult>> {
         // Use cached schema for column names - Arc clone is O(1)
         let columns = info.schema.column_names_arc();
 
         // Use engine's fetch_rows_by_ids for direct MVCC lookup
         // This bypasses the full query planner and goes straight to version store
         // Note: table_name is already lowercased, so storage layer won't call to_lowercase again
-        let rows = self
-            .engine
-            .fetch_rows_by_ids(&info.table_name, &[info.pk_value])?;
+        let rows = self.fetch_rows_in_context(&info.table_name, &[info.pk_value], ctx)?;
 
         // Extract Row values and normalize to current schema (handles ADD/DROP COLUMN)
         let result_rows: RowVec = rows
@@ -328,7 +330,7 @@ impl Executor {
                     if self.engine.schema_epoch() == lookup.cached_epoch {
                         // Fast path: extract value and execute
                         let pk_value = self.extract_pk_value_fast(&lookup.pk_value_source, ctx)?;
-                        return Some(self.execute_compiled_pk_lookup(lookup, pk_value));
+                        return Some(self.execute_compiled_pk_lookup(lookup, pk_value, ctx));
                     }
                     // Epoch changed - some DDL occurred, need to recompile
                     // Fall through to recompile path
@@ -401,6 +403,7 @@ impl Executor {
         &self,
         _stmt: &SelectStatement,
         params: &[Value],
+        ctx: &ExecutionContext,
         compiled: &RwLock<CompiledExecution>,
     ) -> Option<Result<Box<dyn QueryResult>>> {
         // Try read lock first - check if already compiled
@@ -413,7 +416,7 @@ impl Executor {
                     // Fast path: extract value from slice directly
                     let pk_value =
                         Self::extract_pk_value_from_slice(&lookup.pk_value_source, params)?;
-                    Some(self.execute_compiled_pk_lookup(lookup, pk_value))
+                    Some(self.execute_compiled_pk_lookup(lookup, pk_value, ctx))
                 } else {
                     // Epoch changed - need recompile, use normal path
                     None
@@ -429,10 +432,9 @@ impl Executor {
         &self,
         lookup: &CompiledPkLookup,
         pk_value: i64,
+        ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
-        let rows = self
-            .engine
-            .fetch_rows_by_ids(&lookup.table_name, &[pk_value])?;
+        let rows = self.fetch_rows_in_context(&lookup.table_name, &[pk_value], ctx)?;
         // Normalize rows to current schema (handles ADD/DROP COLUMN)
         // Pre-allocate with capacity 1 for single PK lookup (avoids realloc)
         let mut result_rows = RowVec::with_capacity(1);
@@ -472,7 +474,7 @@ impl Executor {
                 // Re-validate epoch: another thread may have compiled before DDL
                 if self.engine.schema_epoch() == lookup.cached_epoch {
                     let pk_value = self.extract_pk_value_fast(&lookup.pk_value_source, ctx)?;
-                    return Some(self.execute_compiled_pk_lookup(lookup, pk_value));
+                    return Some(self.execute_compiled_pk_lookup(lookup, pk_value, ctx));
                 }
                 // Epoch changed since last compilation - fall through to recompile
             }
@@ -551,11 +553,14 @@ impl Executor {
                 // Resolve this execution's value; on failure fall back to
                 // the standard path (the stored PkLookup stays valid).
                 let pk_value = self.extract_pk_value_fast(&pk_value_source, ctx)?;
-                Some(self.execute_pk_lookup(PkLookupInfo {
-                    table_name: table_name.to_string(),
-                    pk_value,
-                    schema,
-                }))
+                Some(self.execute_pk_lookup(
+                    PkLookupInfo {
+                        table_name: table_name.to_string(),
+                        pk_value,
+                        schema,
+                    },
+                    ctx,
+                ))
             }
             None => {
                 *compiled_guard = CompiledExecution::NotOptimizable(self.engine.schema_epoch());

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -290,6 +290,7 @@ impl Executor {
         ctx: &ExecutionContext,
         plan_classification: Option<&std::sync::OnceLock<Arc<QueryClassification>>>,
     ) -> Result<Box<dyn QueryResult>> {
+        super::context::ensure_statement_cache_epoch(ctx);
         // Start timeout guard ONLY at the top level (query_depth == 0).
         // For nested queries (subqueries, views), the parent's TimeoutGuard handles timeout.
         // This ensures the timeout applies to the entire query, not each nested call.
@@ -2228,13 +2229,15 @@ impl Executor {
         // Get table from active transaction or create a new one
         let (table, _standalone_tx) = if let Some(ref tx_state) = *active_tx {
             // Use the active transaction - this allows seeing uncommitted changes
-            let table = tx_state.transaction.get_table(table_name).map_err(|e| {
-                if matches!(e, Error::TableNotFound(_)) {
-                    Error::TableOrViewNotFound(table_name.to_string())
-                } else {
-                    e
-                }
-            })?;
+            let table = ctx
+                .get_table(tx_state.transaction.as_ref(), table_name)
+                .map_err(|e| {
+                    if matches!(e, Error::TableNotFound(_)) {
+                        Error::TableOrViewNotFound(table_name.to_string())
+                    } else {
+                        e
+                    }
+                })?;
             drop(active_tx); // Release lock before doing work
             (table, None)
         } else {
@@ -2277,7 +2280,7 @@ impl Executor {
                     );
                 }
 
-                let table = tx.get_table(table_name).map_err(|e| {
+                let table = ctx.get_table(tx.as_ref(), table_name).map_err(|e| {
                     if matches!(e, Error::TableNotFound(_)) {
                         Error::TableOrViewNotFound(table_name.to_string())
                     } else {
@@ -2474,7 +2477,7 @@ impl Executor {
         // CRITICAL: Disable caching during explicit transactions (BEGIN/COMMIT)
         // to preserve MVCC isolation guarantees. A transaction must see its own
         // consistent snapshot, not cached results from other transactions.
-        let cache_eligible = is_select_star
+        let cache_shape_eligible = is_select_star
             && where_to_use.is_some()
             && !has_aggregation_window_grouping
             && !has_outer_context
@@ -2484,17 +2487,30 @@ impl Executor {
             && !classification.has_order_by
             && !classification.has_distinct
             && !classification.has_limit
-            && !in_explicit_transaction; // MVCC safety: no caching in transactions
+            && !in_explicit_transaction
+            && ctx.transaction_id().is_none()
+            && ctx.statement_snapshot().is_none();
+
+        // Retain this original bound-view proof through cache insertion.
+        let cache_provenance = if cache_shape_eligible {
+            ctx.read_epoch()
+                .and_then(|epoch| self.engine.cache_provenance(epoch))
+        } else {
+            None
+        };
+        let cache_eligible = cache_provenance.is_some();
 
         // Try cache lookup for eligible queries
-        if cache_eligible {
+        if let Some(proof) = cache_provenance {
             if let Some(where_expr) = where_to_use {
                 use super::semantic_cache::CacheLookupResult;
 
-                match self
-                    .semantic_cache
-                    .lookup(table_name, &all_columns, Some(where_expr))
-                {
+                match self.semantic_cache.lookup_with_provenance(
+                    table_name,
+                    &all_columns,
+                    Some(where_expr),
+                    proof,
+                ) {
                     CacheLookupResult::ExactHit(rows_arc) => {
                         // Exact cache hit - return cached rows with zero-copy sharing
                         let output_columns = CompactArc::new(self.get_output_column_names(
@@ -3847,6 +3863,23 @@ impl Executor {
                                 }),
                                 None,
                             )
+                        } else if ctx.read_epoch().is_some() {
+                            // Sort captured FLOAT/nullable input with the window comparator.
+                            let mut rows = table.collect_all_rows(None)?;
+                            let column = schema
+                                .find_column(&col_name)
+                                .ok_or_else(|| Error::ColumnNotFound(col_name.clone()))?
+                                .0;
+                            Self::sort_captured_window_rows(&mut rows, column, ascending);
+                            rows.truncate(fetch_limit);
+                            (
+                                rows,
+                                Some(WindowPreSortedState {
+                                    column: col_lower,
+                                    ascending,
+                                }),
+                                None,
+                            )
                         } else {
                             (table.collect_all_rows(None)?, None, None)
                         }
@@ -3998,15 +4031,16 @@ impl Executor {
         // Note: The cache stores Vec<Row>, so we extract rows from RowVec for caching.
         // The result keeps the original RowVec.
         // Skip caching when deferred projection is used (rows are not projected yet)
-        if cache_eligible && deferred_proj.is_none() {
-            if let Some(where_expr) = where_to_use {
+        if deferred_proj.is_none() {
+            if let (Some(proof), Some(where_expr)) = (cache_provenance, where_to_use) {
                 // Clone rows for cache (cache needs Vec<Row>)
                 let rows_for_cache: Vec<Row> = projected_rows.rows().cloned().collect();
-                self.semantic_cache.insert(
+                self.semantic_cache.insert_with_provenance(
                     table_name,
                     all_columns.to_vec(),
                     rows_for_cache,
                     Some(where_expr.clone()),
+                    proof,
                 );
             }
         }
@@ -4342,6 +4376,7 @@ impl Executor {
                     &join_type,
                     left_alias.as_deref(),
                     right_alias.as_deref(),
+                    Some(ctx),
                 )
             };
 
@@ -4368,6 +4403,7 @@ impl Executor {
                     &join_type,
                     right_alias.as_deref(), // Swap aliases for the check
                     left_alias.as_deref(),
+                    Some(ctx),
                 );
                 if left_as_inner.is_some() {
                     (left_as_inner, true) // Force swap
@@ -4406,6 +4442,7 @@ impl Executor {
                     &join_type,
                     right_alias.as_deref(), // Swap aliases
                     left_alias.as_deref(),
+                    Some(ctx),
                 );
 
                 // Prefer swapped if it gives PK lookup (most efficient)
@@ -4533,9 +4570,8 @@ impl Executor {
                 // continuation finds that a commit moved rows under it
                 let mut snapshot = match ctx.statement_snapshot() {
                     Some(snapshot) => snapshot.clone(),
-                    None => {
-                        self.new_statement_snapshot(crate::core::IsolationLevel::ReadCommitted)?
-                    }
+                    None => self
+                        .new_statement_snapshot(crate::core::IsolationLevel::ReadCommitted, ctx)?,
                 };
                 let mut ctx_join = ctx.with_statement_snapshot(snapshot.clone());
                 // An explicit transaction reads through its own transaction, whose
@@ -4703,7 +4739,7 @@ impl Executor {
                         let mut outer_result = outer_result;
                         let mut inner_table = Some(inner_table);
                         let mut fetched = 0usize;
-                        let mut consistent = false;
+                        let mut consistent = ctx.read_epoch().is_some();
                         loop {
                             let outer_op: Box<dyn Operator> = Box::new(QueryResultOperator::new(
                                 outer_result,
@@ -4789,6 +4825,7 @@ impl Executor {
                             }
                             snapshot = self.new_statement_snapshot(
                                 crate::core::IsolationLevel::SnapshotIsolation,
+                                ctx,
                             )?;
                             ctx_join = ctx.with_statement_snapshot(snapshot.clone());
                             consistent = true;
@@ -7020,7 +7057,7 @@ impl Executor {
         name: &str,
     ) -> Result<Box<dyn crate::storage::traits::Table>> {
         if let Some(active) = self.active_transaction.lock().unwrap().as_ref() {
-            return active.transaction.get_table(name);
+            return snapshot.get_table_for_transaction(active.transaction.as_ref(), name);
         }
         snapshot.get_table(name)
     }
@@ -7029,12 +7066,10 @@ impl Executor {
     fn new_statement_snapshot(
         &self,
         isolation: crate::core::IsolationLevel,
+        ctx: &ExecutionContext,
     ) -> Result<StatementSnapshot> {
-        let mut transaction = self.engine.begin_transaction()?;
-        if isolation != crate::core::IsolationLevel::ReadCommitted {
-            transaction.set_isolation_level(isolation)?;
-        }
-        Ok(StatementSnapshot::new(transaction))
+        let transaction = self.engine.begin_transaction_with_level(isolation)?;
+        Ok(StatementSnapshot::new(transaction).with_epoch(ctx.read_epoch().cloned()))
     }
 
     /// True when a filter carries a subquery anywhere inside it. The grouped
@@ -7145,6 +7180,7 @@ impl Executor {
                 join_type,
                 left_alias,
                 right_alias,
+                Some(ctx),
             )
         else {
             return Ok(None);
@@ -7184,7 +7220,7 @@ impl Executor {
         // explicit transaction the outer side is read whole
         let mut snapshot = match ctx.statement_snapshot() {
             Some(snapshot) => snapshot.clone(),
-            None => self.new_statement_snapshot(crate::core::IsolationLevel::ReadCommitted)?,
+            None => self.new_statement_snapshot(crate::core::IsolationLevel::ReadCommitted, ctx)?,
         };
         let mut ctx_join = ctx.with_statement_snapshot(snapshot.clone());
         let in_explicit_transaction = self.active_transaction.lock().unwrap().is_some();
@@ -7389,7 +7425,7 @@ impl Executor {
         let mut outer_result = outer_result;
         let mut inner_table = Some(inner_table);
         let mut fetched = 0usize;
-        let mut consistent = false;
+        let mut consistent = ctx.read_epoch().is_some();
         loop {
             let outer_op: Box<dyn Operator> =
                 Box::new(QueryResultOperator::new(outer_result, outer_cols.clone()));
@@ -7505,7 +7541,7 @@ impl Executor {
                 continue;
             }
             snapshot =
-                self.new_statement_snapshot(crate::core::IsolationLevel::SnapshotIsolation)?;
+                self.new_statement_snapshot(crate::core::IsolationLevel::SnapshotIsolation, ctx)?;
             ctx_join = ctx.with_statement_snapshot(snapshot.clone());
             inner_table = Some(self.join_table(&snapshot, &table_name)?);
             consistent = true;
@@ -7568,6 +7604,12 @@ impl Executor {
         // Try to extract Arc directly (zero-copy path for CTEs)
         if let Some(arc_rows) = result.try_into_arc_rows() {
             return Ok(arc_rows);
+        }
+
+        // A consuming extraction may fail while closing its captured source.
+        // Surface that error before trusting an estimate for a fallback buffer.
+        if let Some(error) = result.last_error() {
+            return Err(error);
         }
 
         // Pre-allocate based on estimate to avoid reallocations
@@ -9333,7 +9375,19 @@ impl Executor {
             return Some(((0..all_columns.len()).collect(), all_columns.to_vec()));
         }
 
-        let col_index_map = build_column_index_map(all_columns);
+        // A narrow projection should not allocate and lowercase maps for
+        // every input column. Keep the existing Unicode/map path for larger
+        // projections and non-ASCII schemas.
+        let col_index_map =
+            if select_exprs.len() <= 4 && all_columns.iter().all(|name| name.is_ascii()) {
+                None
+            } else {
+                Some(build_column_index_map(all_columns))
+            };
+        let column_index = |name: &str| match &col_index_map {
+            Some(map) => map.get(name).copied(),
+            None => Self::find_ascii_projection_column(all_columns, name),
+        };
 
         let mut indices = Vec::with_capacity(select_exprs.len());
         let mut names = Vec::with_capacity(select_exprs.len());
@@ -9341,39 +9395,23 @@ impl Executor {
         for expr in select_exprs {
             match expr {
                 Expression::Identifier(id) => {
-                    if let Some(&idx) = col_index_map.get(id.value_lower.as_str()) {
-                        indices.push(idx);
-                        names.push(id.value.to_string());
-                    } else {
-                        return None;
-                    }
+                    indices.push(column_index(id.value_lower.as_str())?);
+                    names.push(id.value.to_string());
                 }
                 Expression::QualifiedIdentifier(qid) => {
-                    if let Some(&idx) = col_index_map.get(qid.name.value_lower.as_str()) {
-                        indices.push(idx);
-                        names.push(qid.name.value.to_string());
-                    } else {
-                        return None;
-                    }
+                    indices.push(column_index(qid.name.value_lower.as_str())?);
+                    names.push(qid.name.value.to_string());
                 }
                 Expression::Aliased(aliased) => {
                     // Check if inner expression is simple
                     match &*aliased.expression {
                         Expression::Identifier(id) => {
-                            if let Some(&idx) = col_index_map.get(id.value_lower.as_str()) {
-                                indices.push(idx);
-                                names.push(aliased.alias.value.to_string());
-                            } else {
-                                return None;
-                            }
+                            indices.push(column_index(id.value_lower.as_str())?);
+                            names.push(aliased.alias.value.to_string());
                         }
                         Expression::QualifiedIdentifier(qid) => {
-                            if let Some(&idx) = col_index_map.get(qid.name.value_lower.as_str()) {
-                                indices.push(idx);
-                                names.push(aliased.alias.value.to_string());
-                            } else {
-                                return None;
-                            }
+                            indices.push(column_index(qid.name.value_lower.as_str())?);
+                            names.push(aliased.alias.value.to_string());
                         }
                         _ => return None, // Complex expression in alias
                     }
@@ -9383,6 +9421,30 @@ impl Executor {
         }
 
         Some((indices, names))
+    }
+
+    /// Match build_column_index_map's precedence without allocating: the last
+    /// complete name wins; an absent complete name may use one qualified base.
+    fn find_ascii_projection_column(columns: &[String], name: &str) -> Option<usize> {
+        if let Some(index) = columns
+            .iter()
+            .rposition(|column| column.eq_ignore_ascii_case(name))
+        {
+            return Some(index);
+        }
+        let mut found = None;
+        for (index, column) in columns.iter().enumerate() {
+            if column
+                .rsplit_once('.')
+                .is_some_and(|(_, base)| base.eq_ignore_ascii_case(name))
+            {
+                if found.is_some() {
+                    return None;
+                }
+                found = Some(index);
+            }
+        }
+        found
     }
 
     /// Compare two rows for ORDER BY using pre-computed column indices
@@ -10777,7 +10839,7 @@ impl Executor {
     /// - Join type is INNER or LEFT (not RIGHT or FULL)
     ///
     /// The outer_key_idx will be determined after materializing the outer side.
-    #[allow(clippy::type_complexity)]
+    #[allow(clippy::type_complexity, clippy::too_many_arguments)]
     pub(crate) fn check_index_nested_loop_opportunity(
         &self,
         right_expr: &Expression,
@@ -10785,6 +10847,7 @@ impl Executor {
         join_type: &str,
         left_alias: Option<&str>,
         right_alias: Option<&str>,
+        ctx: Option<&ExecutionContext>,
     ) -> Option<(
         String,              // table_name
         IndexLookupStrategy, // lookup strategy (index or PK)
@@ -10896,8 +10959,15 @@ impl Executor {
         };
 
         // Try to get the table and check for index or PK
-        let txn = self.engine.begin_transaction().ok()?;
-        let table = txn.get_table(table_name_ref).ok()?;
+        let table = match ctx {
+            Some(ctx) => self.table_in_context(table_name_ref, ctx).ok()?,
+            None => self
+                .engine
+                .begin_transaction()
+                .ok()?
+                .get_table(table_name_ref)
+                .ok()?,
+        };
         let schema = table.schema();
 
         // First check if inner column is the PRIMARY KEY (direct row_id lookup)
@@ -10912,6 +10982,13 @@ impl Executor {
                     outer_col,
                 ));
             }
+        }
+
+        // Secondary index contents are live; they may omit a key removed
+        // after the epoch. PK probes derive IDs from the outer rows and are
+        // resolved through the captured table, so that strategy remains safe.
+        if ctx.is_some_and(|ctx| ctx.read_epoch().is_some()) {
+            return None;
         }
 
         // Check if there's a secondary index on the inner column
@@ -11558,6 +11635,75 @@ mod tests {
         let engine = MVCCEngine::in_memory();
         engine.open_engine().unwrap();
         Executor::new(Arc::new(engine))
+    }
+
+    #[test]
+    fn narrow_projection_lookup_matches_map_precedence() {
+        let choices = ["a", "A", "left.a", "right.A", "x.b", "b", "x.y.b", "empty."];
+        for encoded in 0..choices.len().pow(4) {
+            let mut number = encoded;
+            let columns: Vec<String> = (0..4)
+                .map(|_| {
+                    let value = choices[number % choices.len()].to_owned();
+                    number /= choices.len();
+                    value
+                })
+                .collect();
+            let map = build_column_index_map(&columns);
+            for name in [
+                "a", "b", "left.a", "right.a", "x.y.b", "empty.", "", "missing", "é",
+            ] {
+                assert_eq!(
+                    Executor::find_ascii_projection_column(&columns, name),
+                    map.get(name).copied(),
+                    "columns={columns:?}, name={name}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn narrow_projection_preserves_aliases_duplicates_and_unicode_fallback() {
+        let executor = create_test_executor();
+        executor
+            .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, price INTEGER, extra INTEGER)")
+            .unwrap();
+        executor
+            .execute("INSERT INTO t VALUES (1, 17, 23)")
+            .unwrap();
+        executor
+            .execute("CREATE TABLE u (id INTEGER PRIMARY KEY, price INTEGER, É INTEGER)")
+            .unwrap();
+        executor
+            .execute("INSERT INTO u VALUES (1, 17, 23)")
+            .unwrap();
+        for (sql, expected, names) in [
+            (
+                "SELECT price AS p, PRICE, t.id FROM t WHERE id = 1",
+                vec![17, 17, 1],
+                vec!["p", "PRICE", "id"],
+            ),
+            (
+                "SELECT é, price FROM u WHERE id = 1",
+                vec![23, 17],
+                vec!["é", "price"],
+            ),
+            (
+                "SELECT price, price, price, price, id FROM t WHERE id = 1",
+                vec![17, 17, 17, 17, 1],
+                vec!["price", "price", "price", "price", "id"],
+            ),
+        ] {
+            let mut result = executor.execute(sql).unwrap();
+            assert_eq!(result.columns(), names);
+            assert!(result.next());
+            assert_eq!(
+                result.row().as_slice(),
+                expected.into_iter().map(Value::Integer).collect::<Vec<_>>()
+            );
+            assert!(!result.next());
+            assert!(result.last_error().is_none());
+        }
     }
 
     #[test]

--- a/src/executor/result.rs
+++ b/src/executor/result.rs
@@ -24,6 +24,147 @@ use rustc_hash::{FxHashMap, FxHasher};
 
 use super::expression::RowFilter;
 
+/// Retains the statement lease while the underlying lazy result can read.
+/// The inner result is declared first so captured views are destroyed before
+/// the registry may reclaim their transaction metadata.
+pub(crate) struct EpochResult {
+    inner: Option<Box<dyn QueryResult>>,
+    _epoch: Option<crate::storage::mvcc::registry::ReadEpoch>,
+    columns: Option<CompactArc<Vec<String>>>,
+    affected: i64,
+    insert_id: i64,
+    estimated: Option<usize>,
+    pending_error: Option<crate::core::Error>,
+}
+
+impl EpochResult {
+    pub(crate) fn new(
+        inner: Box<dyn QueryResult>,
+        epoch: crate::storage::mvcc::registry::ReadEpoch,
+    ) -> Self {
+        // Retain pure metadata, not the result's captured readers. Most result
+        // implementations already share this Arc. Plain names are copied once
+        // here so exhaustion/close never needs a replacement allocation.
+        let columns = inner.columns_arc().or_else(|| {
+            (!inner.columns().is_empty()).then(|| CompactArc::new(inner.columns().to_vec()))
+        });
+        Self {
+            inner: Some(inner),
+            _epoch: Some(epoch),
+            columns,
+            affected: 0,
+            insert_id: 0,
+            estimated: None,
+            pending_error: None,
+        }
+    }
+
+    fn finish(&mut self) -> Result<()> {
+        let Some(mut inner) = self.inner.take() else {
+            return Ok(());
+        };
+        self.affected = inner.rows_affected();
+        self.insert_id = inner.last_insert_id();
+        self.estimated = inner.estimated_count();
+        if self.pending_error.is_none() {
+            self.pending_error = inner.last_error();
+        }
+        let closed = inner.close();
+        if self.pending_error.is_none() {
+            if let Err(error) = &closed {
+                self.pending_error = Some(error.clone());
+            }
+        }
+        // Even a failed/default no-op close must not keep captured roots or
+        // inner epoch owners alive. Release the outer lease after those owners.
+        drop(inner);
+        self._epoch = None;
+        closed
+    }
+}
+
+impl QueryResult for EpochResult {
+    fn columns(&self) -> &[String] {
+        self.columns
+            .as_ref()
+            .map_or(EMPTY_COLUMNS, |columns| columns.as_slice())
+    }
+    fn columns_arc(&self) -> Option<CompactArc<Vec<String>>> {
+        self.columns.clone()
+    }
+    fn next(&mut self) -> bool {
+        let Some(inner) = &mut self.inner else {
+            return false;
+        };
+        if inner.next() {
+            return true;
+        }
+        let _ = self.finish();
+        false
+    }
+    fn scan(&self, dest: &mut [Value]) -> Result<()> {
+        self.inner
+            .as_ref()
+            .ok_or_else(|| crate::core::Error::internal("result is closed"))?
+            .scan(dest)
+    }
+    fn row(&self) -> &Row {
+        match &self.inner {
+            Some(inner) => inner.row(),
+            None => get_empty_row(),
+        }
+    }
+    fn take_row(&mut self) -> Row {
+        self.inner
+            .as_mut()
+            .map_or_else(Row::new, |inner| inner.take_row())
+    }
+    fn close(&mut self) -> Result<()> {
+        self.finish()
+    }
+    fn rows_affected(&self) -> i64 {
+        self.inner
+            .as_ref()
+            .map_or(self.affected, |inner| inner.rows_affected())
+    }
+    fn last_insert_id(&self) -> i64 {
+        self.inner
+            .as_ref()
+            .map_or(self.insert_id, |inner| inner.last_insert_id())
+    }
+    fn try_into_arc_rows(&mut self) -> Option<CompactArc<Vec<Row>>> {
+        let rows = self.inner.as_mut()?.try_into_arc_rows()?;
+        if self.finish().is_err() || self.pending_error.is_some() {
+            return None;
+        }
+        Some(rows)
+    }
+    fn estimated_count(&self) -> Option<usize> {
+        self.inner
+            .as_ref()
+            .map_or(self.estimated, |inner| inner.estimated_count())
+    }
+    fn exact_len(&self) -> Option<usize> {
+        self.inner
+            .as_ref()
+            .map_or(Some(0), |inner| inner.exact_len())
+    }
+    fn last_error(&mut self) -> Option<crate::core::Error> {
+        if self.pending_error.is_none() {
+            if let Some(inner) = &mut self.inner {
+                self.pending_error = inner.last_error();
+                if self.pending_error.is_some() {
+                    let _ = self.finish();
+                }
+            }
+        }
+        self.pending_error.take()
+    }
+    fn with_aliases(self: Box<Self>, aliases: FxHashMap<String, String>) -> Box<dyn QueryResult> {
+        Box::new(AliasedResult::new(self, aliases))
+    }
+}
+
 /// Execution result for DML operations (INSERT, UPDATE, DELETE)
 ///
 /// This result type tracks the number of rows affected and the last insert ID
@@ -2171,6 +2312,295 @@ impl QueryResult for ColumnarResult {
 mod tests {
     use super::*;
     use crate::core::row_vec::RowVec;
+
+    struct EpochOwnerResult {
+        registry: std::sync::Arc<crate::storage::mvcc::TransactionRegistry>,
+        _epoch: Option<crate::storage::mvcc::registry::ReadEpoch>,
+        dropped: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        columns: CompactArc<Vec<String>>,
+        rows: Option<CompactArc<Vec<Row>>>,
+        remaining: usize,
+        estimate: usize,
+        runtime_error: Option<crate::core::Error>,
+        fail_close: bool,
+    }
+    impl Drop for EpochOwnerResult {
+        fn drop(&mut self) {
+            assert!(
+                self.registry.has_retention_obligations(),
+                "the outer epoch must outlive destruction of captured owners"
+            );
+            self.dropped
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+    impl QueryResult for EpochOwnerResult {
+        fn columns(&self) -> &[String] {
+            &self.columns
+        }
+        fn columns_arc(&self) -> Option<CompactArc<Vec<String>>> {
+            Some(self.columns.clone())
+        }
+        fn next(&mut self) -> bool {
+            if self.remaining == 0 {
+                false
+            } else {
+                self.remaining -= 1;
+                true
+            }
+        }
+        fn scan(&self, _: &mut [Value]) -> Result<()> {
+            Ok(())
+        }
+        fn row(&self) -> &Row {
+            get_empty_row()
+        }
+        fn close(&mut self) -> Result<()> {
+            if self.fail_close {
+                Err(crate::core::Error::internal("close failure"))
+            } else {
+                Ok(())
+            }
+        }
+        fn rows_affected(&self) -> i64 {
+            7
+        }
+        fn last_insert_id(&self) -> i64 {
+            9
+        }
+        fn estimated_count(&self) -> Option<usize> {
+            Some(self.estimate)
+        }
+        fn exact_len(&self) -> Option<usize> {
+            Some(self.remaining)
+        }
+        fn last_error(&mut self) -> Option<crate::core::Error> {
+            if self.remaining == 0 {
+                self.runtime_error.take()
+            } else {
+                None
+            }
+        }
+        fn try_into_arc_rows(&mut self) -> Option<CompactArc<Vec<Row>>> {
+            self.rows.take()
+        }
+        fn with_aliases(
+            self: Box<Self>,
+            aliases: FxHashMap<String, String>,
+        ) -> Box<dyn QueryResult> {
+            Box::new(AliasedResult::new(self, aliases))
+        }
+    }
+
+    #[test]
+    fn epoch_result_releases_owners_on_every_terminal_path_and_keeps_metadata() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+        for inner_owns_epoch in [false, true] {
+            for terminal in [
+                "exhaust",
+                "runtime_error",
+                "error_poll",
+                "close",
+                "close_error",
+                "extract",
+                "drop",
+            ] {
+                let registry = Arc::new(crate::storage::mvcc::TransactionRegistry::new());
+                let epoch = registry.capture_read_epoch();
+                let dropped = Arc::new(AtomicUsize::new(0));
+                let columns = CompactArc::new(vec!["x".to_string()]);
+                let inner = Box::new(EpochOwnerResult {
+                    registry: registry.clone(),
+                    _epoch: inner_owns_epoch.then(|| epoch.clone()),
+                    dropped: dropped.clone(),
+                    columns: columns.clone(),
+                    rows: (terminal == "extract")
+                        .then(|| CompactArc::new(vec![Row::from(vec![Value::Integer(1)])])),
+                    remaining: 1,
+                    estimate: 3,
+                    runtime_error: matches!(terminal, "runtime_error" | "error_poll")
+                        .then(|| crate::core::Error::internal("read failure")),
+                    fail_close: matches!(terminal, "close_error" | "runtime_error" | "error_poll"),
+                });
+                let mut result = Box::new(EpochResult::new(inner, epoch));
+                assert!(registry.has_retention_obligations());
+                assert!(CompactArc::ptr_eq(&result.columns_arc().unwrap(), &columns));
+                match terminal {
+                    "exhaust" | "runtime_error" => {
+                        assert!(result.next());
+                        assert!(!result.next());
+                    }
+                    "error_poll" => {
+                        assert!(result.next());
+                        assert!(result
+                            .last_error()
+                            .unwrap()
+                            .to_string()
+                            .contains("read failure"));
+                    }
+                    "close" => result.close().unwrap(),
+                    "close_error" => assert!(result
+                        .close()
+                        .unwrap_err()
+                        .to_string()
+                        .contains("close failure")),
+                    "extract" => {
+                        assert_eq!(result.try_into_arc_rows().unwrap()[0][0], Value::Integer(1))
+                    }
+                    "drop" => {
+                        drop(result);
+                        assert_eq!(registry.oldest_retention_horizon(), None);
+                        assert_eq!(dropped.load(Ordering::Relaxed), 1);
+                        continue;
+                    }
+                    _ => unreachable!(),
+                }
+                assert_eq!(
+                    registry.oldest_retention_horizon(),
+                    None,
+                    "{terminal}, inner={inner_owns_epoch}"
+                );
+                assert_eq!(dropped.load(Ordering::Relaxed), 1);
+                assert_eq!(result.columns(), &["x"]);
+                assert_eq!(result.rows_affected(), 7);
+                assert_eq!(result.last_insert_id(), 9);
+                assert_eq!(result.estimated_count(), Some(3));
+                assert_eq!(result.exact_len(), Some(0));
+                assert!(!result.next());
+                if terminal == "runtime_error" {
+                    assert!(
+                        result
+                            .last_error()
+                            .unwrap()
+                            .to_string()
+                            .contains("read failure"),
+                        "an inner close error cannot replace the original read error"
+                    );
+                } else if terminal == "close_error" {
+                    assert!(result
+                        .last_error()
+                        .unwrap()
+                        .to_string()
+                        .contains("close failure"));
+                } else {
+                    assert!(result.last_error().is_none());
+                }
+                result.close().unwrap();
+                let mut aliases = FxHashMap::default();
+                aliases.insert("renamed".to_string(), "x".to_string());
+                let mut aliased = result.with_aliases(aliases);
+                assert_eq!(aliased.columns(), &["renamed"]);
+                assert_eq!(aliased.rows_affected(), 7);
+                assert_eq!(aliased.last_insert_id(), 9);
+                assert!(!aliased.next());
+                assert!(aliased.last_error().is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn epoch_result_empty_metadata_needs_no_shared_allocation() {
+        let registry = crate::storage::mvcc::TransactionRegistry::new();
+        let mut result = EpochResult::new(
+            Box::new(ExecResult::new(5, 11)),
+            registry.capture_read_epoch(),
+        );
+        assert!(result.columns.is_none());
+        assert!(!result.next());
+        assert_eq!(result.rows_affected(), 5);
+        assert_eq!(result.last_insert_id(), 11);
+        assert_eq!(registry.oldest_retention_horizon(), None);
+    }
+
+    #[test]
+    fn epoch_result_row_extraction_never_returns_success_after_an_error() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+        for runtime_error in [false, true] {
+            let registry = Arc::new(crate::storage::mvcc::TransactionRegistry::new());
+            let epoch = registry.capture_read_epoch();
+            let dropped = Arc::new(AtomicUsize::new(0));
+            let inner = Box::new(EpochOwnerResult {
+                registry: registry.clone(),
+                _epoch: Some(epoch.clone()),
+                dropped: dropped.clone(),
+                columns: CompactArc::new(vec!["x".to_string()]),
+                rows: Some(CompactArc::new(vec![Row::from(vec![Value::Integer(1)])])),
+                remaining: 0,
+                estimate: 3,
+                runtime_error: runtime_error.then(|| crate::core::Error::internal("read failure")),
+                fail_close: true,
+            });
+            let mut result = EpochResult::new(inner, epoch);
+            assert!(result.try_into_arc_rows().is_none());
+            assert_eq!(dropped.load(Ordering::Relaxed), 1);
+            assert_eq!(registry.oldest_retention_horizon(), None);
+            assert!(!result.next());
+            let error = result.last_error().unwrap().to_string();
+            assert!(error.contains(if runtime_error {
+                "read failure"
+            } else {
+                "close failure"
+            }));
+            assert!(result.try_into_arc_rows().is_none());
+        }
+    }
+
+    #[test]
+    fn epoch_result_plain_columns_and_active_alias_survive_exhaustion() {
+        let registry = crate::storage::mvcc::TransactionRegistry::new();
+        let inner = crate::storage::traits::MemoryResult::with_rows(
+            vec!["x".to_string()],
+            vec![Row::from(vec![Value::Integer(1)])],
+        );
+        let result = Box::new(EpochResult::new(
+            Box::new(inner),
+            registry.capture_read_epoch(),
+        ));
+        assert!(result.columns_arc().is_some());
+        let mut aliases = FxHashMap::default();
+        aliases.insert("renamed".to_string(), "x".to_string());
+        let mut result = result.with_aliases(aliases);
+        assert!(result.next());
+        assert!(!result.next());
+        assert_eq!(registry.oldest_retention_horizon(), None);
+        assert_eq!(result.columns(), &["renamed"]);
+        result.close().unwrap();
+    }
+
+    #[test]
+    fn epoch_result_failed_extraction_checks_error_before_large_fallback_allocation() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+        let registry = Arc::new(crate::storage::mvcc::TransactionRegistry::new());
+        let epoch = registry.capture_read_epoch();
+        let dropped = Arc::new(AtomicUsize::new(0));
+        let inner = Box::new(EpochOwnerResult {
+            registry: registry.clone(),
+            _epoch: Some(epoch.clone()),
+            dropped: dropped.clone(),
+            columns: CompactArc::new(vec!["x".to_string()]),
+            rows: Some(CompactArc::new(vec![Row::from(vec![Value::Integer(1)])])),
+            remaining: 0,
+            estimate: usize::MAX,
+            runtime_error: None,
+            fail_close: true,
+        });
+        let result = Box::new(EpochResult::new(inner, epoch));
+        // Vec<Row>::with_capacity(usize::MAX) would deterministically panic
+        // with capacity overflow. The original close error must win instead.
+        let error = crate::executor::Executor::materialize_result_arc(result).unwrap_err();
+        assert!(error.to_string().contains("close failure"));
+        assert_eq!(dropped.load(Ordering::Relaxed), 1);
+        assert_eq!(registry.oldest_retention_horizon(), None);
+    }
 
     /// Helper to create RowVec from Vec<Row> for tests
     fn make_rows(rows: Vec<Row>) -> RowVec {

--- a/src/executor/semantic_cache.rs
+++ b/src/executor/semantic_cache.rs
@@ -56,23 +56,9 @@
 //!
 //! # Transaction Isolation Considerations
 //!
-//! **Important:** The semantic cache is currently global and does not account for
-//! MVCC transaction isolation. This means:
-//!
-//! - Cache entries are shared across all transactions
-//! - A transaction might see cached results from another transaction's read
-//! - Cache invalidation on DML ensures committed changes are reflected
-//!
-//! This is safe for:
-//! - Single-connection usage
-//! - Read-only workloads
-//! - Scenarios where eventual consistency is acceptable
-//!
-//! For strict serializable isolation with concurrent writes, consider:
-//! - Disabling the cache during critical transactions
-//! - Using explicit cache invalidation between operations
-//!
-//! Future enhancement: Per-transaction cache scoping with timestamp-based invalidation
+//! Executor entries carry an engine-issued scalar committed-view proof. Exact
+//! and subsumption hits require the same proof; invalidation is only eviction.
+//! Legacy standalone APIs remain untagged and never match tagged executor rows.
 
 use crate::common::time_compat::Instant;
 use rustc_hash::FxHasher;
@@ -84,6 +70,7 @@ use std::time::Duration;
 
 use crate::common::{CompactArc, StringMap};
 use crate::core::{Result, Row};
+use crate::storage::mvcc::registry::CacheProvenance;
 
 /// Convert to lowercase without allocation if already lowercase.
 /// Returns Cow::Borrowed for already-lowercase strings (zero allocation).
@@ -171,6 +158,7 @@ impl QueryFingerprint {
 /// Cached query result with metadata
 #[derive(Debug, Clone)]
 pub struct CachedResult {
+    provenance: Option<CacheProvenance>,
     /// The fingerprint identifying this query pattern
     pub fingerprint: QueryFingerprint,
     /// Column names in order
@@ -198,6 +186,7 @@ impl CachedResult {
         let now = Instant::now();
         Self {
             fingerprint,
+            provenance: None,
             column_names,
             rows: CompactArc::new(rows), // Wrap in CompactArc for zero-copy sharing
             predicate,
@@ -220,6 +209,7 @@ impl CachedResult {
         let now = Instant::now();
         Self {
             fingerprint,
+            provenance: None,
             column_names,
             rows, // Use Arc directly - no additional wrapping
             predicate,
@@ -382,6 +372,26 @@ impl SemanticCache {
         columns: &[String],
         predicate: Option<&Expression>,
     ) -> CacheLookupResult {
+        self.lookup_tagged(table_name, columns, predicate, None)
+    }
+
+    pub fn lookup_with_provenance(
+        &self,
+        table_name: &str,
+        columns: &[String],
+        predicate: Option<&Expression>,
+        provenance: CacheProvenance,
+    ) -> CacheLookupResult {
+        self.lookup_tagged(table_name, columns, predicate, Some(provenance))
+    }
+
+    fn lookup_tagged(
+        &self,
+        table_name: &str,
+        columns: &[String],
+        predicate: Option<&Expression>,
+        provenance: Option<CacheProvenance>,
+    ) -> CacheLookupResult {
         let (table_key, column_key) = Self::cache_keys(table_name, columns);
 
         // First pass: read-only search
@@ -418,6 +428,9 @@ impl SemanticCache {
             let mut found = None;
             let now = Instant::now();
             for (idx, entry) in entries.iter().enumerate() {
+                if entry.provenance != provenance {
+                    continue;
+                }
                 // Skip expired entries
                 if entry.is_expired_at(self.ttl, now) {
                     continue;
@@ -500,6 +513,28 @@ impl SemanticCache {
         rows: Vec<Row>,
         predicate: Option<Expression>,
     ) {
+        self.insert_tagged(table_name, columns, rows, predicate, None);
+    }
+
+    pub fn insert_with_provenance(
+        &self,
+        table_name: &str,
+        columns: Vec<String>,
+        rows: Vec<Row>,
+        predicate: Option<Expression>,
+        provenance: CacheProvenance,
+    ) {
+        self.insert_tagged(table_name, columns, rows, predicate, Some(provenance));
+    }
+
+    fn insert_tagged(
+        &self,
+        table_name: &str,
+        columns: Vec<String>,
+        rows: Vec<Row>,
+        predicate: Option<Expression>,
+        provenance: Option<CacheProvenance>,
+    ) {
         let new_row_count = rows.len();
 
         // Don't cache if too many rows in this single result
@@ -513,7 +548,8 @@ impl SemanticCache {
             None => QueryFingerprint::new(table_name, columns.clone()),
         };
 
-        let entry = CachedResult::new(fingerprint, columns, rows, predicate);
+        let mut entry = CachedResult::new(fingerprint, columns, rows, predicate);
+        entry.provenance = provenance;
         self.insert_entry(entry, new_row_count, table_key, column_key);
     }
 

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -465,6 +465,12 @@ impl Executor {
         subquery: &SelectStatement,
         ctx: &ExecutionContext,
     ) -> Result<Option<bool>> {
+        // Live secondary indexes may already have removed keys visible to
+        // this epoch. Filtering their candidate IDs cannot recover omissions.
+        if ctx.read_epoch().is_some() {
+            return Ok(None);
+        }
+
         // Probing the index answers whether a matching row is there, which
         // is the whole question EXISTS asks only when the WHERE decides the
         // rows. The extractor below is shared with the paths that read a
@@ -825,6 +831,12 @@ impl Executor {
         subquery: &SelectStatement,
         ctx: &ExecutionContext,
     ) -> Result<Option<i64>> {
+        // Live secondary indexes may already have removed keys visible to
+        // this epoch. Filtering their candidate IDs cannot recover omissions.
+        if ctx.read_epoch().is_some() {
+            return Ok(None);
+        }
+
         // Need outer row context for correlated subquery
         let outer_row = match ctx.outer_row() {
             Some(row) => row,
@@ -1027,6 +1039,7 @@ impl Executor {
         subquery: &SelectStatement,
         ctx: &ExecutionContext,
     ) -> Option<crate::core::Value> {
+        super::context::ensure_statement_cache_epoch(ctx);
         // Need outer row context for correlated subquery
         let outer_row = ctx.outer_row()?;
 
@@ -1145,6 +1158,7 @@ impl Executor {
         subquery: &SelectStatement,
         ctx: &ExecutionContext,
     ) -> Result<Option<CompactArc<ValueMap<Value>>>> {
+        super::context::ensure_statement_cache_epoch(ctx);
         // Must have single aggregate column
         if subquery.columns.len() != 1 {
             return Ok(None);
@@ -1827,6 +1841,7 @@ impl Executor {
         subquery: &SelectStatement,
         ctx: &ExecutionContext,
     ) -> Result<crate::core::Value> {
+        super::context::ensure_statement_cache_epoch(ctx);
         // Check if this is a non-correlated subquery (no outer row context)
         // Non-correlated subqueries can be cached since they return the same result
         let is_non_correlated =
@@ -1953,6 +1968,7 @@ impl Executor {
         subquery: &SelectStatement,
         ctx: &ExecutionContext,
     ) -> Result<Vec<crate::core::Value>> {
+        super::context::ensure_statement_cache_epoch(ctx);
         // Check if this is a non-correlated subquery (no outer row context)
         // Non-correlated subqueries can be cached since they return the same result
         let is_non_correlated =
@@ -2846,6 +2862,7 @@ impl Executor {
         subquery: &SelectStatement,
         ctx: &ExecutionContext,
     ) -> Option<String> {
+        super::context::ensure_statement_cache_epoch(ctx);
         use std::fmt::Write;
         let mut key = subquery.to_string();
         if key.contains('?') {
@@ -4274,6 +4291,7 @@ impl Executor {
         info: &SemiJoinInfo,
         ctx: &ExecutionContext,
     ) -> Result<CompactArc<ValueSet>> {
+        super::context::ensure_statement_cache_epoch(ctx);
         // Build cache key hash from inner table, column, and WHERE predicate hash
         // Uses u64 hash to avoid any string allocation
         let pred_hash = info
@@ -4394,11 +4412,9 @@ impl Executor {
         info: &SemiJoinInfo,
         outer_rows: CompactArc<Vec<crate::core::Row>>,
         outer_columns: &[String],
-        _ctx: &ExecutionContext,
+        ctx: &ExecutionContext,
     ) -> Result<crate::core::RowVec> {
-        // Direct table access - much faster than going through execute_select
-        let txn = self.engine.begin_transaction()?;
-        let inner_table = txn.get_table(&info.inner_table)?;
+        let inner_table = self.table_in_context(&info.inner_table, ctx)?;
 
         // Convert non-correlated WHERE to storage expression for pushdown
         let storage_expr = info
@@ -4627,7 +4643,9 @@ impl Executor {
                 if let Some(info) = Self::try_extract_semi_join_info(exists, false, outer_tables) {
                     // Check if index-nested-loop would be more efficient
                     // (index exists + no additional predicates, OR index exists + small LIMIT)
-                    if self.should_use_index_nested_loop(&info, outer_limit) {
+                    if ctx.read_epoch().is_none()
+                        && self.should_use_index_nested_loop(&info, outer_limit)
+                    {
                         return Ok(None); // Skip semi-join, use index probing per row
                     }
                     // Semi-join optimization: execute inner query once, collect into hash set
@@ -4643,7 +4661,9 @@ impl Executor {
                     if let Some(info) = Self::try_extract_semi_join_info(exists, true, outer_tables)
                     {
                         // Check if index-nested-loop would be more efficient
-                        if self.should_use_index_nested_loop(&info, outer_limit) {
+                        if ctx.read_epoch().is_none()
+                            && self.should_use_index_nested_loop(&info, outer_limit)
+                        {
                             return Ok(None); // Skip semi-join, use index probing per row
                         }
                         let hash_set = self.execute_semi_join_optimization(&info, ctx)?;

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -3677,6 +3677,30 @@ impl Executor {
         Ordering::Equal
     }
 
+    /// Preserve the indexed window input order when a captured table declines
+    /// its storage ordering shortcut (for example, FLOAT keys with NaNs).
+    /// Sort the retained rows in place, using the window comparator itself.
+    pub(crate) fn sort_captured_window_rows(
+        rows: &mut [(i64, Row)],
+        column: usize,
+        ascending: bool,
+    ) {
+        rows.sort_unstable_by(|(left_id, left), (right_id, right)| {
+            let left = left
+                .get(column)
+                .unwrap_or(&Value::Null(crate::core::DataType::Null));
+            let right = right
+                .get(column)
+                .unwrap_or(&Value::Null(crate::core::DataType::Null));
+            let order = Self::compare_values_fast(left, right).then(left_id.cmp(right_id));
+            if ascending {
+                order
+            } else {
+                order.reverse()
+            }
+        });
+    }
+
     /// Fast value comparison with type-specific paths
     #[inline]
     fn compare_values_fast(a: &Value, b: &Value) -> Ordering {

--- a/src/storage/index/hnsw.rs
+++ b/src/storage/index/hnsw.rs
@@ -2898,6 +2898,11 @@ impl HnswIndex {
         self.metric
     }
 
+    /// Immutable vector shape for preparing an equivalent empty index.
+    pub(crate) fn dimensions(&self) -> usize {
+        self.dims
+    }
+
     /// Get the HNSW tuning parameters (m, ef_construction, ef_search, metric).
     pub fn params(&self) -> (usize, usize, usize, HnswDistanceMetric) {
         (self.m, self.ef_construction, self.ef_search, self.metric)

--- a/src/storage/mvcc/arena.rs
+++ b/src/storage/mvcc/arena.rs
@@ -367,6 +367,11 @@ impl Chunk {
     }
 }
 
+/// Detached chunk ownership, released only after a truncate transfer unlocks.
+pub(crate) struct RetiredArena {
+    _inner: ArenaInner,
+}
+
 struct ArenaInner {
     chunks: Vec<Chunk>,
     active: Option<ChunkId>,
@@ -1121,6 +1126,29 @@ impl RowArena {
         self.bytes.store(0, Ordering::Relaxed);
     }
 
+    /// Detach ownership without dropping row payloads inside a transfer fence.
+    /// The caller drops the returned owner after publication unlocks. Chunk
+    /// identities and independent WAL receipts are never reset by TRUNCATE.
+    pub(crate) fn take_all_for_truncate(&self) -> RetiredArena {
+        let mut inner = self.inner.write();
+        let replacement = ArenaInner {
+            chunks: Vec::new(),
+            active: None,
+            next_chunk_id: inner.next_chunk_id,
+            free_head: None,
+            occupied: 0,
+            slot_count: 0,
+            initial_capacity: inner.initial_capacity,
+            directory_charge: inner
+                .directory_charge
+                .as_ref()
+                .map(|charge| MemoryCharge::new(charge.account(), 0)),
+        };
+        let retired = std::mem::replace(&mut *inner, replacement);
+        self.bytes.store(0, Ordering::Relaxed);
+        RetiredArena { _inner: retired }
+    }
+
     pub fn len(&self) -> usize {
         self.inner.read().occupied
     }
@@ -1790,6 +1818,34 @@ mod tests {
             arena.capacity().lsn_tree_bytes,
             4 * std::mem::size_of::<Option<NonZeroU64>>()
         );
+    }
+
+    #[test]
+    fn truncate_detaches_charges_without_reusing_chunk_ids_or_dropping_receipts() {
+        let account = MemoryAccount::new();
+        let baseline = account.snapshot().accounted_bytes;
+        let arena = RowArena::with_account(0, &account);
+        let first = arena.insert_arc(1, 1, payload(1), lsn(10)).unwrap();
+        let pin = arena.pin_chunk_lsn(first.chunk_id()).unwrap().unwrap();
+        let retained = account.snapshot().retained_bytes;
+        let retired = arena.take_all_for_truncate();
+        assert!(arena.is_empty());
+        assert!(arena.read_guard().get(first).is_none());
+        assert_eq!(arena.capacity().metadata_bytes, 0);
+        assert_eq!(account.snapshot().retained_bytes, retained);
+        assert_eq!(arena.first_lsn(), lsn(10));
+
+        let second = arena.insert_arc(1, 2, payload(2), lsn(20)).unwrap();
+        assert!(second.chunk_id() > first.chunk_id());
+        assert!(arena.read_guard().get(first).is_none());
+        let both = account.snapshot().retained_bytes;
+        drop(retired);
+        assert!(account.snapshot().retained_bytes < both);
+        assert_eq!(arena.first_lsn(), lsn(10));
+        drop(pin);
+        assert_eq!(arena.first_lsn(), lsn(20));
+        drop(arena);
+        assert_eq!(account.snapshot().accounted_bytes, baseline);
     }
 
     #[test]

--- a/src/storage/mvcc/captured_scanner.rs
+++ b/src/storage/mvcc/captured_scanner.rs
@@ -1,0 +1,308 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bounded row materialization over an immutable statement-owned hot view.
+
+use std::ops::Bound;
+use std::sync::Arc;
+
+use crate::common::CompactArc;
+use crate::core::{Result, Row, Schema, Value};
+use crate::storage::expression::Expression;
+use crate::storage::traits::Scanner;
+
+use super::version_store::CapturedHotView;
+
+struct OrderedKey {
+    key: Value,
+    id: i64,
+    ascending: bool,
+}
+
+impl PartialEq for OrderedKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other).is_eq()
+    }
+}
+impl Eq for OrderedKey {}
+impl PartialOrd for OrderedKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for OrderedKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let order = self.key.cmp(&other.key);
+        if self.ascending {
+            order.then(self.id.cmp(&other.id))
+        } else {
+            order.reverse().then(other.id.cmp(&self.id))
+        }
+    }
+}
+
+/// Keep only offset+limit keys; materialize the selected immutable rows once.
+pub(crate) fn sorted_hot_rows(
+    view: &CapturedHotView,
+    schema: &Schema,
+    column: usize,
+    ascending: bool,
+    limit: usize,
+    offset: usize,
+    filter: Option<&dyn Expression>,
+) -> Result<crate::core::RowVec> {
+    let mut rows = crate::core::RowVec::new();
+    if limit == 0 {
+        return Ok(rows);
+    }
+    let needed = limit.saturating_add(offset);
+    let default = schema
+        .columns
+        .get(column)
+        .map(|column| {
+            column
+                .default_value
+                .clone()
+                .unwrap_or_else(|| Value::null(column.data_type))
+        })
+        .unwrap_or_else(Value::null_unknown);
+    let mut heap = std::collections::BinaryHeap::<OrderedKey>::with_capacity(needed.min(256));
+    let mut error = None;
+    view.for_each_visible_until(|id, row| {
+        let key = row.get(column).unwrap_or(&default);
+        if heap.len() == needed {
+            let Some(worst) = heap.peek() else {
+                unreachable!("a full nonzero top-k heap has a head");
+            };
+            let order = key.cmp(&worst.key);
+            let order = if ascending {
+                order.then(id.cmp(&worst.id))
+            } else {
+                order.reverse().then(worst.id.cmp(&id))
+            };
+            if !order.is_lt() {
+                return true;
+            }
+        }
+        if let Some(filter) = filter {
+            let mut normalized;
+            let row = if row.len() < schema.columns.len() {
+                normalized = row.clone();
+                for column in &schema.columns[row.len()..] {
+                    normalized.push(
+                        column
+                            .default_value
+                            .clone()
+                            .unwrap_or_else(|| Value::null(column.data_type)),
+                    );
+                }
+                &normalized
+            } else {
+                row
+            };
+            match filter.evaluate(row) {
+                Ok(true) => (),
+                Ok(false) => return true,
+                Err(failure) => {
+                    error = Some(failure);
+                    return false;
+                }
+            }
+        }
+        if heap.len() == needed {
+            heap.pop();
+        }
+        heap.push(OrderedKey {
+            key: key.clone(),
+            id,
+            ascending,
+        });
+        true
+    });
+    if let Some(error) = error {
+        return Err(error);
+    }
+    for selected in heap.into_sorted_vec().into_iter().skip(offset) {
+        if let super::version_store::CapturedHotRow::Value(source) = view.row_state(selected.id) {
+            let mut row = source.clone();
+            if row.len() < schema.columns.len() {
+                for column in &schema.columns[row.len()..] {
+                    row.push(
+                        column
+                            .default_value
+                            .clone()
+                            .unwrap_or_else(|| Value::null(column.data_type)),
+                    );
+                }
+            } else if row.len() > schema.columns.len() {
+                row.truncate(schema.columns.len());
+            }
+            rows.push((selected.id, row));
+        }
+    }
+    Ok(rows)
+}
+
+pub(crate) struct CapturedHotScanner {
+    view: Option<Arc<CapturedHotView>>,
+    schema: CompactArc<Schema>,
+    filter: Option<Box<dyn Expression>>,
+    projection: Vec<usize>,
+    batch: Vec<(i64, Row)>,
+    position: usize,
+    last_id: Option<i64>,
+    exhausted: bool,
+    error: Option<crate::core::Error>,
+    empty: Row,
+}
+
+impl CapturedHotScanner {
+    const BATCH_ROWS: usize = 128;
+
+    pub(crate) fn new(
+        view: Arc<CapturedHotView>,
+        schema: CompactArc<Schema>,
+        columns: &[usize],
+        filter: Option<&dyn Expression>,
+    ) -> Self {
+        let needs_projection = !columns.is_empty()
+            && (columns.len() != schema.columns.len()
+                || !columns.iter().enumerate().all(|(i, &column)| i == column));
+        let batch_capacity = if view.is_empty() { 0 } else { Self::BATCH_ROWS };
+        Self {
+            view: Some(view),
+            schema,
+            filter: filter.map(Expression::clone_box),
+            projection: if needs_projection {
+                columns.to_vec()
+            } else {
+                Vec::new()
+            },
+            batch: Vec::with_capacity(batch_capacity),
+            position: 0,
+            last_id: None,
+            exhausted: false,
+            error: None,
+            empty: Row::new(),
+        }
+    }
+
+    fn refill(&mut self) {
+        self.batch.clear();
+        self.position = 0;
+        let Some(view) = &self.view else {
+            self.exhausted = true;
+            return;
+        };
+        let start = self.last_id.map_or(Bound::Unbounded, Bound::Excluded);
+        self.exhausted =
+            view.for_each_visible_range_until((start, Bound::Unbounded), |id, source| {
+                self.last_id = Some(id);
+                let mut row = source.clone();
+                if row.len() < self.schema.columns.len() {
+                    for column in &self.schema.columns[row.len()..] {
+                        row.push(
+                            column
+                                .default_value
+                                .clone()
+                                .unwrap_or_else(|| Value::null(column.data_type)),
+                        );
+                    }
+                } else if row.len() > self.schema.columns.len() {
+                    row.truncate(self.schema.columns.len());
+                }
+                let matched = match self
+                    .filter
+                    .as_ref()
+                    .map(|filter| filter.evaluate(&row))
+                    .transpose()
+                {
+                    Ok(matched) => matched.unwrap_or(true),
+                    Err(error) => {
+                        self.error = Some(error);
+                        return false;
+                    }
+                };
+                if matched {
+                    if !self.projection.is_empty() {
+                        row = Row::from_values(
+                            self.projection
+                                .iter()
+                                .map(|&column| {
+                                    row.get(column).cloned().unwrap_or_else(Value::null_unknown)
+                                })
+                                .collect(),
+                        );
+                    }
+                    self.batch.push((id, row));
+                }
+                self.batch.len() < Self::BATCH_ROWS
+            });
+        if self.error.is_some() {
+            self.batch.clear();
+            self.exhausted = true;
+        }
+    }
+}
+
+impl Scanner for CapturedHotScanner {
+    fn next(&mut self) -> bool {
+        if self.position == self.batch.len() {
+            if self.exhausted {
+                let _ = self.close();
+                return false;
+            }
+            self.refill();
+            if self.batch.is_empty() {
+                let _ = self.close();
+                return false;
+            }
+        }
+        self.position += 1;
+        true
+    }
+    fn row(&self) -> &Row {
+        self.position
+            .checked_sub(1)
+            .and_then(|index| self.batch.get(index))
+            .map_or(&self.empty, |(_, row)| row)
+    }
+    fn take_row(&mut self) -> Row {
+        self.position
+            .checked_sub(1)
+            .and_then(|index| self.batch.get_mut(index))
+            .map_or_else(Row::new, |(_, row)| std::mem::take(row))
+    }
+    fn current_row_id(&self) -> i64 {
+        self.position
+            .checked_sub(1)
+            .and_then(|index| self.batch.get(index))
+            .map_or(0, |(id, _)| *id)
+    }
+    fn take_row_with_id(&mut self) -> (i64, Row) {
+        (self.current_row_id(), self.take_row())
+    }
+    fn err(&self) -> Option<&crate::core::Error> {
+        self.error.as_ref()
+    }
+    fn close(&mut self) -> Result<()> {
+        self.view = None;
+        self.filter = None;
+        self.projection = Vec::new();
+        self.batch = Vec::new();
+        self.position = 0;
+        self.exhausted = true;
+        Ok(())
+    }
+}

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -62,6 +62,59 @@ type TxnTableEntry = (SmartString, CompactArc<RwLock<TransactionVersionStore>>);
 /// Uses SmallVec<[T; 2]> since most transactions access 1-2 tables, avoiding heap allocation
 type TxnVersionStoreMap = I64Map<super::accounting::RetainedSmallVec<[TxnTableEntry; 2]>>;
 
+/// The TRUNCATE coordinator needs a weak cache reference: owning it would
+/// create cache -> local store -> parent store -> coordinator -> cache. Keep
+/// the std::Arc allocation allowance at its final owner, while nested map and
+/// local-store allocations retain their exact independent charges.
+struct TxnVersionStoreCache {
+    values: RwLock<TxnVersionStoreMap>,
+    object_charge: CompactArc<crate::common::memory::MemoryCharge>,
+}
+
+/// std::Arc retains its entire allocation while any Weak exists, even after
+/// dropping the payload. Pair every internal Weak with the allocation token.
+/// Field order frees the weak allocation before releasing its last token.
+struct WeakTxnVersionStoreCache {
+    values: std::sync::Weak<TxnVersionStoreCache>,
+    _object_charge: CompactArc<crate::common::memory::MemoryCharge>,
+}
+
+impl WeakTxnVersionStoreCache {
+    fn upgrade(&self) -> Option<Arc<TxnVersionStoreCache>> {
+        self.values.upgrade()
+    }
+}
+
+impl TxnVersionStoreCache {
+    fn new_in(account: &crate::common::memory::MemoryAccount) -> Arc<Self> {
+        Arc::new(Self {
+            values: RwLock::new(I64Map::new_in(account)),
+            object_charge: CompactArc::new_in(
+                crate::common::memory::MemoryCharge::conservative(
+                    account,
+                    std::mem::size_of::<Self>() + 4 * std::mem::size_of::<usize>(),
+                ),
+                account,
+            ),
+        })
+    }
+
+    fn downgrade(cache: &Arc<Self>) -> WeakTxnVersionStoreCache {
+        WeakTxnVersionStoreCache {
+            values: Arc::downgrade(cache),
+            _object_charge: cache.object_charge.clone(),
+        }
+    }
+}
+
+impl std::ops::Deref for TxnVersionStoreCache {
+    type Target = RwLock<TxnVersionStoreMap>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.values
+    }
+}
+
 /// Helper to get registry as the visibility checker type expected by VersionStore.
 /// In production: returns concrete Arc<TransactionRegistry> (zero-cost, inlined).
 /// In tests: returns Arc<dyn VisibilityChecker> for TestVisibilityChecker flexibility.
@@ -473,7 +526,7 @@ pub struct MVCCEngine {
     execution_failed: Arc<AtomicBool>,
     /// Cache of transaction version stores per (txn_id, table_name) for proper commit/rollback
     /// (Arc-wrapped for safe sharing with transactions)
-    txn_version_stores: CompactArc<RwLock<TxnVersionStoreMap>>,
+    txn_version_stores: Arc<TxnVersionStoreCache>,
     /// View definitions (Arc for cheap cloning on lookup)
     views: RwLock<FxHashMap<String, Arc<ViewDefinition>>>,
     /// Persistence manager for WAL and snapshot operations (Arc-wrapped for safe sharing)
@@ -502,6 +555,9 @@ pub struct MVCCEngine {
     /// Key: lowercase table name. Replaces frozen_volumes + volume_tombstones.
     segment_managers:
         Arc<RwLock<FxHashMap<String, Arc<crate::storage::volume::manifest::SegmentManager>>>>,
+    /// File cleanup is deferred until captured identities have no readers.
+    volume_retirements: Arc<crate::storage::volume::io::VolumeRetirementQueue>,
+    truncate_coordinator: std::sync::OnceLock<Arc<dyn super::version_store::TruncateCoordinator>>,
     /// When true, seal_hot_buffers bypasses thresholds and seals all rows.
     /// Set during close_engine to ensure all data is in volumes before shutdown.
     force_seal_all: AtomicBool,
@@ -510,7 +566,7 @@ pub struct MVCCEngine {
     /// Prevents concurrent checkpoint cycles (background thread vs PRAGMA SNAPSHOT).
     /// Without this, two concurrent seal+compact runs can each read the same old
     /// segments, produce overlapping compacted volumes, and delete each other's data.
-    checkpoint_mutex: Mutex<()>,
+    checkpoint_mutex: Arc<Mutex<()>>,
     /// Seal fence: commits acquire READ (shared, ~5ns), micro-seal acquires WRITE
     /// (exclusive, brief ~100ms) to create a quiet moment where all_hot_empty can
     /// be true. This enables WAL truncation under continuous writes.
@@ -534,6 +590,55 @@ impl Drop for AtomicBoolGuard<'_> {
     }
 }
 
+/// Acquire before checkpoint serialization, catalog or seal fences.
+/// Snapshot and restore use the same compaction-flag then checkpoint order;
+/// a caller must never wait for this flag while holding checkpoint_mutex.
+fn claim_compaction_slot(flag: &AtomicBool) -> AtomicBoolGuard<'_> {
+    while flag
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    AtomicBoolGuard(flag)
+}
+
+/// Namespace operations match snapshot/restore: compaction flag first, then
+/// checkpoint mutex. Field order releases the mutex before releasing the flag.
+struct VolumeNamespaceGuard<'a> {
+    _checkpoint: std::sync::MutexGuard<'a, ()>,
+    _compaction: AtomicBoolGuard<'a>,
+}
+
+fn acquire_volume_namespace<'a>(
+    flag: &'a AtomicBool,
+    checkpoint: &'a Mutex<()>,
+) -> Result<VolumeNamespaceGuard<'a>> {
+    let compaction = claim_compaction_slot(flag);
+    let checkpoint = checkpoint
+        .lock()
+        .map_err(|_| Error::internal("checkpoint mutex is poisoned"))?;
+    Ok(VolumeNamespaceGuard {
+        _checkpoint: checkpoint,
+        _compaction: compaction,
+    })
+}
+
+/// Called only after durable removal (manifest or DDL WAL) and outside fences.
+/// The snapshot holds every identity until all queue entries are installed.
+fn retire_manager_volumes(
+    manager: &crate::storage::volume::manifest::SegmentManager,
+    queue: &crate::storage::volume::io::VolumeRetirementQueue,
+) {
+    let previous = manager.segments_raw();
+    manager.clear();
+    for segment in previous.values() {
+        if let Some(backing) = segment.volume.backing.get() {
+            queue.retire(backing);
+        }
+    }
+}
+
 /// Parse a volume ID from a `.vol` filename (e.g., `vol_00065f1a2b3c4d5e.vol` -> `0x00065f1a2b3c4d5e`).
 fn parse_volume_id(path: &std::path::Path) -> Option<u64> {
     path.file_name()
@@ -549,6 +654,7 @@ fn get_or_create_segment_manager(
         FxHashMap<String, Arc<crate::storage::volume::manifest::SegmentManager>>,
     >,
     persistence: &Option<PersistenceManager>,
+    file_catalog: &Arc<crate::storage::volume::io::VolumeRetirementQueue>,
     table_name: &str,
     memory: &crate::common::memory::MemoryAccount,
 ) -> Arc<crate::storage::volume::manifest::SegmentManager> {
@@ -564,16 +670,339 @@ fn get_or_create_segment_manager(
     mgrs.entry(table_name.to_string())
         .or_insert_with(|| {
             let vol_dir = persistence.as_ref().map(|pm| pm.path().join("volumes"));
-            Arc::new(crate::storage::volume::manifest::SegmentManager::new_in(
-                table_name,
-                vol_dir,
-                memory.child(),
-            ))
+            Arc::new(
+                crate::storage::volume::manifest::SegmentManager::new_with_file_catalog_in(
+                    table_name,
+                    vol_dir,
+                    file_catalog.clone(),
+                    memory.child(),
+                ),
+            )
         })
         .clone()
 }
 
+/// Read only current committed references under destructive admission. The
+/// schema is pinned by the caller; no new transaction or ordinary read lease
+/// registration is attempted while the admission flag is held.
+fn truncate_child_has_reference(
+    store: &VersionStore,
+    schema: &Schema,
+    fk: &crate::core::ForeignKeyConstraint,
+    manager: Option<&Arc<crate::storage::volume::manifest::SegmentManager>>,
+    epoch: &super::registry::ReadEpoch,
+) -> Result<bool> {
+    use crate::storage::expression::{Expression, NullCheckExpr};
+    use crate::storage::traits::Scanner;
+    use crate::storage::volume::writer::{compute_column_mapping_with_drops, ColSource};
+    let column = schema
+        .columns
+        .get(fk.column_index)
+        .filter(|column| column.name.eq_ignore_ascii_case(&fk.column_name))
+        .ok_or_else(|| Error::internal("invalid foreign-key column metadata"))?;
+    let (root, cold) = if let Some(manager) = manager {
+        let (root, generation) = manager.capture_with_hot(|| store.capture_hot_root())?;
+        (root, Some(generation))
+    } else {
+        (store.capture_hot_root(), None)
+    };
+    let view = Arc::new(super::version_store::CapturedHotView::new(
+        root,
+        epoch.clone(),
+        None,
+    ));
+    let exhausted = view.for_each_visible_until(|_, row| {
+        row.get(fk.column_index)
+            .or(column.default_value.as_ref())
+            .is_none_or(Value::is_null)
+    });
+    if !exhausted {
+        return Ok(true);
+    }
+    let Some(generation) = cold else {
+        return Ok(false);
+    };
+    // Public schema mutation/cache refresh can be separate calls. Fail closed
+    // if a captured cold mapping has not caught up with the pinned schema.
+    // Scratch is one schema mapping at a time, never a child row collection.
+    if let Some(manager) = manager {
+        let metadata = manager.manifest();
+        for segment in generation.segments.values() {
+            let expected = compute_column_mapping_with_drops(
+                schema,
+                &segment.volume,
+                &metadata.dropped_columns,
+                segment.schema_version,
+                &metadata.column_renames,
+            );
+            let matching = match (
+                expected.sources.get(fk.column_index),
+                segment.mapping.sources.get(fk.column_index),
+            ) {
+                (Some(ColSource::Volume(left)), Some(ColSource::Volume(right))) => left == right,
+                (Some(ColSource::Default(left)), Some(ColSource::Default(right))) => left == right,
+                _ => false,
+            };
+            if !matching {
+                return Err(Error::TableHasActiveTransactions);
+            }
+        }
+    }
+    let mut filter = NullCheckExpr::is_not_null(column.name.as_str());
+    filter.prepare_for_schema(schema);
+    let mut scanner = crate::storage::volume::captured_scanner::CapturedColdScanner::new(
+        generation,
+        view,
+        Arc::new(FxHashSet::default()),
+        vec![fk.column_index],
+        Some(Box::new(filter)),
+        schema,
+    );
+    let found = scanner.next();
+    if let Some(error) = scanner.err() {
+        return Err(error.clone());
+    }
+    Ok(found)
+}
+
+/// One engine context, shared by stores without owning any store. The weak
+/// manager map also prevents a store/context/manager ownership cycle.
+struct EngineTruncateCoordinator {
+    registry: Arc<TransactionRegistry>,
+    schemas: Arc<RwLock<FxHashMap<String, CompactArc<Schema>>>>,
+    version_stores: std::sync::Weak<RwLock<FxHashMap<String, Arc<VersionStore>>>>,
+    txn_version_stores: WeakTxnVersionStoreCache,
+    persistence: Arc<Option<PersistenceManager>>,
+    loading_from_disk: Arc<AtomicBool>,
+    execution_failed: Arc<AtomicBool>,
+    segment_managers: std::sync::Weak<
+        RwLock<FxHashMap<String, Arc<crate::storage::volume::manifest::SegmentManager>>>,
+    >,
+    compaction_running: Arc<AtomicBool>,
+    checkpoint_mutex: Arc<Mutex<()>>,
+    retirements: Arc<crate::storage::volume::io::VolumeRetirementQueue>,
+}
+
+impl super::version_store::TruncateCoordinator for EngineTruncateCoordinator {
+    fn truncate(
+        &self,
+        store: &VersionStore,
+        txn_id: i64,
+        private_epoch: Option<(&super::registry::ReadEpoch, usize)>,
+    ) -> Result<i32> {
+        if self.execution_failed.load(Ordering::Acquire)
+            || self
+                .persistence
+                .as_ref()
+                .as_ref()
+                .is_some_and(PersistenceManager::has_indeterminate_commit)
+        {
+            return Err(Error::internal("engine requires recovery"));
+        }
+        let _namespace =
+            acquire_volume_namespace(&self.compaction_running, &self.checkpoint_mutex)?;
+        let admission = self
+            .registry
+            .prepare_destructive_ddl(txn_id, private_epoch)?;
+        let managers = self
+            .segment_managers
+            .upgrade()
+            .ok_or(Error::EngineNotOpen)?;
+        let stores_owner = self.version_stores.upgrade().ok_or(Error::EngineNotOpen)?;
+        let local_owner = self
+            .txn_version_stores
+            .upgrade()
+            .ok_or(Error::EngineNotOpen)?;
+        // Never wait behind a catalog/schema writer which might itself need
+        // ordinary registration blocked by this admission reservation.
+        let catalog = self
+            .schemas
+            .try_read()
+            .map_err(|_| Error::TableHasActiveTransactions)?;
+        let stores = stores_owner
+            .try_read()
+            .map_err(|_| Error::TableHasActiveTransactions)?;
+        let manager_map = managers
+            .try_read()
+            .map_err(|_| Error::TableHasActiveTransactions)?;
+        let locals = local_owner
+            .try_read()
+            .map_err(|_| Error::TableHasActiveTransactions)?;
+        let mut schemas = Vec::with_capacity(stores.len());
+        for (name, child) in stores.iter() {
+            let schema = child
+                .try_schema_for_ddl()
+                .ok_or(Error::TableHasActiveTransactions)?;
+            if catalog.get(name).is_none_or(|cached| **cached != **schema) {
+                return Err(Error::TableHasActiveTransactions);
+            }
+            schemas.push((name, child, schema));
+        }
+        if catalog.len() != schemas.len() {
+            return Err(Error::TableHasActiveTransactions);
+        }
+        let table_name = schemas
+            .iter()
+            .find(|(_, current, _)| std::ptr::eq(current.as_ref(), store))
+            .map(|(name, _, _)| name.as_str())
+            .ok_or(Error::TableClosed)?;
+        let manager = manager_map.get(table_name).cloned();
+        // A local child DELETE cannot justify nonrollbackable TRUNCATE, and
+        // a later local INSERT must not slip between validation and WAL.
+        let mut child_writes = smallvec::SmallVec::<
+            [std::sync::RwLockWriteGuard<'_, TransactionVersionStore>; 2],
+        >::new();
+        let mut validation_epoch = None;
+        for (name, child, schema) in &schemas {
+            if !schema
+                .foreign_keys
+                .iter()
+                .any(|fk| fk.referenced_table == table_name)
+            {
+                continue;
+            }
+            if let Some((_, local)) = locals.get(txn_id).and_then(|tables| {
+                tables
+                    .iter()
+                    .find(|(local_name, _)| local_name.as_str() == name.as_str())
+            }) {
+                if name.as_str() != table_name {
+                    let held = local
+                        .try_write()
+                        .map_err(|_| Error::TableHasActiveTransactions)?;
+                    if held.has_local_changes() {
+                        return Err(Error::TableHasActiveTransactions);
+                    }
+                    child_writes.push(held);
+                }
+            }
+            for fk in schema
+                .foreign_keys
+                .iter()
+                .filter(|fk| fk.referenced_table == table_name)
+            {
+                let epoch =
+                    validation_epoch.get_or_insert_with(|| admission.capture_current_epoch());
+                if truncate_child_has_reference(
+                    child,
+                    schema,
+                    fk,
+                    manager_map.get(name.as_str()),
+                    epoch,
+                )? {
+                    return Err(Error::foreign_key_violation(
+                        name.as_str(),
+                        &fk.column_name,
+                        table_name,
+                        &fk.referenced_column,
+                        format!(
+                            "cannot truncate table '{}' — rows in '{}' still reference it",
+                            table_name, name
+                        ),
+                    ));
+                }
+            }
+        }
+        let hot = store.prepare_hot_truncate()?;
+        let cold = manager
+            .as_ref()
+            .map(|manager| manager.prepare_truncate())
+            .transpose()?;
+        let mut rows = store.committed_row_count();
+        if let (Some(manager), Some(cold)) = (&manager, &cold) {
+            let tombstones = manager.tombstone_set_arc();
+            for segment in cold.old_segments.values() {
+                for position in 0..segment.volume.meta.row_count {
+                    if !segment.is_visible(position) {
+                        continue;
+                    }
+                    let id = segment.volume.row_id_at(position)?;
+                    if !tombstones.contains_key(&id) && !store.has_committed_row(id) {
+                        rows = rows
+                            .checked_add(1)
+                            .ok_or_else(|| Error::internal("TRUNCATE row count overflow"))?;
+                    }
+                }
+            }
+        }
+        let rows = i32::try_from(rows)
+            .map_err(|_| Error::internal("TRUNCATE row count exceeds API range"))?;
+        let retired_files = cold
+            .as_ref()
+            .filter(|cold| !cold.old_segments.is_empty())
+            .map(|cold| {
+                let mut batch = self.retirements.prepare_retirement(
+                    cold.old_segments
+                        .values()
+                        .filter_map(|segment| segment.volume.backing.get()),
+                );
+                batch.omitted_segment_ids = cold.old_segments.keys().copied().collect();
+                batch
+            });
+
+        // Catalog/schema and caller-local guards retain the validated namespace through WAL.
+        if !self.loading_from_disk.load(Ordering::Acquire) {
+            if let Some(pm) = self
+                .persistence
+                .as_ref()
+                .as_ref()
+                .filter(|pm| pm.is_enabled())
+            {
+                pm.record_ddl_operation(table_name, WALOperationType::TruncateTable, &[])?;
+            }
+        }
+        let retired = {
+            let _fence = manager.as_ref().map(|manager| manager.acquire_seal_write());
+            let old_hot = store.apply_hot_truncate(hot);
+            let old_cold = manager
+                .as_ref()
+                .zip(cold)
+                .map(|(manager, cold)| manager.apply_truncate(cold));
+            (old_hot, old_cold)
+        };
+        if let Some((manager, batch)) = manager.as_ref().zip(retired_files) {
+            manager.park_truncate_retirement(batch);
+        }
+        // New statements may proceed before large detached allocations drop.
+        drop(validation_epoch);
+        drop(child_writes);
+        drop(schemas);
+        drop(locals);
+        drop(manager_map);
+        drop(stores);
+        drop(catalog);
+        drop(admission);
+        drop(retired);
+        // Keep retirements parked for retry if post-COMMIT manifest persistence fails.
+        if let Some(manager) = &manager {
+            let _ = manager.persist_manifest_only();
+        }
+        self.retirements.sweep();
+        Ok(rows)
+    }
+}
+
 impl MVCCEngine {
+    fn truncate_coordinator(&self) -> Arc<dyn super::version_store::TruncateCoordinator> {
+        self.truncate_coordinator
+            .get_or_init(|| {
+                Arc::new(EngineTruncateCoordinator {
+                    registry: self.registry.clone(),
+                    persistence: self.persistence.clone(),
+                    loading_from_disk: self.loading_from_disk.clone(),
+                    execution_failed: self.execution_failed.clone(),
+                    schemas: self.schemas.clone(),
+                    version_stores: Arc::downgrade(&self.version_stores),
+                    txn_version_stores: TxnVersionStoreCache::downgrade(&self.txn_version_stores),
+                    segment_managers: Arc::downgrade(&self.segment_managers),
+                    compaction_running: self.compaction_running.clone(),
+                    checkpoint_mutex: self.checkpoint_mutex.clone(),
+                    retirements: self.volume_retirements.clone(),
+                })
+            })
+            .clone()
+    }
+
     /// Creates a new MVCC engine with the given configuration
     pub fn new(config: Config) -> Self {
         let path = config.path.clone().unwrap_or_default();
@@ -608,7 +1037,7 @@ impl MVCCEngine {
             registry: Arc::new(TransactionRegistry::new_in(&memory)),
             open: AtomicBool::new(false),
             execution_failed: Arc::new(AtomicBool::new(false)),
-            txn_version_stores: CompactArc::new_in(RwLock::new(I64Map::new_in(&memory)), &memory),
+            txn_version_stores: TxnVersionStoreCache::new_in(&memory),
             views: RwLock::new(FxHashMap::default()),
             persistence: Arc::new(persistence),
             loading_from_disk: Arc::new(AtomicBool::new(false)),
@@ -619,9 +1048,13 @@ impl MVCCEngine {
             fk_reverse_cache: RwLock::new((u64::MAX, StringMap::default())),
             snapshot_timestamps: RwLock::new(FxHashMap::default()),
             segment_managers: Arc::new(RwLock::new(FxHashMap::default())),
+            volume_retirements: Arc::new(
+                crate::storage::volume::io::VolumeRetirementQueue::default(),
+            ),
+            truncate_coordinator: std::sync::OnceLock::new(),
             force_seal_all: AtomicBool::new(false),
             hot_limits,
-            checkpoint_mutex: Mutex::new(()),
+            checkpoint_mutex: Arc::new(Mutex::new(())),
             seal_fence: Arc::new(parking_lot::RwLock::new(())),
             compaction_running: Arc::new(AtomicBool::new(false)),
             #[cfg(not(target_arch = "wasm32"))]
@@ -636,6 +1069,7 @@ impl MVCCEngine {
 
     /// Opens the engine (inherent method)
     pub fn open_engine(&self) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         // Use atomic swap to check and set open flag atomically
         if self.open.swap(true, Ordering::AcqRel) {
             return Ok(()); // Already open
@@ -731,6 +1165,11 @@ impl MVCCEngine {
                         }
                     }
                 }
+
+                // Rebuild only after WAL has finalized the schema, restored
+                // defaults and refreshed every cold logical-column mapping.
+                self.populate_all_indexes()?;
+                self.populate_hnsw_from_segments()?;
 
                 // Sync auto-increment counters from segment data so the next
                 // generated row_id doesn't collide with cold rows.
@@ -904,6 +1343,8 @@ impl MVCCEngine {
                     let _row_count = engine.cleanup_deleted_rows(deleted_row_retention);
                     let _prev_version_count = engine.cleanup_old_previous_versions();
                 }
+
+                engine.volume_retirements.sweep();
 
                 // Auto-checkpoint using the cached interval, or right away
                 // when a commit asked for a seal
@@ -1443,14 +1884,6 @@ impl MVCCEngine {
                     );
                 }
 
-                // After WAL replay completes, populate all indexes in a single pass
-                // This is O(N + M) instead of O(N * M) when populating each index separately
-                self.populate_all_indexes();
-
-                // HNSW indexes need cold segment data too — vector similarity search
-                // cannot fall back to zone maps like other index types.
-                self.populate_hnsw_from_segments()?;
-
                 Ok(())
             }
             Err(e) => Err(e),
@@ -1458,11 +1891,12 @@ impl MVCCEngine {
     }
 
     /// Populate all indexes across all version stores in a single pass per table
-    fn populate_all_indexes(&self) {
+    fn populate_all_indexes(&self) -> Result<()> {
         let stores = self.version_stores.read().unwrap();
         for store in stores.values() {
-            store.populate_all_indexes();
+            store.populate_all_indexes()?;
         }
+        Ok(())
     }
 
     /// Populate HNSW indexes from cold segment data.
@@ -1532,17 +1966,26 @@ impl MVCCEngine {
                     let vol = &cs.volume;
                     for i in 0..vol.meta.row_count {
                         let row_id = vol.meta.row_ids[i];
-                        if tombstones.contains_key(&row_id) || !seen.insert(row_id) {
+                        if !cs.is_visible(i)
+                            || tombstones.contains_key(&row_id)
+                            || !seen.insert(row_id)
+                        {
                             continue;
                         }
                         for (batch_idx, (col_indices, _)) in hnsw_infos.iter().enumerate() {
                             values_buf.clear();
                             let mut has_null = false;
                             for &ci in col_indices {
-                                let v = if ci < vol.columns.len() {
-                                    vol.columns.get(ci)?.get_value(i)
-                                } else {
-                                    crate::core::Value::Null(crate::core::DataType::Null)
+                                let source = cs.mapping.sources.get(ci).ok_or_else(|| {
+                                    Error::internal("HNSW index column is outside the cold schema")
+                                })?;
+                                let v = match source {
+                                    crate::storage::volume::writer::ColSource::Volume(physical) => {
+                                        vol.get_value(*physical, i)?
+                                    }
+                                    crate::storage::volume::writer::ColSource::Default(value) => {
+                                        value.clone()
+                                    }
                                 };
                                 if v.is_null() {
                                     has_null = true;
@@ -1559,22 +2002,17 @@ impl MVCCEngine {
                                 batches[batch_idx].push((row_id, owned));
                             }
                         }
-                    }
-
-                    // Flush large batches to limit peak memory
-                    for (idx, (_, index)) in hnsw_infos.iter().enumerate() {
-                        if batches[idx].len() >= HNSW_FLUSH_THRESHOLD {
-                            let entry_refs: Vec<(i64, &[crate::core::Value])> = batches[idx]
-                                .iter()
-                                .map(|(row_id, values)| (*row_id, values.as_slice()))
-                                .collect();
-                            if let Err(e) = index.add_batch_slice(&entry_refs) {
-                                eprintln!(
-                                    "Warning: HNSW index population failed for {}: {}",
-                                    table_name, e
-                                );
+                        // A volume may be arbitrarily large. Bound each batch
+                        // during the row walk, not only at volume boundaries.
+                        for (idx, (_, index)) in hnsw_infos.iter().enumerate() {
+                            if batches[idx].len() >= HNSW_FLUSH_THRESHOLD {
+                                let entry_refs: Vec<(i64, &[crate::core::Value])> = batches[idx]
+                                    .iter()
+                                    .map(|(row_id, values)| (*row_id, values.as_slice()))
+                                    .collect();
+                                index.add_batch_slice(&entry_refs)?;
+                                batches[idx].clear();
                             }
-                            batches[idx].clear();
                         }
                     }
                 }
@@ -1586,12 +2024,7 @@ impl MVCCEngine {
                             .iter()
                             .map(|(row_id, values)| (*row_id, values.as_slice()))
                             .collect();
-                        if let Err(e) = index.add_batch_slice(&entry_refs) {
-                            eprintln!(
-                                "Warning: HNSW index population failed for {}: {}",
-                                table_name, e
-                            );
-                        }
+                        index.add_batch_slice(&entry_refs)?;
                     }
                 }
             }
@@ -2158,6 +2591,7 @@ impl MVCCEngine {
 
     /// Closes the engine (inherent method)
     pub fn close_engine(&self) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         // Use CAS to atomically check and set closed
         if self
             .open
@@ -2235,6 +2669,10 @@ impl MVCCEngine {
                 }
             }
         }
+
+        // Captured readers may survive close. Keep their retired files as
+        // safe orphans; only unowned identities are eligible for this sweep.
+        self.volume_retirements.sweep();
 
         // Release file lock (drops the lock, allowing other processes to access)
         {
@@ -2832,6 +3270,7 @@ impl MVCCEngine {
 
     /// Creates a new table
     pub fn create_table(&self, schema: Schema) -> Result<Schema> {
+        let _logical_change = self.registry.begin_logical_mutation();
         self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
@@ -2887,12 +3326,26 @@ impl MVCCEngine {
 
     /// Drops a table
     pub fn drop_table_internal(&self, name: &str) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
+        let _namespace_guard =
+            acquire_volume_namespace(&self.compaction_running, &self.checkpoint_mutex)?;
         self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
         }
 
         let table_name = name.to_lowercase();
+
+        // Validate under namespace exclusion before recording WAL or mutating schema.
+        if !self
+            .schemas
+            .read()
+            .map_err(|_| Error::internal("schema catalog is poisoned"))?
+            .contains_key(&table_name)
+        {
+            return Err(Error::TableNotFound(table_name.to_string()));
+        }
+        self.record_ddl(name, WALOperationType::DropTable, &[])?;
 
         // Atomically remove schema AND strip FK references under single write lock.
         // This prevents a race where find_referencing_fks reads stale state between
@@ -2918,24 +3371,18 @@ impl MVCCEngine {
             }
         }
 
-        // WAL FIRST: record the drop before deleting segment files.
-        // If crash happens after WAL but before file deletion, WAL replay
-        // will re-execute the drop. Orphan files are harmless.
-        self.record_ddl(name, WALOperationType::DropTable, &[])?;
-
         // Clear in-memory segment state
         {
             let mut mgrs = self.segment_managers.write().unwrap();
             if let Some(mgr) = mgrs.get(&table_name) {
-                mgr.clear();
+                retire_manager_volumes(mgr, &self.volume_retirements);
             }
             mgrs.remove(&table_name);
         }
         // Delete volume files from disk
         if let Some(ref pm) = *self.persistence {
             if pm.is_enabled() {
-                let vol_dir = pm.path().join("volumes");
-                let _ = crate::storage::volume::io::delete_all_volumes(&vol_dir, &table_name);
+                self.volume_retirements.sweep();
             }
         }
 
@@ -2969,6 +3416,7 @@ impl MVCCEngine {
         data_type: DataType,
         nullable: bool,
     ) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
@@ -3035,6 +3483,7 @@ impl MVCCEngine {
         default_expr: Option<String>,
         vector_dimensions: u16,
     ) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
@@ -3096,6 +3545,7 @@ impl MVCCEngine {
     /// Refresh the engine's schema cache for a table from the version store
     /// This is used after DDL operations that modify the table's schema directly
     pub fn refresh_schema_cache(&self, table_name: &str) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
@@ -3133,6 +3583,7 @@ impl MVCCEngine {
         get_or_create_segment_manager(
             &self.segment_managers,
             &self.persistence,
+            &self.volume_retirements,
             table_name,
             &self.memory,
         )
@@ -3263,9 +3714,10 @@ impl MVCCEngine {
             let table_name = entry.file_name().to_string_lossy().to_lowercase();
 
             // Try to load manifest from this table directory
-            match crate::storage::volume::manifest::SegmentManager::load_from_disk_in(
+            match crate::storage::volume::manifest::SegmentManager::load_from_disk_with_file_catalog_in(
                 &table_name,
                 &vol_dir,
+                self.volume_retirements.clone(),
                 self.memory.child(),
             ) {
                 Ok(Some(mgr)) => {
@@ -3555,6 +4007,7 @@ impl MVCCEngine {
 
     /// Drops a column from a table
     pub fn drop_column(&self, table_name: &str, column_name: &str) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
@@ -3613,6 +4066,7 @@ impl MVCCEngine {
 
     /// Renames a column in a table
     pub fn rename_column(&self, table_name: &str, old_name: &str, new_name: &str) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
@@ -3676,6 +4130,7 @@ impl MVCCEngine {
 
     /// Record a column drop so old cold volumes don't leak stale data.
     pub fn propagate_column_drop(&self, table_name: &str, col_name: &str) {
+        let _logical_change = self.registry.begin_logical_mutation();
         let table_name_lower = table_name.to_lowercase();
         let schema = self.schemas.read().unwrap().get(&table_name_lower).cloned();
         let current_epoch = self.schema_epoch.load(Ordering::Acquire);
@@ -3690,6 +4145,7 @@ impl MVCCEngine {
     /// Record a column rename and propagate alias to all cold volumes.
     /// Persists in the manifest so aliases survive restart.
     pub fn propagate_column_alias(&self, table_name: &str, new_name: &str, old_name: &str) {
+        let _logical_change = self.registry.begin_logical_mutation();
         let table_name_lower = table_name.to_lowercase();
         let schema = self.schemas.read().unwrap().get(&table_name_lower).cloned();
         if let Some(mgr) = self.segment_managers.read().unwrap().get(&table_name_lower) {
@@ -3708,6 +4164,7 @@ impl MVCCEngine {
         data_type: DataType,
         nullable: bool,
     ) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
@@ -3769,6 +4226,7 @@ impl MVCCEngine {
         nullable: bool,
         vector_dimensions: u16,
     ) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
@@ -3823,6 +4281,9 @@ impl MVCCEngine {
 
     /// Renames a table
     pub fn rename_table(&self, old_name: &str, new_name: &str) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
+        let _namespace_guard =
+            acquire_volume_namespace(&self.compaction_running, &self.checkpoint_mutex)?;
         self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
@@ -3880,7 +4341,32 @@ impl MVCCEngine {
                 let old_dir = vol_dir.join(&old_name_lower);
                 let new_dir = vol_dir.join(&new_name_lower);
                 if old_dir.exists() {
-                    if let Err(e) = std::fs::rename(&old_dir, &new_dir) {
+                    let manager = {
+                        let Ok(managers) = self.segment_managers.read() else {
+                            panic!("segment manager catalog is poisoned during rename publication");
+                        };
+                        managers.get(&new_name_lower).cloned()
+                    };
+                    let current_volumes: Vec<_> = manager
+                        .as_ref()
+                        .map(|manager| {
+                            manager
+                                .segments_raw()
+                                .values()
+                                .map(|segment| segment.volume.clone())
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let renamed = if let Some(manager) = manager {
+                        manager.rename_volume_directory(&old_dir, &new_dir, &current_volumes)
+                    } else {
+                        self.volume_retirements.rename_directory(
+                            &old_dir,
+                            &new_dir,
+                            &current_volumes,
+                        )
+                    };
+                    if let Err(e) = renamed {
                         // Revert in-memory segment manager rename on disk failure
                         let mut mgrs = self.segment_managers.write().unwrap();
                         if let Some(mgr) = mgrs.remove(&new_name_lower) {
@@ -3969,6 +4455,7 @@ impl MVCCEngine {
 
     /// Create a new view
     pub fn create_view(&self, name: &str, query: String, if_not_exists: bool) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         use crate::storage::mvcc::wal_manager::WALOperationType;
 
         self.check_execution_health()?;
@@ -4016,6 +4503,7 @@ impl MVCCEngine {
 
     /// Drop a view
     pub fn drop_view(&self, name: &str, if_exists: bool) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         use crate::storage::mvcc::wal_manager::WALOperationType;
 
         self.check_execution_health()?;
@@ -4724,6 +5212,7 @@ impl MVCCEngine {
 
     /// Restore the database from a backup snapshot, replacing all current data.
     fn restore_from_snapshot(&self, timestamp: Option<&str>) -> Result<String> {
+        let _logical_change = self.registry.begin_logical_mutation();
         self.check_execution_health()?;
         if !self.is_open() {
             return Err(Error::EngineNotOpen);
@@ -5339,6 +5828,8 @@ impl MVCCEngine {
             }
         }
 
+        self.volume_retirements.sweep();
+
         Ok(())
     }
 
@@ -5350,6 +5841,7 @@ impl MVCCEngine {
         if let Err(e) = self.compact_volumes() {
             eprintln!("Warning: compact_volumes failed: {}", e);
         }
+        self.volume_retirements.sweep();
     }
 
     /// Evict idle volume data to save memory. Volumes not accessed since the
@@ -5547,11 +6039,11 @@ impl MVCCEngine {
 
             let mgr = self.get_or_create_segment_manager(table_name);
 
-            // Per-table snapshot gating: capture the current min snapshot begin_seq
-            // for each table to close the TOCTOU window. A snapshot starting between
-            // tables must not cause earlier compacted tables to lose visible rows.
-            let compact_seal_seq_limit =
-                self.registry.get_min_snapshot_begin_seq().map(|s| s as u64);
+            // Register the fixed eligibility bound before reading any source.
+            // This includes standalone/RC readers and in-flight exclusions, and
+            // remains pinned through publication even if an earlier reader exits.
+            let build_lease = self.registry.register_build_lease();
+            let compact_seal_seq_limit = Some(build_lease.cutoff() as u64);
 
             // Targeted compaction: only rewrite volumes that need work.
             // At-target volumes are left untouched to minimize disk I/O.
@@ -5728,20 +6220,9 @@ impl MVCCEngine {
                     continue;
                 }
 
-                let vol_dir = pm.path().join("volumes");
-                let vol_table_dir = vol_dir.join(table_name);
-                let old_filenames: FxHashSet<String> = old_ids
-                    .iter()
-                    .map(|id| format!("vol_{:016x}.vol", id))
-                    .collect();
-                if let Ok(entries) = std::fs::read_dir(&vol_table_dir) {
-                    for entry in entries.flatten() {
-                        let path = entry.path();
-                        if let Some(fname) = path.file_name().and_then(|n| n.to_str()) {
-                            if old_filenames.contains(fname) {
-                                let _ = std::fs::remove_file(&path);
-                            }
-                        }
+                for (_, volume) in volumes.iter() {
+                    if let Some(backing) = volume.backing.get() {
+                        self.volume_retirements.retire(backing);
                     }
                 }
                 continue;
@@ -5871,24 +6352,18 @@ impl MVCCEngine {
                 continue;
             }
 
-            // Now safe to delete old volume files + stale .dv files.
+            // Defer old files until the last captured identity/reader is gone.
+            for (_, volume) in volumes.iter() {
+                if let Some(backing) = volume.backing.get() {
+                    self.volume_retirements.retire(backing);
+                }
+            }
             let vol_table_dir = vol_dir.join(table_name);
-            let old_filenames: FxHashSet<String> = old_ids
-                .iter()
-                .map(|id| format!("vol_{:016x}.vol", id))
-                .collect();
             if let Ok(entries) = std::fs::read_dir(&vol_table_dir) {
                 for entry in entries.flatten() {
                     let path = entry.path();
-                    let ext = path.extension().and_then(|e| e.to_str());
-                    if ext == Some("dv") {
-                        let _ = std::fs::remove_file(&path);
-                    } else if ext == Some("vol") {
-                        if let Some(fname) = path.file_name().and_then(|n| n.to_str()) {
-                            if old_filenames.contains(fname) {
-                                let _ = std::fs::remove_file(&path);
-                            }
-                        }
+                    if path.extension().and_then(|extension| extension.to_str()) == Some("dv") {
+                        let _ = std::fs::remove_file(path);
                     }
                 }
             }
@@ -6023,16 +6498,9 @@ impl MVCCEngine {
             // The snapshot records each row's txn_id at extraction time.
             // remove_sealed_rows compares against it to detect concurrent
             // commits that modified a row after extraction.
-            // Re-check snapshot state per-table to close the TOCTOU window
-            // between the top-of-function check and extraction. A snapshot that
-            // starts between those points would otherwise cause phantom reads.
-            let per_table_cutoff = self.registry.get_min_snapshot_begin_seq();
-            let (mut all_rows, extraction_snapshot) = if let Some(cutoff) = per_table_cutoff {
-                store.extract_for_seal_with_cutoff(cutoff)
-            } else {
-                let read_txn_id = INVALID_TRANSACTION_ID + 1;
-                store.extract_for_seal(read_txn_id)
-            };
+            // Retain the safe build cutoff before capturing the extraction root.
+            let build_lease = self.registry.register_build_lease();
+            let (mut all_rows, extraction_snapshot) = store.extract_for_seal_in_build(&build_lease);
             // On close (force_seal_all), seal ALL rows regardless of threshold.
             if !self.force_seal_all.load(Ordering::Acquire) {
                 let threshold = if has_segments {
@@ -6111,13 +6579,7 @@ impl MVCCEngine {
 
                         mgr.set_seal_overlap(total_rows);
 
-                        // Stamp seal_seq to reflect what data the volume contains:
-                        // - With cutoff: volume has rows committed before cutoff, so use cutoff
-                        // - Without cutoff: all committed rows, use current sequence
-                        // Compaction skips volumes with seal_seq >= min_snap_begin_seq.
-                        let current_seal_seq = per_table_cutoff
-                            .map(|s| s as u64)
-                            .unwrap_or_else(|| self.registry.get_current_sequence() as u64);
+                        let current_seal_seq = build_lease.cutoff() as u64;
                         for (volume, _path, volume_id) in &sealed_volumes {
                             self.register_volume_with_id_and_seal_seq(
                                 &table_name,
@@ -6131,8 +6593,11 @@ impl MVCCEngine {
                         let mut all_skipped_inner: Vec<i64> = Vec::new();
                         let all_row_ids: Vec<i64> = all_rows.iter().map(|(id, _)| *id).collect();
                         for batch in all_row_ids.chunks(REMOVE_BATCH_SIZE) {
-                            let (removed, cleanup, skipped) =
-                                store.remove_sealed_rows(batch, &extraction_snapshot);
+                            let (removed, cleanup, skipped) = store
+                                .remove_sealed_rows_after_cold_publication(
+                                    batch,
+                                    &extraction_snapshot,
+                                );
                             store.subtract_committed_row_count(removed);
                             index_cleanups.push(cleanup);
                             all_skipped_inner.extend(skipped);
@@ -6208,6 +6673,22 @@ impl MVCCEngine {
 }
 
 impl Engine for MVCCEngine {
+    fn begin_logical_mutation(&self) -> Option<super::registry::LogicalMutationGuard> {
+        Some(self.registry.begin_logical_mutation())
+    }
+
+    fn cache_provenance(
+        &self,
+        epoch: &super::registry::ReadEpoch,
+    ) -> Option<super::registry::CacheProvenance> {
+        self.registry.cache_provenance(epoch)
+    }
+
+    fn capture_read_epoch(&self) -> Result<Option<super::registry::ReadEpoch>> {
+        self.check_execution_health()?;
+        Ok(Some(self.registry.capture_read_epoch()))
+    }
+
     fn check_health(&self) -> Result<()> {
         self.check_execution_health()
     }
@@ -6231,7 +6712,7 @@ impl Engine for MVCCEngine {
         }
 
         // Begin transaction in registry
-        let (txn_id, begin_seq) = self.registry.begin_transaction();
+        let (txn_id, begin_seq) = self.registry.begin_transaction_with_isolation(level);
         if txn_id == INVALID_TRANSACTION_ID {
             return Err(Error::internal(
                 "transaction registry is not accepting new transactions",
@@ -6240,11 +6721,6 @@ impl Engine for MVCCEngine {
 
         // Create transaction
         let mut txn = MvccTransaction::new(txn_id, begin_seq, Arc::clone(&self.registry));
-
-        // Set isolation level if different from default
-        if level != IsolationLevel::ReadCommitted {
-            txn.set_isolation_level(level)?;
-        }
 
         // Set engine operations
         let engine_ops = self.create_engine_operations();
@@ -6480,6 +6956,7 @@ impl Engine for MVCCEngine {
         default_expr: Option<&str>,
         vector_dimensions: u16,
     ) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         if self.should_skip_wal() {
             return Ok(());
         }
@@ -6532,6 +7009,7 @@ impl Engine for MVCCEngine {
     }
 
     fn record_alter_table_drop_column(&self, table_name: &str, column_name: &str) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         if self.should_skip_wal() {
             return Ok(());
         }
@@ -6557,6 +7035,7 @@ impl Engine for MVCCEngine {
         old_column_name: &str,
         new_column_name: &str,
     ) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         if self.should_skip_wal() {
             return Ok(());
         }
@@ -6589,6 +7068,7 @@ impl Engine for MVCCEngine {
         nullable: bool,
         vector_dimensions: u16,
     ) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         if self.should_skip_wal() {
             return Ok(());
         }
@@ -6619,6 +7099,7 @@ impl Engine for MVCCEngine {
     }
 
     fn record_alter_table_rename(&self, old_table_name: &str, new_table_name: &str) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
         if self.should_skip_wal() {
             return Ok(());
         }
@@ -6638,35 +7119,9 @@ impl Engine for MVCCEngine {
         self.record_ddl(old_table_name, WALOperationType::AlterTable, &data)
     }
 
-    fn record_truncate_table(&self, table_name: &str) -> Result<()> {
-        let table_lower = table_name.to_lowercase();
-
-        // WAL FIRST: record the truncate before deleting segment files.
-        // If crash happens after WAL but before file deletion, WAL replay
-        // will re-execute the truncate. Orphan files are harmless.
-        if !self.should_skip_wal() {
-            self.record_ddl(table_name, WALOperationType::TruncateTable, &[])?;
-        }
-
-        // Clear in-memory segment state
-        {
-            let mgrs = self.segment_managers.read().unwrap();
-            if let Some(mgr) = mgrs.get(&table_lower) {
-                mgr.clear();
-            }
-        }
-
-        // Delete volume files from disk (standalone volumes + legacy tombstones)
-        if let Some(ref pm) = *self.persistence {
-            if pm.is_enabled() {
-                let vol_dir = pm.path().join("volumes");
-                let _ = crate::storage::volume::io::delete_all_volumes(&vol_dir, &table_lower);
-                let snapshot_dir = pm.path().join("snapshots");
-                let ts_path = snapshot_dir.join(&table_lower).join("tombstones.dat");
-                let _ = std::fs::remove_file(ts_path);
-            }
-        }
-
+    fn record_truncate_table(&self, _table_name: &str) -> Result<()> {
+        // Compatibility callback: Table::truncate now writes WAL and applies
+        // both layers atomically. A second record could replay a later insert.
         Ok(())
     }
 
@@ -6964,7 +7419,7 @@ struct EngineOperations {
     /// Shared reference to registry
     registry: Arc<TransactionRegistry>,
     /// Shared reference to transaction version stores cache
-    txn_version_stores: CompactArc<RwLock<TxnVersionStoreMap>>,
+    txn_version_stores: Arc<TxnVersionStoreCache>,
     /// Shared reference to persistence manager (optional)
     persistence: Arc<Option<PersistenceManager>>,
     /// Shared reference to loading_from_disk flag
@@ -6972,6 +7427,12 @@ struct EngineOperations {
     /// Shared reference to segment managers
     segment_managers:
         Arc<RwLock<FxHashMap<String, Arc<crate::storage::volume::manifest::SegmentManager>>>>,
+    /// File cleanup is deferred until captured identities have no readers.
+    volume_retirements: Arc<crate::storage::volume::io::VolumeRetirementQueue>,
+    truncate_coordinator: Arc<dyn super::version_store::TruncateCoordinator>,
+    /// Namespace changes serialize with both checkpoint and compaction work.
+    checkpoint_mutex: Arc<Mutex<()>>,
+    compaction_running: Arc<AtomicBool>,
     /// Seal fence for WAL truncation safety
     seal_fence: Arc<parking_lot::RwLock<()>>,
     /// Hot size limits shared with the engine
@@ -6993,6 +7454,10 @@ impl EngineOperations {
             persistence: Arc::clone(&engine.persistence),
             loading_from_disk: Arc::clone(&engine.loading_from_disk),
             segment_managers: Arc::clone(&engine.segment_managers),
+            volume_retirements: Arc::clone(&engine.volume_retirements),
+            truncate_coordinator: engine.truncate_coordinator(),
+            checkpoint_mutex: Arc::clone(&engine.checkpoint_mutex),
+            compaction_running: Arc::clone(&engine.compaction_running),
             seal_fence: Arc::clone(&engine.seal_fence),
             hot_limits: Arc::clone(&engine.hot_limits),
         }
@@ -7270,6 +7735,19 @@ impl TransactionEngineOperations for EngineOperations {
     }
 
     fn get_table_for_transaction(&self, txn_id: i64, table_name: &str) -> Result<Box<dyn Table>> {
+        let epoch = self
+            .registry
+            .read_epoch_for_transaction(txn_id)
+            .unwrap_or_else(|| self.registry.capture_read_epoch());
+        self.get_table_for_transaction_in_epoch(txn_id, table_name, &epoch)
+    }
+
+    fn get_table_for_transaction_in_epoch(
+        &self,
+        txn_id: i64,
+        table_name: &str,
+        epoch: &super::registry::ReadEpoch,
+    ) -> Result<Box<dyn Table>> {
         // Use Cow to avoid allocation when table_name is already lowercase (common case)
         let table_name_lower = to_lowercase_cow(table_name);
 
@@ -7329,7 +7807,8 @@ impl TransactionEngineOperations for EngineOperations {
             }
         };
 
-        let table = MVCCTable::new_with_shared_store(txn_id, version_store, txn_versions);
+        version_store.set_truncate_coordinator(&self.truncate_coordinator);
+        let mut table = MVCCTable::new_with_shared_store(txn_id, version_store, txn_versions);
 
         // A persistent database may seal rows at any moment, so its tables
         // always go through the segment-aware wrapper, even before the first
@@ -7341,6 +7820,7 @@ impl TransactionEngineOperations for EngineOperations {
             get_or_create_segment_manager(
                 &self.segment_managers,
                 &self.persistence,
+                &self.volume_retirements,
                 &table_name_lower,
                 &self.memory,
             )
@@ -7348,25 +7828,19 @@ impl TransactionEngineOperations for EngineOperations {
             let mgrs = self.segment_managers.read().unwrap();
             match mgrs.get(&*table_name_lower) {
                 Some(mgr) if mgr.has_segments() => Arc::clone(mgr),
-                _ => return Ok(Box::new(table)),
+                _ => {
+                    table.set_read_epoch(epoch.clone())?;
+                    return Ok(Box::new(table));
+                }
             }
         };
-        if self.registry.get_isolation_level(txn_id) == crate::IsolationLevel::SnapshotIsolation {
-            let begin_seq = self.registry.get_transaction_begin_sequence(txn_id) as u64;
-            return Ok(Box::new(
-                crate::storage::volume::table::SegmentedTable::with_snapshot_seq(
-                    Box::new(table),
-                    mgr,
-                    begin_seq,
-                ),
-            ));
-        }
-        Ok(Box::new(
-            crate::storage::volume::table::SegmentedTable::new(Box::new(table), mgr),
-        ))
+        let mut table = crate::storage::volume::table::SegmentedTable::new(Box::new(table), mgr);
+        table.set_read_epoch(epoch.clone())?;
+        Ok(Box::new(table))
     }
 
     fn create_table(&self, name: &str, schema: Schema) -> Result<Box<dyn Table>> {
+        let _logical_change = self.registry.begin_logical_mutation();
         let table_name = name.to_lowercase();
 
         // Create version store for this table (before acquiring locks)
@@ -7399,13 +7873,34 @@ impl TransactionEngineOperations for EngineOperations {
         let txn_versions = TransactionVersionStore::new(Arc::clone(&version_store), 0);
 
         // Create MVCC table
+        version_store.set_truncate_coordinator(&self.truncate_coordinator);
         let table = MVCCTable::new(0, version_store, txn_versions);
 
         Ok(Box::new(table))
     }
 
     fn drop_table(&self, name: &str) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
+        let _namespace_guard =
+            acquire_volume_namespace(&self.compaction_running, &self.checkpoint_mutex)?;
         let table_name_lower = name.to_lowercase();
+
+        if !self
+            .schemas()
+            .read()
+            .map_err(|_| Error::internal("schema catalog is poisoned"))?
+            .contains_key(&table_name_lower)
+        {
+            return Err(Error::TableNotFound(table_name_lower.to_string()));
+        }
+        // Record DDL to WAL so the drop survives crash recovery
+        if !self.should_skip_wal() {
+            if let Some(ref pm) = *self.persistence() {
+                if pm.is_enabled() {
+                    pm.record_ddl_operation(name, WALOperationType::DropTable, &[])?;
+                }
+            }
+        }
 
         // Remove schema and clean up FK references in child tables
         {
@@ -7424,20 +7919,11 @@ impl TransactionEngineOperations for EngineOperations {
             }
         }
 
-        // Record DDL to WAL so the drop survives crash recovery
-        if !self.should_skip_wal() {
-            if let Some(ref pm) = *self.persistence() {
-                if pm.is_enabled() {
-                    let _ = pm.record_ddl_operation(name, WALOperationType::DropTable, &[]);
-                }
-            }
-        }
-
         // Clear in-memory segment state (prevents phantom rows on re-create)
         {
             let mut mgrs = self.segment_managers.write().unwrap();
             if let Some(mgr) = mgrs.get(&table_name_lower) {
-                mgr.clear();
+                retire_manager_volumes(mgr, &self.volume_retirements);
             }
             mgrs.remove(&table_name_lower);
         }
@@ -7445,8 +7931,7 @@ impl TransactionEngineOperations for EngineOperations {
         // Delete volume files from disk
         if let Some(ref pm) = *self.persistence() {
             if pm.is_enabled() {
-                let vol_dir = pm.path().join("volumes");
-                let _ = crate::storage::volume::io::delete_all_volumes(&vol_dir, &table_name_lower);
+                self.volume_retirements.sweep();
             }
         }
 
@@ -7459,6 +7944,9 @@ impl TransactionEngineOperations for EngineOperations {
     }
 
     fn rename_table(&self, old_name: &str, new_name: &str) -> Result<()> {
+        let _logical_change = self.registry.begin_logical_mutation();
+        let _namespace_guard =
+            acquire_volume_namespace(&self.compaction_running, &self.checkpoint_mutex)?;
         let old_name_lower = old_name.to_lowercase();
         let new_name_lower = new_name.to_lowercase();
 
@@ -7510,7 +7998,32 @@ impl TransactionEngineOperations for EngineOperations {
                 let old_dir = vol_dir.join(&old_name_lower);
                 let new_dir = vol_dir.join(&new_name_lower);
                 if old_dir.exists() {
-                    if let Err(e) = std::fs::rename(&old_dir, &new_dir) {
+                    let manager = {
+                        let Ok(managers) = self.segment_managers.read() else {
+                            panic!("segment manager catalog is poisoned during rename publication");
+                        };
+                        managers.get(&new_name_lower).cloned()
+                    };
+                    let current_volumes: Vec<_> = manager
+                        .as_ref()
+                        .map(|manager| {
+                            manager
+                                .segments_raw()
+                                .values()
+                                .map(|segment| segment.volume.clone())
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let renamed = if let Some(manager) = manager {
+                        manager.rename_volume_directory(&old_dir, &new_dir, &current_volumes)
+                    } else {
+                        self.volume_retirements.rename_directory(
+                            &old_dir,
+                            &new_dir,
+                            &current_volumes,
+                        )
+                    };
+                    if let Err(e) = renamed {
                         // Revert ALL in-memory renames on disk failure
                         {
                             let mut schemas = self.schemas().write().unwrap();
@@ -7915,7 +8428,7 @@ impl TransactionEngineOperations for EngineOperations {
                 local
                     .write()
                     .map_err(|_| Error::internal("transaction store is poisoned"))?
-                    .apply_prepared_publication()?;
+                    .apply_prepared_publication_in_transaction()?;
                 if let Some(mgr) = mgr {
                     mgr.commit_pending_tombstones(txn_id, commit_seq);
                 }
@@ -8048,16 +8561,23 @@ impl TransactionEngineOperations for EngineOperations {
         limits.admission_waits.fetch_add(1, Ordering::Relaxed);
         limits.seal_requested.store(true, Ordering::Release);
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let retry_interval = std::time::Duration::from_millis(100);
+        let mut next_request = std::time::Instant::now() + retry_interval;
         let mut guard = limits.admission.0.lock().unwrap();
         while over() {
             let now = std::time::Instant::now();
             if now >= deadline {
                 break;
             }
+            // Re-arm no-progress seal requests at a bounded interval until the existing deadline.
+            if now >= next_request {
+                limits.seal_requested.store(true, Ordering::Release);
+                next_request = now + retry_interval;
+            }
             guard = limits
                 .admission
                 .1
-                .wait_timeout(guard, deadline - now)
+                .wait_timeout(guard, (deadline - now).min(next_request - now))
                 .unwrap()
                 .0;
         }
@@ -8068,6 +8588,281 @@ impl TransactionEngineOperations for EngineOperations {
 mod tests {
     use super::*;
     use crate::core::{DataType, IndexType, Row, SchemaBuilder, Value};
+
+    #[test]
+    fn hot_admission_retries_after_a_pinning_reader_releases() {
+        use std::time::{Duration, Instant};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = crate::Database::open(&format!(
+            "file://{}?checkpoint_interval=3600&hot_max_rows=0&hot_max_bytes=200000",
+            dir.path().display()
+        ))
+        .unwrap();
+        let engine = Arc::clone(db.engine());
+        // Drive the first background checkpoint synchronously so its consumed
+        // request and no-progress notification cannot race reader release.
+        if let Some(mut handle) = engine.cleanup_handle.lock().unwrap().take() {
+            handle.stop();
+        }
+        db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, body TEXT)", ())
+            .unwrap();
+        let epoch = engine.registry.capture_read_epoch();
+        db.execute("INSERT INTO t VALUES (1, ?)", ("x".repeat(220_000),))
+            .unwrap();
+        let store = engine.get_version_store("t").unwrap();
+        let pinned_bytes = store.hot_bytes();
+        assert!(pinned_bytes >= 200_000);
+
+        let writer_db = db.clone();
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            sender
+                .send(writer_db.execute("INSERT INTO t VALUES (2, 'later')", ()))
+                .unwrap();
+        });
+        let started = Instant::now();
+        while engine.hot_limits.admission_waits.load(Ordering::Relaxed) == 0 {
+            assert!(started.elapsed() < Duration::from_secs(5));
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(engine
+            .hot_limits
+            .seal_requested
+            .swap(false, Ordering::AcqRel));
+        engine.checkpoint_cycle_inner(false).unwrap();
+        assert_eq!(store.hot_bytes(), pinned_bytes);
+        assert!(engine.volume_stats().is_empty());
+        assert!(receiver.try_recv().is_err());
+
+        drop(epoch);
+        engine.start_cleanup();
+        let progress = receiver.recv_timeout(Duration::from_secs(3));
+        if progress.is_err() {
+            // Let the original implementation's waiter exit promptly after a
+            // failure, instead of leaving a detached ten-second commit behind.
+            engine
+                .hot_limits
+                .seal_requested
+                .store(true, Ordering::Release);
+            receiver
+                .recv_timeout(Duration::from_secs(5))
+                .unwrap()
+                .unwrap();
+        }
+        writer.join().unwrap();
+        progress
+            .expect("reader release must trigger another seal before the ten-second fallback")
+            .unwrap();
+        assert!(store.hot_bytes() < 200_000);
+        assert_eq!(
+            db.query("SELECT COUNT(*) FROM t", ())
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap()
+                .get::<i64>(0)
+                .unwrap(),
+            2
+        );
+    }
+
+    #[test]
+    fn retained_store_truncate_coordinator_does_not_retain_transaction_cache() {
+        let db = crate::Database::open_in_memory().unwrap();
+        db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", ())
+            .unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).unwrap();
+        let store = db.engine().get_version_store("t").unwrap();
+        let cache = TxnVersionStoreCache::downgrade(&db.engine().txn_version_stores);
+        // A real table access attaches the shared coordinator to its store.
+        // Keeping that public store alive after the engine dies must not form
+        // cache -> transaction-local store -> parent -> coordinator -> cache.
+        drop(db);
+        assert!(cache.upgrade().is_none());
+        drop(store);
+    }
+
+    #[test]
+    fn transaction_cache_allocation_charge_survives_until_the_last_weak_owner() {
+        let account = crate::common::memory::MemoryAccount::new();
+        let initial = account.snapshot();
+        let cache = TxnVersionStoreCache::new_in(&account);
+        let weak_a = TxnVersionStoreCache::downgrade(&cache);
+        let weak_b = TxnVersionStoreCache::downgrade(&cache);
+        let allowance = cache.object_charge.bytes();
+        let token_bytes = cache.object_charge.allocation_size();
+        drop(cache);
+        assert!(weak_a.upgrade().is_none());
+        // Nested map buffers died with the last strong payload; the Arc
+        // allocation and its separate exact token are still physically live.
+        assert_eq!(account.snapshot().retained_bytes, token_bytes);
+        assert_eq!(
+            account.snapshot().conservative_bytes,
+            initial.conservative_bytes + allowance
+        );
+        drop(weak_a);
+        assert_eq!(
+            account.snapshot().accounted_bytes,
+            initial.accounted_bytes + allowance + token_bytes
+        );
+        drop(weak_b);
+        assert_eq!(account.snapshot().accounted_bytes, initial.accounted_bytes);
+    }
+
+    #[test]
+    fn cold_hnsw_population_uses_current_mapping_and_defaults() {
+        for defaulted in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let db = crate::Database::open(&format!(
+                "file://{}?checkpoint_interval=3600",
+                dir.path().display()
+            ))
+            .unwrap();
+            db.execute(
+                "CREATE TABLE vectors (id INTEGER PRIMARY KEY, spare TEXT, v VECTOR(2))",
+                (),
+            )
+            .unwrap();
+            db.execute("INSERT INTO vectors VALUES (1, 'unused', '[9, 0]')", ())
+                .unwrap();
+            db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+            let engine = db.engine();
+            let store = engine.get_version_store("vectors").unwrap();
+            assert_eq!(store.row_count(), 0, "fixture must use cold rows");
+            db.execute("ALTER TABLE vectors DROP COLUMN spare", ())
+                .unwrap();
+            if defaulted {
+                // A re-added name must resolve to its default, never to the
+                // physical bytes of the dropped column in the old volume.
+                db.execute("ALTER TABLE vectors DROP COLUMN v", ()).unwrap();
+                db.execute("ALTER TABLE vectors ADD COLUMN v VECTOR(2)", ())
+                    .unwrap();
+                let schema = {
+                    let mut schema = store.schema_mut();
+                    CompactArc::make_mut(&mut schema).columns[1].default_value =
+                        Some(Value::vector(vec![17.0, 0.0]));
+                    schema.clone()
+                };
+                engine.segment_managers.read().unwrap()["vectors"].invalidate_mappings(&schema);
+            }
+            let mut index = crate::storage::index::HnswIndex::new(
+                "idx_v".into(),
+                "vectors".into(),
+                "v".into(),
+                1,
+                2,
+                16,
+                64,
+                32,
+                crate::storage::index::HnswDistanceMetric::L2,
+            );
+            index.attach_memory_account(store.memory_account()).unwrap();
+            let index = Arc::new(index);
+            store.add_index("idx_v".into(), index.clone()).unwrap();
+            engine.populate_hnsw_from_segments().unwrap();
+            let expected = if defaulted { 17.0_f32 } else { 9.0_f32 };
+            let query: Vec<u8> = [expected, 0.0]
+                .into_iter()
+                .flat_map(f32::to_le_bytes)
+                .collect();
+            assert_eq!(index.search_nearest(&query, 1, 16), vec![(1, 0.0)]);
+        }
+    }
+
+    #[test]
+    fn cold_hnsw_population_propagates_index_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = crate::Database::open(&format!(
+            "file://{}?checkpoint_interval=3600",
+            dir.path().display()
+        ))
+        .unwrap();
+        db.execute(
+            "CREATE TABLE vectors (id INTEGER PRIMARY KEY, v VECTOR(2))",
+            (),
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO vectors VALUES (1, '[9, 0]'), (2, '[9, 0]')",
+            (),
+        )
+        .unwrap();
+        db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        let engine = db.engine();
+        let store = engine.get_version_store("vectors").unwrap();
+        assert_eq!(store.row_count(), 0);
+        let mut index = crate::storage::index::HnswIndex::new(
+            "idx_v".into(),
+            "vectors".into(),
+            "v".into(),
+            1,
+            2,
+            16,
+            64,
+            32,
+            crate::storage::index::HnswDistanceMetric::L2,
+        );
+        index.set_unique(true);
+        store.add_index("idx_v".into(), Arc::new(index)).unwrap();
+        assert!(engine.populate_hnsw_from_segments().is_err());
+    }
+
+    #[test]
+    fn cold_hnsw_reopen_refreshes_mapping_before_index_population() {
+        let dir = tempfile::tempdir().unwrap();
+        let dsn = format!("file://{}?checkpoint_interval=3600", dir.path().display());
+        {
+            let db = crate::Database::open(&dsn).unwrap();
+            db.execute(
+                "CREATE TABLE vectors (id INTEGER PRIMARY KEY, spare TEXT, v VECTOR(2))",
+                (),
+            )
+            .unwrap();
+            db.execute("INSERT INTO vectors VALUES (1, 'unused', '[9, 0]')", ())
+                .unwrap();
+            db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+            assert_eq!(
+                db.engine()
+                    .get_version_store("vectors")
+                    .unwrap()
+                    .row_count(),
+                0
+            );
+            db.execute("ALTER TABLE vectors DROP COLUMN spare", ())
+                .unwrap();
+            db.execute("CREATE INDEX idx_v ON vectors(v) USING HNSW", ())
+                .unwrap();
+        }
+        // Force cold rebuilding rather than accepting a previously saved graph.
+        // Every removed file belongs to this disposable test database.
+        let graphs = dir.path().join("snapshots").join("vectors");
+        if graphs.exists() {
+            for entry in std::fs::read_dir(graphs).unwrap() {
+                let entry = entry.unwrap();
+                if entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("hnsw_idx_v")
+                {
+                    std::fs::remove_file(entry.path()).unwrap();
+                }
+            }
+        }
+        let db = crate::Database::open(&dsn).unwrap();
+        let store = db.engine().get_version_store("vectors").unwrap();
+        assert_eq!(store.row_count(), 0);
+        let index = store.get_index("idx_v").unwrap();
+        let hnsw = index
+            .as_any()
+            .downcast_ref::<crate::storage::index::HnswIndex>()
+            .unwrap();
+        let query: Vec<u8> = [9.0_f32, 0.0]
+            .into_iter()
+            .flat_map(f32::to_le_bytes)
+            .collect();
+        assert_eq!(hnsw.search_nearest(&query, 1, 16), vec![(1, 0.0)]);
+    }
 
     #[test]
     fn test_engine_creation() {

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -37,6 +37,7 @@
 
 pub(crate) mod accounting;
 pub mod arena;
+mod captured_scanner;
 pub mod engine;
 pub mod file_lock;
 pub mod persistence;

--- a/src/storage/mvcc/registry.rs
+++ b/src/storage/mvcc/registry.rs
@@ -12,72 +12,61 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Transaction registry for MVCC visibility.
+//! Transaction state, fixed read epochs, and retention leases for MVCC.
 //!
-//! Optimized design with minimal memory footprint:
-//! - Active/Committing/Aborted transactions: tracked in single map
-//! - Committed transactions: implicit (not in map = committed)
-//! - Single lock acquisition in hot path
-//!
-//! Memory: O(active_transactions + aborted_transactions)
+//! Lifecycle transitions and retention registration share one mutex. Completed
+//! outcomes become implicit only after their mappings precede every retained view.
 
-use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU8, AtomicUsize, Ordering};
+use std::sync::Arc;
 
-use parking_lot::Mutex;
+use parking_lot::{Condvar, Mutex};
+use smallvec::SmallVec;
 
-use crate::common::I64Map;
+use crate::common::{CompactArc, I64Map};
 use crate::core::IsolationLevel;
 use crate::storage::VisibilityChecker;
 
-/// Invalid transaction ID returned when registry is not accepting new transactions.
 pub const INVALID_TRANSACTION_ID: i64 = -999999999;
-
-/// Special transaction ID for recovery transactions (always visible).
 pub const RECOVERY_TRANSACTION_ID: i64 = -1;
-
-/// Sentinel value for aborted transactions (negative begin_seq).
 const ABORTED_SENTINEL: i64 = -1;
+const STATUS_SHIFT: u32 = 62;
+const SEQ_MASK: i64 = (1i64 << STATUS_SHIFT) - 1;
+const SNAPSHOT_FLAG: i64 = 1i64 << STATUS_SHIFT;
+// Namespaces are never reused, including after an engine is dropped. Assigned
+// once per registry; no global atomic access occurs during statement reads.
+static NEXT_REGISTRY_NAMESPACE: AtomicUsize = AtomicUsize::new(1);
 
-/// Transaction status.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u8)]
 pub enum TxnStatus {
-    /// Transaction is in progress
     Active = 0,
-    /// Two-phase commit in progress
     Committing = 1,
-    /// Transaction was aborted
     Aborted = 2,
 }
 
-/// Packed transaction state (16 bytes).
-///
-/// - For Active/Committing: begin_seq > 0, state_seq encodes status + commit_seq
-/// - For Aborted: begin_seq = ABORTED_SENTINEL (-1)
+/// Transaction state and its begin-view registration. The begin word records the
+/// transaction's effective isolation level; changing the global default does
+/// not change transactions which have already begun.
+/// Active state_seq stores the begin registration; Committing stores its commit
+/// sequence and moves the registration into the small in-flight commit list.
+/// Aborted state_seq stores the rollback acknowledgment. Keep this state 16 bytes
+/// because the main registry also retains completed abort markers until GC.
 #[derive(Clone, Copy, Debug)]
 pub struct TxnState {
-    /// Sequence when transaction began (negative = aborted sentinel)
     begin_seq: i64,
-    /// Packed: lower 62 bits = commit_seq, upper 2 bits = status
     state_seq: i64,
 }
 
-const STATUS_SHIFT: u32 = 62;
-const SEQ_MASK: i64 = (1i64 << STATUS_SHIFT) - 1;
-
 impl TxnState {
-    /// Creates a new active transaction state.
     #[inline]
-    const fn new_active(begin_seq: i64) -> Self {
+    const fn new_active(begin_seq: i64, snapshot: bool, begin_registration: i64) -> Self {
         Self {
-            begin_seq,
-            state_seq: 0, // Active=0, commit_seq=0
+            begin_seq: begin_seq | if snapshot { SNAPSHOT_FLAG } else { 0 },
+            state_seq: begin_registration,
         }
     }
 
-    /// Creates an aborted transaction marker.
-    #[inline]
     const fn new_aborted() -> Self {
         Self {
             begin_seq: ABORTED_SENTINEL,
@@ -85,174 +74,723 @@ impl TxnState {
         }
     }
 
-    /// Returns true if this is an aborted transaction.
     #[inline(always)]
     pub const fn is_aborted(&self) -> bool {
         self.begin_seq == ABORTED_SENTINEL
     }
 
-    /// Returns the begin sequence (0 if aborted).
     #[inline(always)]
     pub const fn begin_seq(&self) -> i64 {
-        if self.begin_seq == ABORTED_SENTINEL {
+        if self.is_aborted() {
             0
         } else {
-            self.begin_seq
+            self.begin_seq & SEQ_MASK
         }
     }
 
-    /// Returns the transaction status.
     #[inline(always)]
     pub const fn status(&self) -> TxnStatus {
-        if self.begin_seq == ABORTED_SENTINEL {
-            return TxnStatus::Aborted;
-        }
-        match (self.state_seq >> STATUS_SHIFT) as u8 {
-            0 => TxnStatus::Active,
-            1 => TxnStatus::Committing,
-            _ => TxnStatus::Aborted,
+        if self.is_aborted() {
+            TxnStatus::Aborted
+        } else if self.state_seq >> STATUS_SHIFT == 0 {
+            TxnStatus::Active
+        } else {
+            TxnStatus::Committing
         }
     }
 
-    /// Returns true if Active or Committing (not aborted).
     #[inline(always)]
     pub const fn is_active_or_committing(&self) -> bool {
-        self.begin_seq != ABORTED_SENTINEL
+        !self.is_aborted()
     }
 
-    /// Sets status to Committing with given commit_seq.
-    #[inline(always)]
+    #[inline]
+    const fn is_snapshot(&self) -> bool {
+        !self.is_aborted() && self.begin_seq & SNAPSHOT_FLAG != 0
+    }
+
+    fn set_snapshot(&mut self, snapshot: bool) {
+        self.begin_seq = self.begin_seq() | if snapshot { SNAPSHOT_FLAG } else { 0 };
+    }
+
+    #[inline]
+    const fn active_begin_registration(&self) -> Option<i64> {
+        if !self.is_aborted() && self.state_seq >> STATUS_SHIFT == 0 {
+            Some(self.state_seq & SEQ_MASK)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
     fn set_committing(&mut self, commit_seq: i64) {
         self.state_seq = commit_seq | (1i64 << STATUS_SHIFT);
     }
 
-    /// Returns the commit sequence (0 if not committing).
-    #[inline(always)]
-    pub const fn commit_seq(&self) -> i64 {
-        self.state_seq & SEQ_MASK
+    fn rollback_acknowledgment(&self) -> Option<i64> {
+        (self.is_aborted() && self.state_seq & SEQ_MASK != 0)
+            .then(|| (self.state_seq & SEQ_MASK) - 1)
     }
-}
 
-/// Thread-local cache size (512KB per thread).
-const CACHE_SIZE: usize = 65536;
-
-/// Cache index shift for XOR mixing (log2 of CACHE_SIZE).
-/// XOR mixing prevents 0% hit rate when txn_ids are strided by CACHE_SIZE.
-const CACHE_SHIFT: u32 = CACHE_SIZE.trailing_zeros();
-
-thread_local! {
-    static COMMITTED_CACHE: RefCell<CommittedCache> = const { RefCell::new(CommittedCache::new()) };
-}
-
-/// Direct-mapped cache for committed transaction IDs.
-struct CommittedCache {
-    entries: [i64; CACHE_SIZE],
-}
-
-impl CommittedCache {
-    #[inline]
-    const fn new() -> Self {
-        Self {
-            entries: [0; CACHE_SIZE],
+    fn acknowledge_rollback(&mut self, registration: i64) {
+        if self.rollback_acknowledgment().is_none() {
+            self.state_seq = ((TxnStatus::Aborted as i64) << STATUS_SHIFT) | (registration + 1);
         }
     }
 
-    /// Compute cache index with XOR mixing to avoid collisions on strided IDs.
     #[inline(always)]
-    fn cache_index(txn_id: i64) -> usize {
+    pub const fn commit_seq(&self) -> i64 {
+        if !self.is_aborted() && self.state_seq >> STATUS_SHIFT == 1 {
+            self.state_seq & SEQ_MASK
+        } else {
+            0
+        }
+    }
+}
+
+/// No process TLS: equal transaction IDs in separate registries never alias.
+const CACHE_SIZE: usize = 256;
+struct CommittedCache {
+    entries: [AtomicI64; CACHE_SIZE],
+}
+
+impl CommittedCache {
+    fn new() -> Self {
+        Self {
+            entries: std::array::from_fn(|_| AtomicI64::new(0)),
+        }
+    }
+
+    #[inline(always)]
+    fn index(txn_id: i64) -> usize {
         let x = txn_id as u64;
-        ((x ^ (x >> CACHE_SHIFT)) as usize) & (CACHE_SIZE - 1)
+        ((x ^ (x >> CACHE_SIZE.trailing_zeros())) as usize) & (CACHE_SIZE - 1)
     }
 
     #[inline(always)]
     fn contains(&self, txn_id: i64) -> bool {
-        let idx = Self::cache_index(txn_id);
-        self.entries[idx] == txn_id
+        txn_id > 0 && self.entries[Self::index(txn_id)].load(Ordering::Relaxed) == txn_id
     }
 
-    #[inline(always)]
-    fn insert(&mut self, txn_id: i64) {
-        let idx = Self::cache_index(txn_id);
-        self.entries[idx] = txn_id;
+    #[inline]
+    fn insert(&self, txn_id: i64) {
+        self.entries[Self::index(txn_id)].store(txn_id, Ordering::Relaxed);
+    }
+
+    fn invalidate(&self, txn_id: i64) {
+        self.entries[Self::index(txn_id)].store(0, Ordering::Relaxed);
     }
 }
 
-/// Transaction registry with minimal memory footprint.
-///
-/// Design:
-/// - `transactions`: Single map for Active/Committing/Aborted
-/// - If txn_id not in map and valid → committed (implicit)
-/// - `snapshot_seqs`: Commit sequences for snapshot isolation
-///
-/// Memory: O(active + aborted) instead of O(total)
-pub struct TransactionRegistry {
-    /// All tracked transactions (Active, Committing, Aborted).
-    /// Committed transactions are REMOVED from this map.
-    transactions: Mutex<I64Map<TxnState>>,
+#[derive(Clone, Debug)]
+struct EpochData {
+    cutoff: i64,
+    // Zero means this view cannot authorize shared result reuse. Historical
+    // views must never inherit the generation current when they are reopened.
+    cache_generation: u64,
+    // None avoids an empty-slice allocation in the common case.
+    excluded: Option<CompactArc<[i64]>>,
+}
 
-    /// For SNAPSHOT ISOLATION: txn_id -> commit_seq.
-    /// GC removes old entries when commit_seq < min_active_begin_seq.
-    snapshot_seqs: Mutex<I64Map<i64>>,
+impl EpochData {
+    fn exclusions(&self) -> &[i64] {
+        self.excluded.as_deref().unwrap_or(&[])
+    }
 
-    /// Last assigned transaction ID (after begin_transaction, equals txn_id).
-    next_txn_id: AtomicI64,
+    fn horizon(&self) -> i64 {
+        self.exclusions()
+            .first()
+            .map_or(self.cutoff, |seq| self.cutoff.min(seq - 1))
+    }
 
-    /// Last assigned sequence number (after begin/commit, equals that seq).
-    next_sequence: AtomicI64,
+    #[inline]
+    fn admits(&self, sequence: i64) -> bool {
+        // Zero is the prehistory marker used by recovered legacy tombstones.
+        sequence >= 0
+            && sequence <= self.cutoff
+            && self.exclusions().binary_search(&sequence).is_err()
+    }
+}
 
-    /// Global isolation level (0 = ReadCommitted, 1 = SnapshotIsolation).
+/// Fixed committed view. Clones share one registered lease; the last owner
+/// unregisters it. This handle may outlive its originating transaction.
+#[derive(Clone)]
+pub struct ReadEpoch {
+    lease: Arc<EpochLease>,
+}
+
+/// Scalar proof of one engine's committed logical view. It retains no epoch,
+/// row tree, file, or registry owner. Only a matching engine can issue it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CacheProvenance {
+    namespace: usize,
+    generation: std::num::NonZeroU64,
+}
+
+struct EpochLease {
+    registry: Arc<RegistryShared>,
+    id: i64,
+    data: EpochData,
+}
+
+impl Drop for EpochLease {
+    fn drop(&mut self) {
+        let mut state = self.registry.state.lock();
+        state.leases.remove(self.id);
+        state.reset_retention_if_idle(self.registry.active_txn_count.load(Ordering::Relaxed));
+    }
+}
+
+impl std::fmt::Debug for ReadEpoch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReadEpoch")
+            .field("cutoff", &self.cutoff())
+            .field("exclusions", &self.excluded_sequences())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ReadEpoch {
+    /// Used only while all claimed owners are exclusively borrowed by a
+    /// destructive DDL operation. The caller must count actual private epoch
+    /// values, and reject cached views with any externally shared Arc owner.
+    pub(crate) fn has_exact_owners(&self, owners: usize) -> bool {
+        owners != 0 && Arc::strong_count(&self.lease) == owners
+    }
+
+    pub(crate) fn cache_identity(&self) -> (usize, i64) {
+        (self.lease.registry.namespace, self.lease.id)
+    }
+
+    /// True for handles sharing the same registered statement lease.
+    #[inline]
+    pub fn same_epoch(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.lease, &other.lease)
+    }
+
+    pub fn cutoff(&self) -> i64 {
+        self.lease.data.cutoff
+    }
+    pub fn excluded_sequences(&self) -> &[i64] {
+        self.lease.data.exclusions()
+    }
+    pub fn retention_horizon(&self) -> i64 {
+        self.lease.data.horizon()
+    }
+
+    /// Apply the same fixed decision to versioned cold tombstones.
+    pub fn admits_commit_sequence(&self, sequence: i64) -> bool {
+        self.lease.data.admits(sequence)
+    }
+
+    /// Committed visibility only. The transaction's own writes belong to the
+    /// caller's separate overlay and are not made committed by this method.
+    pub fn is_visible(&self, txn_id: i64) -> bool {
+        if txn_id == RECOVERY_TRANSACTION_ID {
+            return true;
+        }
+        self.lease
+            .registry
+            .state
+            .lock()
+            .visible_at(txn_id, &self.lease.data)
+    }
+}
+
+/// A small, allocation-free cache for one iterator over a fixed epoch. Answers
+/// for versions reachable from a valid captured view are immutable, including
+/// transactions that were Active or Committing at capture. After acknowledged
+/// undo, newer captures cannot contain that aborted version; GC may retire its
+/// marker, so arbitrary queries about that retired identity are not stable.
+pub struct EpochReader<'a> {
+    lease: &'a EpochLease,
+    cache: [(i64, bool); 8],
+}
+
+impl ReadEpoch {
+    pub fn reader(&self) -> EpochReader<'_> {
+        EpochReader {
+            lease: &self.lease,
+            cache: [(0, false); 8],
+        }
+    }
+}
+
+impl EpochReader<'_> {
+    #[inline]
+    pub fn is_visible(&mut self, txn_id: i64) -> bool {
+        if txn_id <= 0 {
+            return txn_id == RECOVERY_TRANSACTION_ID;
+        }
+        let slot = CommittedCache::index(txn_id) & (self.cache.len() - 1);
+        if self.cache[slot].0 == txn_id {
+            return self.cache[slot].1;
+        }
+        let visible = self
+            .lease
+            .registry
+            .state
+            .lock()
+            .visible_at(txn_id, &self.lease.data);
+        self.cache[slot] = (txn_id, visible);
+        visible
+    }
+}
+
+/// A fixed seal/compaction eligibility bound registered before capture starts.
+/// Dropping it releases retention, without changing any already issued epoch.
+#[derive(Clone)]
+pub struct BuildLease {
+    lease: Arc<EpochLease>,
+}
+
+impl BuildLease {
+    pub fn reader(&self) -> EpochReader<'_> {
+        EpochReader {
+            lease: &self.lease,
+            cache: [(0, false); 8],
+        }
+    }
+
+    pub fn cutoff(&self) -> i64 {
+        self.lease.data.cutoff
+    }
+
+    pub fn is_eligible(&self, txn_id: i64) -> bool {
+        if txn_id == RECOVERY_TRANSACTION_ID {
+            return true;
+        }
+        self.lease
+            .registry
+            .state
+            .lock()
+            .visible_at(txn_id, &self.lease.data)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct CommittingTxn {
+    id: i64,
+    commit_seq: i64,
+    begin_registration: i64,
+}
+
+struct RegistryState {
+    /// Prevent new read/build/transaction registrations while a prevalidated
+    /// destructive DDL writes WAL. No lifecycle mutex is held during that IO.
+    destructive_ddl: bool,
+    logical_generation: u64,
+    immediate_mutations: usize,
+    transactions: I64Map<TxnState>,
+    snapshot_seqs: I64Map<i64>,
+    // Preserve begin-time exclusions for legacy callers that set isolation
+    // after begin. Empty exclusions need no map entry/allocation.
+    begin_exclusions: I64Map<CompactArc<[i64]>>,
+    // Only committing transactions, normally inline. Avoid scanning all active
+    // transactions whenever a statement or transaction captures an epoch.
+    committing: SmallVec<[CommittingTxn; 4]>,
+    committing_charge: Option<crate::common::memory::MemoryCharge>,
+    leases: I64Map<i64>,
+    // Lowered atomically with each registration; stale low floors only retain
+    // extra history. Exact GC/pressure refresh raises it without per-row scans.
+    cached_retention_horizon: Option<i64>,
+    next_registration: i64,
+    next_txn_id: i64,
+    next_sequence: i64,
+    // Every omitted committed mapping is known to be at or below this floor.
+    // A bare historical cutoff older than it cannot safely infer visibility.
+    discarded_through: i64,
+}
+
+impl RegistryState {
+    fn advance_logical_generation(&mut self) {
+        // Exhaustion disables reuse permanently. In particular, completion of
+        // a durable COMMIT must neither fail nor reuse an earlier identity.
+        if self.logical_generation != 0 {
+            self.logical_generation = self.logical_generation.checked_add(1).unwrap_or(0);
+        }
+    }
+
+    fn allocate_sequence(&mut self) -> i64 {
+        let Some(next) = self
+            .next_sequence
+            .checked_add(1)
+            .filter(|seq| *seq <= SEQ_MASK)
+        else {
+            panic!("transaction sequence exhausted");
+        };
+        self.next_sequence = next;
+        next
+    }
+
+    fn capture_data(&self) -> EpochData {
+        let mut excluded: SmallVec<[i64; 4]> =
+            self.committing.iter().map(|txn| txn.commit_seq).collect();
+        excluded.sort_unstable();
+        EpochData {
+            cutoff: self.next_sequence,
+            cache_generation: if self.immediate_mutations == 0 && !self.destructive_ddl {
+                self.logical_generation
+            } else {
+                0
+            },
+            excluded: (!excluded.is_empty()).then(|| match self.transactions.memory_account() {
+                Some(account) => CompactArc::from_slice_in(excluded.as_slice(), account),
+                None => CompactArc::from_slice(excluded.as_slice()),
+            }),
+        }
+    }
+
+    fn transaction_data(&self, txn_id: i64) -> Option<EpochData> {
+        let txn = self.transactions.get(txn_id)?;
+        txn.is_active_or_committing().then(|| EpochData {
+            cutoff: txn.begin_seq(),
+            cache_generation: 0,
+            excluded: self.begin_exclusions.get(txn_id).cloned(),
+        })
+    }
+
+    fn allocate_registration(&mut self) -> i64 {
+        let Some(next) = self
+            .next_registration
+            .checked_add(1)
+            .filter(|id| *id < SEQ_MASK)
+        else {
+            panic!("read registration identity exhausted");
+        };
+        self.next_registration = next;
+        next
+    }
+
+    fn register_lease(&mut self, data: &EpochData) -> i64 {
+        let id = self.allocate_registration();
+        let horizon = data.horizon();
+        self.lower_retention_horizon(horizon);
+        self.leases.insert(id, horizon);
+        id
+    }
+
+    fn lower_retention_horizon(&mut self, horizon: i64) {
+        self.cached_retention_horizon = Some(
+            self.cached_retention_horizon
+                .map_or(horizon, |old| old.min(horizon)),
+        );
+    }
+
+    fn reset_retention_if_idle(&mut self, active: usize) {
+        if active == 0 && self.leases.is_empty() {
+            self.cached_retention_horizon = None;
+        }
+    }
+
+    fn refresh_retention_horizon(&mut self) -> Option<i64> {
+        let horizon = self.retention_horizon();
+        self.cached_retention_horizon = horizon;
+        horizon
+    }
+
+    fn oldest_registration(&self) -> Option<i64> {
+        self.transactions
+            .values()
+            .filter_map(TxnState::active_begin_registration)
+            .chain(self.committing.iter().map(|txn| txn.begin_registration))
+            .chain(self.leases.keys())
+            .min()
+    }
+
+    fn safe_completed_cutoff(&self) -> i64 {
+        self.committing
+            .iter()
+            .map(|txn| txn.commit_seq - 1)
+            .min()
+            .unwrap_or(self.next_sequence)
+    }
+
+    fn retention_horizon(&self) -> Option<i64> {
+        // The legacy isolation setter can promote an active transaction to SI.
+        // Preserve its begin view until that compatibility API is retired.
+        let transactions = self
+            .transactions
+            .iter()
+            .filter(|(_, txn)| txn.is_active_or_committing())
+            .map(|(id, txn)| {
+                self.begin_exclusions
+                    .get(id)
+                    .and_then(|seqs| seqs.first())
+                    .map_or(txn.begin_seq(), |seq| txn.begin_seq().min(seq - 1))
+            });
+        transactions.chain(self.leases.values().copied()).min()
+    }
+
+    fn committed(&self, txn_id: i64) -> bool {
+        txn_id > 0 && txn_id <= self.next_txn_id && !self.transactions.contains_key(txn_id)
+    }
+
+    fn visible_at(&self, txn_id: i64, epoch: &EpochData) -> bool {
+        self.visible_at_parts(txn_id, epoch.cutoff, epoch.exclusions())
+    }
+
+    fn visible_at_parts(&self, txn_id: i64, cutoff: i64, excluded: &[i64]) -> bool {
+        if !self.committed(txn_id) {
+            return false;
+        }
+        match self.snapshot_seqs.get(txn_id) {
+            Some(&sequence) => {
+                sequence >= 0 && sequence <= cutoff && excluded.binary_search(&sequence).is_err()
+            }
+            None => {
+                self.discarded_through <= excluded.first().map_or(cutoff, |seq| cutoff.min(seq - 1))
+            }
+        }
+    }
+
+    fn push_committing(&mut self, txn: CommittingTxn) {
+        if let Some(charge) = self.committing_charge.as_mut() {
+            if self.committing.len() == self.committing.capacity() {
+                let Some(capacity) = self.committing.capacity().checked_mul(2) else {
+                    panic!("committing capacity exhausted");
+                };
+                let replacement = SmallVec::with_capacity(capacity);
+                let new_bytes = capacity * std::mem::size_of::<CommittingTxn>();
+                // Charge both live buffers until the old allocation is released.
+                charge.resize(charge.bytes() + new_bytes);
+                let previous = std::mem::replace(&mut self.committing, replacement);
+                self.committing.extend(previous);
+                charge.resize(new_bytes);
+            }
+        }
+        self.committing.push(txn);
+    }
+
+    fn remove_committing(&mut self, txn_id: i64) {
+        if let Some(index) = self.committing.iter().position(|txn| txn.id == txn_id) {
+            self.committing.swap_remove(index);
+        }
+    }
+}
+
+struct RegistryShared {
+    namespace: usize,
+    state: Mutex<RegistryState>,
+    ddl_finished: Condvar,
     global_isolation_level: AtomicU8,
-
-    /// Per-transaction isolation level overrides.
-    isolation_overrides: Mutex<I64Map<u8>>,
-
-    /// Count of active isolation overrides (skip lookup when 0).
-    override_count: AtomicUsize,
-
-    /// Count of active transactions (O(1) lookup).
     active_txn_count: AtomicUsize,
-
-    /// Whether new transactions are being accepted.
+    snapshot_txn_count: AtomicUsize,
     accepting: AtomicBool,
-    // The std::Arc control block is opaque; keep its allowance conservative.
+    current_sequence: AtomicI64,
+    committed_cache: CommittedCache,
     _object_charge: Option<crate::common::memory::MemoryCharge>,
 }
 
+/// Registry facade. Leases keep the state and retention metadata alive without
+/// a cycle: registry state stores only lease IDs/horizons, never lease handles.
+pub struct TransactionRegistry {
+    shared: Arc<RegistryShared>,
+    _object_charge: Option<crate::common::memory::MemoryCharge>,
+}
+
+/// Marks a logical mutation which does not wait for transaction visibility.
+/// Owned guards may nest; they hold no mutex during the operation or its I/O.
+#[must_use = "keep the guard alive through the complete logical mutation"]
+pub struct LogicalMutationGuard {
+    shared: Arc<RegistryShared>,
+}
+
+impl Drop for LogicalMutationGuard {
+    fn drop(&mut self) {
+        let mut state = self.shared.state.lock();
+        state.advance_logical_generation();
+        state.immediate_mutations -= 1;
+    }
+}
+
+/// Admission reservation, not a held mutex: registered epochs cannot be
+/// created between destructive DDL prevalidation and its completed mutation.
+pub(crate) struct DestructiveDdlGuard<'a> {
+    shared: &'a Arc<RegistryShared>,
+}
+
+impl DestructiveDdlGuard<'_> {
+    /// Internal current-state validation is part of the reserved operation.
+    /// It must not wait on its own admission flag or reuse an older SI epoch.
+    pub(crate) fn capture_current_epoch(&self) -> ReadEpoch {
+        let (data, id) = {
+            let mut state = self.shared.state.lock();
+            debug_assert!(state.destructive_ddl);
+            let data = state.capture_data();
+            let id = state.register_lease(&data);
+            (data, id)
+        };
+        ReadEpoch {
+            lease: Arc::new(EpochLease {
+                registry: Arc::clone(self.shared),
+                id,
+                data,
+            }),
+        }
+    }
+}
+
+impl Drop for DestructiveDdlGuard<'_> {
+    fn drop(&mut self) {
+        let mut state = self.shared.state.lock();
+        state.advance_logical_generation();
+        state.destructive_ddl = false;
+        self.shared.ddl_finished.notify_all();
+    }
+}
+
 impl TransactionRegistry {
-    /// Creates a new transaction registry.
+    pub fn begin_logical_mutation(&self) -> LogicalMutationGuard {
+        let mut state = self.shared.state.lock();
+        let Some(count) = state.immediate_mutations.checked_add(1) else {
+            panic!("logical mutation count exhausted");
+        };
+        state.immediate_mutations = count;
+        state.advance_logical_generation();
+        LogicalMutationGuard {
+            shared: Arc::clone(&self.shared),
+        }
+    }
+
+    /// Call after binding the table and schema. Never stamp a completed old
+    /// result with a newly sampled generation; retain this original proof.
+    pub fn cache_provenance(&self, epoch: &ReadEpoch) -> Option<CacheProvenance> {
+        if !Arc::ptr_eq(&self.shared, &epoch.lease.registry) {
+            return None;
+        }
+        let generation = std::num::NonZeroU64::new(epoch.lease.data.cache_generation)?;
+        let state = self.shared.state.lock();
+        (state.logical_generation == generation.get()
+            && state.immediate_mutations == 0
+            && !state.destructive_ddl)
+            .then_some(CacheProvenance {
+                namespace: self.shared.namespace,
+                generation,
+            })
+    }
+
+    fn wait_for_ddl(&self, state: &mut parking_lot::MutexGuard<'_, RegistryState>) {
+        while state.destructive_ddl {
+            self.shared.ddl_finished.wait(state);
+        }
+    }
+
+    /// The caller exclusively borrows every counted epoch value until this
+    /// guard drops. No additional lease is exempted, including another lease
+    /// issued for the same transaction. This permits private table bindings,
+    /// but rejects a delayed table capture/result sharing the caller's epoch.
+    pub(crate) fn prepare_destructive_ddl(
+        &self,
+        txn_id: i64,
+        private_epoch: Option<(&ReadEpoch, usize)>,
+    ) -> crate::core::Result<DestructiveDdlGuard<'_>> {
+        let mut state = self.shared.state.lock();
+        if state.destructive_ddl
+            || !self.shared.accepting.load(Ordering::Acquire)
+            || state
+                .transactions
+                .get(txn_id)
+                .is_none_or(|txn| txn.status() != TxnStatus::Active)
+            || state
+                .transactions
+                .iter()
+                .any(|(id, txn)| id != txn_id && txn.is_active_or_committing())
+        {
+            return Err(crate::core::Error::TableHasActiveTransactions);
+        }
+        let exempt = match private_epoch {
+            Some((epoch, owners))
+                if Arc::ptr_eq(&self.shared, &epoch.lease.registry)
+                    && epoch.has_exact_owners(owners) =>
+            {
+                Some(epoch.lease.id)
+            }
+            Some(_) => return Err(crate::core::Error::TableHasActiveTransactions),
+            None => None,
+        };
+        if state.leases.keys().any(|id| Some(id) != exempt) {
+            return Err(crate::core::Error::TableHasActiveTransactions);
+        }
+        state.advance_logical_generation();
+        state.destructive_ddl = true;
+        Ok(DestructiveDdlGuard {
+            shared: &self.shared,
+        })
+    }
+
     pub fn new() -> Self {
         Self::with_capacity(1024)
     }
 
-    /// Creates a new transaction registry with pre-allocated capacity.
     pub fn with_capacity(capacity: usize) -> Self {
+        Self::with_optional_account(capacity, None)
+    }
+
+    fn with_optional_account(
+        capacity: usize,
+        account: Option<&crate::common::memory::MemoryAccount>,
+    ) -> Self {
+        let Ok(namespace) =
+            NEXT_REGISTRY_NAMESPACE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |next| {
+                next.checked_add(1)
+            })
+        else {
+            panic!("registry namespace exhausted");
+        };
         Self {
-            transactions: Mutex::new(I64Map::with_capacity(capacity)),
-            snapshot_seqs: Mutex::new(I64Map::new()),
-            next_txn_id: AtomicI64::new(0),
-            next_sequence: AtomicI64::new(0),
-            global_isolation_level: AtomicU8::new(0),
-            isolation_overrides: Mutex::new(I64Map::new()),
-            override_count: AtomicUsize::new(0),
-            active_txn_count: AtomicUsize::new(0),
-            accepting: AtomicBool::new(true),
-            _object_charge: None,
+            shared: Arc::new(RegistryShared {
+                namespace,
+                state: Mutex::new(RegistryState {
+                    destructive_ddl: false,
+                    logical_generation: 1,
+                    immediate_mutations: 0,
+                    transactions: account.map_or_else(
+                        || I64Map::with_capacity(capacity),
+                        |origin| I64Map::with_capacity_in(capacity, origin),
+                    ),
+                    snapshot_seqs: account.map_or_else(I64Map::new, I64Map::new_in),
+                    begin_exclusions: account.map_or_else(I64Map::new, I64Map::new_in),
+                    committing: SmallVec::new(),
+                    committing_charge: account
+                        .map(|origin| crate::common::memory::MemoryCharge::new(origin, 0)),
+                    leases: account.map_or_else(I64Map::new, I64Map::new_in),
+                    cached_retention_horizon: None,
+                    next_registration: 0,
+                    next_txn_id: 0,
+                    next_sequence: 0,
+                    discarded_through: 0,
+                }),
+                ddl_finished: Condvar::new(),
+                global_isolation_level: AtomicU8::new(0),
+                active_txn_count: AtomicUsize::new(0),
+                snapshot_txn_count: AtomicUsize::new(0),
+                accepting: AtomicBool::new(true),
+                current_sequence: AtomicI64::new(0),
+                committed_cache: CommittedCache::new(),
+                // std::Arc headers are opaque. Keep the allowance with this
+                // physical owner: external epochs can outlive the facade.
+                _object_charge: account.map(|origin| {
+                    crate::common::memory::MemoryCharge::conservative(
+                        origin,
+                        std::mem::size_of::<RegistryShared>() + 4 * std::mem::size_of::<usize>(),
+                    )
+                }),
+            }),
+            _object_charge: account.map(|origin| {
+                crate::common::memory::MemoryCharge::conservative(
+                    origin,
+                    std::mem::size_of::<Self>() + 4 * std::mem::size_of::<usize>(),
+                )
+            }),
         }
     }
 
     pub(crate) fn new_in(account: &crate::common::memory::MemoryAccount) -> Self {
-        let mut registry = Self::with_capacity(0);
-        registry.transactions = Mutex::new(I64Map::with_capacity_in(16, account));
-        registry.snapshot_seqs = Mutex::new(I64Map::new_in(account));
-        registry.isolation_overrides = Mutex::new(I64Map::new_in(account));
-        registry._object_charge = Some(crate::common::memory::MemoryCharge::conservative(
-            account,
-            std::mem::size_of::<Self>() + 4 * std::mem::size_of::<usize>(),
-        ));
-        registry
+        Self::with_optional_account(16, Some(account))
     }
 
-    #[inline(always)]
+    #[inline]
     const fn isolation_to_u8(level: IsolationLevel) -> u8 {
         match level {
             IsolationLevel::ReadCommitted => 0,
@@ -260,720 +798,664 @@ impl TransactionRegistry {
         }
     }
 
-    #[inline(always)]
-    const fn u8_to_isolation(value: u8) -> IsolationLevel {
-        match value {
-            0 => IsolationLevel::ReadCommitted,
-            _ => IsolationLevel::SnapshotIsolation,
+    #[inline]
+    const fn u8_to_isolation(level: u8) -> IsolationLevel {
+        if level == 0 {
+            IsolationLevel::ReadCommitted
+        } else {
+            IsolationLevel::SnapshotIsolation
         }
     }
 
-    /// Sets the global isolation level.
     pub fn set_global_isolation_level(&self, level: IsolationLevel) {
-        self.global_isolation_level
+        let _state = self.shared.state.lock();
+        self.shared
+            .global_isolation_level
             .store(Self::isolation_to_u8(level), Ordering::Release);
     }
 
-    /// Gets the current global isolation level.
-    #[inline(always)]
     pub fn get_global_isolation_level(&self) -> IsolationLevel {
-        Self::u8_to_isolation(self.global_isolation_level.load(Ordering::Acquire))
+        Self::u8_to_isolation(self.shared.global_isolation_level.load(Ordering::Acquire))
     }
 
-    /// Sets the isolation level for a specific transaction.
     pub fn set_transaction_isolation_level(&self, txn_id: i64, level: IsolationLevel) {
-        let mut map = self.isolation_overrides.lock();
-        let is_new = !map.contains_key(txn_id);
-        map.insert(txn_id, Self::isolation_to_u8(level));
-        if is_new {
-            self.override_count.fetch_add(1, Ordering::Relaxed);
-        }
-    }
-
-    /// Removes the isolation level override for a transaction.
-    pub fn remove_transaction_isolation_level(&self, txn_id: i64) {
-        if self.isolation_overrides.lock().remove(txn_id).is_some() {
-            self.override_count.fetch_sub(1, Ordering::Relaxed);
-        }
-    }
-
-    /// Gets the isolation level for a specific transaction.
-    #[inline(always)]
-    pub fn get_isolation_level(&self, txn_id: i64) -> IsolationLevel {
-        if self.override_count.load(Ordering::Relaxed) > 0 {
-            if let Some(&level) = self.isolation_overrides.lock().get(txn_id) {
-                return Self::u8_to_isolation(level);
+        let mut state = self.shared.state.lock();
+        self.wait_for_ddl(&mut state);
+        if let Some(txn) = state.transactions.get_mut(txn_id) {
+            if !txn.is_active_or_committing() {
+                return;
             }
-        }
-        self.get_global_isolation_level()
-    }
-
-    /// Checks if snapshot isolation is needed for a transaction.
-    #[inline(always)]
-    fn needs_snapshot_isolation(&self, txn_id: i64) -> bool {
-        let global = self.global_isolation_level.load(Ordering::Relaxed);
-        if global == 1 {
-            return true;
-        }
-        if self.override_count.load(Ordering::Relaxed) > 0 {
-            if let Some(&level) = self.isolation_overrides.lock().get(txn_id) {
-                return level == 1;
-            }
-        }
-        false
-    }
-
-    /// Check if any active transaction uses snapshot isolation.
-    /// Used by seal_hot_buffers to avoid breaking snapshot isolation guarantees.
-    pub fn has_active_snapshot_transactions(&self) -> bool {
-        let global = self.global_isolation_level.load(Ordering::Relaxed);
-        if global == 1 {
-            // Global snapshot isolation — any active transaction uses it
-            return !self.transactions.lock().is_empty();
-        }
-        if self.override_count.load(Ordering::Relaxed) > 0 {
-            // Lock order: transactions FIRST, then isolation_overrides
-            // (matches get_snapshot_transaction_ids to prevent ABBA deadlock)
-            let transactions = self.transactions.lock();
-            let overrides = self.isolation_overrides.lock();
-            for txn_id in transactions.keys() {
-                if overrides.get(txn_id) == Some(&1) {
-                    return true;
+            let snapshot = level == IsolationLevel::SnapshotIsolation;
+            if txn.is_snapshot() != snapshot {
+                if snapshot {
+                    self.shared
+                        .snapshot_txn_count
+                        .fetch_add(1, Ordering::Relaxed);
+                } else {
+                    self.shared
+                        .snapshot_txn_count
+                        .fetch_sub(1, Ordering::Relaxed);
                 }
+                txn.set_snapshot(snapshot);
             }
         }
-        false
     }
 
-    /// Get transaction IDs of all active snapshot-isolation transactions.
+    pub fn remove_transaction_isolation_level(&self, txn_id: i64) {
+        self.set_transaction_isolation_level(txn_id, self.get_global_isolation_level());
+    }
+
+    pub fn get_isolation_level(&self, txn_id: i64) -> IsolationLevel {
+        if self.shared.snapshot_txn_count.load(Ordering::Relaxed) == 0
+            && self.shared.global_isolation_level.load(Ordering::Relaxed) == 0
+        {
+            return IsolationLevel::ReadCommitted;
+        }
+        let state = self.shared.state.lock();
+        match state
+            .transactions
+            .get(txn_id)
+            .filter(|txn| txn.is_active_or_committing())
+        {
+            Some(txn) => Self::u8_to_isolation(txn.is_snapshot() as u8),
+            None => self.get_global_isolation_level(),
+        }
+    }
+
+    #[inline]
+    fn needs_snapshot_isolation(&self, txn_id: i64) -> bool {
+        self.shared.snapshot_txn_count.load(Ordering::Relaxed) > 0
+            && self
+                .shared
+                .state
+                .lock()
+                .transactions
+                .get(txn_id)
+                .is_some_and(TxnState::is_snapshot)
+    }
+
+    pub fn has_active_snapshot_transactions(&self) -> bool {
+        self.shared.snapshot_txn_count.load(Ordering::Relaxed) > 0
+    }
+
     pub fn get_snapshot_transaction_ids(&self) -> Vec<i64> {
-        let global = self.global_isolation_level.load(Ordering::Relaxed);
-        let transactions = self.transactions.lock();
-
-        if global == 1 {
-            // All active transactions use snapshot isolation
-            return transactions.keys().collect();
-        }
-
-        if self.override_count.load(Ordering::Relaxed) > 0 {
-            let overrides = self.isolation_overrides.lock();
-            return transactions
-                .keys()
-                .filter(|txn_id| overrides.get(*txn_id) == Some(&1))
-                .collect();
-        }
-
-        Vec::new()
+        self.shared
+            .state
+            .lock()
+            .transactions
+            .iter()
+            .filter_map(|(id, txn)| txn.is_snapshot().then_some(id))
+            .collect()
     }
 
-    /// Get the minimum begin_seq among active snapshot isolation transactions.
-    /// Returns None if no snapshot transactions are active (seal/compaction can proceed freely).
-    /// Returns Some(min_begin_seq) otherwise — only rows committed before this seq are safe to seal.
-    pub fn get_min_snapshot_begin_seq(&self) -> Option<i64> {
-        let global = self.global_isolation_level.load(Ordering::Relaxed);
-        let transactions = self.transactions.lock();
-
-        if global == 1 {
-            return transactions
-                .values()
-                .filter(|s| s.is_active_or_committing())
-                .map(|s| s.begin_seq())
-                .min();
+    /// Capture and register before releasing the lifecycle mutex.
+    pub fn capture_read_epoch(&self) -> ReadEpoch {
+        let (data, id) = {
+            let mut state = self.shared.state.lock();
+            self.wait_for_ddl(&mut state);
+            let data = state.capture_data();
+            let id = state.register_lease(&data);
+            (data, id)
+        };
+        ReadEpoch {
+            lease: Arc::new(EpochLease {
+                registry: Arc::clone(&self.shared),
+                id,
+                data,
+            }),
         }
-
-        if self.override_count.load(Ordering::Relaxed) > 0 {
-            let overrides = self.isolation_overrides.lock();
-            return transactions
-                .iter()
-                .filter(|(id, s)| s.is_active_or_committing() && overrides.get(*id) == Some(&1))
-                .map(|(_, s)| s.begin_seq())
-                .min();
-        }
-
-        None
     }
 
-    /// Begins a new transaction.
+    /// SI reuses its original begin epoch; RC captures this statement's epoch.
+    /// Returns None after the transaction has reached a terminal state.
+    pub fn read_epoch_for_transaction(&self, txn_id: i64) -> Option<ReadEpoch> {
+        let (data, id) = {
+            let mut state = self.shared.state.lock();
+            self.wait_for_ddl(&mut state);
+            let txn = state.transactions.get(txn_id)?;
+            if !txn.is_active_or_committing() {
+                return None;
+            }
+            let data = if txn.is_snapshot() {
+                state.transaction_data(txn_id)?
+            } else {
+                state.capture_data()
+            };
+            let id = state.register_lease(&data);
+            (data, id)
+        };
+        Some(ReadEpoch {
+            lease: Arc::new(EpochLease {
+                registry: Arc::clone(&self.shared),
+                id,
+                data,
+            }),
+        })
+    }
+
+    /// Choose one safe bound and register its retention in the same critical
+    /// section. The bound never advances, even when an excluded commit finishes.
+    pub fn register_build_lease(&self) -> BuildLease {
+        let (data, id) = {
+            let mut state = self.shared.state.lock();
+            self.wait_for_ddl(&mut state);
+            let safe = state.safe_completed_cutoff();
+            let cutoff = state
+                .refresh_retention_horizon()
+                .map_or(safe, |horizon| safe.min(horizon));
+            let data = EpochData {
+                cutoff,
+                cache_generation: 0,
+                excluded: None,
+            };
+            let id = state.register_lease(&data);
+            (data, id)
+        };
+        BuildLease {
+            lease: Arc::new(EpochLease {
+                registry: Arc::clone(&self.shared),
+                id,
+                data,
+            }),
+        }
+    }
+
+    pub fn oldest_retention_horizon(&self) -> Option<i64> {
+        self.refresh_retention_horizon()
+    }
+
+    /// Conservative O(1) floor for publication. Registration lowers the floor
+    /// before becoming observable. Last-obligation release resets it in O(1).
+    /// Continuous overlap may leave a stale low floor until explicit refresh.
+    pub fn cached_retention_horizon(&self) -> Option<i64> {
+        self.shared.state.lock().cached_retention_horizon
+    }
+
+    /// Refresh before pressure-driven history cleanup declares a live reader
+    /// pin. This and normal GC perform the full scan outside row mutation paths.
+    pub fn refresh_retention_horizon(&self) -> Option<i64> {
+        self.shared.state.lock().refresh_retention_horizon()
+    }
+
+    /// Check a bounded candidate prefix under one registry lock. The supplied
+    /// identities belong to one row's newest-to-oldest version chain.
+    pub fn history_retention(
+        &self,
+        creators: &[i64],
+    ) -> crate::storage::mvcc::version_store::HistoryRetention {
+        use crate::storage::mvcc::version_store::HistoryRetention;
+        let state = self.shared.state.lock();
+        let Some(cutoff) = state.cached_retention_horizon else {
+            return HistoryRetention::Unprotected;
+        };
+        let epoch = EpochData {
+            cutoff,
+            cache_generation: 0,
+            excluded: None,
+        };
+        creators
+            .iter()
+            .position(|&id| id == RECOVERY_TRANSACTION_ID || state.visible_at(id, &epoch))
+            .map_or(HistoryRetention::Protected, HistoryRetention::KeepThrough)
+    }
+
+    /// Presence-only check for history-cap decisions. Avoid computing the
+    /// minimum across every registration for each row in a publishing batch.
+    pub fn has_retention_obligations(&self) -> bool {
+        let state = self.shared.state.lock();
+        self.shared.active_txn_count.load(Ordering::Relaxed) != 0 || !state.leases.is_empty()
+    }
+
     pub fn begin_transaction(&self) -> (i64, i64) {
-        if !self.accepting.load(Ordering::Acquire) {
+        self.begin_transaction_inner(None)
+    }
+
+    /// Unlike begin-then-set, the initial isolation and epoch are published
+    /// atomically with the transaction's identity.
+    pub fn begin_transaction_with_isolation(&self, isolation: IsolationLevel) -> (i64, i64) {
+        self.begin_transaction_inner(Some(isolation))
+    }
+
+    fn begin_transaction_inner(&self, isolation: Option<IsolationLevel>) -> (i64, i64) {
+        let mut state = self.shared.state.lock();
+        self.wait_for_ddl(&mut state);
+        if !self.shared.accepting.load(Ordering::Acquire) {
             return (INVALID_TRANSACTION_ID, 0);
         }
-
-        let txn_id = self.next_txn_id.fetch_add(1, Ordering::AcqRel) + 1;
-        let begin_seq = self.next_sequence.fetch_add(1, Ordering::AcqRel) + 1;
-
-        self.transactions
-            .lock()
-            .insert(txn_id, TxnState::new_active(begin_seq));
-        self.active_txn_count.fetch_add(1, Ordering::Relaxed);
-
+        let Some(txn_id) = state.next_txn_id.checked_add(1) else {
+            panic!("transaction identity exhausted");
+        };
+        let data = state.capture_data();
+        let begin_seq = state.allocate_sequence();
+        let begin_registration = state.allocate_registration();
+        let snapshot = isolation.unwrap_or_else(|| self.get_global_isolation_level())
+            == IsolationLevel::SnapshotIsolation;
+        state.next_txn_id = txn_id;
+        let horizon = data
+            .exclusions()
+            .first()
+            .map_or(begin_seq, |seq| begin_seq.min(seq - 1));
+        state.lower_retention_horizon(horizon);
+        state.transactions.insert(
+            txn_id,
+            TxnState::new_active(begin_seq, snapshot, begin_registration),
+        );
+        if let Some(excluded) = data.excluded {
+            state.begin_exclusions.insert(txn_id, excluded);
+        }
+        self.shared.active_txn_count.fetch_add(1, Ordering::Relaxed);
+        if snapshot {
+            self.shared
+                .snapshot_txn_count
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        self.shared
+            .current_sequence
+            .store(begin_seq, Ordering::Release);
         (txn_id, begin_seq)
     }
 
-    /// Starts the commit process (two-phase commit).
     #[inline]
     pub fn start_commit(&self, txn_id: i64) -> i64 {
-        let commit_seq = self.next_sequence.fetch_add(1, Ordering::AcqRel) + 1;
+        self.start_commit_after_sequence(txn_id, || {})
+    }
 
-        if let Some(entry) = self.transactions.lock().get_mut(txn_id) {
-            entry.set_committing(commit_seq);
-        }
+    fn start_commit_after_sequence(&self, txn_id: i64, after_sequence: impl FnOnce()) -> i64 {
+        let mut state = self.shared.state.lock();
+        self.wait_for_ddl(&mut state);
+        let Some(mut txn) = state.transactions.get(txn_id).copied() else {
+            return 0;
+        };
+        let begin_registration = match txn.active_begin_registration() {
+            Some(registration) => registration,
+            None => return txn.commit_seq(),
+        };
+        let commit_seq = state.allocate_sequence();
+        after_sequence();
+        // Retain Active ownership until the in-flight list has grown successfully.
+        state.push_committing(CommittingTxn {
+            id: txn_id,
+            commit_seq,
+            begin_registration,
+        });
+        txn.set_committing(commit_seq);
+        let Some(slot) = state.transactions.get_mut(txn_id) else {
+            unreachable!("validated transaction remains under lifecycle lock");
+        };
+        *slot = txn;
 
+        self.shared
+            .current_sequence
+            .store(commit_seq, Ordering::Release);
         commit_seq
     }
 
-    /// Completes the commit process (two-phase commit).
+    fn finish_commit_locked(
+        &self,
+        state: &mut RegistryState,
+        txn_id: i64,
+        txn: TxnState,
+        commit_seq: i64,
+    ) {
+        state.advance_logical_generation();
+        state.transactions.remove(txn_id);
+        state.remove_committing(txn_id);
+        state.begin_exclusions.remove(txn_id);
+        self.shared.active_txn_count.fetch_sub(1, Ordering::Relaxed);
+        if txn.is_snapshot() {
+            self.shared
+                .snapshot_txn_count
+                .fetch_sub(1, Ordering::Relaxed);
+        }
+        if self.shared.active_txn_count.load(Ordering::Relaxed) > 0
+            || !state.leases.is_empty()
+            || self.shared.global_isolation_level.load(Ordering::Relaxed) == 1
+        {
+            state.snapshot_seqs.insert(txn_id, commit_seq);
+        } else {
+            state.discarded_through = state.discarded_through.max(commit_seq);
+        }
+        // Publish only while holding the state lock; recovery invalidation uses
+        // the same lock and cannot race a stale cache insertion.
+        self.shared.committed_cache.insert(txn_id);
+        state.reset_retention_if_idle(self.shared.active_txn_count.load(Ordering::Relaxed));
+    }
+
     #[inline]
     pub fn complete_commit(&self, txn_id: i64) {
-        {
-            let mut txns = self.transactions.lock();
-            let seq = txns.get(txn_id).map(|e| e.commit_seq()).unwrap_or(0);
-
-            // Store commit_seq for snapshot isolation while holding transactions lock
-            // This prevents a race where the transaction is removed from txns but not yet
-            // in snapshot_seqs, which could cause concurrent readers to incorrectly
-            // treat it as an "old committed" transaction (visible).
-            if self.global_isolation_level.load(Ordering::Relaxed) == 1
-                || self.override_count.load(Ordering::Relaxed) > 0
-            {
-                self.snapshot_seqs.lock().insert(txn_id, seq);
-            }
-
-            txns.remove(txn_id);
+        let mut state = self.shared.state.lock();
+        self.wait_for_ddl(&mut state);
+        // Read-only transactions use this API without start_commit.
+        let Some(txn) = state.transactions.get(txn_id).copied() else {
+            return;
         };
-        self.active_txn_count.fetch_sub(1, Ordering::Relaxed);
+        let commit_seq = match txn.status() {
+            TxnStatus::Active => state.allocate_sequence(),
+            TxnStatus::Committing => txn.commit_seq(),
+            TxnStatus::Aborted => return,
+        };
+        self.finish_commit_locked(&mut state, txn_id, txn, commit_seq);
+        self.shared
+            .current_sequence
+            .store(state.next_sequence, Ordering::Release);
     }
 
-    /// Commits a transaction (single-phase).
     pub fn commit_transaction(&self, txn_id: i64) -> i64 {
-        let commit_seq = self.next_sequence.fetch_add(1, Ordering::AcqRel) + 1;
-
-        {
-            let mut txns = self.transactions.lock();
-
-            // Store commit_seq for snapshot isolation while holding transactions lock
-            if self.global_isolation_level.load(Ordering::Relaxed) == 1
-                || self.override_count.load(Ordering::Relaxed) > 0
-            {
-                self.snapshot_seqs.lock().insert(txn_id, commit_seq);
-            }
-
-            txns.remove(txn_id);
-        }
-        self.active_txn_count.fetch_sub(1, Ordering::Relaxed);
-
+        let mut state = self.shared.state.lock();
+        self.wait_for_ddl(&mut state);
+        let Some(txn) = state.transactions.get(txn_id).copied() else {
+            return state.snapshot_seqs.get(txn_id).copied().unwrap_or(0);
+        };
+        let commit_seq = match txn.status() {
+            TxnStatus::Active => state.allocate_sequence(),
+            TxnStatus::Committing => txn.commit_seq(),
+            TxnStatus::Aborted => return state.snapshot_seqs.get(txn_id).copied().unwrap_or(0),
+        };
+        self.finish_commit_locked(&mut state, txn_id, txn, commit_seq);
+        self.shared
+            .current_sequence
+            .store(state.next_sequence, Ordering::Release);
         commit_seq
     }
 
-    /// Aborts a transaction.
     #[inline]
     pub fn abort_transaction(&self, txn_id: i64) {
-        // Replace with aborted marker (don't remove - need to track for visibility)
-        // Only decrement counter if transaction was actually active/committing
-        //
-        // CRITICAL: We must check if the transaction exists before inserting the aborted marker.
-        // If it's not in the map, it's already committed (or invalid), and we must NOT
-        // resurrect it as an aborted transaction.
-        let should_decrement = {
-            let mut txns = self.transactions.lock();
-            if let Some(state) = txns.get_mut(txn_id) {
-                let was_active = state.is_active_or_committing();
-                *state = TxnState::new_aborted();
-                was_active
-            } else {
-                false
+        let mut state = self.shared.state.lock();
+        self.wait_for_ddl(&mut state);
+        let registration = state.next_registration;
+        if let Some(txn) = state.transactions.get_mut(txn_id) {
+            if !txn.is_active_or_committing() {
+                return;
             }
-        };
-
-        if should_decrement {
-            self.active_txn_count.fetch_sub(1, Ordering::Relaxed);
+            let unpublished = txn.status() == TxnStatus::Active;
+            if txn.is_snapshot() {
+                self.shared
+                    .snapshot_txn_count
+                    .fetch_sub(1, Ordering::Relaxed);
+            }
+            *txn = TxnState::new_aborted();
+            // Active transactions have not published global versions. A failed
+            // Committing transaction needs explicit successful-undo acknowledgment.
+            if unpublished {
+                txn.acknowledge_rollback(registration);
+            }
+            state.begin_exclusions.remove(txn_id);
+            state.remove_committing(txn_id);
+            self.shared.active_txn_count.fetch_sub(1, Ordering::Relaxed);
+            state.reset_retention_if_idle(self.shared.active_txn_count.load(Ordering::Relaxed));
         }
     }
 
-    /// Recovers a committed transaction during startup recovery.
+    /// Call only after all published versions have been successfully undone and
+    /// transaction-local state discarded. A pre-ack captured tree can still own
+    /// an aborted head, so GC waits for every pre-ack read/begin registration.
+    /// Repeated acknowledgments do not advance the retirement watermark.
+    pub fn acknowledge_rollback(&self, txn_id: i64) {
+        let mut state = self.shared.state.lock();
+        let registration = state.next_registration;
+        if let Some(txn) = state
+            .transactions
+            .get_mut(txn_id)
+            .filter(|txn| txn.is_aborted())
+        {
+            txn.acknowledge_rollback(registration);
+        }
+    }
+
+    /// Startup-only recovery keeps assignment watermarks and mappings atomic.
+    /// WAL also contains negative system identities (recovery and DDL); these
+    /// advance the sequence watermark without consuming user transaction IDs.
     pub fn recover_committed_transaction(&self, txn_id: i64, commit_seq: i64) {
-        // Store in snapshot_seqs for visibility checks
-        self.snapshot_seqs.lock().insert(txn_id, commit_seq);
-
-        // Update next_txn_id if necessary (next_txn_id = last assigned)
-        loop {
-            let current = self.next_txn_id.load(Ordering::Acquire);
-            if txn_id > current {
-                if self
-                    .next_txn_id
-                    .compare_exchange(current, txn_id, Ordering::AcqRel, Ordering::Acquire)
-                    .is_ok()
-                {
-                    break;
+        assert!(
+            (0..=SEQ_MASK).contains(&commit_seq),
+            "invalid recovered transaction: id={txn_id}, sequence={commit_seq}"
+        );
+        let mut state = self.shared.state.lock();
+        state.advance_logical_generation();
+        if let Some(txn) = state.transactions.remove(txn_id) {
+            if txn.is_active_or_committing() {
+                self.shared.active_txn_count.fetch_sub(1, Ordering::Relaxed);
+                if txn.is_snapshot() {
+                    self.shared
+                        .snapshot_txn_count
+                        .fetch_sub(1, Ordering::Relaxed);
                 }
-            } else {
-                break;
             }
         }
-
-        // Update next_sequence if necessary (next_sequence = last assigned)
-        loop {
-            let current = self.next_sequence.load(Ordering::Acquire);
-            if commit_seq > current {
-                if self
-                    .next_sequence
-                    .compare_exchange(current, commit_seq, Ordering::AcqRel, Ordering::Acquire)
-                    .is_ok()
-                {
-                    break;
-                }
-            } else {
-                break;
-            }
-        }
+        state.begin_exclusions.remove(txn_id);
+        state.remove_committing(txn_id);
+        state.snapshot_seqs.insert(txn_id, commit_seq);
+        state.next_txn_id = state.next_txn_id.max(txn_id);
+        state.next_sequence = state.next_sequence.max(commit_seq);
+        self.shared
+            .current_sequence
+            .store(state.next_sequence, Ordering::Release);
+        self.shared.committed_cache.invalidate(txn_id);
+        state.reset_retention_if_idle(self.shared.active_txn_count.load(Ordering::Relaxed));
     }
 
-    /// Records an aborted transaction during recovery.
+    /// Startup-only recovery. Acknowledgment remains separate until recovery
+    /// has confirmed that the transaction's published state is absent.
     pub fn recover_aborted_transaction(&self, txn_id: i64) {
-        self.transactions
-            .lock()
-            .insert(txn_id, TxnState::new_aborted());
-
-        // Update next_txn_id if necessary (next_txn_id = last assigned)
-        loop {
-            let current = self.next_txn_id.load(Ordering::Acquire);
-            if txn_id > current {
-                if self
-                    .next_txn_id
-                    .compare_exchange(current, txn_id, Ordering::AcqRel, Ordering::Acquire)
-                    .is_ok()
-                {
-                    break;
+        assert!(txn_id > 0, "invalid recovered transaction");
+        let mut state = self.shared.state.lock();
+        state.advance_logical_generation();
+        if let Some(txn) = state.transactions.insert(txn_id, TxnState::new_aborted()) {
+            if txn.is_active_or_committing() {
+                self.shared.active_txn_count.fetch_sub(1, Ordering::Relaxed);
+                if txn.is_snapshot() {
+                    self.shared
+                        .snapshot_txn_count
+                        .fetch_sub(1, Ordering::Relaxed);
                 }
-            } else {
-                break;
             }
         }
+        state.begin_exclusions.remove(txn_id);
+        state.remove_committing(txn_id);
+        state.snapshot_seqs.remove(txn_id);
+        state.next_txn_id = state.next_txn_id.max(txn_id);
+        self.shared.committed_cache.invalidate(txn_id);
+        state.reset_retention_if_idle(self.shared.active_txn_count.load(Ordering::Relaxed));
     }
 
-    /// Checks if a version is visible (main entry point).
-    ///
-    /// Hot path - optimized with single lock acquisition.
     #[inline(always)]
     pub fn is_visible(&self, version_txn_id: i64, viewer_txn_id: i64) -> bool {
-        // FAST PATH 1: Own writes always visible
-        if version_txn_id == viewer_txn_id {
+        if version_txn_id == viewer_txn_id || version_txn_id == RECOVERY_TRANSACTION_ID {
             return true;
         }
-
-        // FAST PATH 2: Recovery transactions always visible
-        if version_txn_id == RECOVERY_TRANSACTION_ID {
-            return true;
+        if self.shared.snapshot_txn_count.load(Ordering::Relaxed) == 0 {
+            return self.check_committed(version_txn_id);
         }
-
-        // FAST PATH 3: Check isolation level
-        let needs_snapshot = self.needs_snapshot_isolation(viewer_txn_id);
-
-        if needs_snapshot {
-            self.is_visible_snapshot(version_txn_id, viewer_txn_id)
+        let state = self.shared.state.lock();
+        if let Some(txn) = state
+            .transactions
+            .get(viewer_txn_id)
+            .filter(|txn| txn.is_snapshot())
+        {
+            let excluded = state
+                .begin_exclusions
+                .get(viewer_txn_id)
+                .map_or(&[][..], |seqs| seqs.as_ref());
+            state.visible_at_parts(version_txn_id, txn.begin_seq(), excluded)
         } else {
-            self.check_committed(version_txn_id)
+            state.committed(version_txn_id)
         }
     }
 
-    /// Checks if a transaction is committed (READ COMMITTED visibility).
-    ///
-    /// Single lock acquisition for the hot path.
     #[inline(always)]
     fn check_committed(&self, txn_id: i64) -> bool {
-        // Cache check first (no lock)
-        if COMMITTED_CACHE.with(|c| c.borrow().contains(txn_id)) {
+        if self.shared.committed_cache.contains(txn_id) {
             return true;
         }
-
-        // SINGLE lock acquisition - check if in transactions map
-        // If in map = Active, Committing, or Aborted = not committed
-        if self.transactions.lock().contains_key(txn_id) {
-            return false;
+        let state = self.shared.state.lock();
+        if state.committed(txn_id) {
+            self.shared.committed_cache.insert(txn_id);
+            true
+        } else {
+            false
         }
-
-        // Not in map - committed if valid txn_id
-        let next = self.next_txn_id.load(Ordering::Acquire);
-        if txn_id > 0 && txn_id <= next {
-            COMMITTED_CACHE.with(|c| c.borrow_mut().insert(txn_id));
-            return true;
-        }
-
-        false
     }
 
-    /// Checks if a version is directly visible (for READ COMMITTED).
     #[inline(always)]
     pub fn is_directly_visible(&self, version_txn_id: i64) -> bool {
-        if version_txn_id == RECOVERY_TRANSACTION_ID {
-            return true;
-        }
-        self.check_committed(version_txn_id)
+        version_txn_id == RECOVERY_TRANSACTION_ID || self.check_committed(version_txn_id)
     }
 
-    /// Snapshot isolation visibility check.
-    ///
-    /// Avoids nested locking by releasing transactions lock before acquiring snapshot_seqs.
-    #[cold]
-    #[inline(never)]
-    fn is_visible_snapshot(&self, version_txn_id: i64, viewer_txn_id: i64) -> bool {
-        // First lock: get transaction states
-        let (version_state, viewer_begin_seq) = {
-            let txns = self.transactions.lock();
+    /// Legacy API: zero means committed before the retained mapping floor.
+    /// Fixed epochs/build leases use visible_at and never treat zero as an
+    /// exact sequence that can be compared with an arbitrary historical cutoff.
+    pub fn get_commit_sequence(&self, txn_id: i64) -> Option<i64> {
+        let state = self.shared.state.lock();
+        state
+            .committed(txn_id)
+            .then(|| state.snapshot_seqs.get(txn_id).copied().unwrap_or(0))
+    }
 
-            // Get viewer's begin_seq (must be active to be viewing)
-            let viewer_begin_seq = match txns.get(viewer_txn_id) {
-                Some(state) if state.is_active_or_committing() => state.begin_seq(),
-                _ => {
-                    // Viewer not active - this is unusual but handle gracefully
-                    drop(txns);
-                    // For a committed viewer, use current sequence as begin_seq
-                    // (they can see everything committed before they finished)
-                    return self.check_committed(version_txn_id);
-                }
-            };
+    pub fn get_transaction_begin_sequence(&self, txn_id: i64) -> i64 {
+        self.shared
+            .state
+            .lock()
+            .transactions
+            .get(txn_id)
+            .map_or(0, TxnState::begin_seq)
+    }
 
-            // Get version's state
-            let version_state = txns.get(version_txn_id).copied();
+    pub fn get_committing_sequence(&self, txn_id: i64) -> i64 {
+        self.shared
+            .state
+            .lock()
+            .transactions
+            .get(txn_id)
+            .filter(|txn| txn.status() == TxnStatus::Committing)
+            .map_or(0, TxnState::commit_seq)
+    }
 
-            (version_state, viewer_begin_seq)
-        };
-        // transactions lock released here
+    pub fn get_current_sequence(&self) -> i64 {
+        self.shared.current_sequence.load(Ordering::Acquire)
+    }
+    pub fn current_commit_sequence(&self) -> i64 {
+        self.get_current_sequence()
+    }
 
-        // Check version state
-        match version_state {
-            Some(state) => {
-                if state.is_aborted() {
-                    return false; // Aborted = never visible
-                }
-                // Active or Committing = not visible to others
+    pub fn safe_snapshot_cutoff(&self) -> i64 {
+        self.shared.state.lock().safe_completed_cutoff()
+    }
+
+    /// Registration, lifecycle changes, horizon selection, and pruning cannot
+    /// interleave: all operate under this same mutex.
+    pub fn run_gc(&self) -> usize {
+        self.run_gc_after_horizon(|| {})
+    }
+
+    fn run_gc_after_horizon(&self, after_horizon: impl FnOnce()) -> usize {
+        let mut state = self.shared.state.lock();
+        let horizon = state
+            .refresh_retention_horizon()
+            .unwrap_or(state.next_sequence);
+        let oldest_registration = state.oldest_registration();
+        after_horizon();
+        let old_transactions = state.transactions.len();
+        state.transactions.retain(|_, txn| {
+            !txn.rollback_acknowledgment()
+                .is_some_and(|ack| oldest_registration.is_none_or(|oldest| oldest > ack))
+        });
+        let old_sequences = state.snapshot_seqs.len();
+        let mut discarded_through = state.discarded_through;
+        state.snapshot_seqs.retain(|_, seq| {
+            if *seq <= horizon {
+                discarded_through = discarded_through.max(*seq);
                 false
-            }
-            None => {
-                // Not in transactions map - either committed or invalid
-                let next = self.next_txn_id.load(Ordering::Acquire);
-                if version_txn_id <= 0 || version_txn_id > next {
-                    return false; // Invalid txn_id
-                }
-
-                // Second lock: get commit_seq (only if needed)
-                let commit_seq = self.snapshot_seqs.lock().get(version_txn_id).copied();
-
-                // Committed - check commit_seq against viewer's begin_seq
-                if let Some(commit_seq) = commit_seq {
-                    return commit_seq <= viewer_begin_seq;
-                }
-
-                // Not in snapshot_seqs = old committed (GC'd)
-                // GC only removes when commit_seq < min_active_begin_seq
-                // Since viewer is active, viewer_begin_seq >= min_active_begin_seq
-                // So if GC'd, commit_seq < min_active_begin_seq <= viewer_begin_seq
-                // Therefore visible
+            } else {
                 true
             }
-        }
+        });
+        state.discarded_through = discarded_through;
+        old_transactions - state.transactions.len() + old_sequences - state.snapshot_seqs.len()
     }
 
-    /// Gets the commit sequence for a transaction.
-    pub fn get_commit_sequence(&self, txn_id: i64) -> Option<i64> {
-        // Check snapshot_seqs first
-        if let Some(&seq) = self.snapshot_seqs.lock().get(txn_id) {
-            return Some(seq);
-        }
-
-        // Check if still active/aborted
-        if let Some(state) = self.transactions.lock().get(txn_id) {
-            if state.is_aborted() || state.is_active_or_committing() {
-                return None;
-            }
-        }
-
-        // Valid committed transaction (GC'd from snapshot_seqs)
-        let next = self.next_txn_id.load(Ordering::Acquire);
-        if txn_id > 0 && txn_id <= next {
-            return Some(0); // Committed but commit_seq unknown
-        }
-
-        None
-    }
-
-    /// Gets the begin sequence for an active transaction.
-    pub fn get_transaction_begin_sequence(&self, txn_id: i64) -> i64 {
-        self.transactions
-            .lock()
-            .get(txn_id)
-            .map(|e| e.begin_seq())
-            .unwrap_or(0)
-    }
-
-    /// Gets the commit sequence for a transaction that is currently committing.
-    /// Returns 0 if the transaction is not found or not in committing state.
-    pub fn get_committing_sequence(&self, txn_id: i64) -> i64 {
-        self.transactions
-            .lock()
-            .get(txn_id)
-            .map(|e| e.commit_seq())
-            .unwrap_or(0)
-    }
-
-    /// Gets the current sequence number.
-    pub fn get_current_sequence(&self) -> i64 {
-        self.next_sequence.load(Ordering::Acquire)
-    }
-
-    /// Gets the current commit sequence number.
-    pub fn current_commit_sequence(&self) -> i64 {
-        self.next_sequence.load(Ordering::Acquire)
-    }
-
-    /// Gets a snapshot-safe commit sequence cutoff.
-    ///
-    /// Returns the minimum commit_seq among all in-flight (committing)
-    /// transactions minus 1, or `current_commit_sequence()` if none are
-    /// in-flight. This guarantees all commits with seq ≤ the returned
-    /// value have fully completed (versions applied, tombstones applied,
-    /// removed from transactions map).
-    pub fn safe_snapshot_cutoff(&self) -> i64 {
-        let txns = self.transactions.lock();
-        let mut min_committing = i64::MAX;
-        for (_, entry) in txns.iter() {
-            if entry.status() == TxnStatus::Committing {
-                let seq = entry.commit_seq();
-                if seq > 0 && seq < min_committing {
-                    min_committing = seq;
-                }
-            }
-        }
-        // Read next_sequence WHILE holding the lock to prevent a concurrent
-        // start_commit from bumping the sequence between the scan and this read.
-        let current = self.next_sequence.load(Ordering::Acquire);
-        drop(txns);
-        if min_committing == i64::MAX {
-            current
-        } else {
-            min_committing - 1
-        }
-    }
-
-    /// Runs garbage collection.
-    ///
-    /// Removes:
-    /// - Old aborted entries (txn_id < min_active_txn_id - buffer)
-    /// - Old snapshot_seqs entries (commit_seq < min_active_begin_seq)
-    /// - Isolation overrides for completed transactions
-    pub fn run_gc(&self) -> usize {
-        let mut removed = 0;
-
-        // Step 1: Collect override keys FIRST if any exist (O(Overrides))
-        // This avoids building O(ActiveTxns) set just to filter O(Overrides) entries
-        let override_keys: Vec<i64> = if self.override_count.load(Ordering::Relaxed) > 0 {
-            self.isolation_overrides.lock().keys().collect()
-        } else {
-            Vec::new()
-        };
-
-        // Step 2: Single lock on transactions to:
-        // - Calculate min values
-        // - Remove old aborted entries
-        // - Check which override keys are no longer active
-        let (min_begin_seq, invalid_overrides) = {
-            let mut txns = self.transactions.lock();
-            let mut min_begin = i64::MAX;
-            let mut min_id = i64::MAX;
-
-            for (id, state) in txns.iter() {
-                if state.is_active_or_committing() {
-                    min_begin = min_begin.min(state.begin_seq());
-                    min_id = min_id.min(id);
-                }
-            }
-
-            if min_id == i64::MAX {
-                min_id = self.next_txn_id.load(Ordering::Acquire);
-            }
-
-            // GC aborted entries while holding lock
-            let aborted_cutoff = min_id.saturating_sub(10000);
-            if aborted_cutoff > 0 {
-                let len_before = txns.len();
-                txns.retain(|id, state| !state.is_aborted() || id >= aborted_cutoff);
-                removed += len_before - txns.len();
-            }
-
-            // Check which override keys are no longer active (O(Overrides) lookups)
-            let invalid: Vec<i64> = override_keys
-                .iter()
-                .filter(|&&txn_id| {
-                    // Invalid if not in transactions map (committed/unknown)
-                    // or if aborted
-                    match txns.get(txn_id) {
-                        None => true, // Not active = committed or never existed
-                        Some(state) => state.is_aborted(),
-                    }
-                })
-                .copied()
-                .collect();
-
-            (min_begin, invalid)
-        };
-
-        // Step 3: GC snapshot_seqs
-        {
-            let mut seqs = self.snapshot_seqs.lock();
-            let len_before = seqs.len();
-            seqs.retain(|_, &mut commit_seq| commit_seq >= min_begin_seq);
-            removed += len_before - seqs.len();
-        }
-
-        // Step 4: Remove invalid isolation overrides (O(InvalidOverrides))
-        if !invalid_overrides.is_empty() {
-            let mut overrides = self.isolation_overrides.lock();
-            let mut actual_removals = 0usize;
-            for txn_id in &invalid_overrides {
-                if overrides.remove(*txn_id).is_some() {
-                    removed += 1;
-                    actual_removals += 1;
-                }
-            }
-            if actual_removals > 0 {
-                self.override_count
-                    .fetch_sub(actual_removals, Ordering::Relaxed);
-            }
-        }
-
-        removed
-    }
-
-    /// Cleans up old transactions (legacy API).
     pub fn cleanup_old_transactions(&self, _max_age: std::time::Duration) -> i32 {
         self.run_gc() as i32
     }
 
-    /// Waits for active transactions to complete with timeout.
     pub fn wait_for_active_transactions(&self, timeout: std::time::Duration) -> i32 {
         let deadline = crate::common::time_compat::Instant::now() + timeout;
-
         loop {
             if crate::common::time_compat::Instant::now() > deadline {
                 break;
             }
-
-            let count = self.active_count();
-            if count == 0 {
+            if self.active_count() == 0 {
                 return 0;
             }
-
             #[cfg(not(target_arch = "wasm32"))]
             std::thread::sleep(std::time::Duration::from_millis(10));
             #[cfg(target_arch = "wasm32")]
             break;
         }
-
         self.active_count() as i32
     }
 
-    /// Stops accepting new transactions.
     pub fn stop_accepting_transactions(&self) {
-        self.accepting.store(false, Ordering::Release);
+        let _state = self.shared.state.lock();
+        self.shared.accepting.store(false, Ordering::Release);
     }
-
-    /// Starts accepting new transactions.
     pub fn start_accepting_transactions(&self) {
-        self.accepting.store(true, Ordering::Release);
+        let _state = self.shared.state.lock();
+        self.shared.accepting.store(true, Ordering::Release);
     }
-
-    /// Shuts down the registry.
     pub fn shutdown(&self) {
         self.stop_accepting_transactions();
     }
-
-    /// Checks if the registry is accepting new transactions.
     pub fn is_accepting(&self) -> bool {
-        self.accepting.load(Ordering::Acquire)
+        self.shared.accepting.load(Ordering::Acquire)
     }
-
-    /// Gets the count of active transactions.
-    #[inline]
     pub fn active_count(&self) -> usize {
-        self.active_txn_count.load(Ordering::Relaxed)
+        self.shared.active_txn_count.load(Ordering::Relaxed)
     }
-
-    /// Returns all currently active transaction IDs.
-    ///
-    /// Used by cleanup routines to identify which transactions still hold
-    /// resources (e.g., pending cold deletes in segment managers).
     pub fn active_transaction_ids(&self) -> Vec<i64> {
-        self.transactions
+        self.shared
+            .state
             .lock()
+            .transactions
             .iter()
-            .filter(|(_, s)| {
-                let status = s.status();
-                status == TxnStatus::Active || status == TxnStatus::Committing
-            })
+            .filter(|(_, txn)| txn.is_active_or_committing())
             .map(|(id, _)| id)
             .collect()
     }
-
-    /// Gets the count of entries in snapshot_seqs.
     pub fn committed_count(&self) -> usize {
-        self.snapshot_seqs.lock().len()
+        self.shared.state.lock().snapshot_seqs.len()
     }
-
-    /// Checks if a transaction is active.
     pub fn is_active(&self, txn_id: i64) -> bool {
-        self.transactions
+        self.shared
+            .state
             .lock()
+            .transactions
             .get(txn_id)
-            .map(|e| e.status() == TxnStatus::Active)
-            .unwrap_or(false)
+            .is_some_and(|txn| txn.status() == TxnStatus::Active)
     }
-
-    /// Checks if a transaction is committed.
     pub fn is_committed(&self, txn_id: i64) -> bool {
-        // Check if in transactions map
-        if self.transactions.lock().contains_key(txn_id) {
-            // If aborted or active/committing, not committed
-            return false;
-        }
-
-        // Not in map - committed if valid ID
-        let next = self.next_txn_id.load(Ordering::Acquire);
-        txn_id > 0 && txn_id <= next
+        self.check_committed(txn_id)
     }
-
-    /// Checks if a transaction is in committing state.
     #[cfg(test)]
     pub fn is_committing(&self, txn_id: i64) -> bool {
-        self.transactions
+        self.shared
+            .state
             .lock()
+            .transactions
             .get(txn_id)
-            .map(|e| e.status() == TxnStatus::Committing)
-            .unwrap_or(false)
+            .is_some_and(|txn| txn.status() == TxnStatus::Committing)
     }
-
-    /// Checks if a transaction was committed before a given sequence.
     pub fn is_committed_before(&self, txn_id: i64, cutoff_commit_seq: i64) -> bool {
-        // Special case: negative IDs are always "old"
-        if txn_id < 0 {
+        if txn_id == RECOVERY_TRANSACTION_ID {
             return true;
         }
-
-        // Check if still in transactions map
-        if self.transactions.lock().contains_key(txn_id) {
-            // If aborted or still active/committing, not committed
-            return false;
-        }
-
-        // Check snapshot_seqs for exact commit_seq
-        if let Some(&commit_seq) = self.snapshot_seqs.lock().get(txn_id) {
-            return commit_seq <= cutoff_commit_seq;
-        }
-
-        // Not in snapshot_seqs = old committed (GC'd)
-        // GC'd means commit_seq was < min_active_begin_seq
-        // Therefore definitely < cutoff_commit_seq
-        let next = self.next_txn_id.load(Ordering::Acquire);
-        txn_id > 0 && txn_id <= next
+        self.shared.state.lock().visible_at(
+            txn_id,
+            &EpochData {
+                cutoff: cutoff_commit_seq,
+                cache_generation: 0,
+                excluded: None,
+            },
+        )
     }
 }
 
@@ -984,35 +1466,120 @@ impl Default for TransactionRegistry {
 }
 
 impl VisibilityChecker for TransactionRegistry {
+    fn begin_logical_mutation(&self) -> Option<LogicalMutationGuard> {
+        Some(TransactionRegistry::begin_logical_mutation(self))
+    }
+
+    fn capture_current_read_epoch(&self) -> Option<ReadEpoch> {
+        Some(self.capture_read_epoch())
+    }
+
+    fn has_retention_obligations(&self) -> bool {
+        TransactionRegistry::has_retention_obligations(self)
+    }
+
+    fn oldest_retention_horizon(&self) -> Option<i64> {
+        TransactionRegistry::oldest_retention_horizon(self)
+    }
+    fn cached_retention_horizon(&self) -> Option<i64> {
+        TransactionRegistry::cached_retention_horizon(self)
+    }
+    fn history_retention(
+        &self,
+        creators: &[i64],
+    ) -> crate::storage::mvcc::version_store::HistoryRetention {
+        TransactionRegistry::history_retention(self, creators)
+    }
+
     fn is_visible(&self, version_txn_id: i64, viewing_txn_id: i64) -> bool {
         TransactionRegistry::is_visible(self, version_txn_id, viewing_txn_id)
     }
-
     fn get_current_sequence(&self) -> i64 {
-        TransactionRegistry::get_current_sequence(self)
+        self.get_current_sequence()
     }
-
     fn get_active_transaction_ids(&self) -> Vec<i64> {
-        self.transactions
-            .lock()
-            .iter()
-            .filter(|(_, s)| s.status() == TxnStatus::Active)
-            .map(|(id, _)| id)
-            .collect()
+        self.active_transaction_ids()
     }
-
     fn is_committed_before(&self, txn_id: i64, cutoff_commit_seq: i64) -> bool {
-        TransactionRegistry::is_committed_before(self, txn_id, cutoff_commit_seq)
+        self.is_committed_before(txn_id, cutoff_commit_seq)
     }
-
     fn needs_snapshot_isolation(&self, txn_id: i64) -> bool {
-        TransactionRegistry::needs_snapshot_isolation(self, txn_id)
+        self.needs_snapshot_isolation(txn_id)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cached_retention_floor_lowers_on_registration_and_refreshes_after_overlap() {
+        let registry = TransactionRegistry::new();
+        assert_eq!(registry.cached_retention_horizon(), None);
+        let (older, old_begin) = registry.begin_transaction();
+        let (newer, new_begin) = registry.begin_transaction();
+        assert_eq!(registry.cached_retention_horizon(), Some(old_begin));
+        registry.abort_transaction(older);
+        assert_eq!(registry.cached_retention_horizon(), Some(old_begin));
+        assert_eq!(registry.refresh_retention_horizon(), Some(new_begin));
+        assert_eq!(registry.cached_retention_horizon(), Some(new_begin));
+        registry.start_commit(newer);
+        let epoch = registry.capture_read_epoch();
+        registry.complete_commit(newer);
+        assert!(registry.cached_retention_horizon().unwrap() <= epoch.retention_horizon());
+        assert!(!epoch.is_visible(newer));
+        registry.run_gc();
+        assert_eq!(
+            registry.cached_retention_horizon(),
+            Some(epoch.retention_horizon())
+        );
+        let held = epoch.clone();
+        drop(epoch);
+        assert!(registry.cached_retention_horizon().is_some());
+        drop(held);
+        assert_eq!(registry.cached_retention_horizon(), None);
+        let build = registry.register_build_lease();
+        assert!(registry.cached_retention_horizon().is_some());
+        drop(build);
+        assert_eq!(registry.cached_retention_horizon(), None);
+    }
+
+    #[test]
+    fn cached_retention_floor_resets_for_serial_writers_and_recovery() {
+        let registry = TransactionRegistry::new();
+        for _ in 0..128 {
+            let (txn, begin) = registry.begin_transaction();
+            assert_eq!(registry.cached_retention_horizon(), Some(begin));
+            registry.commit_transaction(txn);
+            assert_eq!(registry.cached_retention_horizon(), None);
+        }
+        let (committed, _) = registry.begin_transaction();
+        let commit_seq = registry.start_commit(committed);
+        registry.recover_committed_transaction(committed, commit_seq);
+        assert_eq!(registry.cached_retention_horizon(), None);
+        let (aborted, _) = registry.begin_transaction();
+        registry.recover_aborted_transaction(aborted);
+        assert_eq!(registry.cached_retention_horizon(), None);
+    }
+
+    #[test]
+    fn retention_presence_tracks_transactions_and_external_leases() {
+        let registry = TransactionRegistry::new();
+        assert!(!registry.has_retention_obligations());
+        let (txn, _) = registry.begin_transaction();
+        assert!(registry.has_retention_obligations());
+        registry.start_commit(txn);
+        assert!(registry.has_retention_obligations());
+        let epoch = registry.capture_read_epoch();
+        registry.abort_transaction(txn);
+        assert!(registry.has_retention_obligations());
+        drop(epoch);
+        assert!(!registry.has_retention_obligations());
+        let build = registry.register_build_lease();
+        assert!(registry.has_retention_obligations());
+        drop(build);
+        assert!(!registry.has_retention_obligations());
+    }
 
     #[test]
     fn test_begin_transaction() {
@@ -1068,7 +1635,13 @@ mod tests {
         assert!(!registry.is_committed(txn_id));
 
         // Verify aborted status
-        let state = registry.transactions.lock().get(txn_id).copied();
+        let state = registry
+            .shared
+            .state
+            .lock()
+            .transactions
+            .get(txn_id)
+            .copied();
         assert!(state.map(|s| s.is_aborted()).unwrap_or(false));
     }
 
@@ -1196,7 +1769,7 @@ mod tests {
             registry.commit_transaction(txn_id);
         }
 
-        assert_eq!(registry.snapshot_seqs.lock().len(), 10);
+        assert_eq!(registry.shared.state.lock().snapshot_seqs.len(), 10);
 
         let (active_txn, _) = registry.begin_transaction();
 
@@ -1262,7 +1835,7 @@ mod tests {
         registry.commit_transaction(txn_id);
 
         // override_count == 0, global != snapshot => snapshot_seqs NOT populated
-        assert!(registry.snapshot_seqs.lock().is_empty());
+        assert!(registry.shared.state.lock().snapshot_seqs.is_empty());
     }
 
     // === recover_committed_transaction: lines 416, 432 ===
@@ -1311,7 +1884,7 @@ mod tests {
         // Must be aborted, not committed, not active
         assert!(!registry.is_committed(42));
         assert!(!registry.is_active(42));
-        let state = registry.transactions.lock().get(42).copied();
+        let state = registry.shared.state.lock().transactions.get(42).copied();
         assert!(state.is_some());
         assert!(state.unwrap().is_aborted());
     }
@@ -1482,7 +2055,7 @@ mod tests {
         // version_txn_id beyond next_txn_id is invalid
         // Catches > → == mutation: 9999 == next would be false (not caught),
         // but next+1 is immediately beyond
-        let next = registry.next_txn_id.load(Ordering::Acquire);
+        let next = registry.shared.state.lock().next_txn_id;
         assert!(!registry.is_visible(next + 1, viewer));
         assert!(!registry.is_visible(next + 100, viewer));
     }
@@ -1553,5 +2126,859 @@ mod tests {
         // With snapshot isolation, exact commit_seq is stored
         assert_eq!(registry.get_commit_sequence(txn_id), Some(commit_seq));
         assert!(commit_seq > 0);
+    }
+}
+
+#[cfg(test)]
+mod epoch_tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    #[test]
+    fn committed_cache_never_aliases_independent_registries() {
+        let first = TransactionRegistry::new();
+        let second = TransactionRegistry::new();
+        let (a, _) = first.begin_transaction();
+        first.commit_transaction(a);
+        assert!(first.is_directly_visible(a));
+        let (b, _) = second.begin_transaction();
+        assert_eq!(a, b);
+        assert!(!second.is_directly_visible(b));
+        second.start_commit(b);
+        assert!(!second.is_directly_visible(b));
+        second.abort_transaction(b);
+        assert!(!second.is_directly_visible(b));
+        assert!(first.is_directly_visible(a));
+        // Recovery can replace a cached status before serving the recovered DB.
+        first.recover_aborted_transaction(a);
+        assert!(!first.is_directly_visible(a));
+    }
+
+    #[test]
+    fn in_flight_exclusions_survive_completion_gc_and_reader_cache() {
+        let registry = TransactionRegistry::new();
+        let (a, _) = registry.begin_transaction();
+        let a_seq = registry.start_commit(a);
+        let (b, _) = registry.begin_transaction();
+        let b_seq = registry.commit_transaction(b);
+        let epoch = registry.capture_read_epoch();
+        assert_eq!(epoch.cutoff(), b_seq);
+        assert_eq!(epoch.excluded_sequences(), &[a_seq]);
+        assert_eq!(epoch.retention_horizon(), a_seq - 1);
+        let mut reader = epoch.reader();
+        assert!(!reader.is_visible(a));
+        assert!(reader.is_visible(b));
+        registry.complete_commit(a);
+        registry.run_gc();
+        assert!(!epoch.is_visible(a));
+        assert!(!reader.is_visible(a));
+        assert!(reader.is_visible(b));
+        assert!(!epoch.admits_commit_sequence(a_seq));
+        assert!(epoch.admits_commit_sequence(b_seq));
+        assert_eq!(registry.get_commit_sequence(a), Some(a_seq));
+        let build = registry.register_build_lease();
+        assert_eq!(build.cutoff(), a_seq - 1);
+        assert!(!build.is_eligible(a));
+        assert!(!build.is_eligible(b));
+    }
+
+    #[test]
+    fn active_at_capture_remains_invisible_after_later_commit() {
+        let registry = TransactionRegistry::new();
+        let (writer, _) = registry.begin_transaction();
+        let epoch = registry.capture_read_epoch();
+        let mut reader = epoch.reader();
+        assert!(!reader.is_visible(writer));
+        let sequence = registry.commit_transaction(writer);
+        assert!(sequence > epoch.cutoff());
+        assert!(!epoch.is_visible(writer));
+        assert!(!reader.is_visible(writer));
+        assert!(registry.capture_read_epoch().is_visible(writer));
+    }
+
+    #[test]
+    fn snapshot_begin_is_atomic_and_legacy_promotion_preserves_original_exclusions() {
+        let registry = TransactionRegistry::new();
+        let (writer, _) = registry.begin_transaction();
+        let writer_seq = registry.start_commit(writer);
+        let (snapshot, begin_seq) =
+            registry.begin_transaction_with_isolation(IsolationLevel::SnapshotIsolation);
+        let (legacy, _) = registry.begin_transaction();
+        registry.complete_commit(writer);
+        registry.run_gc();
+        registry.set_transaction_isolation_level(legacy, IsolationLevel::SnapshotIsolation);
+        assert!(!registry.is_visible(writer, snapshot));
+        assert!(!registry.is_visible(writer, legacy));
+        let epoch = registry.read_epoch_for_transaction(snapshot).unwrap();
+        assert_eq!(epoch.cutoff(), begin_seq);
+        assert_eq!(epoch.excluded_sequences(), &[writer_seq]);
+        assert!(!epoch.is_visible(writer));
+        // Changing the default affects only future transactions.
+        registry.set_global_isolation_level(IsolationLevel::SnapshotIsolation);
+        let (rc, _) = registry.begin_transaction_with_isolation(IsolationLevel::ReadCommitted);
+        assert_eq!(
+            registry.get_isolation_level(rc),
+            IsolationLevel::ReadCommitted
+        );
+        assert!(registry.is_visible(writer, rc));
+    }
+
+    #[test]
+    fn read_committed_statements_advance_but_snapshot_statements_do_not() {
+        let registry = TransactionRegistry::new();
+        let (rc, _) = registry.begin_transaction();
+        let (si, _) = registry.begin_transaction_with_isolation(IsolationLevel::SnapshotIsolation);
+        let rc_first = registry.read_epoch_for_transaction(rc).unwrap();
+        let si_first = registry.read_epoch_for_transaction(si).unwrap();
+        let (writer, _) = registry.begin_transaction();
+        registry.commit_transaction(writer);
+        assert!(!rc_first.is_visible(writer));
+        assert!(!si_first.is_visible(writer));
+        assert!(registry
+            .read_epoch_for_transaction(rc)
+            .unwrap()
+            .is_visible(writer));
+        assert!(!registry
+            .read_epoch_for_transaction(si)
+            .unwrap()
+            .is_visible(writer));
+        registry.abort_transaction(rc);
+        assert!(registry.read_epoch_for_transaction(rc).is_none());
+        assert!(!rc_first.is_visible(writer));
+    }
+
+    #[test]
+    fn rc_read_lease_retains_commit_mappings_until_final_drop() {
+        let registry = TransactionRegistry::new();
+        let epoch = registry.capture_read_epoch();
+        let clone = epoch.clone();
+        let (writer, _) = registry.begin_transaction();
+        let sequence = registry.commit_transaction(writer);
+        registry.run_gc();
+        assert_eq!(registry.get_commit_sequence(writer), Some(sequence));
+        drop(epoch);
+        registry.run_gc();
+        assert_eq!(registry.get_commit_sequence(writer), Some(sequence));
+        drop(clone);
+        registry.run_gc();
+        assert_eq!(registry.get_commit_sequence(writer), Some(0));
+        // An unleased historical cutoff must not treat unknown commit time as zero.
+        assert!(!registry.is_committed_before(writer, sequence - 1));
+        assert!(registry.is_committed_before(writer, sequence));
+    }
+
+    #[test]
+    fn leases_release_horizons_and_can_outlive_registry_facade() {
+        let registry = TransactionRegistry::new();
+        let epoch = registry.capture_read_epoch();
+        let clone = epoch.clone();
+        let build = registry.register_build_lease();
+        assert_eq!(registry.oldest_retention_horizon(), Some(0));
+        drop(epoch);
+        drop(build);
+        assert_eq!(registry.oldest_retention_horizon(), Some(0));
+        let weak = Arc::downgrade(&registry.shared);
+        drop(registry);
+        assert!(weak.upgrade().is_some());
+        assert!(!clone.is_visible(1));
+        drop(clone);
+        assert!(weak.upgrade().is_none());
+    }
+
+    #[test]
+    fn build_bound_is_fixed_and_uses_compatibility_begin_horizon() {
+        let registry = TransactionRegistry::new();
+        let (old, _) = registry.begin_transaction();
+        registry.commit_transaction(old);
+        let (idle_rc, begin) = registry.begin_transaction();
+        let build = registry.register_build_lease();
+        assert_eq!(build.cutoff(), begin);
+        assert!(build.is_eligible(old));
+        let (new, _) = registry.begin_transaction();
+        registry.commit_transaction(new);
+        registry.abort_transaction(idle_rc);
+        registry.run_gc();
+        assert_eq!(build.cutoff(), begin);
+        assert!(!build.is_eligible(new));
+        assert_eq!(registry.oldest_retention_horizon(), Some(begin));
+        drop(build);
+        assert_eq!(registry.oldest_retention_horizon(), None);
+    }
+
+    #[test]
+    fn gc_horizon_pruning_is_atomic_with_new_snapshot_registration() {
+        let registry = Arc::new(TransactionRegistry::new());
+        registry.set_global_isolation_level(IsolationLevel::SnapshotIsolation);
+        let (old, _) = registry.begin_transaction();
+        registry.commit_transaction(old);
+        let (horizon_tx, horizon_rx) = mpsc::channel();
+        let (resume_tx, resume_rx) = mpsc::channel();
+        let (attempt_tx, attempt_rx) = mpsc::channel();
+        let (begun_tx, begun_rx) = mpsc::channel();
+        std::thread::scope(|scope| {
+            let gc_registry = Arc::clone(&registry);
+            scope.spawn(move || {
+                gc_registry.run_gc_after_horizon(|| {
+                    horizon_tx.send(()).unwrap();
+                    resume_rx.recv().unwrap();
+                })
+            });
+            horizon_rx.recv().unwrap();
+            let reader_registry = Arc::clone(&registry);
+            scope.spawn(move || {
+                attempt_tx.send(()).unwrap();
+                let (reader, _) = reader_registry
+                    .begin_transaction_with_isolation(IsolationLevel::SnapshotIsolation);
+                begun_tx.send(reader).unwrap();
+            });
+            attempt_rx.recv().unwrap();
+            assert!(matches!(
+                begun_rx.try_recv(),
+                Err(mpsc::TryRecvError::Empty)
+            ));
+            resume_tx.send(()).unwrap();
+            let reader = begun_rx.recv().unwrap();
+            let (writer, _) = registry.begin_transaction();
+            let sequence = registry.commit_transaction(writer);
+            registry.run_gc();
+            assert_eq!(registry.get_commit_sequence(writer), Some(sequence));
+            assert!(!registry.is_visible(writer, reader));
+            registry.abort_transaction(reader);
+        });
+    }
+
+    #[test]
+    fn repeated_terminal_calls_keep_counts_and_commit_identity_stable() {
+        let registry = TransactionRegistry::new();
+        let (txn, _) = registry.begin_transaction_with_isolation(IsolationLevel::SnapshotIsolation);
+        let sequence = registry.start_commit(txn);
+        assert_eq!(registry.start_commit(txn), sequence);
+        registry.complete_commit(txn);
+        registry.complete_commit(txn);
+        registry.abort_transaction(txn);
+        assert_eq!(registry.active_count(), 0);
+        assert!(!registry.has_active_snapshot_transactions());
+        let (read_only, _) = registry.begin_transaction();
+        registry.complete_commit(read_only);
+        assert!(registry.is_committed(read_only));
+        assert_eq!(registry.active_count(), 0);
+        assert_eq!(registry.start_commit(read_only), 0);
+    }
+
+    #[test]
+    fn rollback_ack_waits_for_pre_ack_captures_even_after_abort() {
+        let registry = TransactionRegistry::new();
+        let (writer, _) = registry.begin_transaction();
+        registry.start_commit(writer);
+        registry.abort_transaction(writer);
+        // A root captured after the abort can still retain its not-yet-undone head.
+        let captured = registry.capture_read_epoch();
+        registry.acknowledge_rollback(writer);
+        registry.run_gc();
+        assert!(!registry.is_committed(writer));
+        assert!(!captured.is_visible(writer));
+        let new_capture = registry.capture_read_epoch();
+        drop(captured);
+        registry.run_gc();
+        assert!(!registry
+            .shared
+            .state
+            .lock()
+            .transactions
+            .contains_key(writer));
+        // A post-ack capture does not prevent retirement of this marker.
+        drop(new_capture);
+    }
+
+    #[test]
+    fn rollback_ack_waits_for_legacy_begin_snapshot_and_unacked_markers_remain() {
+        let registry = TransactionRegistry::new();
+        let (writer, _) = registry.begin_transaction();
+        registry.start_commit(writer);
+        registry.abort_transaction(writer);
+        let (reader, _) = registry.begin_transaction();
+        registry.acknowledge_rollback(writer);
+        registry.run_gc();
+        assert!(!registry.is_visible(writer, reader));
+        registry.abort_transaction(reader);
+        registry.run_gc();
+        assert!(!registry
+            .shared
+            .state
+            .lock()
+            .transactions
+            .contains_key(writer));
+        let (unacked, _) = registry.begin_transaction();
+        registry.start_commit(unacked);
+        registry.abort_transaction(unacked);
+        registry.run_gc();
+        assert!(!registry.is_committed(unacked));
+        registry.acknowledge_rollback(unacked);
+        registry.run_gc();
+        assert!(!registry
+            .shared
+            .state
+            .lock()
+            .transactions
+            .contains_key(unacked));
+    }
+
+    #[test]
+    fn active_abort_is_unpublished_and_automatically_acknowledged() {
+        let registry = TransactionRegistry::new();
+        let (txn, _) = registry.begin_transaction();
+        registry.abort_transaction(txn);
+        registry.run_gc();
+        assert!(!registry.shared.state.lock().transactions.contains_key(txn));
+        assert_eq!(registry.active_count(), 0);
+    }
+
+    #[test]
+    fn stop_accepting_is_serialized_with_begin_and_empty_exclusions_do_not_allocate() {
+        let registry = TransactionRegistry::new();
+        let epoch = registry.capture_read_epoch();
+        assert!(epoch.lease.data.excluded.is_none());
+        let (txn, _) = registry.begin_transaction();
+        assert!(registry.shared.state.lock().begin_exclusions.is_empty());
+        registry.stop_accepting_transactions();
+        assert_eq!(registry.begin_transaction(), (INVALID_TRANSACTION_ID, 0));
+        assert_eq!(registry.active_count(), 1);
+        registry.abort_transaction(txn);
+        registry.start_accepting_transactions();
+        assert!(registry.begin_transaction().0 > txn);
+    }
+
+    #[test]
+    fn sequence_assignment_and_committing_transition_exclude_epoch_capture_gap() {
+        let registry = Arc::new(TransactionRegistry::new());
+        let (writer, begin) = registry.begin_transaction();
+        let (allocated_tx, allocated_rx) = mpsc::channel();
+        let (resume_tx, resume_rx) = mpsc::channel();
+        let (attempt_tx, attempt_rx) = mpsc::channel();
+        let (captured_tx, captured_rx) = mpsc::channel();
+        std::thread::scope(|scope| {
+            let commit_registry = Arc::clone(&registry);
+            scope.spawn(move || {
+                commit_registry.start_commit_after_sequence(writer, || {
+                    allocated_tx.send(()).unwrap();
+                    resume_rx.recv().unwrap();
+                })
+            });
+            allocated_rx.recv().unwrap();
+            assert_eq!(registry.get_current_sequence(), begin);
+            let capture_registry = Arc::clone(&registry);
+            scope.spawn(move || {
+                attempt_tx.send(()).unwrap();
+                captured_tx
+                    .send(capture_registry.capture_read_epoch())
+                    .unwrap();
+            });
+            attempt_rx.recv().unwrap();
+            assert!(matches!(
+                captured_rx.try_recv(),
+                Err(mpsc::TryRecvError::Empty)
+            ));
+            resume_tx.send(()).unwrap();
+            let epoch = captured_rx.recv().unwrap();
+            let sequence = registry.get_committing_sequence(writer);
+            assert!(sequence > begin);
+            assert_eq!(epoch.excluded_sequences(), &[sequence]);
+            assert_eq!(registry.safe_snapshot_cutoff(), sequence - 1);
+            registry.complete_commit(writer);
+            assert!(!epoch.is_visible(writer));
+        });
+    }
+
+    #[test]
+    fn recovered_zero_sequence_is_prehistory_and_negative_tombstones_are_invalid() {
+        let registry = TransactionRegistry::new();
+        registry.recover_committed_transaction(5, 0);
+        let epoch = registry.capture_read_epoch();
+        assert!(epoch.is_visible(5));
+        assert!(epoch.admits_commit_sequence(0));
+        assert!(!epoch.admits_commit_sequence(-2));
+        let build_reader = registry.register_build_lease();
+        assert!(build_reader.reader().is_visible(5));
+        registry.run_gc();
+        assert!(epoch.is_visible(5));
+    }
+
+    #[test]
+    fn snapshot_recovery_transaction_advances_sequence_without_consuming_user_identity() {
+        let registry = TransactionRegistry::new();
+        registry.recover_committed_transaction(RECOVERY_TRANSACTION_ID, 300);
+        assert!(registry
+            .capture_read_epoch()
+            .is_visible(RECOVERY_TRANSACTION_ID));
+        let (txn, sequence) = registry.begin_transaction();
+        assert_eq!(txn, 1);
+        assert!(sequence > 300);
+    }
+
+    #[test]
+    fn ddl_recovery_identity_advances_watermark_without_becoming_a_visible_row_writer() {
+        let registry = TransactionRegistry::new();
+        // persistence::DDL_TXN_ID is -2; its COMMIT records also replay here.
+        registry.recover_committed_transaction(-2, 400);
+        assert!(!registry.capture_read_epoch().is_visible(-2));
+        let (txn, sequence) = registry.begin_transaction();
+        assert_eq!(txn, 1);
+        assert!(sequence > 400);
+    }
+}
+
+#[cfg(test)]
+mod packing_tests {
+    use super::*;
+
+    #[test]
+    fn packing_keeps_active_commit_and_abort_words_disjoint() {
+        assert_eq!(std::mem::size_of::<TxnState>(), 16);
+        #[repr(C)]
+        struct Slot {
+            key: i64,
+            value: std::mem::MaybeUninit<TxnState>,
+        }
+        assert_eq!(std::mem::size_of::<Slot>(), 24);
+        let mut active = TxnState::new_active(SEQ_MASK, true, SEQ_MASK - 1);
+        assert_eq!(active.status(), TxnStatus::Active);
+        assert_eq!(active.begin_seq(), SEQ_MASK);
+        assert_eq!(active.commit_seq(), 0);
+        assert_eq!(active.active_begin_registration(), Some(SEQ_MASK - 1));
+        assert!(active.is_snapshot());
+        active.set_snapshot(false);
+        assert_eq!(active.active_begin_registration(), Some(SEQ_MASK - 1));
+        active.set_snapshot(true);
+        active.set_committing(SEQ_MASK);
+        assert_eq!(active.status(), TxnStatus::Committing);
+        assert_eq!(active.commit_seq(), SEQ_MASK);
+        assert_eq!(active.active_begin_registration(), None);
+        assert!(active.is_snapshot());
+        let mut aborted = TxnState::new_aborted();
+        assert_eq!(aborted.status(), TxnStatus::Aborted);
+        assert_eq!(aborted.commit_seq(), 0);
+        assert_eq!(aborted.active_begin_registration(), None);
+        assert_eq!(aborted.rollback_acknowledgment(), None);
+        aborted.acknowledge_rollback(SEQ_MASK - 1);
+        aborted.acknowledge_rollback(2);
+        assert_eq!(aborted.rollback_acknowledgment(), Some(SEQ_MASK - 1));
+    }
+
+    #[test]
+    fn packing_preserves_begin_registration_through_inflight_spill_and_recovery() {
+        let registry = TransactionRegistry::with_capacity(8);
+        let txns: [(i64, i64); 6] = std::array::from_fn(|_| registry.begin_transaction());
+        let oldest = registry.shared.state.lock().oldest_registration();
+        let mut sequences = [0; 6];
+        for i in 0..4 {
+            sequences[i] = registry.start_commit(txns[i].0);
+        }
+        assert!(!registry.shared.state.lock().committing.spilled());
+        assert_eq!(registry.shared.state.lock().oldest_registration(), oldest);
+        sequences[4] = registry.start_commit(txns[4].0);
+        assert!(registry.shared.state.lock().committing.spilled());
+        sequences[5] = registry.start_commit(txns[5].0);
+        assert_eq!(registry.start_commit(txns[4].0), sequences[4]);
+        assert_eq!(registry.shared.state.lock().committing.len(), 6);
+        assert_eq!(registry.shared.state.lock().oldest_registration(), oldest);
+        let epoch = registry.capture_read_epoch();
+        assert_eq!(epoch.excluded_sequences(), sequences);
+        assert_eq!(registry.safe_snapshot_cutoff(), sequences[0] - 1);
+        registry.recover_aborted_transaction(txns[0].0);
+        assert_eq!(registry.shared.state.lock().committing.len(), 5);
+        registry.acknowledge_rollback(txns[0].0);
+        registry.recover_committed_transaction(txns[1].0, sequences[1]);
+        assert_eq!(registry.shared.state.lock().committing.len(), 4);
+        for (id, _) in &txns[2..] {
+            registry.complete_commit(*id);
+        }
+        assert!(registry.shared.state.lock().committing.is_empty());
+        assert_eq!(registry.active_count(), 0);
+        for (id, _) in txns {
+            assert!(!epoch.is_visible(id));
+        }
+    }
+
+    #[test]
+    fn packing_committing_old_begin_still_pins_acknowledged_abort() {
+        let registry = TransactionRegistry::new();
+        let (old_reader, _) = registry.begin_transaction();
+        let oldest = registry.shared.state.lock().oldest_registration();
+        let (victim, _) = registry.begin_transaction();
+        registry.start_commit(victim);
+        registry.abort_transaction(victim);
+        registry.acknowledge_rollback(victim);
+        // Its later commit sequence cannot replace its earlier registration.
+        registry.start_commit(old_reader);
+        assert_eq!(registry.shared.state.lock().oldest_registration(), oldest);
+        registry.run_gc();
+        assert!(!registry.is_committed(victim));
+        registry.complete_commit(old_reader);
+        registry.run_gc();
+        assert!(!registry
+            .shared
+            .state
+            .lock()
+            .transactions
+            .contains_key(victim));
+    }
+
+    #[test]
+    fn packing_prepublication_unwind_keeps_active_registration() {
+        let registry = TransactionRegistry::new();
+        let (txn, _) = registry.begin_transaction();
+        let oldest = registry.shared.state.lock().oldest_registration();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            registry.start_commit_after_sequence(txn, || panic!("before publication"));
+        }));
+        assert!(result.is_err());
+        let state = registry.shared.state.lock();
+        assert_eq!(
+            state.transactions.get(txn).unwrap().status(),
+            TxnStatus::Active
+        );
+        assert_eq!(state.transactions.get(txn).unwrap().commit_seq(), 0);
+        assert_eq!(state.oldest_registration(), oldest);
+        assert!(state.committing.is_empty());
+        drop(state);
+        assert!(registry.start_commit(txn) > 0);
+        registry.complete_commit(txn);
+    }
+}
+
+#[cfg(test)]
+mod destructive_ddl_tests {
+    use super::*;
+    use std::sync::{mpsc, Barrier};
+    use std::time::Duration;
+
+    #[test]
+    fn ddl_rejects_other_transaction_and_delayed_read_or_build_capture() {
+        let registry = TransactionRegistry::new();
+        let (older, _) =
+            registry.begin_transaction_with_isolation(IsolationLevel::SnapshotIsolation);
+        let (owner, _) = registry.begin_transaction();
+        assert!(registry.prepare_destructive_ddl(owner, None).is_err());
+        registry.abort_transaction(older);
+        let read = registry.capture_read_epoch();
+        assert!(registry.prepare_destructive_ddl(owner, None).is_err());
+        drop(read);
+        let build = registry.register_build_lease();
+        assert!(registry.prepare_destructive_ddl(owner, None).is_err());
+        drop(build);
+        assert!(registry.prepare_destructive_ddl(owner, None).is_ok());
+    }
+
+    #[test]
+    fn ddl_private_epoch_exemption_rejects_external_alias_and_foreign_registry() {
+        let registry = TransactionRegistry::new();
+        let (owner, _) = registry.begin_transaction();
+        let epoch = registry.read_epoch_for_transaction(owner).unwrap();
+        let external = epoch.clone();
+        assert!(registry
+            .prepare_destructive_ddl(owner, Some((&epoch, 1)))
+            .is_err());
+        drop(external);
+        let guard = registry
+            .prepare_destructive_ddl(owner, Some((&epoch, 1)))
+            .unwrap();
+        assert!(
+            registry.shared.state.try_lock().is_some(),
+            "WAL runs without the lifecycle mutex"
+        );
+        drop(guard);
+        let foreign = TransactionRegistry::new().capture_read_epoch();
+        assert!(registry
+            .prepare_destructive_ddl(owner, Some((&foreign, 1)))
+            .is_err());
+    }
+
+    #[test]
+    fn ddl_blocks_all_new_registration_and_isolation_paths_until_apply_finishes() {
+        let registry = Arc::new(TransactionRegistry::new());
+        let (owner, _) = registry.begin_transaction();
+        let guard = registry.prepare_destructive_ddl(owner, None).unwrap();
+        let (done, rx) = mpsc::channel();
+        let start = Arc::new(Barrier::new(5));
+        let mut threads = Vec::new();
+        for mode in 0..4 {
+            let registry = registry.clone();
+            let done = done.clone();
+            let start = start.clone();
+            threads.push(std::thread::spawn(move || {
+                start.wait();
+                match mode {
+                    0 => {
+                        let _ = registry.begin_transaction();
+                    }
+                    1 => {
+                        let _ = registry.capture_read_epoch();
+                    }
+                    2 => {
+                        let _ = registry.register_build_lease();
+                    }
+                    _ => registry
+                        .set_transaction_isolation_level(owner, IsolationLevel::SnapshotIsolation),
+                }
+                done.send(mode).unwrap();
+            }));
+        }
+        start.wait();
+        assert!(rx.recv_timeout(Duration::from_millis(20)).is_err());
+        assert!(registry.shared.state.try_lock().is_some());
+        drop(guard);
+        for _ in 0..4 {
+            rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn ddl_error_or_unwind_reopens_registration() {
+        let registry = TransactionRegistry::new();
+        let (owner, _) = registry.begin_transaction();
+        let result: crate::core::Result<()> = (|| {
+            let _guard = registry.prepare_destructive_ddl(owner, None)?;
+            Err(crate::core::Error::internal("injected WAL failure"))
+        })();
+        assert!(result.is_err());
+        assert!(!registry.shared.state.lock().destructive_ddl);
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = registry.prepare_destructive_ddl(owner, None).unwrap();
+            panic!("injected preparation panic");
+        }));
+        assert!(panic.is_err());
+        assert!(!registry.shared.state.lock().destructive_ddl);
+        let lease = registry.read_epoch_for_transaction(owner).unwrap();
+        assert!(lease.cutoff() > 0);
+    }
+}
+
+#[cfg(test)]
+mod cache_provenance_tests {
+    use super::*;
+
+    #[test]
+    fn ordinary_reads_reuse_proof_but_every_visible_outcome_changes_it() {
+        let registry = TransactionRegistry::new();
+        let first = registry.capture_read_epoch();
+        let proof = registry.cache_provenance(&first).unwrap();
+        for _ in 0..3 {
+            let (reader, _) = registry.begin_transaction();
+            registry.abort_transaction(reader);
+            registry.acknowledge_rollback(reader);
+            let next = registry.capture_read_epoch();
+            assert_eq!(registry.cache_provenance(&next), Some(proof));
+        }
+        let (early, _) = registry.begin_transaction();
+        let (late, _) = registry.begin_transaction();
+        let early_seq = registry.start_commit(early);
+        let late_seq = registry.start_commit(late);
+        let excluded = registry.capture_read_epoch();
+        assert_eq!(excluded.excluded_sequences(), [early_seq, late_seq]);
+        assert_eq!(registry.cache_provenance(&excluded), Some(proof));
+        registry.complete_commit(late);
+        let after_late = registry.capture_read_epoch();
+        let late_proof = registry.cache_provenance(&after_late).unwrap();
+        assert_ne!(late_proof, proof);
+        assert!(registry.cache_provenance(&excluded).is_none());
+        registry.complete_commit(early);
+        let after_both = registry.capture_read_epoch();
+        assert_ne!(registry.cache_provenance(&after_both), Some(late_proof));
+        assert!(!after_late.is_visible(early));
+        assert!(after_both.is_visible(early));
+        assert!(registry.cache_provenance(&first).is_none());
+        let (direct, _) = registry.begin_transaction();
+        registry.complete_commit(direct); // Public direct Active -> committed path.
+        assert!(registry.cache_provenance(&after_both).is_none());
+    }
+
+    #[test]
+    fn historical_foreign_and_in_mutation_views_never_gain_fresh_proof() {
+        let registry = TransactionRegistry::new();
+        let other = TransactionRegistry::new();
+        let foreign = other.capture_read_epoch();
+        assert!(registry.cache_provenance(&foreign).is_none());
+        let (snapshot, _) =
+            registry.begin_transaction_with_isolation(IsolationLevel::SnapshotIsolation);
+        let historical = registry.read_epoch_for_transaction(snapshot).unwrap();
+        assert!(registry.cache_provenance(&historical).is_none());
+        let before = registry.capture_read_epoch();
+        let outer = registry.begin_logical_mutation();
+        let during = registry.capture_read_epoch();
+        assert!(registry.cache_provenance(&before).is_none());
+        assert!(registry.cache_provenance(&during).is_none());
+        {
+            let _inner = registry.begin_logical_mutation();
+        }
+        assert!(registry
+            .cache_provenance(&registry.capture_read_epoch())
+            .is_none());
+        drop(outer);
+        assert!(registry.cache_provenance(&during).is_none());
+        assert!(registry.cache_provenance(&historical).is_none());
+        assert!(registry
+            .cache_provenance(&registry.capture_read_epoch())
+            .is_some());
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = registry.begin_logical_mutation();
+            panic!("failed immediate operation");
+        }));
+        assert!(result.is_err());
+        assert_eq!(registry.shared.state.lock().immediate_mutations, 0);
+        registry.abort_transaction(snapshot);
+    }
+
+    #[test]
+    fn failed_publication_guard_covers_abort_through_undo_acknowledgment() {
+        let registry = TransactionRegistry::new();
+        let (writer, _) = registry.begin_transaction();
+        registry.start_commit(writer);
+        let before_abort = registry.capture_read_epoch();
+        assert!(registry.cache_provenance(&before_abort).is_some());
+        let undo = registry.begin_logical_mutation();
+        registry.abort_transaction(writer);
+        let after_abort_before_undo = registry.capture_read_epoch();
+        assert!(after_abort_before_undo.excluded_sequences().is_empty());
+        assert!(registry
+            .cache_provenance(&after_abort_before_undo)
+            .is_none());
+        registry.acknowledge_rollback(writer);
+        drop(undo);
+        assert!(registry
+            .cache_provenance(&after_abort_before_undo)
+            .is_none());
+        assert!(registry.cache_provenance(&before_abort).is_none());
+        assert!(registry
+            .cache_provenance(&registry.capture_read_epoch())
+            .is_some());
+    }
+
+    #[test]
+    fn cached_scalar_does_not_keep_a_read_registration_alive() {
+        let registry = TransactionRegistry::new();
+        let epoch = registry.capture_read_epoch();
+        let proof = registry.cache_provenance(&epoch).unwrap();
+        let cache = crate::executor::semantic_cache::SemanticCache::new();
+        cache.insert_with_provenance("t", vec!["id".into()], Vec::new(), None, proof);
+        drop(epoch);
+        let (owner, _) = registry.begin_transaction();
+        assert!(registry.prepare_destructive_ddl(owner, None).is_ok());
+        drop(cache);
+        registry.abort_transaction(owner);
+    }
+
+    #[test]
+    fn proof_exhaustion_disables_reuse_without_failing_commit_or_wrapping() {
+        let registry = TransactionRegistry::new();
+        registry.shared.state.lock().logical_generation = u64::MAX;
+        let before = registry.capture_read_epoch();
+        assert!(registry.cache_provenance(&before).is_some());
+        let (writer, _) = registry.begin_transaction();
+        registry.start_commit(writer);
+        registry.complete_commit(writer);
+        assert!(registry.is_committed(writer));
+        assert_eq!(registry.shared.state.lock().logical_generation, 0);
+        assert!(registry.cache_provenance(&before).is_none());
+        for _ in 0..3 {
+            drop(registry.begin_logical_mutation());
+            assert!(registry
+                .cache_provenance(&registry.capture_read_epoch())
+                .is_none());
+        }
+    }
+}
+
+#[cfg(test)]
+mod memory_ownership_tests {
+    use super::*;
+    use crate::common::memory::MemoryAccount;
+
+    #[test]
+    fn committing_spill_accounts_replacement_overlap_without_charging_inline_entries() {
+        let account = MemoryAccount::new();
+        let initial = account.snapshot().accounted_bytes;
+        let registry = TransactionRegistry::new_in(&account);
+        let txns: [i64; 9] = std::array::from_fn(|_| registry.begin_transaction().0);
+        let before = account.snapshot();
+        for &txn in &txns[..4] {
+            registry.start_commit(txn);
+        }
+        assert_eq!(account.snapshot().accounted_bytes, before.accounted_bytes);
+        registry.start_commit(txns[4]);
+        let first_capacity = 8 * std::mem::size_of::<CommittingTxn>();
+        assert_eq!(
+            account.snapshot().retained_bytes,
+            before.retained_bytes + first_capacity
+        );
+        for &txn in &txns[5..] {
+            registry.start_commit(txn);
+        }
+        let second_capacity = 16 * std::mem::size_of::<CommittingTxn>();
+        let after = account.snapshot();
+        assert_eq!(
+            after.retained_bytes,
+            before.retained_bytes + second_capacity
+        );
+        assert!(
+            after.peak_accounted_bytes >= before.accounted_bytes + first_capacity + second_capacity
+        );
+        for txn in txns {
+            registry.complete_commit(txn);
+        }
+        let state = registry.shared.state.lock();
+        assert!(state.committing.is_empty());
+        assert_eq!(
+            state.committing_charge.as_ref().unwrap().bytes(),
+            second_capacity
+        );
+        drop(state);
+        drop(registry);
+        assert_eq!(account.snapshot().accounted_bytes, initial);
+    }
+
+    #[test]
+    fn shared_exclusions_and_registry_state_keep_their_own_last_owner_charges() {
+        let account = MemoryAccount::new();
+        let initial = account.snapshot();
+        let registry = TransactionRegistry::new_in(&account);
+        let txns: [i64; 6] = std::array::from_fn(|_| registry.begin_transaction().0);
+        for txn in txns {
+            registry.start_commit(txn);
+        }
+        let (reader, _) =
+            registry.begin_transaction_with_isolation(IsolationLevel::SnapshotIsolation);
+        let epoch = registry.read_epoch_for_transaction(reader).unwrap();
+        let exclusions = epoch.lease.data.excluded.as_ref().unwrap().clone();
+        {
+            let state = registry.shared.state.lock();
+            assert!(CompactArc::ptr_eq(
+                state.begin_exclusions.get(reader).unwrap(),
+                &exclusions
+            ));
+            assert!(exclusions.belongs_to(&account));
+        }
+        for txn in txns {
+            registry.complete_commit(txn);
+            assert!(!epoch.is_visible(txn));
+        }
+        registry.abort_transaction(reader);
+        registry.acknowledge_rollback(reader);
+        drop(registry);
+        // The read lease retains RegistryShared, but not its original facade.
+        assert!(account.snapshot().retained_bytes > exclusions.allocation_size());
+        drop(epoch);
+        assert_eq!(
+            account.snapshot().retained_bytes,
+            exclusions.allocation_size()
+        );
+        assert_eq!(
+            account.snapshot().conservative_bytes,
+            initial.conservative_bytes
+        );
+        drop(exclusions);
+        assert_eq!(account.snapshot().accounted_bytes, initial.accounted_bytes);
     }
 }

--- a/src/storage/mvcc/scanner.rs
+++ b/src/storage/mvcc/scanner.rs
@@ -225,6 +225,10 @@ impl Scanner for MVCCScanner {
         self.rows[self.current_index as usize].0
     }
 
+    fn take_row_with_id(&mut self) -> (i64, Row) {
+        (self.current_row_id(), self.take_row())
+    }
+
     fn estimated_count(&self) -> Option<usize> {
         Some(self.rows.len())
     }

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -27,10 +27,20 @@ use crate::core::{
 use crate::storage::expression::logical::OrExpr;
 use crate::storage::expression::Expression;
 use crate::storage::index::{BTreeIndex, BitmapIndex, HashIndex, HnswIndex, MultiColumnIndex};
+use crate::storage::mvcc::registry::ReadEpoch;
 use crate::storage::mvcc::scanner::MVCCScanner;
+use crate::storage::mvcc::version_store::{CapturedHotRoot, CapturedHotRow, CapturedHotView};
 use crate::storage::mvcc::{TransactionVersionStore, VersionStore};
 use crate::storage::traits::{Index, QueryResult, ScanPlan, Scanner, Table};
 use crate::storage::MemoryResult;
+
+/// Write-only statements bind an epoch/root without copying previous local
+/// writes. A real read freezes its own overlay before returning a lazy result.
+struct CapturedReadBinding {
+    root: CapturedHotRoot,
+    epoch: ReadEpoch,
+    view: std::sync::OnceLock<Arc<CapturedHotView>>,
+}
 
 /// MVCC Table wrapper that provides MVCC isolation for tables
 pub struct MVCCTable {
@@ -42,6 +52,7 @@ pub struct MVCCTable {
     txn_versions: CompactArc<RwLock<TransactionVersionStore>>,
     /// Cached schema for returning references (Arc clone from version_store - O(1) instead of cloning)
     cached_schema: CompactArc<Schema>,
+    read_view: Option<CapturedReadBinding>,
 }
 
 /// Where a WHERE conjunction sits on a multi-column index: equalities on the
@@ -52,6 +63,10 @@ struct PrefixPlan {
     lower: Option<(Value, bool)>,
     upper: Option<(Value, bool)>,
 }
+
+/// Selected global rows retain exact conflict metadata; own writes already
+/// have their original version in the transaction's write set.
+type DmlTargets = (Vec<(i64, Row, crate::storage::mvcc::RowVersion)>, RowVec);
 
 /// The comparisons of an AND tree; false when a leaf is not a comparison
 fn collect_conjuncts<'a>(
@@ -73,6 +88,34 @@ fn collect_conjuncts<'a>(
 }
 
 impl MVCCTable {
+    fn prepare_filter_if_needed(
+        &self,
+        filter: Option<&dyn Expression>,
+    ) -> Option<Box<dyn Expression>> {
+        filter.filter(|filter| !filter.is_prepared()).map(|filter| {
+            let mut filter = filter.clone_box();
+            filter.prepare_for_schema(&self.cached_schema);
+            filter
+        })
+    }
+
+    fn captured_view(&self) -> Option<&Arc<CapturedHotView>> {
+        self.read_view.as_ref().map(|binding| {
+            binding.view.get_or_init(|| {
+                let own = {
+                    let Ok(versions) = self.txn_versions.read() else {
+                        panic!("transaction store is poisoned during view capture");
+                    };
+                    versions.capture_hot_overlay()
+                };
+                Arc::new(CapturedHotView::new(
+                    binding.root.clone(),
+                    binding.epoch.clone(),
+                    own,
+                ))
+            })
+        })
+    }
     /// Creates a new MVCC table with an owned transaction version store
     /// (wraps it in Arc<RwLock> internally)
     pub fn new(
@@ -89,6 +132,7 @@ impl MVCCTable {
             version_store,
             txn_versions,
             cached_schema,
+            read_view: None,
         }
     }
 
@@ -106,6 +150,7 @@ impl MVCCTable {
             version_store,
             txn_versions,
             cached_schema,
+            read_view: None,
         }
     }
 
@@ -122,6 +167,122 @@ impl MVCCTable {
     /// Returns a reference to the shared transaction version store
     pub fn txn_versions(&self) -> &CompactArc<RwLock<TransactionVersionStore>> {
         &self.txn_versions
+    }
+
+    /// Write-set metadata describes the value visible at the read epoch, not
+    /// an excluded physical deletion layered on that value. Keep its creator,
+    /// timestamp, and payload; old-index projection must still see a live row.
+    fn dml_observed_original(
+        version: &crate::storage::mvcc::RowVersion,
+    ) -> crate::storage::mvcc::RowVersion {
+        let mut observed = version.clone();
+        observed.deleted_at_txn_id = 0;
+        observed
+    }
+
+    /// DML reads its latest own state separately. Only the committed fallback
+    /// uses the fixed statement epoch, preserving the original conflict token.
+    fn dml_global_version(&self, row_id: i64) -> Option<crate::storage::mvcc::RowVersion> {
+        if let Some(binding) = &self.read_view {
+            // A captured Value may carry an invisible deletion marker. Its
+            // tri-state decision is authoritative; do not call is_deleted again.
+            binding
+                .root
+                .visible_version(row_id, &binding.epoch)
+                .map(Self::dml_observed_original)
+        } else {
+            self.version_store
+                .get_visible_version(row_id, self.txn_id)
+                .filter(|version| !version.is_deleted())
+        }
+    }
+
+    fn dml_global_rows_by_ids(
+        &self,
+        row_ids: &[i64],
+    ) -> Vec<(i64, Row, crate::storage::mvcc::RowVersion)> {
+        if let Some(binding) = &self.read_view {
+            row_ids
+                .iter()
+                .filter_map(|&id| {
+                    binding
+                        .root
+                        .visible_version(id, &binding.epoch)
+                        .map(|version| {
+                            (
+                                id,
+                                version.data.clone(),
+                                Self::dml_observed_original(version),
+                            )
+                        })
+                })
+                .collect()
+        } else {
+            self.version_store
+                .get_visible_versions_for_update(row_ids, self.txn_id)
+        }
+    }
+
+    /// Normalize only when schema evolution requires it, and copy a matching
+    /// payload after the predicate. Predicate errors abort selection.
+    fn dml_matching_row(&self, row: &Row, filter: Option<&dyn Expression>) -> Result<Option<Row>> {
+        if row.len() == self.cached_schema.columns.len() {
+            if filter.map_or(Ok(true), |filter| filter.evaluate(row))? {
+                Ok(Some(row.clone()))
+            } else {
+                Ok(None)
+            }
+        } else {
+            let row = self.normalize_row_to_schema(row.clone(), &self.cached_schema);
+            if filter.map_or(Ok(true), |filter| filter.evaluate(&row))? {
+                Ok(Some(row))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    /// A full DML scan visits own writes once, without constructing a frozen
+    /// read overlay. Own identities mask global data before filtering, including
+    /// local deletes and writes that no longer match the predicate.
+    fn captured_dml_targets(&self, filter: Option<&dyn Expression>) -> Result<Option<DmlTargets>> {
+        let Some(binding) = &self.read_view else {
+            return Ok(None);
+        };
+        let txn_versions = self
+            .txn_versions
+            .read()
+            .map_err(|_| Error::internal("transaction store is poisoned"))?;
+        let mut globals = Vec::new();
+        let mut selection_error = None;
+        binding
+            .root
+            .for_each_visible_version_until(&binding.epoch, |id, version| {
+                if txn_versions.get_local_version(id).is_some() {
+                    return true;
+                }
+                match self.dml_matching_row(&version.data, filter) {
+                    Ok(Some(row)) => globals.push((id, row, Self::dml_observed_original(version))),
+                    Ok(None) => {}
+                    Err(error) => {
+                        selection_error = Some(error);
+                        return false;
+                    }
+                }
+                true
+            });
+        if let Some(error) = selection_error {
+            return Err(error);
+        }
+        let mut locals = RowVec::new();
+        for (id, version) in txn_versions.iter_local() {
+            if !version.is_deleted() {
+                if let Some(row) = self.dml_matching_row(&version.data, filter)? {
+                    locals.push((id, row));
+                }
+            }
+        }
+        Ok(Some((globals, locals)))
     }
 
     /// Auto-selects the optimal index type based on column data types
@@ -384,6 +545,9 @@ impl MVCCTable {
     }
 
     fn try_index_lookup(&self, expr: &dyn Expression) -> Option<RowIdVec> {
+        if self.read_view.is_some() {
+            return None;
+        }
         use crate::core::Operator;
         use crate::storage::index::intersect_sorted_ids;
 
@@ -1553,6 +1717,11 @@ impl MVCCTable {
     /// OPTIMIZATION: Uses single-pass counting instead of per-row visibility checks.
     /// Reduces lock acquisitions from O(N) to O(1) for the global store.
     pub fn row_count(&self) -> usize {
+        if let Some(view) = self.captured_view() {
+            let mut count = 0;
+            view.for_each_visible(|_, _| count += 1);
+            return count;
+        }
         // Count global visible versions in single pass (O(1) lock instead of O(N))
         let mut count = self.version_store.count_visible_rows(self.txn_id);
 
@@ -1587,6 +1756,9 @@ impl MVCCTable {
     /// instead of iterating all rows with visibility checks.
     #[inline]
     pub fn fast_row_count(&self) -> Option<usize> {
+        if self.read_view.is_some() {
+            return Some(self.row_count());
+        }
         // Check if there are any local changes
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
@@ -1601,6 +1773,44 @@ impl MVCCTable {
         Some(self.version_store.committed_row_count())
     }
 
+    fn collect_captured_filtered(
+        &self,
+        view: &CapturedHotView,
+        filter: Option<&dyn Expression>,
+        limit: usize,
+        offset: usize,
+    ) -> Result<RowVec> {
+        let mut rows = RowVec::new();
+        if limit == 0 {
+            return Ok(rows);
+        }
+        let prepared = self.prepare_filter_if_needed(filter);
+        let filter = prepared.as_deref().or(filter);
+        let mut skipped = 0;
+        let mut error = None;
+        view.for_each_visible_until(|id, row| {
+            let row = self.normalize_row_to_schema(row.clone(), &self.cached_schema);
+            match filter.map(|filter| filter.evaluate(&row)).transpose() {
+                Err(failure) => {
+                    error = Some(failure);
+                    return false;
+                }
+                Ok(Some(false)) => return true,
+                _ => (),
+            }
+            if skipped < offset {
+                skipped += 1;
+                return true;
+            }
+            rows.push((id, row));
+            rows.len() < limit
+        });
+        match error {
+            Some(error) => Err(error),
+            None => Ok(rows),
+        }
+    }
+
     /// Collect all visible rows, optionally filtered
     ///
     /// Optimized to use batch fetch even when there are local changes,
@@ -1608,6 +1818,18 @@ impl MVCCTable {
     /// Returns RowVec for zero-allocation reuse across queries.
     #[inline]
     fn collect_visible_rows(&self, filter: Option<&dyn Expression>) -> RowVec {
+        if let Some(view) = self.captured_view() {
+            let prepared = self.prepare_filter_if_needed(filter);
+            let filter = prepared.as_deref().or(filter);
+            let mut rows = RowVec::new();
+            view.for_each_visible(|id, row| {
+                let row = self.normalize_row_to_schema(row.clone(), &self.cached_schema);
+                if filter.is_none_or(|filter| filter.evaluate_fast(&row)) {
+                    rows.push((id, row));
+                }
+            });
+            return rows;
+        }
         let txn_versions = self.txn_versions.read().unwrap();
         let schema = &self.cached_schema;
 
@@ -1704,6 +1926,9 @@ impl MVCCTable {
     /// Returns rows in version store iteration order.
     #[inline]
     fn collect_visible_rows_unsorted(&self) -> RowVec {
+        if self.read_view.is_some() {
+            return self.collect_visible_rows(None);
+        }
         // For GROUP BY, order doesn't matter - use same cached path
         self.collect_visible_rows(None)
     }
@@ -1716,6 +1941,26 @@ impl MVCCTable {
         limit: usize,
         offset: usize,
     ) -> RowVec {
+        if let Some(view) = self.captured_view() {
+            let prepared = self.prepare_filter_if_needed(filter);
+            let filter = prepared.as_deref().or(filter);
+            let mut rows = RowVec::with_capacity(limit.min(256));
+            let mut skipped = 0;
+            if limit != 0 {
+                view.for_each_visible_until(|id, row| {
+                    let row = self.normalize_row_to_schema(row.clone(), &self.cached_schema);
+                    if filter.is_none_or(|expr| expr.evaluate_fast(&row)) {
+                        if skipped < offset {
+                            skipped += 1;
+                        } else {
+                            rows.push((id, row));
+                        }
+                    }
+                    rows.len() < limit
+                });
+            }
+            return rows;
+        }
         let schema = &self.cached_schema;
 
         // FAST PATH: Check if this is a primary key equality lookup (WHERE id = X)
@@ -1876,6 +2121,9 @@ impl MVCCTable {
         limit: usize,
         offset: usize,
     ) -> RowVec {
+        if self.read_view.is_some() {
+            return self.collect_visible_rows_with_limit(filter, limit, offset);
+        }
         let schema = &self.cached_schema;
 
         // FAST PATH: Check if this is a primary key equality lookup (WHERE id = X)
@@ -1969,6 +2217,43 @@ impl MVCCTable {
 }
 
 impl Table for MVCCTable {
+    fn begin_logical_mutation(&self) -> Option<super::registry::LogicalMutationGuard> {
+        self.version_store.begin_logical_mutation()
+    }
+
+    fn set_read_epoch(&mut self, epoch: ReadEpoch) -> Result<()> {
+        if self
+            .read_view
+            .as_ref()
+            .is_some_and(|binding| binding.epoch.same_epoch(&epoch))
+        {
+            return Ok(());
+        }
+        self.read_view = Some(CapturedReadBinding {
+            root: self.version_store.capture_hot_root(),
+            epoch,
+            view: std::sync::OnceLock::new(),
+        });
+        Ok(())
+    }
+
+    fn capture_hot_root(&self) -> Option<CapturedHotRoot> {
+        Some(self.version_store.capture_hot_root())
+    }
+
+    fn replace_hot_root(&mut self, root: CapturedHotRoot) -> Result<()> {
+        let binding = self
+            .read_view
+            .as_mut()
+            .ok_or_else(|| Error::internal("hot root capture has no read epoch"))?;
+        binding.root = root;
+        binding.view.take();
+        Ok(())
+    }
+
+    fn captured_hot_view(&self) -> Option<Arc<CapturedHotView>> {
+        self.captured_view().cloned()
+    }
     fn name(&self) -> &str {
         self.version_store.table_name()
     }
@@ -1992,6 +2277,19 @@ impl Table for MVCCTable {
         filter: &dyn Expression,
         rows: &mut RowVec,
     ) -> Result<()> {
+        if let Some(view) = self.captured_view() {
+            let prepared = self.prepare_filter_if_needed(Some(filter));
+            let filter = prepared.as_deref().unwrap_or(filter);
+            for &id in row_ids {
+                if let CapturedHotRow::Value(row) = view.row_state(id) {
+                    let row = self.normalize_row_to_schema(row.clone(), &self.cached_schema);
+                    if filter.evaluate(&row)? {
+                        rows.push((id, row));
+                    }
+                }
+            }
+            return Ok(());
+        }
         let txn_versions = self.txn_versions.read().unwrap();
         let schema = &self.cached_schema;
 
@@ -2058,6 +2356,7 @@ impl Table for MVCCTable {
         default_expr: Option<String>,
         default_value: Option<Value>,
     ) -> Result<()> {
+        let _logical_change = self.version_store.begin_logical_mutation();
         // Create a SchemaColumn and add to both version store and cached schema
         // Get the next column ID
         let next_id = self.cached_schema.columns.len();
@@ -2081,6 +2380,7 @@ impl Table for MVCCTable {
     }
 
     fn drop_column(&mut self, name: &str) -> Result<()> {
+        let _logical_change = self.version_store.begin_logical_mutation();
         // Remove column from both version store and cached schema
         {
             let mut schema_guard = self.version_store.schema_mut();
@@ -2135,15 +2435,9 @@ impl Table for MVCCTable {
                             // Local version - no need to track original (already in write-set)
                             Some((local.data.clone(), None))
                         }
-                    } else if let Some(version) =
-                        self.version_store.get_visible_version(pk_id, self.txn_id)
-                    {
-                        if !version.is_deleted() {
-                            let data = version.data.clone();
-                            Some((data, Some(version)))
-                        } else {
-                            None
-                        }
+                    } else if let Some(version) = self.dml_global_version(pk_id) {
+                        let data = version.data.clone();
+                        Some((data, Some(version)))
                     } else {
                         None
                     }
@@ -2206,9 +2500,7 @@ impl Table for MVCCTable {
 
                 // Step 2: Batch fetch remaining from version store (1 lock for N rows)
                 if !remaining_row_ids.is_empty() {
-                    let batch_rows = self
-                        .version_store
-                        .get_visible_versions_for_update(&remaining_row_ids, self.txn_id);
+                    let batch_rows = self.dml_global_rows_by_ids(&remaining_row_ids);
                     for (row_id, row, version) in batch_rows {
                         let row = self.normalize_row_to_schema(row, schema);
                         let (updated_row, changed) = setter(row)?;
@@ -2263,9 +2555,7 @@ impl Table for MVCCTable {
                 let mut rows_with_originals: Vec<(i64, Row, crate::storage::mvcc::RowVersion)> =
                     Vec::with_capacity(remaining_row_ids.len());
                 if !remaining_row_ids.is_empty() {
-                    let batch_rows = self
-                        .version_store
-                        .get_visible_versions_for_update(&remaining_row_ids, self.txn_id);
+                    let batch_rows = self.dml_global_rows_by_ids(&remaining_row_ids);
                     for (row_id, row, original) in batch_rows {
                         // Normalize row to match current schema (handles ALTER TABLE ADD/DROP COLUMN)
                         let row = self.normalize_row_to_schema(row, schema);
@@ -2333,79 +2623,87 @@ impl Table for MVCCTable {
             }
         }
 
-        // Fall back to full scan - use batch fetch WITH original versions for O(1) lock
-        // OPTIMIZATION: When WHERE clause exists, push filter to storage layer
-        // This avoids allocating Row objects for non-matching rows
-        let mut rows_with_originals: Vec<(i64, Row, crate::storage::mvcc::RowVersion)> =
-            if let Some(expr) = where_expr {
-                // Use filtered scan - filter is applied BEFORE cloning rows
-                self.version_store
-                    .get_all_visible_rows_for_update_filtered(self.txn_id, expr)
-                    .into_iter()
-                    .map(|(row_id, row, orig)| {
-                        // Normalize row to match current schema (handles ALTER TABLE ADD/DROP COLUMN)
-                        (row_id, self.normalize_row_to_schema(row, schema), orig)
-                    })
-                    .collect()
-            } else {
-                // No filter - get all rows
-                self.version_store
-                    .get_all_visible_rows_for_update(self.txn_id)
-                    .into_iter()
-                    .map(|(row_id, row, orig)| {
-                        // Normalize row to match current schema (handles ALTER TABLE ADD/DROP COLUMN)
-                        (row_id, self.normalize_row_to_schema(row, schema), orig)
+        let (mut rows_with_originals, local_rows_to_update) = if let Some(targets) =
+            self.captured_dml_targets(where_expr)?
+        {
+            targets
+        } else {
+            // Fall back to full scan - use batch fetch WITH original versions for O(1) lock
+            // OPTIMIZATION: When WHERE clause exists, push filter to storage layer
+            // This avoids allocating Row objects for non-matching rows
+            let mut rows_with_originals: Vec<(i64, Row, crate::storage::mvcc::RowVersion)> =
+                if let Some(expr) = where_expr {
+                    // Use filtered scan - filter is applied BEFORE cloning rows
+                    self.version_store
+                        .get_all_visible_rows_for_update_filtered(self.txn_id, expr)
+                        .into_iter()
+                        .map(|(row_id, row, orig)| {
+                            // Normalize row to match current schema (handles ALTER TABLE ADD/DROP COLUMN)
+                            (row_id, self.normalize_row_to_schema(row, schema), orig)
+                        })
+                        .collect()
+                } else {
+                    // No filter - get all rows
+                    self.version_store
+                        .get_all_visible_rows_for_update(self.txn_id)
+                        .into_iter()
+                        .map(|(row_id, row, orig)| {
+                            // Normalize row to match current schema (handles ALTER TABLE ADD/DROP COLUMN)
+                            (row_id, self.normalize_row_to_schema(row, schema), orig)
+                        })
+                        .collect()
+                };
+
+            // Overlay local transaction changes onto the global rows:
+            // - Rows locally updated: use local data instead of stale global data
+            // - Rows locally deleted: remove from update set
+            // - Rows locally inserted (not in global store): add to update set
+            let local_rows_to_update: RowVec = {
+                let txn_versions = self.txn_versions.read().unwrap();
+                if txn_versions.has_local_changes() {
+                    // Fix up global rows that have local modifications
+                    rows_with_originals.retain_mut(|(row_id, row, _orig)| {
+                        if let Some(local_version) = txn_versions.get_latest_local(*row_id) {
+                            if local_version.is_deleted() {
+                                // Locally deleted — exclude from update
+                                return false;
+                            }
+                            // Locally modified — use local data instead of stale global data
+                            *row = self.normalize_row_to_schema(local_version.data.clone(), schema);
+                            // Re-check filter against local data
+                            if let Some(expr) = where_expr {
+                                if !expr.evaluate(row).unwrap_or(false) {
+                                    return false;
+                                }
+                            }
+                        }
+                        true
+                    });
+                }
+
+                // Collect local-only inserts (not in global store)
+                txn_versions
+                    .iter_local()
+                    .filter_map(|(row_id, version)| {
+                        // Skip if already in global store (processed above)
+                        if self.version_store.quick_check_row_existence(row_id) {
+                            return None;
+                        }
+                        if version.is_deleted() {
+                            return None;
+                        }
+                        let row = self.normalize_row_to_schema(version.data.clone(), schema);
+                        if let Some(expr) = where_expr {
+                            if !expr.evaluate(&row).unwrap_or(false) {
+                                return None;
+                            }
+                        }
+                        Some((row_id, row))
                     })
                     .collect()
             };
 
-        // Overlay local transaction changes onto the global rows:
-        // - Rows locally updated: use local data instead of stale global data
-        // - Rows locally deleted: remove from update set
-        // - Rows locally inserted (not in global store): add to update set
-        let local_rows_to_update: RowVec = {
-            let txn_versions = self.txn_versions.read().unwrap();
-            if txn_versions.has_local_changes() {
-                // Fix up global rows that have local modifications
-                rows_with_originals.retain_mut(|(row_id, row, _orig)| {
-                    if let Some(local_version) = txn_versions.get_latest_local(*row_id) {
-                        if local_version.is_deleted() {
-                            // Locally deleted — exclude from update
-                            return false;
-                        }
-                        // Locally modified — use local data instead of stale global data
-                        *row = self.normalize_row_to_schema(local_version.data.clone(), schema);
-                        // Re-check filter against local data
-                        if let Some(expr) = where_expr {
-                            if !expr.evaluate(row).unwrap_or(false) {
-                                return false;
-                            }
-                        }
-                    }
-                    true
-                });
-            }
-
-            // Collect local-only inserts (not in global store)
-            txn_versions
-                .iter_local()
-                .filter_map(|(row_id, version)| {
-                    // Skip if already in global store (processed above)
-                    if self.version_store.quick_check_row_existence(row_id) {
-                        return None;
-                    }
-                    if version.is_deleted() {
-                        return None;
-                    }
-                    let row = self.normalize_row_to_schema(version.data.clone(), schema);
-                    if let Some(expr) = where_expr {
-                        if !expr.evaluate(&row).unwrap_or(false) {
-                            return None;
-                        }
-                    }
-                    Some((row_id, row))
-                })
-                .collect()
+            (rows_with_originals, local_rows_to_update)
         };
 
         // Apply setter to rows with originals (from version store), filtering out unchanged
@@ -2497,9 +2795,7 @@ impl Table for MVCCTable {
         let mut rows_with_originals: Vec<(i64, Row, crate::storage::mvcc::RowVersion)> =
             Vec::with_capacity(remaining_row_ids.len());
         if !remaining_row_ids.is_empty() {
-            let batch_rows = self
-                .version_store
-                .get_visible_versions_for_update(&remaining_row_ids, self.txn_id);
+            let batch_rows = self.dml_global_rows_by_ids(&remaining_row_ids);
             for (row_id, row, version) in batch_rows {
                 let row = self.normalize_row_to_schema(row, schema);
                 let (updated_row, changed) = setter(row)?;
@@ -2553,9 +2849,7 @@ impl Table for MVCCTable {
         // Track which remaining row_ids have hot versions (cold-only rows won't)
         let mut found_ids = rustc_hash::FxHashSet::default();
         if !remaining_row_ids.is_empty() {
-            let batch_rows = self
-                .version_store
-                .get_visible_versions_for_update(&remaining_row_ids, self.txn_id);
+            let batch_rows = self.dml_global_rows_by_ids(&remaining_row_ids);
             for (row_id, row, version) in batch_rows {
                 found_ids.insert(row_id);
                 let row = self.normalize_row_to_schema(row, schema);
@@ -2568,7 +2862,15 @@ impl Table for MVCCTable {
         // tombstone recovery on restart.
         let cold_only_ids: Vec<i64> = remaining_row_ids
             .iter()
-            .filter(|id| !found_ids.contains(id))
+            .filter(|id| {
+                !found_ids.contains(id)
+                    && self.read_view.as_ref().is_none_or(|binding| {
+                        !matches!(
+                            binding.root.version_state(**id, &binding.epoch),
+                            crate::storage::mvcc::version_store::CapturedHotVersion::Deleted
+                        )
+                    })
+            })
             .copied()
             .collect();
 
@@ -2600,6 +2902,11 @@ impl Table for MVCCTable {
     }
 
     fn get_active_row_ids(&self) -> Result<Vec<i64>> {
+        if let Some(view) = self.captured_view() {
+            let mut ids = Vec::new();
+            view.for_each_visible(|id, _| ids.push(id));
+            return Ok(ids);
+        }
         // Only the keys this transaction sees: a committed delete stays in
         // the version tree until it is collected, but it is not a row
         let mut ids = self.version_store.visible_row_ids_excluding(
@@ -2632,6 +2939,18 @@ impl Table for MVCCTable {
         exclude: &crate::common::I64Set,
         limit: usize,
     ) -> Result<Vec<i64>> {
+        if let Some(view) = self.captured_view() {
+            let mut ids = Vec::with_capacity(limit.min(256));
+            if limit != 0 {
+                view.for_each_visible_until(|id, _| {
+                    if !exclude.contains(id) {
+                        ids.push(id);
+                    }
+                    ids.len() < limit
+                });
+            }
+            return Ok(ids);
+        }
         // A transaction with writes of its own reads the whole key list
         if self.txn_versions.read().unwrap().has_local_changes() {
             let mut ids = self.get_active_row_ids()?;
@@ -2652,6 +2971,9 @@ impl Table for MVCCTable {
     }
 
     fn has_row_id(&self, row_id: i64) -> Result<bool> {
+        if let Some(view) = self.captured_view() {
+            return Ok(matches!(view.row_state(row_id), CapturedHotRow::Value(_)));
+        }
         Ok(self.version_store.has_committed_row(row_id))
     }
 
@@ -2667,6 +2989,31 @@ impl Table for MVCCTable {
             .write()
             .unwrap()
             .track_external_claim(row_id);
+        Ok(())
+    }
+
+    fn captured_mutation_has_hot_authority(&self, row_id: i64) -> Option<bool> {
+        let binding = self.read_view.as_ref()?;
+        let has_local = {
+            let Ok(versions) = self.txn_versions.read() else {
+                panic!("transaction store is poisoned during authority lookup");
+            };
+            versions.get_local_version(row_id).is_some()
+        };
+        if has_local {
+            return Some(true);
+        }
+        Some(!matches!(
+            binding.root.version_state(row_id, &binding.epoch),
+            super::version_store::CapturedHotVersion::NoVisibleVersion
+        ))
+    }
+
+    fn validate_cold_mutation(&self, row_id: i64) -> Result<()> {
+        if let Some(binding) = &self.read_view {
+            self.version_store
+                .validate_mutation_epoch(row_id, &binding.epoch)?;
+        }
         Ok(())
     }
 
@@ -2690,15 +3037,9 @@ impl Table for MVCCTable {
                             // Local version - no need to track original (already in write-set)
                             Some((local.data.clone(), None))
                         }
-                    } else if let Some(version) =
-                        self.version_store.get_visible_version(pk_id, self.txn_id)
-                    {
-                        if !version.is_deleted() {
-                            let data = version.data.clone();
-                            Some((data, Some(version)))
-                        } else {
-                            None
-                        }
+                    } else if let Some(version) = self.dml_global_version(pk_id) {
+                        let data = version.data.clone();
+                        Some((data, Some(version)))
                     } else {
                         None
                     }
@@ -2747,9 +3088,7 @@ impl Table for MVCCTable {
 
                 // Step 2: Batch fetch remaining from version store (1 lock for N rows)
                 if !remaining_row_ids.is_empty() {
-                    let batch_rows = self
-                        .version_store
-                        .get_visible_versions_for_update(&remaining_row_ids, self.txn_id);
+                    let batch_rows = self.dml_global_rows_by_ids(&remaining_row_ids);
                     for (row_id, row, version) in batch_rows {
                         rows_with_originals.push((row_id, row, version));
                     }
@@ -2819,6 +3158,19 @@ impl Table for MVCCTable {
                 }
                 return Ok(delete_count);
             }
+        }
+
+        if let Some((globals, locals)) = self.captured_dml_targets(where_expr)? {
+            let count = (globals.len() + locals.len()) as i32;
+            if count != 0 {
+                let mut txn_versions = self
+                    .txn_versions
+                    .write()
+                    .map_err(|_| Error::internal("transaction store is poisoned"))?;
+                txn_versions.put_batch_deleted_with_originals(globals)?;
+                txn_versions.put_batch_deleted(locals)?;
+            }
+            return Ok(count);
         }
 
         // Fall back to full scan
@@ -2915,10 +3267,50 @@ impl Table for MVCCTable {
     }
 
     fn truncate(&mut self) -> Result<i32> {
-        // Fast path: drop all storage directly, bypassing per-row MVCC versioning.
-        // This is O(1) instead of O(N) for delete-all.
-        // Fails if other transactions have uncommitted writes on this table.
-        self.version_store.truncate_all()
+        self.truncate_with_outer_epoch(&mut None)
+    }
+
+    fn truncate_with_outer_epoch(&mut self, outer_epoch: &mut Option<ReadEpoch>) -> Result<i32> {
+        // Hold the transaction guard before namespace/registry/transfer reservations through WAL.
+        let local = self
+            .txn_versions
+            .write()
+            .map_err(|_| Error::internal("transaction store is poisoned"))?;
+        if local.has_local_changes() {
+            return Err(Error::TableHasActiveTransactions);
+        }
+        let mut owners = 0;
+        let epoch = match self.read_view.as_mut() {
+            Some(binding) => {
+                owners += 1;
+                if let Some(view) = binding.view.get_mut() {
+                    // An external result can share this Arc without cloning
+                    // its nested ReadEpoch, including via a later Weak upgrade.
+                    // get_mut atomically proves no other strong OR weak owner.
+                    if Arc::get_mut(view).is_none() {
+                        return Err(Error::TableHasActiveTransactions);
+                    }
+                    owners += 1;
+                }
+                if let Some(outer) = outer_epoch.as_mut() {
+                    if !outer.same_epoch(&binding.epoch) {
+                        return Err(Error::TableHasActiveTransactions);
+                    }
+                    owners += 1;
+                }
+                Some((&binding.epoch, owners))
+            }
+            None => outer_epoch.as_mut().map(|epoch| (&*epoch, 1)),
+        };
+        let rows = self
+            .version_store
+            .coordinated_truncate(self.txn_id, epoch)?;
+        // The immutable pre-truncate view remains intact on every error. Only
+        // successful physical mutation makes this handle read the empty table.
+        self.read_view = None;
+        outer_epoch.take();
+        drop(local);
+        Ok(rows)
     }
 
     fn scan(
@@ -2926,6 +3318,54 @@ impl Table for MVCCTable {
         column_indices: &[usize],
         where_expr: Option<&dyn Expression>,
     ) -> Result<Box<dyn Scanner>> {
+        if let Some(view) = self.captured_view() {
+            let prepared = self.prepare_filter_if_needed(where_expr);
+            let where_expr = prepared.as_deref().or(where_expr);
+            if let Some(id) =
+                where_expr.and_then(|expr| self.try_pk_lookup(expr, &self.cached_schema))
+            {
+                let mut rows = RowVec::new();
+                if let CapturedHotRow::Value(row) = view.row_state(id) {
+                    let row = self.normalize_row_to_schema(row.clone(), &self.cached_schema);
+                    if where_expr
+                        .map(|expr| expr.evaluate(&row))
+                        .transpose()?
+                        .unwrap_or(true)
+                    {
+                        let row = if !column_indices.is_empty()
+                            && (column_indices.len() != row.len()
+                                || !column_indices
+                                    .iter()
+                                    .enumerate()
+                                    .all(|(i, &column)| i == column))
+                        {
+                            Row::from_values(
+                                column_indices
+                                    .iter()
+                                    .map(|&column| {
+                                        row.get(column).cloned().unwrap_or_else(Value::null_unknown)
+                                    })
+                                    .collect(),
+                            )
+                        } else {
+                            row
+                        };
+                        rows.push((id, row));
+                    }
+                }
+                return Ok(Box::new(MVCCScanner::from_rows(
+                    rows,
+                    self.cached_schema.clone(),
+                    Vec::new(),
+                )));
+            }
+            return Ok(Box::new(super::captured_scanner::CapturedHotScanner::new(
+                view.clone(),
+                self.cached_schema.clone(),
+                column_indices,
+                where_expr,
+            )));
+        }
         // CompactArc clone - O(1) reference count increment instead of full Schema clone
         let schema = self.cached_schema.clone();
 
@@ -2999,6 +3439,24 @@ impl Table for MVCCTable {
         limit: usize,
         offset: usize,
     ) -> Result<Option<RowVec>> {
+        if let Some(view) = self.captured_view() {
+            let Some((column, definition)) = self.cached_schema.find_column(column_name) else {
+                return Ok(None);
+            };
+            if definition.nullable || definition.data_type == DataType::Float {
+                return Ok(None);
+            }
+            let prepared = self.prepare_filter_if_needed(where_expr);
+            return Ok(Some(super::captured_scanner::sorted_hot_rows(
+                view,
+                &self.cached_schema,
+                column,
+                ascending,
+                limit,
+                offset,
+                prepared.as_deref().or(where_expr),
+            )?));
+        }
         let needed = limit.saturating_add(offset);
         if needed == 0 {
             return Ok(Some(RowVec::new()));
@@ -3080,6 +3538,9 @@ impl Table for MVCCTable {
     }
 
     fn collect_all_rows(&self, where_expr: Option<&dyn Expression>) -> Result<RowVec> {
+        if let Some(view) = self.captured_view() {
+            return self.collect_captured_filtered(view, where_expr, usize::MAX, 0);
+        }
         // Return cached row vector directly - caller iterates (i64, Row) tuples
         Ok(self.collect_visible_rows(where_expr))
     }
@@ -3089,6 +3550,18 @@ impl Table for MVCCTable {
     }
 
     fn collect_rows_by_ids(&self, row_ids: &[i64]) -> Result<RowVec> {
+        if let Some(view) = self.captured_view() {
+            let mut rows = RowVec::with_capacity(row_ids.len().min(256));
+            for &id in row_ids {
+                if let CapturedHotRow::Value(row) = view.row_state(id) {
+                    rows.push((
+                        id,
+                        self.normalize_row_to_schema(row.clone(), &self.cached_schema),
+                    ));
+                }
+            }
+            return Ok(rows);
+        }
         let mut rows = RowVec::with_capacity(row_ids.len());
         for &row_id in row_ids {
             if let Some(version) = self.version_store.get_visible_version(row_id, self.txn_id) {
@@ -3106,6 +3579,9 @@ impl Table for MVCCTable {
         limit: usize,
         offset: usize,
     ) -> Result<RowVec> {
+        if let Some(view) = self.captured_view() {
+            return self.collect_captured_filtered(view, where_expr, limit, offset);
+        }
         // Use the optimized version with limit/offset
         Ok(self.collect_visible_rows_with_limit(where_expr, limit, offset))
     }
@@ -3116,6 +3592,9 @@ impl Table for MVCCTable {
         limit: usize,
         offset: usize,
     ) -> Result<RowVec> {
+        if let Some(view) = self.captured_view() {
+            return self.collect_captured_filtered(view, where_expr, limit, offset);
+        }
         // Use the optimized unordered version with true early termination
         Ok(self.collect_visible_rows_with_limit_unordered(where_expr, limit, offset))
     }
@@ -3127,6 +3606,20 @@ impl Table for MVCCTable {
         limit: usize,
         offset: usize,
     ) -> Result<Vec<Row>> {
+        if let Some(view) = self.captured_view() {
+            return Ok(super::captured_scanner::sorted_hot_rows(
+                view,
+                &self.cached_schema,
+                sort_col_idx,
+                ascending,
+                limit,
+                offset,
+                None,
+            )?
+            .into_iter()
+            .map(|(_, row)| row)
+            .collect());
+        }
         // DEFERRED MATERIALIZATION OPTIMIZATION
         // Instead of cloning all rows, sorting, and taking limit:
         // 1. Get row indices (no cloning)
@@ -3187,6 +3680,7 @@ impl Table for MVCCTable {
     fn close(&mut self) -> Result<()> {
         // Rollback any uncommitted changes
         self.txn_versions.write().unwrap().rollback();
+        self.read_view = None;
         Ok(())
     }
 
@@ -3462,49 +3956,11 @@ impl Table for MVCCTable {
 
         self.version_store.attach_index_memory(&mut index)?;
 
-        // Populate the index with existing data using batch_slice for better performance
-        // Collect all entries first, then add in a single batch operation
-        let mut entries: Vec<(i64, Vec<Value>)> = Vec::new();
-
-        for row_id in self.version_store.get_all_visible_row_ids(self.txn_id) {
-            if let Some(version) = self.version_store.get_visible_version(row_id, self.txn_id) {
-                if !version.is_deleted() {
-                    let values: Vec<Value> = col_indices
-                        .iter()
-                        .map(|&idx| {
-                            version
-                                .data
-                                .get(idx)
-                                .cloned()
-                                .unwrap_or(Value::Null(DataType::Null))
-                        })
-                        .collect();
-                    entries.push((row_id, values));
-                }
-            }
-        }
-
-        // Also collect any local uncommitted data
-        {
-            let txn_versions = self.txn_versions.read().unwrap();
-            for (row_id, version) in txn_versions.iter_local() {
-                if !version.is_deleted() && !self.version_store.quick_check_row_existence(row_id) {
-                    let values: Vec<Value> = col_indices
-                        .iter()
-                        .map(|&idx| {
-                            version
-                                .data
-                                .get(idx)
-                                .cloned()
-                                .unwrap_or(Value::Null(DataType::Null))
-                        })
-                        .collect();
-                    entries.push((row_id, values));
-                }
-            }
-        }
-
-        // Add all entries in a single batch operation
+        // Build the shared index from current committed canonical keys. The
+        // requesting transaction's older snapshot and local writes stay private.
+        let entries = self
+            .version_store
+            .current_index_entries(&schema, &col_indices)?;
         if !entries.is_empty() {
             let entry_refs: Vec<(i64, &[Value])> = entries
                 .iter()
@@ -3612,33 +4068,11 @@ impl Table for MVCCTable {
         let mut index: Arc<dyn Index> = Arc::new(hnsw);
         self.version_store.attach_index_memory(&mut index)?;
 
-        // Populate with existing data
-        let mut entries: Vec<(i64, Vec<Value>)> = Vec::new();
-        for row_id in self.version_store.get_all_visible_row_ids(self.txn_id) {
-            if let Some(version) = self.version_store.get_visible_version(row_id, self.txn_id) {
-                if !version.is_deleted() {
-                    let val = version
-                        .data
-                        .get(col_idx)
-                        .cloned()
-                        .unwrap_or(Value::Null(DataType::Null));
-                    entries.push((row_id, vec![val]));
-                }
-            }
-        }
-        {
-            let txn_versions = self.txn_versions.read().unwrap();
-            for (row_id, version) in txn_versions.iter_local() {
-                if !version.is_deleted() && !self.version_store.quick_check_row_existence(row_id) {
-                    let val = version
-                        .data
-                        .get(col_idx)
-                        .cloned()
-                        .unwrap_or(Value::Null(DataType::Null));
-                    entries.push((row_id, vec![val]));
-                }
-            }
-        }
+        // Build the shared index from current committed canonical keys. The
+        // requesting transaction's older snapshot and local writes stay private.
+        let entries = self
+            .version_store
+            .current_index_entries(&schema, &[col_idx])?;
         if !entries.is_empty() {
             let entry_refs: Vec<(i64, &[Value])> = entries
                 .iter()
@@ -3681,6 +4115,15 @@ impl Table for MVCCTable {
     }
 
     fn get_index_on_column(&self, column_name: &str) -> Option<std::sync::Arc<dyn Index>> {
+        self.version_store.get_index_by_column(column_name)
+    }
+
+    fn lookup_index_on_column(&self, column_name: &str) -> Option<std::sync::Arc<dyn Index>> {
+        // Current index membership cannot prove completeness at an older epoch.
+        // Catalog and constraint callers still use get_index_on_column.
+        if self.read_view.is_some() {
+            return None;
+        }
         self.version_store.get_index_by_column(column_name)
     }
 
@@ -3831,36 +4274,11 @@ impl Table for MVCCTable {
 
         index.attach_memory_account(self.version_store.memory_account())?;
 
-        // Populate the index with existing data using batch_slice
-        let mut entries: Vec<(i64, Vec<Value>)> = Vec::new();
-
-        // Scan all visible rows
-        for row_id in self.version_store.get_all_visible_row_ids(self.txn_id) {
-            if let Some(version) = self.version_store.get_visible_version(row_id, self.txn_id) {
-                if !version.is_deleted() {
-                    if let Some(value) = version.data.get(col_idx) {
-                        entries.push((row_id, vec![value.clone()]));
-                    }
-                }
-            }
-        }
-
-        // Also collect any local uncommitted data
-        {
-            let txn_versions = self.txn_versions.read().unwrap();
-            for (row_id, version) in txn_versions.iter_local() {
-                if !version.is_deleted() {
-                    if let Some(value) = version.data.get(col_idx) {
-                        // Skip if already added from global store
-                        if !self.version_store.quick_check_row_existence(row_id) {
-                            entries.push((row_id, vec![value.clone()]));
-                        }
-                    }
-                }
-            }
-        }
-
-        // Add all entries in a single batch operation
+        // Build the shared index from current committed canonical keys. The
+        // requesting transaction's older snapshot and local writes stay private.
+        let entries = self
+            .version_store
+            .current_index_entries(&schema, &[col_idx])?;
         if !entries.is_empty() {
             let entry_refs: Vec<(i64, &[Value])> = entries
                 .iter()
@@ -3948,52 +4366,11 @@ impl Table for MVCCTable {
 
         index.attach_memory_account(self.version_store.memory_account())?;
 
-        // Populate the index with existing data using batch_slice
-        let mut entries: Vec<(i64, Vec<Value>)> = Vec::new();
-
-        for row_id in self.version_store.get_all_visible_row_ids(self.txn_id) {
-            if let Some(version) = self.version_store.get_visible_version(row_id, self.txn_id) {
-                if !version.is_deleted() {
-                    // Collect values for all columns in the index
-                    let values: Vec<Value> = col_indices
-                        .iter()
-                        .map(|&idx| {
-                            version
-                                .data
-                                .get(idx)
-                                .cloned()
-                                .unwrap_or(Value::Null(DataType::Null))
-                        })
-                        .collect();
-                    entries.push((row_id, values));
-                }
-            }
-        }
-
-        // Also collect any local uncommitted data
-        {
-            let txn_versions = self.txn_versions.read().unwrap();
-            for (row_id, version) in txn_versions.iter_local() {
-                if !version.is_deleted() {
-                    // Skip if already added from global store
-                    if !self.version_store.quick_check_row_existence(row_id) {
-                        let values: Vec<Value> = col_indices
-                            .iter()
-                            .map(|&idx| {
-                                version
-                                    .data
-                                    .get(idx)
-                                    .cloned()
-                                    .unwrap_or(Value::Null(DataType::Null))
-                            })
-                            .collect();
-                        entries.push((row_id, values));
-                    }
-                }
-            }
-        }
-
-        // Add all entries in a single batch operation
+        // Build the shared index from current committed canonical keys. The
+        // requesting transaction's older snapshot and local writes stay private.
+        let entries = self
+            .version_store
+            .current_index_entries(&schema, &col_indices)?;
         if !entries.is_empty() {
             let entry_refs: Vec<(i64, &[Value])> = entries
                 .iter()
@@ -4039,6 +4416,9 @@ impl Table for MVCCTable {
     }
 
     fn get_index_min_value(&self, column_name: &str) -> Option<Value> {
+        if self.read_view.is_some() {
+            return None;
+        }
         // Try to find an index on this column and get its minimum value
         if let Some(index) = self.version_store.get_index_by_column(column_name) {
             return index.get_min_value();
@@ -4047,6 +4427,9 @@ impl Table for MVCCTable {
     }
 
     fn get_index_max_value(&self, column_name: &str) -> Option<Value> {
+        if self.read_view.is_some() {
+            return None;
+        }
         // Try to find an index on this column and get its maximum value
         if let Some(index) = self.version_store.get_index_by_column(column_name) {
             return index.get_max_value();
@@ -4079,6 +4462,37 @@ impl Table for MVCCTable {
         limit: usize,
         offset: usize,
     ) -> Result<Option<RowVec>> {
+        if let Some(view) = self.captured_view() {
+            if self.cached_schema.pk_column_index().is_some_and(|index| {
+                self.cached_schema.columns[index]
+                    .name
+                    .eq_ignore_ascii_case(column_name)
+            }) {
+                let mut rows = RowVec::with_capacity(limit.min(128));
+                if limit == 0 {
+                    return Ok(Some(rows));
+                }
+                let mut skipped = 0;
+                let mut visit = |id, row: &Row| {
+                    if skipped < offset {
+                        skipped += 1;
+                        return true;
+                    }
+                    rows.push((
+                        id,
+                        self.normalize_row_to_schema(row.clone(), &self.cached_schema),
+                    ));
+                    rows.len() < limit
+                };
+                if ascending {
+                    view.for_each_visible_until(&mut visit);
+                } else {
+                    view.for_each_visible_range_rev_until(.., &mut visit);
+                }
+                return Ok(Some(rows));
+            }
+            return self.scan_top_k(None, column_name, ascending, limit, offset);
+        }
         // If transaction has local changes (inserts/updates/deletes), fall back to
         // the regular path which correctly merges local changes via collect_visible_rows.
         // This optimization only reads from the global version store and indexes.
@@ -4216,6 +4630,33 @@ impl Table for MVCCTable {
         ascending: bool,
         limit: usize,
     ) -> Option<RowVec> {
+        if let Some(view) = self.captured_view() {
+            self.cached_schema.pk_column_index()?;
+            let mut rows = RowVec::with_capacity(limit.min(128));
+            if limit == 0 {
+                return Some(rows);
+            }
+            let start = start_after
+                .map(std::ops::Bound::Excluded)
+                .or_else(|| start_from.map(std::ops::Bound::Included))
+                .unwrap_or(std::ops::Bound::Unbounded);
+            let mut visit = |id, row: &Row| {
+                rows.push((
+                    id,
+                    self.normalize_row_to_schema(row.clone(), &self.cached_schema),
+                ));
+                rows.len() < limit
+            };
+            if ascending {
+                view.for_each_visible_range_until((start, std::ops::Bound::Unbounded), &mut visit);
+            } else {
+                view.for_each_visible_range_rev_until(
+                    (start, std::ops::Bound::Unbounded),
+                    &mut visit,
+                );
+            }
+            return Some(rows);
+        }
         // Only works if table has a single-column INTEGER PRIMARY KEY
         self.cached_schema.pk_column_index()?;
 
@@ -4242,6 +4683,9 @@ impl Table for MVCCTable {
         &self,
         column_name: &str,
     ) -> Result<Option<Vec<(Value, RowVec)>>> {
+        if self.read_view.is_some() {
+            return Ok(None);
+        }
         // If transaction has local changes, fall back to regular path
         {
             let txn_versions = self.txn_versions.read().unwrap();
@@ -4289,6 +4733,31 @@ impl Table for MVCCTable {
     }
 
     fn get_partition_values(&self, column_name: &str) -> Result<Option<Vec<Value>>> {
+        if let Some(view) = self.captured_view() {
+            let Some((column, _)) = self.cached_schema.find_column(column_name) else {
+                return Ok(None);
+            };
+            return crate::storage::volume::captured_aggregate::grouped(
+                &self.cached_schema,
+                view,
+                None,
+                &[column],
+                &[],
+            )?
+            .map(|groups| {
+                groups
+                    .into_iter()
+                    .map(|group| {
+                        group
+                            .group_values
+                            .into_iter()
+                            .next()
+                            .ok_or_else(|| Error::internal("distinct group has no key"))
+                    })
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose();
+        }
         // Only use index-based distinct values if no uncommitted local changes
         // (local changes are in txn_versions, not reflected in the index)
         let txn_versions = self.txn_versions.read().unwrap();
@@ -4306,6 +4775,11 @@ impl Table for MVCCTable {
     }
 
     fn get_partition_count(&self, column_name: &str) -> Result<Option<usize>> {
+        if self.read_view.is_some() {
+            return Ok(self
+                .get_partition_values(column_name)?
+                .map(|values| values.into_iter().filter(|value| !value.is_null()).count()));
+        }
         // Only use index-based count if no uncommitted local changes
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
@@ -4326,6 +4800,9 @@ impl Table for MVCCTable {
         column_name: &str,
         partition_value: &Value,
     ) -> Result<Option<RowVec>> {
+        if self.read_view.is_some() {
+            return Ok(None);
+        }
         // If transaction has local changes, fall back to regular path
         {
             let txn_versions = self.txn_versions.read().unwrap();
@@ -4357,6 +4834,7 @@ impl Table for MVCCTable {
     }
 
     fn rename_column(&mut self, old_name: &str, new_name: &str) -> Result<()> {
+        let _logical_change = self.version_store.begin_logical_mutation();
         // Rename column in both version store and cached schema
         {
             let mut schema_guard = self.version_store.schema_mut();
@@ -4367,6 +4845,7 @@ impl Table for MVCCTable {
     }
 
     fn modify_column(&mut self, name: &str, column_type: DataType, nullable: bool) -> Result<()> {
+        let _logical_change = self.version_store.begin_logical_mutation();
         // Modify column in both version store and cached schema
         {
             let mut schema_guard = self.version_store.schema_mut();
@@ -4822,6 +5301,28 @@ impl Table for MVCCTable {
     }
 
     fn sum_column(&self, col_idx: usize) -> Result<Option<(f64, usize)>> {
+        if let Some(view) = self.captured_view() {
+            let Some(column) = self.cached_schema.columns.get(col_idx) else {
+                return Ok(None);
+            };
+            let default = column
+                .default_value
+                .clone()
+                .unwrap_or_else(|| Value::null(column.data_type));
+            let mut int_sum = 0i128;
+            let mut float_sum = 0.0;
+            let mut count = 0;
+            view.for_each_visible(|_, row| {
+                match row.get(col_idx).unwrap_or(&default) {
+                    Value::Integer(value) => int_sum += *value as i128,
+                    Value::Float(value) => float_sum += *value,
+                    Value::Boolean(value) => int_sum += i128::from(*value),
+                    _ => return,
+                }
+                count += 1;
+            });
+            return Ok(Some((int_sum as f64 + float_sum, count)));
+        }
         // Only use deferred aggregation if no uncommitted local changes
         // (local changes are in txn_versions, not the main version_store)
         let txn_versions = self.txn_versions.read().unwrap();
@@ -4834,6 +5335,27 @@ impl Table for MVCCTable {
     }
 
     fn min_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
+        if let Some(view) = self.captured_view() {
+            let Some(column) = self.cached_schema.columns.get(col_idx) else {
+                return Ok(None);
+            };
+            let default = column
+                .default_value
+                .clone()
+                .unwrap_or_else(|| Value::null(column.data_type));
+            let mut best: Option<Value> = None;
+            view.for_each_visible(|_, row| {
+                let value = row.get(col_idx).unwrap_or(&default);
+                if !value.is_null()
+                    && best
+                        .as_ref()
+                        .is_none_or(|best| value.compare(best).is_ok_and(|order| order.is_lt()))
+                {
+                    best = Some(value.clone());
+                }
+            });
+            return Ok(Some(best));
+        }
         // Only use deferred aggregation if no uncommitted local changes
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
@@ -4845,6 +5367,27 @@ impl Table for MVCCTable {
     }
 
     fn max_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
+        if let Some(view) = self.captured_view() {
+            let Some(column) = self.cached_schema.columns.get(col_idx) else {
+                return Ok(None);
+            };
+            let default = column
+                .default_value
+                .clone()
+                .unwrap_or_else(|| Value::null(column.data_type));
+            let mut best: Option<Value> = None;
+            view.for_each_visible(|_, row| {
+                let value = row.get(col_idx).unwrap_or(&default);
+                if !value.is_null()
+                    && best
+                        .as_ref()
+                        .is_none_or(|best| value.compare(best).is_ok_and(|order| order.is_gt()))
+                {
+                    best = Some(value.clone());
+                }
+            });
+            return Ok(Some(best));
+        }
         // Only use deferred aggregation if no uncommitted local changes
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
@@ -4855,11 +5398,37 @@ impl Table for MVCCTable {
         Ok(Some(self.version_store.max_column(self.txn_id, col_idx)))
     }
 
+    fn compute_filtered_aggregates(
+        &self,
+        aggregates: &[(crate::storage::mvcc::version_store::AggregateOp, usize)],
+        where_expr: &dyn Expression,
+    ) -> Result<Option<Vec<Value>>> {
+        let Some(view) = self.captured_view() else {
+            return Ok(None);
+        };
+        crate::storage::volume::captured_aggregate::filtered(
+            &self.cached_schema,
+            view,
+            None,
+            aggregates,
+            where_expr,
+        )
+    }
+
     fn compute_grouped_aggregates(
         &self,
         group_by_indices: &[usize],
         aggregates: &[(crate::storage::mvcc::version_store::AggregateOp, usize)],
     ) -> Result<Option<Vec<crate::storage::mvcc::version_store::GroupedAggregateResult>>> {
+        if let Some(view) = self.captured_view() {
+            return crate::storage::volume::captured_aggregate::grouped(
+                &self.cached_schema,
+                view,
+                None,
+                group_by_indices,
+                aggregates,
+            );
+        }
         // Only use storage-level aggregation if no uncommitted local changes
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {

--- a/src/storage/mvcc/transaction.rs
+++ b/src/storage/mvcc/transaction.rs
@@ -20,6 +20,7 @@
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
+use super::registry::ReadEpoch;
 use crate::core::{Error, IsolationLevel, Result, Schema, SchemaColumn};
 use crate::storage::mvcc::{get_fast_timestamp, TransactionRegistry};
 use crate::storage::traits::{QueryResult, Table, Transaction};
@@ -97,6 +98,17 @@ pub struct MvccTransaction {
 pub trait TransactionEngineOperations: Send + Sync {
     /// Get a table by name, initializing transaction-local version store
     fn get_table_for_transaction(&self, txn_id: i64, table_name: &str) -> Result<Box<dyn Table>>;
+
+    fn get_table_for_transaction_in_epoch(
+        &self,
+        txn_id: i64,
+        table_name: &str,
+        epoch: &ReadEpoch,
+    ) -> Result<Box<dyn Table>> {
+        let mut table = self.get_table_for_transaction(txn_id, table_name)?;
+        table.set_read_epoch(epoch.clone())?;
+        Ok(table)
+    }
 
     /// Create a new table
     fn create_table(&self, name: &str, schema: Schema) -> Result<Box<dyn Table>>;
@@ -237,7 +249,7 @@ impl MvccTransaction {
             id,
             state: TransactionState::Active,
             tables: FxHashMap::default(),
-            isolation_level: None,
+            isolation_level: Some(registry.get_isolation_level(id)),
             registry,
             begin_seq,
             last_table_name: None,
@@ -449,6 +461,17 @@ impl MvccTransaction {
 }
 
 impl Transaction for MvccTransaction {
+    fn capture_read_epoch(&self) -> Result<Option<ReadEpoch>> {
+        self.check_active()?;
+        Ok(self.registry.read_epoch_for_transaction(self.id))
+    }
+
+    fn get_table_in_epoch(&self, name: &str, epoch: &ReadEpoch) -> Result<Box<dyn Table>> {
+        self.check_active()?;
+        self.get_engine_ops()?
+            .get_table_for_transaction_in_epoch(self.id, name, epoch)
+    }
+
     fn id(&self) -> i64 {
         self.id
     }
@@ -502,6 +525,10 @@ impl Transaction for MvccTransaction {
             if let Some(ops) = &self.engine_operations {
                 let (_, error) = ops.commit_all_tables(self.id);
                 if let Some(error) = error {
+                    // Cold tombstones carry a commit sequence: removing its
+                    // registry exclusion before undo must not authorize shared
+                    // results from that provisional physical state.
+                    let _logical_undo = self.registry.begin_logical_mutation();
                     self.registry.abort_transaction(self.id);
                     if let Err(undo_error) = ops.finish_publication(self.id, false) {
                         ops.handle_publication_undo_failure(&undo_error);
@@ -509,6 +536,7 @@ impl Transaction for MvccTransaction {
                         return Err(undo_error);
                     }
                     ops.rollback_all_tables(self.id);
+                    self.registry.acknowledge_rollback(self.id);
                     self.state = TransactionState::RolledBack;
                     self.cleanup();
                     return Err(error);
@@ -526,6 +554,7 @@ impl Transaction for MvccTransaction {
                         // Engine health fencing prevents reads/writes until recovery.
                         return Err(error);
                     }
+                    let _logical_undo = self.registry.begin_logical_mutation();
                     self.registry.abort_transaction(self.id);
                     if let Err(undo_error) = ops.finish_publication(self.id, false) {
                         ops.handle_publication_undo_failure(&undo_error);
@@ -533,6 +562,7 @@ impl Transaction for MvccTransaction {
                         return Err(undo_error);
                     }
                     ops.rollback_all_tables(self.id);
+                    self.registry.acknowledge_rollback(self.id);
                     self.state = TransactionState::RolledBack;
                     self.cleanup();
                     return Err(error);
@@ -586,6 +616,8 @@ impl Transaction for MvccTransaction {
             // Clean up txn_version_stores entry to prevent memory leak
             ops.rollback_all_tables(self.id);
         }
+
+        self.registry.acknowledge_rollback(self.id);
 
         // Record in WAL if not read-only
         if !is_read_only {
@@ -714,9 +746,8 @@ impl Transaction for MvccTransaction {
         // For now, always get from engine (engine will handle caching internally).
         // The tables HashMap is used for tracking which tables were accessed for commit/rollback.
 
-        // Get from engine
-        let ops = self.get_engine_ops()?;
-        ops.get_table_for_transaction(self.id, name)
+        let epoch = self.capture_read_epoch()?.ok_or(Error::TransactionClosed)?;
+        self.get_table_in_epoch(name, &epoch)
     }
 
     fn list_tables(&self) -> Result<Vec<String>> {
@@ -893,6 +924,7 @@ impl Drop for MvccTransaction {
                 // but are dropped without explicit commit/rollback
                 ops.rollback_all_tables(self.id);
             }
+            self.registry.acknowledge_rollback(self.id);
 
             self.cleanup();
         }

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -46,6 +46,7 @@ use crate::storage::mvcc::arena::{ArenaId, RowArena};
 use crate::storage::mvcc::get_fast_timestamp;
 #[cfg(not(test))]
 use crate::storage::mvcc::registry::TransactionRegistry;
+use crate::storage::mvcc::registry::{EpochReader, ReadEpoch};
 use crate::storage::mvcc::streaming_result::{StreamingResult, VisibleRowInfo};
 use crate::storage::Index;
 use ahash::AHashMap;
@@ -202,6 +203,342 @@ struct VersionChainEntry {
     prev: Option<CompactArc<VersionChainEntry>>,
     /// Stable arena address, absent for historical payloads outside the arena.
     arena_idx: Option<ArenaId>,
+}
+
+/// An immutable hot-tree root captured while the hot/cold publication fence is
+/// held. Cloning only retains existing tree nodes; it performs no allocation or
+/// I/O. Payloads belong to the captured tree, never to mutable arena slots.
+#[derive(Clone)]
+pub struct CapturedHotRoot {
+    inner: crate::common::CowBTree<VersionChainEntry>,
+}
+
+/// Epoch authority retaining original version identities for DML conflict
+/// detection. A Value's raw deletion marker may be nonzero but invisible in
+/// this epoch; callers must use this state rather than RowVersion::is_deleted.
+#[derive(Debug)]
+pub enum CapturedHotVersion<'a> {
+    Value(&'a RowVersion),
+    Deleted,
+    NoVisibleVersion,
+}
+
+impl CapturedHotRoot {
+    /// Metadata-only proof that this root has no possible hot authority.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    fn chain_state<'a>(
+        mut entry: &'a VersionChainEntry,
+        reader: &mut EpochReader<'_>,
+    ) -> CapturedHotVersion<'a> {
+        loop {
+            let version = &entry.version;
+            if reader.is_visible(version.txn_id) {
+                return if version.deleted_at_txn_id != 0
+                    && reader.is_visible(version.deleted_at_txn_id)
+                {
+                    CapturedHotVersion::Deleted
+                } else {
+                    CapturedHotVersion::Value(version)
+                };
+            }
+            match entry.prev.as_deref() {
+                Some(previous) => entry = previous,
+                None => return CapturedHotVersion::NoVisibleVersion,
+            }
+        }
+    }
+
+    pub fn version_state(&self, row_id: i64, epoch: &ReadEpoch) -> CapturedHotVersion<'_> {
+        self.inner
+            .get(row_id)
+            .map_or(CapturedHotVersion::NoVisibleVersion, |entry| {
+                Self::chain_state(entry, &mut epoch.reader())
+            })
+    }
+
+    /// Return original metadata for an epoch-visible value, without copying
+    /// the transaction's own overlay. DML checks its latest own write first.
+    pub fn visible_version(&self, row_id: i64, epoch: &ReadEpoch) -> Option<&RowVersion> {
+        match self.version_state(row_id, epoch) {
+            CapturedHotVersion::Value(version) => Some(version),
+            CapturedHotVersion::Deleted | CapturedHotVersion::NoVisibleVersion => None,
+        }
+    }
+
+    pub fn for_each_visible_version_until(
+        &self,
+        epoch: &ReadEpoch,
+        mut visit: impl FnMut(i64, &RowVersion) -> bool,
+    ) -> bool {
+        let mut reader = epoch.reader();
+        for (&id, entry) in self.inner.iter() {
+            if let CapturedHotVersion::Value(version) = Self::chain_state(entry, &mut reader) {
+                if !visit(id, version) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
+/// Frozen latest writes of the reading transaction. Built before the capture
+/// fence and shared by lazy results, including after commit drains local writes.
+#[derive(Clone)]
+pub struct CapturedHotOverlay {
+    rows: Arc<Vec<(i64, RowVersion)>>,
+}
+
+/// Authority of the captured hot store for one row identity. An invisible hot
+/// version must not hide an older visible cold value.
+#[derive(Debug, PartialEq)]
+pub enum CapturedHotRow<'a> {
+    Value(&'a Row),
+    Deleted,
+    NoVisibleVersion,
+}
+
+/// A fixed statement's hot view. Clones share the epoch lease and payloads.
+/// Binding the epoch and copying the local overlay happen outside publication fences.
+#[derive(Clone)]
+pub struct CapturedHotView {
+    root: CapturedHotRoot,
+    epoch: ReadEpoch,
+    own: Option<CapturedHotOverlay>,
+}
+
+impl CapturedHotView {
+    /// Conservative O(1) check; invisible or deleted tree entries still count.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.root.is_empty() && self.own.as_ref().is_none_or(|own| own.rows.is_empty())
+    }
+
+    pub fn new(root: CapturedHotRoot, epoch: ReadEpoch, own: Option<CapturedHotOverlay>) -> Self {
+        Self { root, epoch, own }
+    }
+
+    #[inline]
+    pub fn same_epoch(&self, epoch: &ReadEpoch) -> bool {
+        self.epoch.same_epoch(epoch)
+    }
+
+    pub fn epoch(&self) -> &ReadEpoch {
+        &self.epoch
+    }
+
+    #[inline]
+    fn overlay_state(version: &RowVersion) -> CapturedHotRow<'_> {
+        if version.is_deleted() {
+            CapturedHotRow::Deleted
+        } else {
+            CapturedHotRow::Value(&version.data)
+        }
+    }
+
+    fn chain_state<'a>(
+        entry: &'a VersionChainEntry,
+        reader: &mut EpochReader<'_>,
+    ) -> CapturedHotRow<'a> {
+        match CapturedHotRoot::chain_state(entry, reader) {
+            CapturedHotVersion::Value(version) => CapturedHotRow::Value(&version.data),
+            CapturedHotVersion::Deleted => CapturedHotRow::Deleted,
+            CapturedHotVersion::NoVisibleVersion => CapturedHotRow::NoVisibleVersion,
+        }
+    }
+
+    fn row_state_with_reader(
+        &self,
+        row_id: i64,
+        reader: &mut EpochReader<'_>,
+    ) -> CapturedHotRow<'_> {
+        if let Some(own) = &self.own {
+            if let Ok(index) = own.rows.binary_search_by_key(&row_id, |(id, _)| *id) {
+                return Self::overlay_state(&own.rows[index].1);
+            }
+        }
+        self.root
+            .inner
+            .get(row_id)
+            .map_or(CapturedHotRow::NoVisibleVersion, |entry| {
+                Self::chain_state(entry, reader)
+            })
+    }
+
+    pub fn row_state(&self, row_id: i64) -> CapturedHotRow<'_> {
+        self.row_state_with_reader(row_id, &mut self.epoch.reader())
+    }
+
+    /// Conservative bounds over every retained head and own write, including
+    /// invisible versions and delete markers. Captured roots are immutable, so
+    /// probing their left edge and cached right edge cannot race publication.
+    fn authority_bounds(&self) -> Option<(i64, i64)> {
+        let mut bounds = self
+            .root
+            .inner
+            .iter()
+            .next()
+            .zip(self.root.inner.max_key())
+            .map(|((&first, _), last)| (first, last));
+        if !self.root.inner.is_empty() && bounds.is_none() {
+            return None;
+        }
+        if let Some(own) = &self.own {
+            if let Some((first, last)) = own.rows.first().zip(own.rows.last()) {
+                bounds = Some(bounds.map_or((first.0, last.0), |(min, max)| {
+                    (min.min(first.0), max.max(last.0))
+                }));
+            }
+        }
+        bounds
+    }
+
+    /// Mark hot authority for a bounded cold-row batch using one epoch cache.
+    /// Required words are overwritten, including unused tail bits; any extra
+    /// caller-owned words are untouched. No predicate is evaluated here.
+    pub fn mark_authoritative(&self, row_ids: &[i64], bits: &mut [u64]) {
+        let words = row_ids.len().div_ceil(64);
+        assert!(bits.len() >= words, "hot authority output is too short");
+        bits[..words].fill(0);
+        if self.is_empty() {
+            return;
+        }
+        let bounds = self.authority_bounds();
+        let mut reader = self.epoch.reader();
+        for (ordinal, &row_id) in row_ids.iter().enumerate() {
+            // Bounds reject misses independently of the input order.
+            if bounds.is_some_and(|(min, max)| row_id < min || row_id > max) {
+                continue;
+            }
+            if !matches!(
+                self.row_state_with_reader(row_id, &mut reader),
+                CapturedHotRow::NoVisibleVersion
+            ) {
+                bits[ordinal / 64] |= 1u64 << (ordinal % 64);
+            }
+        }
+    }
+
+    pub fn for_each_visible(&self, mut visit: impl FnMut(i64, &Row)) {
+        self.for_each_visible_until(|id, row| {
+            visit(id, row);
+            true
+        });
+    }
+
+    /// Visit visible rows in ascending identity order. Return false from the
+    /// callback to stop; the method returns true only if the range was exhausted.
+    pub fn for_each_visible_until(&self, visit: impl FnMut(i64, &Row) -> bool) -> bool {
+        self.for_each_visible_range_until(.., visit)
+    }
+
+    /// Allocation-free range traversal; the root and the sorted own overlay are
+    /// merged once, and one visibility cache serves the complete traversal.
+    pub fn for_each_visible_range_until<R>(
+        &self,
+        range: R,
+        mut visit: impl FnMut(i64, &Row) -> bool,
+    ) -> bool
+    where
+        R: std::ops::RangeBounds<i64>,
+    {
+        use std::ops::Bound;
+        let rows = self.own.as_ref().map_or(&[][..], |own| own.rows.as_slice());
+        let start = match range.start_bound() {
+            Bound::Included(id) => rows.partition_point(|(key, _)| key < id),
+            Bound::Excluded(id) => rows.partition_point(|(key, _)| key <= id),
+            Bound::Unbounded => 0,
+        };
+        let end = match range.end_bound() {
+            Bound::Included(id) => rows.partition_point(|(key, _)| key <= id),
+            Bound::Excluded(id) => rows.partition_point(|(key, _)| key < id),
+            Bound::Unbounded => rows.len(),
+        };
+        let mut own = rows[start.min(end)..end].iter().peekable();
+        let mut committed = self.root.inner.range(range).peekable();
+        let mut reader = self.epoch.reader();
+        loop {
+            let (id, state) = match (committed.peek().copied(), own.peek().copied()) {
+                (Some((id, _)), Some((own_id, version))) if own_id <= id => {
+                    if own_id == id {
+                        committed.next();
+                    }
+                    own.next();
+                    (*own_id, Self::overlay_state(version))
+                }
+                (Some((id, entry)), _) => {
+                    committed.next();
+                    (*id, Self::chain_state(entry, &mut reader))
+                }
+                (None, Some((id, version))) => {
+                    own.next();
+                    (*id, Self::overlay_state(version))
+                }
+                (None, None) => return true,
+            };
+            if let CapturedHotRow::Value(row) = state {
+                if !visit(id, row) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    /// Descending identity traversal with the same own-write authority and
+    /// fixed epoch as the forward visitor. Stops without collecting row IDs.
+    pub fn for_each_visible_range_rev_until<R>(
+        &self,
+        range: R,
+        mut visit: impl FnMut(i64, &Row) -> bool,
+    ) -> bool
+    where
+        R: std::ops::RangeBounds<i64>,
+    {
+        use std::ops::Bound;
+        let rows = self.own.as_ref().map_or(&[][..], |own| own.rows.as_slice());
+        let start = match range.start_bound() {
+            Bound::Included(id) => rows.partition_point(|(key, _)| key < id),
+            Bound::Excluded(id) => rows.partition_point(|(key, _)| key <= id),
+            Bound::Unbounded => 0,
+        };
+        let end = match range.end_bound() {
+            Bound::Included(id) => rows.partition_point(|(key, _)| key <= id),
+            Bound::Excluded(id) => rows.partition_point(|(key, _)| key < id),
+            Bound::Unbounded => rows.len(),
+        };
+        let mut own = rows[start.min(end)..end].iter().rev().peekable();
+        let mut committed = self.root.inner.range_rev(range).peekable();
+        let mut reader = self.epoch.reader();
+        loop {
+            let (id, state) = match (committed.peek().copied(), own.peek().copied()) {
+                (Some((id, _)), Some((own_id, version))) if own_id >= id => {
+                    if own_id == id {
+                        committed.next();
+                    }
+                    own.next();
+                    (*own_id, Self::overlay_state(version))
+                }
+                (Some((id, entry)), _) => {
+                    committed.next();
+                    (*id, Self::chain_state(entry, &mut reader))
+                }
+                (None, Some((id, version))) => {
+                    own.next();
+                    (*id, Self::overlay_state(version))
+                }
+                (None, None) => return true,
+            };
+            if let CapturedHotRow::Value(row) = state {
+                if !visit(id, row) {
+                    return false;
+                }
+            }
+        }
+    }
 }
 
 /// Count the depth of a version chain by traversing prev pointers.
@@ -400,10 +737,25 @@ enum AggregateAccumulator {
     Avg(i128, f64, usize),
 }
 
+/// Retention decision for a bounded newest-to-oldest history prefix.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HistoryRetention {
+    /// No transaction/read/build lease can need this old history.
+    Unprotected,
+    /// Retain this prefix through its first creator visible at the floor.
+    KeepThrough(usize),
+    /// The required baseline lies outside the supplied prefix (or is unknown).
+    Protected,
+}
+
 /// Visibility checker trait - will be implemented by TransactionRegistry
 ///
 /// This allows VersionStore to check visibility without circular dependencies
 pub trait VisibilityChecker: Send + Sync {
+    fn begin_logical_mutation(&self) -> Option<super::registry::LogicalMutationGuard> {
+        None
+    }
+
     /// Check if a version created by `version_txn_id` is visible to `viewing_txn_id`
     fn is_visible(&self, version_txn_id: i64, viewing_txn_id: i64) -> bool;
 
@@ -412,6 +764,41 @@ pub trait VisibilityChecker: Send + Sync {
 
     /// Get all active transaction IDs (for cleanup operations)
     fn get_active_transaction_ids(&self) -> Vec<i64>;
+
+    /// Capture a fresh committed view for catalog builds, independent of the
+    /// transaction that requested DDL. Test-only checkers may use the legacy
+    /// current-committed visibility fallback instead.
+    fn capture_current_read_epoch(&self) -> Option<ReadEpoch> {
+        None
+    }
+
+    /// Oldest registered read/build or transaction begin horizon. A lease can
+    /// outlive the transaction that created it.
+    fn oldest_retention_horizon(&self) -> Option<i64> {
+        None
+    }
+
+    /// Presence-only hot-path check; the registry overrides this without
+    /// computing the minimum across its registered readers.
+    fn has_retention_obligations(&self) -> bool {
+        self.oldest_retention_horizon().is_some()
+    }
+
+    fn cached_retention_horizon(&self) -> Option<i64> {
+        self.oldest_retention_horizon()
+    }
+
+    /// The registry overrides this to classify the complete bounded prefix
+    /// under one mutex, without scanning registrations or allocating.
+    fn history_retention(&self, creators: &[i64]) -> HistoryRetention {
+        match self.cached_retention_horizon() {
+            None => HistoryRetention::Unprotected,
+            Some(floor) => creators
+                .iter()
+                .position(|&id| self.is_committed_before(id, floor))
+                .map_or(HistoryRetention::Protected, HistoryRetention::KeepThrough),
+        }
+    }
 
     /// Check if a transaction was committed before a given commit sequence cutoff.
     ///
@@ -433,6 +820,30 @@ pub trait VisibilityChecker: Send + Sync {
     fn needs_snapshot_isolation(&self, _txn_id: i64) -> bool {
         false // Default: ReadCommitted (arena fast path is safe)
     }
+}
+
+/// Shared engine operation. A store keeps one engine-owned coordinator; table
+/// handles only borrow it. The engine context never owns the store map strongly.
+pub(crate) trait TruncateCoordinator: Send + Sync {
+    fn truncate(
+        &self,
+        store: &VersionStore,
+        txn_id: i64,
+        private_epoch: Option<(&ReadEpoch, usize)>,
+    ) -> crate::core::Result<i32>;
+}
+
+pub(crate) struct PreparedHotTruncate {
+    versions: crate::common::CowBTree<VersionChainEntry>,
+    indexes: FxHashMap<String, Arc<dyn Index>>,
+}
+
+/// All displaced ownership leaves the publication fence as one stack value.
+pub(crate) struct RetiredHotTruncate {
+    _versions: crate::common::CowBTree<VersionChainEntry>,
+    _indexes: FxHashMap<String, Arc<dyn Index>>,
+    _arena: crate::storage::mvcc::arena::RetiredArena,
+    _zone_maps: Option<Arc<crate::storage::mvcc::zonemap::TableZoneMap>>,
 }
 
 /// Opaque snapshot of the version store at extraction time.
@@ -601,6 +1012,26 @@ impl IndexUndo {
     }
 }
 
+/// Schema lock plus logical mutation lifetime. Field order releases the schema
+/// lock before making cache proofs eligible again; no registry mutex is held.
+pub struct SchemaMutationGuard<'a> {
+    schema: parking_lot::RwLockWriteGuard<'a, CompactArc<Schema>>,
+    _logical: Option<super::registry::LogicalMutationGuard>,
+}
+
+impl std::ops::Deref for SchemaMutationGuard<'_> {
+    type Target = CompactArc<Schema>;
+    fn deref(&self) -> &Self::Target {
+        &self.schema
+    }
+}
+
+impl std::ops::DerefMut for SchemaMutationGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.schema
+    }
+}
+
 /// VersionStore tracks the latest committed version of each row for a table
 ///
 /// Uses CowBTreeMap (RwLock<CowBTree>) for the version store because:
@@ -659,12 +1090,20 @@ pub struct VersionStore {
     publishing: AtomicUsize,
     publication_keys: Mutex<PublicationOwners>,
     index_catalog: Arc<AtomicUsize>,
+    truncate_coordinator: std::sync::OnceLock<Arc<dyn TruncateCoordinator>>,
     /// Publishes completed
     publish_epoch: AtomicU64,
     _object_charge: crate::common::memory::MemoryCharge,
 }
 
 impl VersionStore {
+    /// Retain the immutable hot root only; safe inside the capture fence.
+    pub fn capture_hot_root(&self) -> CapturedHotRoot {
+        CapturedHotRoot {
+            inner: self.versions.read().clone(),
+        }
+    }
+
     /// Creates a new version store
     pub fn new(table_name: impl Into<SmartString>, schema: Schema) -> Self {
         Self::with_capacity(table_name, schema, None, 0)
@@ -730,6 +1169,7 @@ impl VersionStore {
             publishing: AtomicUsize::new(0),
             publication_keys: Mutex::new(publication_keys),
             index_catalog: Arc::new(AtomicUsize::new(0)),
+            truncate_coordinator: std::sync::OnceLock::new(),
             publish_epoch: AtomicU64::new(0),
             _object_charge: crate::common::memory::MemoryCharge::conservative(
                 &memory,
@@ -746,7 +1186,8 @@ impl VersionStore {
     /// Sets the maximum version history limit per row
     ///
     /// This controls how many previous versions are kept for each row.
-    /// Lower values reduce memory usage but limit time-travel query range.
+    /// Lower values reduce idle history but cannot evict a version protected by
+    /// a registered transaction, read epoch, or build lease.
     /// - 0 = unlimited (not recommended for write-heavy workloads)
     /// - 1 = only keep immediate previous (minimal memory, limited AS OF range)
     /// - 10 = default, good balance for most workloads
@@ -804,10 +1245,28 @@ impl VersionStore {
         self.schema.read().clone()
     }
 
+    /// Destructive DDL pins schema metadata without waiting behind a public
+    /// mutation that may subsequently need the engine catalog lock.
+    pub(crate) fn try_schema_for_ddl(
+        &self,
+    ) -> Option<parking_lot::RwLockReadGuard<'_, CompactArc<Schema>>> {
+        self.schema.try_read()
+    }
+
     /// Returns a mutable reference to the schema (for modifications)
     /// Callers must use CompactArc::make_mut() to get &mut Schema
-    pub fn schema_mut(&self) -> parking_lot::RwLockWriteGuard<'_, CompactArc<Schema>> {
-        self.schema.write()
+    pub fn schema_mut(&self) -> SchemaMutationGuard<'_> {
+        let logical = self.begin_logical_mutation();
+        SchemaMutationGuard {
+            schema: self.schema.write(),
+            _logical: logical,
+        }
+    }
+
+    pub(crate) fn begin_logical_mutation(&self) -> Option<super::registry::LogicalMutationGuard> {
+        self.visibility_checker
+            .as_ref()
+            .and_then(|checker| VisibilityChecker::begin_logical_mutation(checker.as_ref()))
     }
 
     /// Returns the current auto-increment counter value
@@ -860,6 +1319,72 @@ impl VersionStore {
         self.auto_increment_counter.load(Ordering::Acquire)
     }
 
+    /// Clone one historical head while retaining its existing immutable tail.
+    fn retain_history(
+        &self,
+        existing: &VersionChainEntry,
+    ) -> Option<CompactArc<VersionChainEntry>> {
+        Some(CompactArc::new_in(
+            VersionChainEntry {
+                version: existing.version.clone(),
+                prev: existing.prev.clone(),
+                arena_idx: None,
+            },
+            &self.memory,
+        ))
+    }
+
+    /// Bound work by the configured cap, even when a long reader protects an
+    /// arbitrarily deep chain. Prune only below a baseline proven safe for the
+    /// oldest retained epoch; an unseen baseline keeps the shared tail intact.
+    fn history_for_next_version(
+        &self,
+        existing: &VersionChainEntry,
+    ) -> Option<CompactArc<VersionChainEntry>> {
+        let limit = self.max_version_history;
+        if limit == 0 || (limit > 1 && existing.prev.is_none()) {
+            return self.retain_history(existing);
+        }
+        let mut prefix: SmallVec<[&VersionChainEntry; 10]> = SmallVec::new();
+        let mut current = Some(existing);
+        while prefix.len() < limit {
+            let Some(entry) = current else {
+                return self.retain_history(existing);
+            };
+            prefix.push(entry);
+            current = entry.prev.as_deref();
+        }
+        let decision =
+            self.visibility_checker
+                .as_ref()
+                .map_or(HistoryRetention::Unprotected, |checker| {
+                    let creators: SmallVec<[i64; 10]> =
+                        prefix.iter().map(|entry| entry.version.txn_id).collect();
+                    checker.history_retention(&creators)
+                });
+        match decision {
+            HistoryRetention::Unprotected => None,
+            HistoryRetention::Protected => self.retain_history(existing),
+            HistoryRetention::KeepThrough(index) => {
+                if prefix[index].prev.is_none() {
+                    return self.retain_history(existing);
+                }
+                let mut prev = None;
+                for entry in prefix[..=index].iter().rev() {
+                    prev = Some(CompactArc::new_in(
+                        VersionChainEntry {
+                            version: entry.version.clone(),
+                            prev,
+                            arena_idx: None,
+                        },
+                        &self.memory,
+                    ));
+                }
+                prev
+            }
+        }
+    }
+
     /// Publish one version without a WAL source (in-memory or legacy recovery).
     pub fn add_version(&self, row_id: i64, version: RowVersion) -> Result<(), Error> {
         self.add_version_with_lsn(row_id, version, None)
@@ -867,6 +1392,17 @@ impl VersionStore {
 
     #[inline]
     pub fn add_version_with_lsn(
+        &self,
+        row_id: i64,
+        version: RowVersion,
+        source_lsn: Option<NonZeroU64>,
+    ) -> Result<(), Error> {
+        let _logical_change = self.begin_logical_mutation();
+        self.add_version_with_lsn_raw(row_id, version, source_lsn)
+    }
+
+    #[inline]
+    fn add_version_with_lsn_raw(
         &self,
         row_id: i64,
         version: RowVersion,
@@ -882,6 +1418,7 @@ impl VersionStore {
     /// that fails. Transaction publication retains the complete undo journal.
     #[inline]
     pub fn add_versions_batch(&self, batch: Vec<(i64, RowVersion)>) -> Result<(), Error> {
+        let _logical_change = self.begin_logical_mutation();
         self.add_versions_with_lsns(batch.into_iter().map(|(id, version)| (id, version, None)))
     }
 
@@ -954,20 +1491,7 @@ impl VersionStore {
                     }
                     existing.arena_idx
                 };
-                let prev = if self.max_version_history > 0
-                    && count_chain_depth(existing) + 1 > self.max_version_history
-                {
-                    None
-                } else {
-                    Some(CompactArc::new_in(
-                        VersionChainEntry {
-                            version: existing.version.clone(),
-                            prev: existing.prev.clone(),
-                            arena_idx: None,
-                        },
-                        &self.memory,
-                    ))
-                };
+                let prev = self.history_for_next_version(existing);
                 occupied.insert(VersionChainEntry {
                     version,
                     prev,
@@ -1861,6 +2385,141 @@ impl VersionStore {
             .is_some_and(|c| c.needs_snapshot_isolation(txn_id))
     }
 
+    pub(crate) fn set_truncate_coordinator(&self, coordinator: &Arc<dyn TruncateCoordinator>) {
+        if self.truncate_coordinator.get().is_none() {
+            let _ = self.truncate_coordinator.set(coordinator.clone());
+        }
+    }
+
+    pub(crate) fn coordinated_truncate(
+        &self,
+        txn_id: i64,
+        private_epoch: Option<(&ReadEpoch, usize)>,
+    ) -> crate::core::Result<i32> {
+        self.truncate_coordinator
+            .get()
+            .ok_or_else(|| Error::internal("physical TRUNCATE requires an engine coordinator"))?
+            .truncate(self, txn_id, private_epoch)
+    }
+
+    /// Call while registry DDL admission excludes writers, before WAL. Native
+    /// empty replacements remove fallible Index::clear calls from publication.
+    /// Unknown custom indexes fail here, while all prior state still exists.
+    pub(crate) fn prepare_hot_truncate(&self) -> crate::core::Result<PreparedHotTruncate> {
+        use crate::storage::index::{
+            BTreeIndex, BitmapIndex, HashIndex, HnswIndex, MultiColumnIndex, PkIndex,
+        };
+        if self.is_closed() {
+            return Err(Error::TableClosed);
+        }
+        if !self.uncommitted_writes.read().is_empty()
+            || self.publishing.load(Ordering::Acquire) != 0
+        {
+            return Err(Error::TableHasActiveTransactions);
+        }
+        let indexes = self.indexes.read();
+        let mut empty = FxHashMap::with_capacity_and_hasher(indexes.len(), Default::default());
+        for (key, index) in indexes.iter() {
+            let name = index.name().to_owned();
+            let table = index.table_name().to_owned();
+            let ids = index.column_ids();
+            let names = index.column_names();
+            let types = index.data_types();
+            let unique = index.is_unique();
+            let mut replacement: Arc<dyn Index> = if index.as_any().is::<PkIndex>() {
+                Arc::new(PkIndex::new(name, table, ids[0], names[0].clone()))
+            } else if index.as_any().is::<BTreeIndex>() {
+                Arc::new(BTreeIndex::new(
+                    name,
+                    table,
+                    ids[0],
+                    names[0].clone(),
+                    types[0],
+                    unique,
+                    0,
+                ))
+            } else if index.as_any().is::<HashIndex>() {
+                Arc::new(HashIndex::new(
+                    name,
+                    table,
+                    names.to_vec(),
+                    ids.to_vec(),
+                    types.to_vec(),
+                    unique,
+                    0,
+                ))
+            } else if index.as_any().is::<BitmapIndex>() {
+                Arc::new(BitmapIndex::new(
+                    name,
+                    table,
+                    names.to_vec(),
+                    ids.to_vec(),
+                    types.to_vec(),
+                    unique,
+                    0,
+                ))
+            } else if index.as_any().is::<MultiColumnIndex>() {
+                Arc::new(MultiColumnIndex::new(
+                    name,
+                    table,
+                    names.to_vec(),
+                    ids.to_vec(),
+                    types.to_vec(),
+                    unique,
+                    0,
+                ))
+            } else if let Some(hnsw) = index.as_any().downcast_ref::<HnswIndex>() {
+                let dims = hnsw.dimensions();
+                let (m, construction, search, metric) = hnsw.params();
+                let mut replacement = HnswIndex::new(
+                    name,
+                    table,
+                    names[0].clone(),
+                    ids[0],
+                    dims,
+                    m,
+                    construction,
+                    search,
+                    metric,
+                );
+                replacement.set_unique(unique);
+                Arc::new(replacement)
+            } else {
+                return Err(Error::internal(
+                    "physical TRUNCATE does not support this custom index",
+                ));
+            };
+            Arc::get_mut(&mut replacement)
+                .ok_or_else(|| Error::internal("truncate replacement index is shared"))?
+                .attach_memory_account(&self.memory)?;
+            empty.insert(key.clone(), replacement);
+        }
+        Ok(PreparedHotTruncate {
+            versions: crate::common::CowBTree::new_in(self.memory.clone()),
+            indexes: empty,
+        })
+    }
+
+    /// Infallible after preparation: only swaps/moves and atomics. All old
+    /// ownership is returned for destruction after the transfer fence unlocks.
+    pub(crate) fn apply_hot_truncate(&self, prepared: PreparedHotTruncate) -> RetiredHotTruncate {
+        let _claims = self.uncommitted_writes.write();
+        let mut versions = self.versions.write();
+        let old_versions = std::mem::replace(&mut *versions, prepared.versions);
+        let old_arena = self.arena.take_all_for_truncate();
+        let old_indexes = std::mem::replace(&mut *self.indexes.write(), prepared.indexes);
+        let old_zone_maps = self.zone_maps.write().take();
+        self.committed_row_count.store(0, Ordering::SeqCst);
+        self.auto_increment_counter.store(0, Ordering::Release);
+        self.publish_epoch.fetch_add(1, Ordering::Release);
+        RetiredHotTruncate {
+            _versions: old_versions,
+            _indexes: old_indexes,
+            _arena: old_arena,
+            _zone_maps: old_zone_maps,
+        }
+    }
+
     /// Clears all data in O(1) for TRUNCATE.
     /// Drops all versions, arena data, indexes, and resets row count.
     /// Returns the number of rows that were truncated.
@@ -1874,6 +2533,7 @@ impl VersionStore {
     /// Fails with `TableHasActiveTransactions` if another transaction holds
     /// uncommitted UPDATE/DELETE claims on this table.
     pub fn truncate_all(&self) -> crate::core::Result<i32> {
+        let _logical_change = self.begin_logical_mutation();
         // Hold uncommitted_writes(W) for the ENTIRE check-and-clear sequence
         // to prevent TOCTOU race: without this, a concurrent try_claim_row()
         // could add a claim between the check and the clear, and truncate would
@@ -1940,6 +2600,24 @@ impl VersionStore {
     pub fn extract_for_seal(&self, txn_id: i64) -> (RowVec, ExtractionSnapshot) {
         let snapshot = self.versions.read().clone();
         let rows = self.get_all_visible_rows_internal(txn_id);
+        (rows, ExtractionSnapshot { inner: snapshot })
+    }
+
+    /// Select only eligible heads from the exact root later used by removal.
+    /// An older version must never stand in for an ineligible head: removing
+    /// that head would destroy the newer value. Deletions stay hot for transfer.
+    pub(crate) fn extract_for_seal_in_build(
+        &self,
+        build: &super::registry::BuildLease,
+    ) -> (RowVec, ExtractionSnapshot) {
+        let snapshot = self.versions.read().clone();
+        let mut reader = build.reader();
+        let mut rows = RowVec::new();
+        for (&row_id, entry) in snapshot.iter() {
+            if entry.version.deleted_at_txn_id == 0 && reader.is_visible(entry.version.txn_id) {
+                rows.push((row_id, entry.version.data.clone()));
+            }
+        }
         (rows, ExtractionSnapshot { inner: snapshot })
     }
 
@@ -4341,6 +5019,83 @@ impl VersionStore {
         parking_lot::Mutex::lock_arc(&self.upsert_mutex)
     }
 
+    /// Visit current committed payloads under the caller's index-build lease.
+    /// Reject unresolved heads before installing the index.
+    fn for_each_current_index_row(
+        &self,
+        mut visit: impl FnMut(i64, &Row),
+    ) -> crate::core::Result<()> {
+        let epoch = self
+            .visibility_checker
+            .as_ref()
+            .and_then(|checker| checker.capture_current_read_epoch());
+        let root = self.capture_hot_root();
+        let mut reader = epoch.as_ref().map(ReadEpoch::reader);
+        let mut is_visible = |txn_id| {
+            if let Some(reader) = reader.as_mut() {
+                return reader.is_visible(txn_id);
+            }
+            // Standalone stores and lightweight test checkers have no epoch
+            // registry. Their unregistered viewer means current committed.
+            self.visibility_checker.as_ref().is_none_or(|checker| {
+                checker.is_visible(
+                    txn_id,
+                    crate::storage::mvcc::registry::INVALID_TRANSACTION_ID + 1,
+                )
+            })
+        };
+        for (&row_id, entry) in root.inner.iter() {
+            let version = &entry.version;
+            if !is_visible(version.txn_id)
+                || (version.deleted_at_txn_id != 0 && !is_visible(version.deleted_at_txn_id))
+            {
+                // Also conservatively reject a definitely aborted raw head;
+                // its owner's undo must complete before rebuilding the catalog.
+                return Err(Error::internal(
+                    "write conflict: index build encountered an unresolved row mutation",
+                ));
+            }
+            if version.deleted_at_txn_id == 0 {
+                visit(row_id, &version.data);
+            }
+        }
+        Ok(())
+    }
+
+    /// Project only indexed columns, applying the same schema defaults as row
+    /// readers. Older payloads can be shorter after ADD COLUMN.
+    fn current_index_values(row: &Row, schema: &Schema, columns: &[usize]) -> Vec<Value> {
+        columns
+            .iter()
+            .map(|&column| {
+                row.get(column).cloned().unwrap_or_else(|| {
+                    schema
+                        .columns
+                        .get(column)
+                        .map_or_else(Value::null_unknown, |col| {
+                            col.default_value
+                                .clone()
+                                .unwrap_or(Value::Null(col.data_type))
+                        })
+                })
+            })
+            .collect()
+    }
+
+    /// Collect a detached index's keys while its catalog build lease is held.
+    /// No full normalized row or transaction-local overlay is copied.
+    pub(crate) fn current_index_entries(
+        &self,
+        schema: &Schema,
+        columns: &[usize],
+    ) -> crate::core::Result<Vec<(i64, Vec<Value>)>> {
+        let mut entries = Vec::new();
+        self.for_each_current_index_row(|row_id, row| {
+            entries.push((row_id, Self::current_index_values(row, schema, columns)));
+        })?;
+        Ok(entries)
+    }
+
     /// Exclude publishers for the complete index build, before scanning rows.
     pub(crate) fn begin_index_build(&self) -> Result<IndexCatalogLease, Error> {
         IndexCatalogLease::try_acquire(&self.index_catalog, true).ok_or_else(|| {
@@ -4591,6 +5346,7 @@ impl VersionStore {
 
     /// Close the version store
     pub fn close(&self) {
+        let _logical_change = self.begin_logical_mutation();
         self.closed.store(true, Ordering::Release);
     }
 
@@ -4624,6 +5380,7 @@ impl VersionStore {
         version: RowVersion,
         source_lsn: Option<NonZeroU64>,
     ) -> Result<(), Error> {
+        let _logical_change = self.begin_logical_mutation();
         let is_deleted = version.is_deleted();
         let row_data = version.data.clone();
 
@@ -4648,7 +5405,7 @@ impl VersionStore {
         }
 
         // Add the version to the store
-        self.add_version_with_lsn(row_id, version, source_lsn)?;
+        self.add_version_with_lsn_raw(row_id, version, source_lsn)?;
 
         // Update auto_increment counter if this row_id is higher
         // This ensures the counter is restored to at least the max seen row_id
@@ -4700,6 +5457,7 @@ impl VersionStore {
         txn_id: i64,
         source_lsn: Option<NonZeroU64>,
     ) -> Result<(), Error> {
+        let _logical_change = self.begin_logical_mutation();
         // Get the old row data for index removal BEFORE creating the deleted version
         let old_row = self
             .get_visible_version(row_id, txn_id)
@@ -4715,7 +5473,7 @@ impl VersionStore {
                 .map(|d| d.as_nanos() as i64)
                 .unwrap_or(0),
         };
-        self.add_version_with_lsn(row_id, deleted_version, source_lsn)?;
+        self.add_version_with_lsn_raw(row_id, deleted_version, source_lsn)?;
 
         // Remove from indexes using old row data
         if let Some(old_data) = old_row {
@@ -4779,6 +5537,9 @@ impl VersionStore {
     ) -> crate::core::Result<()> {
         use crate::core::IndexType;
         use crate::storage::index::{BitmapIndex, HashIndex};
+
+        let catalog_build = self.begin_index_build()?;
+        let schema = self.schema();
 
         // Check if we have the required column information
         if meta.column_names.is_empty() {
@@ -4956,27 +5717,17 @@ impl VersionStore {
             // Populate the index with existing data unless deferred
             // Uses batch_slice for better performance
             if !skip_population {
-                let col_idx = column_id as usize;
-                let versions = self.versions.read().clone();
-                let mut entries: Vec<(i64, Vec<crate::core::Value>)> = Vec::new();
-                for (&row_id, version_chain) in versions.iter() {
-                    let version = &version_chain.version;
-                    if !version.is_deleted() {
-                        if let Some(value) = version.data.get(col_idx) {
-                            entries.push((row_id, vec![value.clone()]));
-                        }
-                    }
-                }
+                let entries = self.current_index_entries(&schema, &[column_id as usize])?;
                 if !entries.is_empty() {
                     let entry_refs: Vec<(i64, &[crate::core::Value])> = entries
                         .iter()
                         .map(|(row_id, values)| (*row_id, values.as_slice()))
                         .collect();
-                    let _ = index.add_batch_slice(&entry_refs);
+                    index.add_batch_slice(&entry_refs)?;
                 }
             }
 
-            self.add_index(meta.name.clone(), index)?;
+            self.add_index_under_build(meta.name.clone(), index, &catalog_build)?;
         } else {
             // Multi-column index: use MultiColumnIndex
             let mut index = crate::storage::index::MultiColumnIndex::new(
@@ -4997,33 +5748,17 @@ impl VersionStore {
             if !skip_population {
                 let col_indices: Vec<usize> =
                     meta.column_ids.iter().map(|&id| id as usize).collect();
-                let versions = self.versions.read().clone();
-                let mut entries: Vec<(i64, Vec<crate::core::Value>)> = Vec::new();
-                for (&row_id, version_chain) in versions.iter() {
-                    let version = &version_chain.version;
-                    if !version.is_deleted() {
-                        let values: Vec<crate::core::Value> =
-                            col_indices
-                                .iter()
-                                .map(|&idx| {
-                                    version.data.get(idx).cloned().unwrap_or(
-                                        crate::core::Value::Null(crate::core::DataType::Null),
-                                    )
-                                })
-                                .collect();
-                        entries.push((row_id, values));
-                    }
-                }
+                let entries = self.current_index_entries(&schema, &col_indices)?;
                 if !entries.is_empty() {
                     let entry_refs: Vec<(i64, &[crate::core::Value])> = entries
                         .iter()
                         .map(|(row_id, values)| (*row_id, values.as_slice()))
                         .collect();
-                    let _ = index.add_batch_slice(&entry_refs);
+                    index.add_batch_slice(&entry_refs)?;
                 }
             }
 
-            self.add_index(meta.name.clone(), index)?;
+            self.add_index_under_build(meta.name.clone(), index, &catalog_build)?;
         }
 
         Ok(())
@@ -5031,17 +5766,18 @@ impl VersionStore {
 
     /// Populate all indexes in a single pass over the version store
     ///
-    /// This is O(N + M) where N = number of rows and M = number of indexes,
-    /// compared to O(N * M) when populating each index separately.
+    /// Walks the tree once and projects each index from the same committed view.
     ///
     /// OPTIMIZATION: Uses batch_slice operations to reduce lock acquisitions
     /// from O(rows × indexes) to O(indexes).
     ///
     /// Call this after WAL replay completes with skip_population=true.
-    pub fn populate_all_indexes(&self) {
+    pub fn populate_all_indexes(&self) -> crate::core::Result<()> {
+        let _catalog_build = self.begin_index_build()?;
+        let schema = self.schema();
         let indexes = self.indexes.read();
         if indexes.is_empty() {
-            return;
+            return Ok(());
         }
 
         // Collect index info: (column_ids as Vec<usize>, index_arc)
@@ -5062,7 +5798,7 @@ impl VersionStore {
         drop(indexes); // Release lock before iteration
 
         if index_infos.is_empty() {
-            return;
+            return Ok(());
         }
 
         // Pre-allocate per-index batch vectors
@@ -5070,37 +5806,12 @@ impl VersionStore {
         let mut batches: Vec<Vec<(i64, Vec<crate::core::Value>)>> =
             (0..num_indexes).map(|_| Vec::new()).collect();
 
-        // First pass: Collect all entries per index
-        let versions = self.versions.read().clone();
-        for (&row_id, version_chain) in versions.iter() {
-            let version = &version_chain.version;
-
-            if version.is_deleted() {
-                continue;
+        // One canonical row walk; materialize only each index's columns.
+        self.for_each_current_index_row(|row_id, row| {
+            for (idx, (columns, _)) in index_infos.iter().enumerate() {
+                batches[idx].push((row_id, Self::current_index_values(row, &schema, columns)));
             }
-
-            // Collect entries for each index
-            for (idx, (col_indices, _)) in index_infos.iter().enumerate() {
-                if col_indices.len() == 1 {
-                    // Single-column index
-                    if let Some(value) = version.data.get(col_indices[0]) {
-                        batches[idx].push((row_id, vec![value.clone()]));
-                    }
-                } else {
-                    // Multi-column index
-                    let values: Vec<crate::core::Value> =
-                        col_indices
-                            .iter()
-                            .map(|&col_idx| {
-                                version.data.get(col_idx).cloned().unwrap_or(
-                                    crate::core::Value::Null(crate::core::DataType::Null),
-                                )
-                            })
-                            .collect();
-                    batches[idx].push((row_id, values));
-                }
-            }
-        }
+        })?;
 
         // Second pass: Apply batch operations per index
         // This reduces lock acquisitions from O(rows × indexes) to O(indexes)
@@ -5110,9 +5821,10 @@ impl VersionStore {
                     .iter()
                     .map(|(row_id, values)| (*row_id, values.as_slice()))
                     .collect();
-                let _ = index.add_batch_slice(&entry_refs);
+                index.add_batch_slice(&entry_refs)?;
             }
         }
+        Ok(())
     }
 
     /// Populate HNSW indexes from external rows (e.g., cold segment data).
@@ -5124,10 +5836,15 @@ impl VersionStore {
     ///
     /// HnswInner::insert skips duplicate row_ids, so calling this after
     /// populate_all_indexes() is safe (hot rows already in the index).
-    pub fn populate_hnsw_from_rows(&self, rows: &[(i64, crate::core::Row)]) {
+    pub fn populate_hnsw_from_rows(
+        &self,
+        rows: &[(i64, crate::core::Row)],
+    ) -> crate::core::Result<()> {
+        let _catalog_build = self.begin_index_build()?;
+        let schema = self.schema();
         let indexes = self.indexes.read();
         if indexes.is_empty() || rows.is_empty() {
-            return;
+            return Ok(());
         }
 
         // Collect only HNSW indexes with their column indices
@@ -5147,7 +5864,7 @@ impl VersionStore {
         drop(indexes);
 
         if hnsw_infos.is_empty() {
-            return;
+            return Ok(());
         }
 
         // Pre-allocate per-index batch vectors
@@ -5156,22 +5873,8 @@ impl VersionStore {
             .collect();
 
         for &(row_id, ref row) in rows {
-            for (idx, (col_indices, _)) in hnsw_infos.iter().enumerate() {
-                if col_indices.len() == 1 {
-                    if let Some(value) = row.get(col_indices[0]) {
-                        batches[idx].push((row_id, vec![value.clone()]));
-                    }
-                } else {
-                    let values: Vec<crate::core::Value> = col_indices
-                        .iter()
-                        .map(|&col_idx| {
-                            row.get(col_idx)
-                                .cloned()
-                                .unwrap_or(crate::core::Value::Null(crate::core::DataType::Null))
-                        })
-                        .collect();
-                    batches[idx].push((row_id, values));
-                }
+            for (idx, (columns, _)) in hnsw_infos.iter().enumerate() {
+                batches[idx].push((row_id, Self::current_index_values(row, &schema, columns)));
             }
         }
 
@@ -5181,9 +5884,10 @@ impl VersionStore {
                     .iter()
                     .map(|(row_id, values)| (*row_id, values.as_slice()))
                     .collect();
-                let _ = index.add_batch_slice(&entry_refs);
+                index.add_batch_slice(&entry_refs)?;
             }
         }
+        Ok(())
     }
 
     // =========================================================================
@@ -5215,6 +5919,18 @@ impl VersionStore {
         row_ids: &[i64],
         extraction_snapshot: &ExtractionSnapshot,
     ) -> (usize, SealedIndexCleanup, Vec<i64>) {
+        let _logical_change = self.begin_logical_mutation();
+        self.remove_sealed_rows_after_cold_publication(row_ids, extraction_snapshot)
+    }
+
+    /// Engine-only physical relocation after equivalent cold data was published
+    /// under the common seal fence. Public removal lacks that proof and must
+    /// invalidate reusable logical read provenance.
+    pub(crate) fn remove_sealed_rows_after_cold_publication(
+        &self,
+        row_ids: &[i64],
+        extraction_snapshot: &ExtractionSnapshot,
+    ) -> (usize, SealedIndexCleanup, Vec<i64>) {
         if row_ids.is_empty() {
             return (0, SealedIndexCleanup::default(), Vec::new());
         }
@@ -5242,12 +5958,13 @@ impl VersionStore {
                     // If they differ, a concurrent commit changed this row
                     // after we extracted it — the sealed volume has stale data
                     // for this row. Keep the newer version in hot.
-                    let extracted_txn_id = extraction_snapshot
+                    let extracted_identity = extraction_snapshot
                         .inner
                         .get(row_id)
-                        .map(|e| e.version.txn_id)
-                        .unwrap_or(0);
-                    if entry.version.txn_id != extracted_txn_id {
+                        .map(|e| (e.version.txn_id, e.version.deleted_at_txn_id));
+                    if Some((entry.version.txn_id, entry.version.deleted_at_txn_id))
+                        != extracted_identity
+                    {
                         skipped_ids.push(row_id);
                         continue;
                     }
@@ -5474,6 +6191,17 @@ impl VersionStore {
             None => return true, // No checker, assume safe
         };
 
+        // A captured result may outlive every active transaction. Remove a
+        // deletion only when both identities are committed at/before the oldest
+        // retained horizon; newer/excluded deletions may still expose payloads.
+        if let Some(horizon) = checker.oldest_retention_horizon() {
+            return checker.is_committed_before(version.txn_id, horizon)
+                && checker.is_committed_before(version.deleted_at_txn_id, horizon);
+        }
+        if !checker.is_committed_before(version.deleted_at_txn_id, checker.get_current_sequence()) {
+            return false;
+        }
+
         // Get all active transaction IDs
         let active_txns = checker.get_active_transaction_ids();
 
@@ -5547,6 +6275,9 @@ impl VersionStore {
         for chunk in candidate_row_ids.chunks(2_000) {
             let uncommitted = self.uncommitted_writes.read();
             let mut versions = self.versions.write();
+            // Sample after taking the live tree lock. A new publisher cannot
+            // replace HEAD between this horizon decision and the pruning below.
+            let horizon = checker.oldest_retention_horizon();
 
             for &row_id in chunk {
                 if uncommitted.contains_key(row_id) {
@@ -5568,19 +6299,29 @@ impl VersionStore {
                     continue;
                 }
 
-                // Check each previous version independently — do NOT assume monotonic
-                // visibility. With rapid updates, a newer prev version may be invisible
-                // to an active txn while an older one IS visible (e.g., HEAD seq=120,
-                // prev_0 seq=110, prev_1 seq=80, active txn snapshot at seq=100 needs prev_1).
+                // Retain through the first committed creator at the oldest protected horizon.
+                let mut needs_baseline = horizon.is_some_and(|floor| {
+                    !checker.is_committed_before(chain_entry.version.txn_id, floor)
+                });
                 let mut keep_count = 0;
                 for (i, prev_entry) in prev_versions.iter().enumerate() {
-                    let mut keep = false;
+                    let mut keep = needs_baseline;
+                    if needs_baseline
+                        && horizon.is_some_and(|floor| {
+                            checker.is_committed_before(prev_entry.version.txn_id, floor)
+                        })
+                    {
+                        needs_baseline = false;
+                    }
 
-                    // Rule 1: Keep if needed by any active transaction
-                    for &txn_id in &active_txns {
-                        if checker.is_visible(prev_entry.version.txn_id, txn_id) {
-                            keep = true;
-                            break;
+                    // Compatibility for custom visibility checkers that do not
+                    // expose epochs. The registry uses the bounded floor above.
+                    if horizon.is_none() {
+                        for &txn_id in &active_txns {
+                            if checker.is_visible(prev_entry.version.txn_id, txn_id) {
+                                keep = true;
+                                break;
+                            }
                         }
                     }
 
@@ -5757,7 +6498,8 @@ impl VersionStore {
     /// detection (First-Committer-Wins).
     ///
     /// Returns:
-    /// - Some(txn_id) if the row exists
+    /// - Some(mutation_txn_id) if the row exists (deleter for a deletion,
+    ///   otherwise creator)
     /// - None if the row does not exist
     pub fn get_latest_version_id(&self, row_id: i64) -> Option<i64> {
         if self.closed.load(Ordering::Acquire) {
@@ -5765,7 +6507,36 @@ impl VersionStore {
         }
 
         let versions = self.versions.read();
-        versions.get(row_id).map(|entry| entry.version.txn_id)
+        versions.get(row_id).map(|entry| {
+            // A version can retain its creator while a different transaction
+            // publishes its deletion. Both are writes for conflict detection.
+            if entry.version.deleted_at_txn_id != 0 {
+                entry.version.deleted_at_txn_id
+            } else {
+                entry.version.txn_id
+            }
+        })
+    }
+
+    /// The caller holds this row's write claim. Inspect the current head, not
+    /// an older visible chain entry, when validating a captured cold baseline.
+    pub(crate) fn validate_mutation_epoch(
+        &self,
+        row_id: i64,
+        epoch: &super::registry::ReadEpoch,
+    ) -> Result<(), Error> {
+        let versions = self.versions.read();
+        if let Some(entry) = versions.get(row_id) {
+            if !epoch.is_visible(entry.version.txn_id)
+                || (entry.version.deleted_at_txn_id != 0
+                    && !epoch.is_visible(entry.version.deleted_at_txn_id))
+            {
+                return Err(Error::internal(format!(
+                    "write conflict: row {row_id} changed after the captured read epoch"
+                )));
+            }
+        }
+        Ok(())
     }
 
     /// Compute grouped aggregates directly from arena storage.
@@ -6894,6 +7665,27 @@ impl TransactionVersionStore {
             .and_then(|versions| versions.last())
     }
 
+    /// Freeze the transaction's latest writes before binding a read epoch. The
+    /// empty/read-only path allocates nothing. All payloads become shared here,
+    /// so subsequent lazy reads and owning row results do not clone value arrays.
+    pub fn capture_hot_overlay(&self) -> Option<CapturedHotOverlay> {
+        if !self.has_local_changes() {
+            return None;
+        }
+        let mut rows: Vec<_> = self
+            .iter_local()
+            .map(|(id, version)| {
+                let mut version = version.clone();
+                version.data = version.data.into_shared();
+                (id, version)
+            })
+            .collect();
+        rows.sort_unstable_by_key(|(id, _)| *id);
+        Some(CapturedHotOverlay {
+            rows: Arc::new(rows),
+        })
+    }
+
     /// Iterate over local versions (returns most recent version per row)
     pub fn iter_local(&self) -> impl Iterator<Item = (i64, &RowVersion)> {
         self.local_versions
@@ -7234,6 +8026,15 @@ impl TransactionVersionStore {
     }
 
     pub fn apply_prepared_publication(&mut self) -> Result<(), Error> {
+        let _logical_change = self.parent_store.begin_logical_mutation();
+        self.apply_prepared_publication_in_transaction()
+    }
+
+    /// Engine-only path: the owning MvccTransaction started registry commit and
+    /// will either publish its outcome or guard the complete abort/undo interval.
+    /// Direct callers may supply an already-visible creator and use the guarded
+    /// public entry point instead. This keeps normal DML free of per-row hooks.
+    pub(crate) fn apply_prepared_publication_in_transaction(&mut self) -> Result<(), Error> {
         let indexes = self
             .mutation
             .as_ref()
@@ -7257,7 +8058,7 @@ impl TransactionVersionStore {
         if local.len() == 1 {
             if let Some((row_id, versions)) = local.iter().next() {
                 if let Some(version) = versions.last() {
-                    self.parent_store.add_version_with_lsn(
+                    self.parent_store.add_version_with_lsn_raw(
                         row_id,
                         version.clone(),
                         source_lsn(row_id),
@@ -7280,6 +8081,7 @@ impl TransactionVersionStore {
     }
 
     pub fn finish_publication(&mut self, committed: bool) -> Result<(), Error> {
+        let _logical_undo = (!committed).then(|| self.parent_store.begin_logical_mutation());
         if !committed {
             self.undo_index_updates()?;
         }
@@ -7882,6 +8684,529 @@ mod tests {
     use crate::core::Value;
     use crate::storage::mvcc::arena::{ChunkId, ARENA_CHUNK_MASK, ARENA_CHUNK_SHIFT};
     use std::sync::atomic::AtomicI64;
+
+    fn epoch_test_store() -> (
+        Arc<crate::storage::mvcc::registry::TransactionRegistry>,
+        Arc<VersionStore>,
+    ) {
+        let registry = Arc::new(crate::storage::mvcc::registry::TransactionRegistry::new());
+        let store = Arc::new(VersionStore::with_visibility_checker(
+            "epoch_test",
+            test_schema(),
+            registry.clone(),
+        ));
+        (registry, store)
+    }
+
+    fn commit_epoch_row(
+        registry: &crate::storage::mvcc::registry::TransactionRegistry,
+        store: &VersionStore,
+        id: i64,
+        value: i64,
+    ) -> i64 {
+        let (txn, _) = registry.begin_transaction();
+        registry.start_commit(txn);
+        store
+            .add_version(
+                id,
+                RowVersion::new_with_timestamp(txn, Row::from(vec![Value::Integer(value)]), 0),
+            )
+            .unwrap();
+        registry.complete_commit(txn);
+        txn
+    }
+
+    #[test]
+    fn seal_build_removal_preserves_a_distinct_deleter_after_extraction() {
+        let (registry, store) = epoch_test_store();
+        let creator = commit_epoch_row(&registry, &store, 1, 10);
+        let build = registry.register_build_lease();
+        let (rows, snapshot) = store.extract_for_seal_in_build(&build);
+        assert_eq!(rows.len(), 1);
+        let (deleter, _) = registry.begin_transaction();
+        registry.start_commit(deleter);
+        let mut deleted = snapshot.inner.get(1).unwrap().version.clone();
+        assert_eq!(deleted.txn_id, creator);
+        deleted.deleted_at_txn_id = deleter;
+        store.add_version(1, deleted).unwrap();
+        registry.complete_commit(deleter);
+        let (removed, _, skipped) = store.remove_sealed_rows(&[1], &snapshot);
+        assert_eq!(
+            removed, 0,
+            "a changed deleter is a changed extraction identity"
+        );
+        assert_eq!(skipped, vec![1]);
+        assert_eq!(
+            store
+                .versions
+                .read()
+                .get(1)
+                .unwrap()
+                .version
+                .deleted_at_txn_id,
+            deleter
+        );
+    }
+
+    #[test]
+    fn seal_build_zero_cutoff_and_late_heads_never_mean_unfiltered() {
+        let (registry, store) = epoch_test_store();
+        let earliest = registry.capture_read_epoch();
+        assert_eq!(earliest.cutoff(), 0);
+        let (inflight, _) = registry.begin_transaction();
+        let committed_sequence = registry.start_commit(inflight);
+        store
+            .add_version(
+                1,
+                RowVersion::new(inflight, Row::from(vec![Value::Integer(10)])),
+            )
+            .unwrap();
+        let zero = registry.register_build_lease();
+        assert_eq!(zero.cutoff(), 0);
+        assert!(store.extract_for_seal_in_build(&zero).0.is_empty());
+        registry.complete_commit(inflight);
+        assert!(
+            store.extract_for_seal_in_build(&zero).0.is_empty(),
+            "a publisher completing cannot broaden the fixed build eligibility"
+        );
+        drop(zero);
+        drop(earliest);
+
+        let build = registry.register_build_lease();
+        assert_eq!(build.cutoff(), committed_sequence);
+        let (rows, _) = store.extract_for_seal_in_build(&build);
+        assert_eq!(rows[0], (1, Row::from(vec![Value::Integer(10)])));
+        let (later, _) = registry.begin_transaction();
+        registry.start_commit(later);
+        store
+            .add_version(
+                1,
+                RowVersion::new(later, Row::from(vec![Value::Integer(20)])),
+            )
+            .unwrap();
+        store
+            .add_version(
+                2,
+                RowVersion::new(later, Row::from(vec![Value::Integer(30)])),
+            )
+            .unwrap();
+        registry.complete_commit(later);
+        assert!(
+            store.extract_for_seal_in_build(&build).0.is_empty(),
+            "an older eligible historical version must never stand in for an ineligible head"
+        );
+        drop(build);
+        let newer = registry.register_build_lease();
+        assert_eq!(store.extract_for_seal_in_build(&newer).0.len(), 2);
+    }
+
+    #[test]
+    fn captured_authority_bounds_preserve_unsorted_extremes_own_writes_and_replaced_roots() {
+        use crate::storage::mvcc::registry::{TransactionRegistry, RECOVERY_TRANSACTION_ID};
+        let registry = TransactionRegistry::new();
+        let root_for = |ids: &[i64]| {
+            let mut inner = crate::common::CowBTree::new();
+            for &id in ids {
+                inner.insert(
+                    id,
+                    VersionChainEntry {
+                        version: RowVersion::new(
+                            RECOVERY_TRANSACTION_ID,
+                            Row::from(vec![Value::Integer(id)]),
+                        ),
+                        prev: None,
+                        arena_idx: None,
+                    },
+                );
+            }
+            CapturedHotRoot { inner }
+        };
+        let own = CapturedHotOverlay {
+            rows: Arc::new(vec![
+                (
+                    i64::MIN,
+                    RowVersion::new(17, Row::from(vec![Value::Integer(1)])),
+                ),
+                (i64::MAX, RowVersion::new_deleted(17, Row::new())),
+            ]),
+        };
+        let mut view = CapturedHotView::new(
+            root_for(&[10, 20]),
+            registry.capture_read_epoch(),
+            Some(own),
+        );
+        let ids = [i64::MAX, 21, 10, i64::MIN, 9, 20, -1];
+        let mut bits = [u64::MAX; 2];
+        view.mark_authoritative(&ids, &mut bits);
+        assert_eq!(bits, [0b10_1101, u64::MAX]);
+        assert_eq!(view.authority_bounds(), Some((i64::MIN, i64::MAX)));
+        view.own = None;
+        assert_eq!(view.authority_bounds(), Some((10, 20)));
+        view.mark_authoritative(&ids, &mut bits);
+        assert_eq!(bits, [0b10_0100, u64::MAX]);
+        view = CapturedHotView::new(root_for(&[-3, -1]), view.epoch().clone(), None);
+        view.mark_authoritative(&ids, &mut bits);
+        assert_eq!(bits, [1 << 6, u64::MAX]);
+        view = CapturedHotView::new(root_for(&[i64::MIN, i64::MAX]), view.epoch().clone(), None);
+        view.mark_authoritative(&ids, &mut bits);
+        assert_eq!(bits, [0b1001, u64::MAX]);
+        view = CapturedHotView::new(root_for(&[]), view.epoch().clone(), None);
+        view.mark_authoritative(&ids, &mut bits);
+        assert_eq!(bits, [0, u64::MAX]);
+    }
+
+    #[test]
+    fn captured_hot_epoch_excludes_late_commit_and_owns_payload_after_arena_changes() {
+        let (registry, store) = epoch_test_store();
+        let creator = commit_epoch_row(&registry, &store, 0, 10);
+        commit_epoch_row(&registry, &store, -9, 9);
+        let (pending, _) = registry.begin_transaction();
+        registry.start_commit(pending);
+        store
+            .add_versions_batch(vec![
+                (
+                    0,
+                    RowVersion::new(pending, Row::from(vec![Value::Integer(20)])),
+                ),
+                (
+                    100,
+                    RowVersion::new(pending, Row::from(vec![Value::Integer(100)])),
+                ),
+            ])
+            .unwrap();
+        let epoch = registry.capture_read_epoch();
+        let view = CapturedHotView::new(store.capture_hot_root(), epoch.clone(), None);
+        assert!(view.same_epoch(&epoch));
+        registry.complete_commit(pending);
+        commit_epoch_row(&registry, &store, 0, 30);
+        registry.run_gc();
+        // The frozen root contains the pending head, but the excluded publisher
+        // remains invisible even after completion. Mutable arena now holds 30.
+        assert_eq!(
+            view.row_state(0),
+            CapturedHotRow::Value(&Row::from(vec![Value::Integer(10)]))
+        );
+        assert_eq!(view.row_state(100), CapturedHotRow::NoVisibleVersion);
+        assert_eq!(view.row_state(999), CapturedHotRow::NoVisibleVersion);
+        assert_eq!(
+            view.root.visible_version(0, &epoch).unwrap().txn_id,
+            creator
+        );
+        assert!(view.root.visible_version(100, &epoch).is_none());
+        let mut original_ids = Vec::new();
+        view.root.for_each_visible_version_until(&epoch, |id, _| {
+            original_ids.push(id);
+            true
+        });
+        assert_eq!(original_ids, vec![-9, 0]);
+        let mut cold_ids = [999; 66];
+        cold_ids[0] = 0;
+        cold_ids[1] = 100;
+        cold_ids[2] = -9;
+        cold_ids[63] = -9;
+        cold_ids[64] = 0;
+        cold_ids[65] = 100;
+        let mut authority = [u64::MAX; 3];
+        view.mark_authoritative(&cold_ids, &mut authority);
+        assert_eq!(authority, [1 | 4 | (1u64 << 63), 1, u64::MAX]);
+
+        let mut ids = Vec::new();
+        view.for_each_visible(|id, _| ids.push(id));
+        assert_eq!(ids, vec![-9, 0]);
+        drop(store);
+        assert_eq!(
+            view.row_state(0),
+            CapturedHotRow::Value(&Row::from(vec![Value::Integer(10)]))
+        );
+    }
+
+    #[test]
+    fn captured_hot_own_overlay_is_sorted_frozen_and_survives_commit() {
+        let (registry, store) = epoch_test_store();
+        for id in [-3, 0, 5] {
+            commit_epoch_row(&registry, &store, id, id);
+        }
+        let (txn, _) = registry.begin_transaction();
+        let mut local = TransactionVersionStore::new(store.clone(), txn);
+        assert!(local.capture_hot_overlay().is_none());
+        assert!(local.local_versions.is_none());
+        local
+            .put(10, Row::from(vec![Value::Integer(10)]), false)
+            .unwrap();
+        local
+            .put(-3, Row::from(vec![Value::Integer(30)]), false)
+            .unwrap();
+        local.put(0, Row::new(), true).unwrap();
+        local
+            .put(10, Row::from(vec![Value::Integer(11)]), false)
+            .unwrap();
+        let epoch = registry.read_epoch_for_transaction(txn).unwrap();
+        let view =
+            CapturedHotView::new(store.capture_hot_root(), epoch, local.capture_hot_overlay());
+        assert_eq!(view.row_state(0), CapturedHotRow::Deleted);
+        let mut authority = [u64::MAX];
+        view.mark_authoritative(&[-3, 0, 10, 999], &mut authority);
+        assert_eq!(authority, [0b111]);
+
+        local
+            .put(10, Row::from(vec![Value::Integer(99)]), false)
+            .unwrap();
+        registry.start_commit(txn);
+        local.commit().unwrap();
+        registry.complete_commit(txn);
+        assert!(!local.has_local_changes());
+        drop(local);
+        drop(store);
+        assert_eq!(
+            view.row_state(10),
+            CapturedHotRow::Value(&Row::from(vec![Value::Integer(11)]))
+        );
+        let mut rows = Vec::new();
+        view.for_each_visible(|id, row| rows.push((id, row.get(0).unwrap().clone())));
+        assert_eq!(
+            rows,
+            vec![
+                (-3, Value::Integer(30)),
+                (5, Value::Integer(5)),
+                (10, Value::Integer(11))
+            ]
+        );
+        let mut range = Vec::new();
+        view.for_each_visible_range_until(-3..10, |id, _| {
+            range.push(id);
+            true
+        });
+        assert_eq!(range, vec![-3, 5]);
+        range.clear();
+        assert!(view.for_each_visible_range_until(
+            (std::ops::Bound::Excluded(-3), std::ops::Bound::Included(10)),
+            |id, _| {
+                range.push(id);
+                true
+            }
+        ));
+        assert_eq!(range, vec![5, 10]);
+        let mut visited = 0;
+        assert!(!view.for_each_visible_until(|_, _| {
+            visited += 1;
+            false
+        }));
+        assert_eq!(visited, 1);
+    }
+
+    #[test]
+    fn captured_hot_lease_overrides_history_limit_until_delayed_root_capture() {
+        let registry = Arc::new(crate::storage::mvcc::registry::TransactionRegistry::new());
+        let mut store =
+            VersionStore::with_visibility_checker("epoch_test", test_schema(), registry.clone());
+        store.set_max_version_history(0);
+        for value in 1..=3 {
+            commit_epoch_row(&registry, &store, 7, value);
+        }
+        store.set_max_version_history(1);
+        let epoch = registry.capture_read_epoch();
+        // A statement registered its horizon but has not captured this table.
+        // Exercise all publication entry points beyond the former hard cap.
+        for value in 4..=33 {
+            let (txn, _) = registry.begin_transaction();
+            registry.start_commit(txn);
+            let row =
+                RowVersion::new_with_timestamp(txn, Row::from(vec![Value::Integer(value)]), 0);
+            match value % 3 {
+                0 => store.add_version(7, row),
+                1 => store.add_version_single(7, row),
+                _ => store.add_versions_batch(vec![(7, row)]),
+            }
+            .unwrap();
+            registry.complete_commit(txn);
+            registry.run_gc();
+        }
+        assert_eq!(
+            store.cleanup_old_previous_versions_with_retention(std::time::Duration::ZERO),
+            0
+        );
+        let view = CapturedHotView::new(store.capture_hot_root(), epoch, None);
+        assert_eq!(
+            view.row_state(7),
+            CapturedHotRow::Value(&Row::from(vec![Value::Integer(3)]))
+        );
+        assert_eq!(count_chain_depth(store.versions.read().get(7).unwrap()), 31);
+        {
+            let versions = store.versions.read();
+            let mut previous = versions.get(7).unwrap().prev.as_ref();
+            while let Some(entry) = previous {
+                assert!(entry.belongs_to(&store.memory));
+                previous = entry.prev.as_ref();
+            }
+        }
+        drop(view);
+        assert_eq!(
+            store.cleanup_old_previous_versions_with_retention(std::time::Duration::ZERO),
+            30
+        );
+        assert_eq!(count_chain_depth(store.versions.read().get(7).unwrap()), 1);
+    }
+
+    #[test]
+    fn transactional_history_cap_keeps_only_required_self_begin_baseline() {
+        for limit in [1, 4, 10] {
+            let registry = Arc::new(crate::storage::mvcc::registry::TransactionRegistry::new());
+            let mut store =
+                VersionStore::with_visibility_checker("bounded", test_schema(), registry.clone());
+            store.set_max_version_history(limit);
+            for value in 1..=200 {
+                let (txn, _) = registry.begin_transaction();
+                registry.start_commit(txn);
+                let row = RowVersion::new(txn, Row::from(vec![Value::Integer(value)]));
+                match value % 3 {
+                    0 => store.add_version(1, row),
+                    1 => store.add_version_single(1, row),
+                    _ => store.add_versions_batch(vec![(1, row)]),
+                }
+                .unwrap();
+                registry.complete_commit(txn);
+                assert!(count_chain_depth(store.versions.read().get(1).unwrap()) <= limit.max(2));
+                assert_eq!(registry.cached_retention_horizon(), None);
+            }
+        }
+    }
+
+    #[test]
+    fn overlapping_result_floor_refresh_allows_bounded_prefix_pruning() {
+        let registry = Arc::new(crate::storage::mvcc::registry::TransactionRegistry::new());
+        let mut store =
+            VersionStore::with_visibility_checker("overlap", test_schema(), registry.clone());
+        store.set_max_version_history(3);
+        commit_epoch_row(&registry, &store, 1, 1);
+        let older = registry.capture_read_epoch();
+        for value in 2..=12 {
+            commit_epoch_row(&registry, &store, 1, value);
+        }
+        let newer = registry.capture_read_epoch();
+        let old_floor = registry.cached_retention_horizon();
+        drop(older);
+        for value in 13..=14 {
+            commit_epoch_row(&registry, &store, 1, value);
+        }
+        // Continuous overlap conservatively inherits a stale low cache. It
+        // cannot silently advance while any registration may need that floor.
+        assert_eq!(registry.cached_retention_horizon(), old_floor);
+        assert_eq!(count_chain_depth(store.versions.read().get(1).unwrap()), 14);
+        assert_eq!(
+            registry.refresh_retention_horizon(),
+            Some(newer.retention_horizon())
+        );
+        commit_epoch_row(&registry, &store, 1, 15);
+        assert_eq!(count_chain_depth(store.versions.read().get(1).unwrap()), 4);
+        let view = CapturedHotView::new(store.capture_hot_root(), newer, None);
+        assert_eq!(
+            view.row_state(1),
+            CapturedHotRow::Value(&Row::from(vec![Value::Integer(12)]))
+        );
+    }
+
+    #[test]
+    fn captured_hot_empty_metadata_never_discards_possible_authority() {
+        let (registry, store) = epoch_test_store();
+        let epoch = registry.capture_read_epoch();
+        assert!(store.capture_hot_root().is_empty());
+        assert!(CapturedHotView::new(store.capture_hot_root(), epoch.clone(), None).is_empty());
+        let (txn, _) = registry.begin_transaction();
+        let mut local = TransactionVersionStore::new(store.clone(), txn);
+        local.put(1, Row::new(), true).unwrap();
+        assert!(!CapturedHotView::new(
+            store.capture_hot_root(),
+            epoch.clone(),
+            local.capture_hot_overlay()
+        )
+        .is_empty());
+        commit_epoch_row(&registry, &store, 2, 2);
+        let view = CapturedHotView::new(store.capture_hot_root(), epoch, None);
+        assert_eq!(view.row_state(2), CapturedHotRow::NoVisibleVersion);
+        assert!(!view.is_empty());
+    }
+
+    #[test]
+    fn captured_hot_distinct_deleter_and_result_lease_protect_deleted_row() {
+        let (registry, store) = epoch_test_store();
+        let creator = commit_epoch_row(&registry, &store, 7, 70);
+        let epoch = registry.capture_read_epoch();
+        let (deleter, _) = registry.begin_transaction();
+        registry.start_commit(deleter);
+        let mut deleted =
+            RowVersion::new_with_timestamp(creator, Row::from(vec![Value::Integer(70)]), 0);
+        deleted.deleted_at_txn_id = deleter;
+        store.add_version(7, deleted).unwrap();
+        registry.complete_commit(deleter);
+        assert!(registry.get_active_transaction_ids().is_empty());
+        assert_eq!(store.cleanup_deleted_rows(std::time::Duration::ZERO), 0);
+        let old = CapturedHotView::new(store.capture_hot_root(), epoch, None);
+        assert_eq!(
+            old.row_state(7),
+            CapturedHotRow::Value(&Row::from(vec![Value::Integer(70)]))
+        );
+        let current = CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        );
+        assert_eq!(current.row_state(7), CapturedHotRow::Deleted);
+        let original = old.root.visible_version(7, old.epoch()).unwrap();
+        assert_eq!(original.txn_id, creator);
+        assert_eq!(original.deleted_at_txn_id, deleter);
+        assert!(current.root.visible_version(7, current.epoch()).is_none());
+        assert!(matches!(
+            current.root.version_state(7, current.epoch()),
+            CapturedHotVersion::Deleted
+        ));
+
+        drop(current);
+        drop(old);
+        assert_eq!(store.cleanup_deleted_rows(std::time::Duration::ZERO), 1);
+    }
+
+    #[test]
+    fn prepared_truncate_preserves_account_for_replacement_tree_and_indexes() {
+        let store = VersionStore::new("test_table", test_schema());
+        store
+            .add_index(
+                "pk".into(),
+                Arc::new(crate::storage::index::PkIndex::new(
+                    "pk".into(),
+                    "test_table".into(),
+                    0,
+                    "id".into(),
+                )),
+            )
+            .unwrap();
+        let prepared = store.prepare_hot_truncate().unwrap();
+        assert!(prepared
+            .versions
+            .memory_account()
+            .unwrap()
+            .same_origin(&store.memory));
+        assert!(prepared
+            .indexes
+            .values()
+            .all(|index| index.memory_account().unwrap().same_origin(&store.memory)));
+        let retired = store.apply_hot_truncate(prepared);
+        drop(retired);
+        store
+            .add_version(
+                1,
+                RowVersion::new(
+                    crate::storage::mvcc::registry::RECOVERY_TRANSACTION_ID,
+                    Row::from(vec![Value::Integer(1)]),
+                ),
+            )
+            .unwrap();
+        assert!(store
+            .capture_hot_root()
+            .inner
+            .memory_account()
+            .unwrap()
+            .same_origin(&store.memory));
+    }
 
     /// Simple visibility checker for testing
     struct TestVisibilityChecker {

--- a/src/storage/traits/engine.rs
+++ b/src/storage/traits/engine.rs
@@ -41,6 +41,26 @@ use crate::storage::traits::{Index, Transaction};
 /// engine.close()?;
 /// ```
 pub trait Engine: Send + Sync {
+    /// An immediate schema/namespace mutation, including its mapping updates.
+    fn begin_logical_mutation(
+        &self,
+    ) -> Option<crate::storage::mvcc::registry::LogicalMutationGuard> {
+        None
+    }
+
+    /// Authorize shared results only for this engine and an unchanged bound view.
+    fn cache_provenance(
+        &self,
+        _epoch: &crate::storage::mvcc::registry::ReadEpoch,
+    ) -> Option<crate::storage::mvcc::registry::CacheProvenance> {
+        None
+    }
+
+    /// Register a fixed read-committed statement epoch before capturing data.
+    fn capture_read_epoch(&self) -> Result<Option<crate::storage::mvcc::registry::ReadEpoch>> {
+        Ok(None)
+    }
+
     /// Check whether execution can safely observe the current engine state.
     /// Implementations with uncertain durable transaction outcomes fail closed.
     fn check_health(&self) -> Result<()> {

--- a/src/storage/traits/table.rs
+++ b/src/storage/traits/table.rs
@@ -242,6 +242,38 @@ impl fmt::Display for ScanPlan {
 /// }
 /// ```
 pub trait Table: Send + Sync {
+    fn begin_logical_mutation(
+        &self,
+    ) -> Option<crate::storage::mvcc::registry::LogicalMutationGuard> {
+        None
+    }
+
+    /// Bind reads to one statement epoch. MVCC implementations retain the
+    /// lease and capture their immutable view before performing any reads.
+    /// Rebinding the same lease preserves the already captured view.
+    fn set_read_epoch(&mut self, _epoch: crate::storage::mvcc::registry::ReadEpoch) -> Result<()> {
+        Ok(())
+    }
+
+    /// Clone only the owned hot root while a two-layer capture fence is held.
+    fn capture_hot_root(&self) -> Option<crate::storage::mvcc::version_store::CapturedHotRoot> {
+        None
+    }
+
+    /// Install the jointly captured hot root after releasing that fence.
+    fn replace_hot_root(
+        &mut self,
+        _root: crate::storage::mvcc::version_store::CapturedHotRoot,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn captured_hot_view(
+        &self,
+    ) -> Option<std::sync::Arc<crate::storage::mvcc::version_store::CapturedHotView>> {
+        None
+    }
+
     /// Returns the name of the table
     fn name(&self) -> &str;
 
@@ -418,6 +450,18 @@ pub trait Table: Send + Sync {
         Ok(())
     }
 
+    /// Resolve hot authority for a write target without freezing/copying the
+    /// entire own-write overlay. Deleted rows also suppress cold fallback.
+    fn captured_mutation_has_hot_authority(&self, _row_id: i64) -> Option<bool> {
+        None
+    }
+
+    /// Validate a cold baseline after acquiring its row claim. A later hot
+    /// publication must not turn an old cold snapshot into a lost update.
+    fn validate_cold_mutation(&self, _row_id: i64) -> Result<()> {
+        Ok(())
+    }
+
     /// Deletes rows matching the given expression
     ///
     /// # Arguments
@@ -432,6 +476,19 @@ pub trait Table: Send + Sync {
     /// Default implementation falls back to delete(None).
     fn truncate(&mut self) -> Result<i32> {
         self.delete(None)
+    }
+
+    /// Internal layering hook for physical TRUNCATE. The outer segmented
+    /// wrapper lends its private epoch value exclusively for the admission
+    /// proof; implementations that cannot coordinate both layers fail closed.
+    #[doc(hidden)]
+    fn truncate_with_outer_epoch(
+        &mut self,
+        _outer_epoch: &mut Option<crate::storage::mvcc::registry::ReadEpoch>,
+    ) -> Result<i32> {
+        Err(crate::core::Error::internal(
+            "table cannot coordinate physical TRUNCATE",
+        ))
     }
 
     /// Scans the table and returns a scanner over matching rows

--- a/src/storage/traits/transaction.rs
+++ b/src/storage/traits/transaction.rs
@@ -46,6 +46,23 @@ use crate::storage::traits::{QueryResult, Table};
 /// tx.commit()?;
 /// ```
 pub trait Transaction: Send {
+    /// Capture one statement lease: a fresh cutoff for read committed, or
+    /// the transaction's original begin cutoff for snapshot isolation.
+    fn capture_read_epoch(&self) -> Result<Option<crate::storage::mvcc::registry::ReadEpoch>> {
+        Ok(None)
+    }
+
+    /// Get a table using the caller's already registered statement lease.
+    fn get_table_in_epoch(
+        &self,
+        name: &str,
+        epoch: &crate::storage::mvcc::registry::ReadEpoch,
+    ) -> Result<Box<dyn Table>> {
+        let mut table = self.get_table(name)?;
+        table.set_read_epoch(epoch.clone())?;
+        Ok(table)
+    }
+
     /// Begins the transaction
     fn begin(&mut self) -> Result<()>;
 

--- a/src/storage/volume/captured_aggregate.rs
+++ b/src/storage/volume/captured_aggregate.rs
@@ -1,0 +1,2273 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Typed aggregation over one captured hot/cold view. Visibility is resolved
+//! before predicates or column reads, and only one cold volume is active.
+
+use std::cell::OnceCell;
+use std::cmp::Ordering;
+use std::sync::Arc;
+
+use ahash::AHashMap;
+use chrono::{DateTime, Utc};
+use rustc_hash::FxHashSet;
+use smallvec::SmallVec;
+
+use crate::common::SmartString;
+use crate::core::{DataType, Error, Operator, Result, Row, Schema, Value};
+use crate::storage::expression::Expression;
+use crate::storage::mvcc::version_store::{AggregateOp, CapturedHotView, GroupedAggregateResult};
+
+use super::column::{ColumnData, DictFilter, ROW_GROUP_SIZE};
+use super::manifest::{ColdGeneration, ColdSegment};
+use super::writer::ColSource;
+
+type ColdInput<'a> = Option<(&'a ColdGeneration, &'a FxHashSet<i64>)>;
+
+// Reuse bounded scratch across groups without growing with input cardinality.
+const DICTIONARY_WINDOW: usize = 1024;
+const DICTIONARY_PREFIX: usize = 4;
+
+/// A borrowed scalar, never a reconstructed Row or a cloned hot payload.
+#[derive(Clone, Copy)]
+enum Cell<'a> {
+    Null,
+    Integer(i64),
+    Float(f64),
+    Boolean(bool),
+    Timestamp(DateTime<Utc>),
+    Text(&'a SmartString),
+    Other(DataType),
+}
+
+impl<'a> Cell<'a> {
+    fn from_value(value: &'a Value) -> Self {
+        match value {
+            Value::Null(_) => Self::Null,
+            Value::Integer(v) => Self::Integer(*v),
+            Value::Float(v) => Self::Float(*v),
+            Value::Boolean(v) => Self::Boolean(*v),
+            Value::Timestamp(v) => Self::Timestamp(*v),
+            Value::Text(v) => Self::Text(v),
+            Value::Extension(_) => Self::Other(value.data_type()),
+        }
+    }
+
+    #[inline]
+    fn from_column(column: &'a ColumnData, index: usize) -> Self {
+        if column.is_null(index) {
+            return Self::Null;
+        }
+        match column {
+            ColumnData::Int64 { values, .. } => Self::Integer(values[index]),
+            ColumnData::Float64 { values, .. } => Self::Float(values[index]),
+            ColumnData::Boolean { values, .. } => Self::Boolean(values[index]),
+            ColumnData::TimestampNanos { values, .. } => {
+                Self::Timestamp(DateTime::from_timestamp_nanos(values[index]))
+            }
+            ColumnData::Dictionary {
+                ids, dictionary, ..
+            } => Self::Text(&dictionary[ids[index] as usize]),
+            ColumnData::Bytes { ext_type, .. } => Self::Other(*ext_type),
+        }
+    }
+
+    fn compare(self, other: Self) -> Option<Ordering> {
+        match (self, other) {
+            (Self::Integer(a), Self::Integer(b)) => Some(a.cmp(&b)),
+            (Self::Float(a), Self::Float(b)) => a.partial_cmp(&b),
+            (Self::Integer(a), Self::Float(b)) => crate::core::value::cmp_i64_f64(a, b),
+            (Self::Float(a), Self::Integer(b)) => {
+                crate::core::value::cmp_i64_f64(b, a).map(Ordering::reverse)
+            }
+            (Self::Boolean(a), Self::Boolean(b)) => Some(a.cmp(&b)),
+            (Self::Timestamp(a), Self::Timestamp(b)) => Some(a.cmp(&b)),
+            (Self::Text(a), Self::Text(b)) => Some(a.cmp(b)),
+            _ => None,
+        }
+    }
+
+    fn data_type(self) -> DataType {
+        match self {
+            Self::Null => DataType::Null,
+            Self::Integer(_) => DataType::Integer,
+            Self::Float(_) => DataType::Float,
+            Self::Boolean(_) => DataType::Boolean,
+            Self::Timestamp(_) => DataType::Timestamp,
+            Self::Text(_) => DataType::Text,
+            Self::Other(data_type) => data_type,
+        }
+    }
+}
+
+struct Predicate<'a> {
+    column: usize,
+    operator: Operator,
+    target: Cell<'a>,
+}
+
+struct DictionaryPredicate {
+    physical: usize,
+    target: Option<u32>,
+}
+
+impl Predicate<'_> {
+    fn bind_dictionary(&self, columns: &GroupColumns<'_>) -> Option<DictionaryPredicate> {
+        if !matches!(self.operator, Operator::Eq | Operator::Ne) {
+            return None;
+        }
+        let Cell::Text(target) = self.target else {
+            return None;
+        };
+        let ColSource::Volume(physical) = columns.segment.mapping.sources[self.column] else {
+            return None;
+        };
+        let (column, _) = columns.columns[physical].get()?.data();
+        let ColumnData::Dictionary { dictionary, .. } = column else {
+            return None;
+        };
+        Some(DictionaryPredicate {
+            physical,
+            target: dictionary
+                .iter()
+                .position(|value| value == target)
+                .map(|index| index as u32),
+        })
+    }
+
+    #[inline]
+    fn matches_cold(
+        &self,
+        columns: &GroupColumns<'_>,
+        local: usize,
+        dictionary: Option<&DictionaryPredicate>,
+    ) -> Result<bool> {
+        if let Some(predicate) = dictionary {
+            let (column, offset) = columns.bound_column(predicate.physical);
+            if let ColumnData::Dictionary { ids, nulls, .. } = column {
+                if nulls[offset + local] {
+                    return Ok(false);
+                }
+                let equal = Some(ids[offset + local]) == predicate.target;
+                return Ok(if self.operator == Operator::Eq {
+                    equal
+                } else {
+                    !equal
+                });
+            }
+        }
+        self.matches(columns.get(self.column, local))
+    }
+
+    #[inline]
+    fn matches(&self, value: Cell<'_>) -> Result<bool> {
+        if matches!(self.operator, Operator::IsNull) {
+            return Ok(matches!(value, Cell::Null));
+        }
+        if matches!(self.operator, Operator::IsNotNull) {
+            return Ok(!matches!(value, Cell::Null));
+        }
+        if matches!(value, Cell::Null) || matches!(self.target, Cell::Null) {
+            return Ok(false);
+        }
+        // Equality can reject different string lengths without ordering or
+        // scanning their shared prefix. Keep ordered and mixed-type semantics
+        // in the common comparison path below.
+        if let (Cell::Text(value), Cell::Text(target)) = (value, self.target) {
+            match self.operator {
+                Operator::Eq => return Ok(value == target),
+                Operator::Ne => return Ok(value != target),
+                _ => (),
+            }
+        }
+        let order = value.compare(self.target);
+        if order.is_none()
+            && !matches!(
+                (value, self.target),
+                (
+                    Cell::Integer(_) | Cell::Float(_),
+                    Cell::Integer(_) | Cell::Float(_)
+                )
+            )
+        {
+            return Err(Error::type_conversion(
+                format!("{:?}", value.data_type()),
+                format!("{:?}", self.target.data_type()),
+            ));
+        }
+        Ok(match self.operator {
+            Operator::Eq => order == Some(Ordering::Equal),
+            Operator::Ne => order != Some(Ordering::Equal),
+            Operator::Lt => order == Some(Ordering::Less),
+            Operator::Lte => matches!(order, Some(Ordering::Less | Ordering::Equal)),
+            Operator::Gt => order == Some(Ordering::Greater),
+            Operator::Gte => matches!(order, Some(Ordering::Greater | Ordering::Equal)),
+            _ => unreachable!("preflight rejects unsupported operators"),
+        })
+    }
+}
+
+fn scalar_type(data_type: DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Integer
+            | DataType::Float
+            | DataType::Boolean
+            | DataType::Timestamp
+            | DataType::Text
+    )
+}
+
+/// Inspect every leaf. collect_comparisons alone can silently omit an IN or
+/// other conjunct and must not be used as proof that the whole filter is bound.
+fn predicates<'a>(
+    expression: &'a dyn Expression,
+    schema: &Schema,
+    output: &mut Vec<Predicate<'a>>,
+) -> bool {
+    if let Some(children) = expression.get_and_operands() {
+        return children
+            .iter()
+            .all(|child| predicates(&**child, schema, output));
+    }
+    let Some((name, operator, target)) = expression.get_comparison_info() else {
+        return false;
+    };
+    if !matches!(
+        operator,
+        Operator::Eq
+            | Operator::Ne
+            | Operator::Lt
+            | Operator::Lte
+            | Operator::Gt
+            | Operator::Gte
+            | Operator::IsNull
+            | Operator::IsNotNull
+    ) {
+        return false;
+    }
+    let Some(&column) = schema.column_index_map().get(&name.to_lowercase()) else {
+        return false;
+    };
+    let data_type = schema.columns[column].data_type;
+    if data_type == DataType::Boolean
+        && !matches!(
+            operator,
+            Operator::Eq | Operator::Ne | Operator::IsNull | Operator::IsNotNull
+        )
+    {
+        return false;
+    }
+    if !matches!(operator, Operator::IsNull | Operator::IsNotNull)
+        && !target.is_null()
+        && !(scalar_type(data_type)
+            && (data_type == target.data_type()
+                || matches!(
+                    (data_type, target.data_type()),
+                    (DataType::Integer, DataType::Float) | (DataType::Float, DataType::Integer)
+                )))
+    {
+        return false;
+    }
+    output.push(Predicate {
+        column,
+        operator,
+        target: Cell::from_value(target),
+    });
+    true
+}
+
+#[derive(Clone)]
+enum Extremum {
+    Integer(i64),
+    Float(f64),
+    Boolean(bool),
+    Timestamp(DateTime<Utc>),
+    Text(SmartString),
+}
+
+impl Extremum {
+    fn cell(&self) -> Cell<'_> {
+        match self {
+            Self::Integer(v) => Cell::Integer(*v),
+            Self::Float(v) => Cell::Float(*v),
+            Self::Boolean(v) => Cell::Boolean(*v),
+            Self::Timestamp(v) => Cell::Timestamp(*v),
+            Self::Text(v) => Cell::Text(v),
+        }
+    }
+    fn from_cell(cell: Cell<'_>) -> Option<Self> {
+        Some(match cell {
+            Cell::Integer(v) => Self::Integer(v),
+            Cell::Float(v) if !v.is_nan() => Self::Float(v),
+            Cell::Boolean(v) => Self::Boolean(v),
+            Cell::Timestamp(v) => Self::Timestamp(v),
+            Cell::Text(v) => Self::Text(v.clone()),
+            _ => return None,
+        })
+    }
+    fn into_value(self) -> Value {
+        match self {
+            Self::Integer(v) => Value::Integer(v),
+            Self::Float(v) => Value::Float(v),
+            Self::Boolean(v) => Value::Boolean(v),
+            Self::Timestamp(v) => Value::Timestamp(v),
+            Self::Text(v) => Value::Text(v),
+        }
+    }
+}
+
+/// Widened integer sum, separate floating sum, and NULL/NaN numeric exclusion.
+/// Grouped SUM preserves the SQL grouped path's Float result across hot and
+/// cold layouts. Filtered global SUM retains its integer narrowing behavior.
+#[derive(Default)]
+struct Accumulator {
+    count: i64,
+    integer: i128,
+    float: f64,
+    saw_float: bool,
+    extremum: Option<Extremum>,
+}
+
+impl Accumulator {
+    #[inline(always)]
+    fn add(&mut self, operation: AggregateOp, cell: Cell<'_>) {
+        match operation {
+            AggregateOp::CountStar => self.count += 1,
+            AggregateOp::Count => self.count += i64::from(!matches!(cell, Cell::Null)),
+            AggregateOp::Sum | AggregateOp::Avg => match cell {
+                Cell::Integer(v) => {
+                    self.integer += i128::from(v);
+                    self.count += 1;
+                }
+                Cell::Boolean(v) => {
+                    self.integer += i128::from(v);
+                    self.count += 1;
+                }
+                Cell::Float(v) if !v.is_nan() => {
+                    self.float += v;
+                    self.count += 1;
+                    self.saw_float = true;
+                }
+                _ => (),
+            },
+            AggregateOp::Min | AggregateOp::Max => self.add_extremum(operation, cell),
+        }
+    }
+
+    // Keep the larger comparison/owned-text path out of numeric row loops.
+    #[inline(never)]
+    fn add_extremum(&mut self, operation: AggregateOp, cell: Cell<'_>) {
+        let replace = self.extremum.as_ref().is_none_or(|current| {
+            cell.compare(current.cell()).is_some_and(|order| {
+                if operation == AggregateOp::Min {
+                    order.is_lt()
+                } else {
+                    order.is_gt()
+                }
+            })
+        });
+        if replace {
+            if let Some(value) = Extremum::from_cell(cell) {
+                self.extremum = Some(value);
+            }
+        }
+    }
+    fn finish(self, operation: AggregateOp, data_type: DataType, grouped: bool) -> Value {
+        match operation {
+            AggregateOp::Count | AggregateOp::CountStar => Value::Integer(self.count),
+            AggregateOp::Sum if self.count != 0 => {
+                if !grouped && !self.saw_float {
+                    if let Ok(integer) = i64::try_from(self.integer) {
+                        return Value::Integer(integer);
+                    }
+                }
+                Value::Float(self.integer as f64 + self.float)
+            }
+            AggregateOp::Avg if self.count != 0 => {
+                Value::Float((self.integer as f64 + self.float) / self.count as f64)
+            }
+            AggregateOp::Sum | AggregateOp::Avg => Value::Null(DataType::Float),
+            AggregateOp::Min | AggregateOp::Max => self
+                .extremum
+                .map(Extremum::into_value)
+                .unwrap_or(Value::Null(data_type)),
+        }
+    }
+}
+
+#[derive(Clone, Hash, PartialEq, Eq)]
+enum KeyPart {
+    Null,
+    Integer(i64),
+    Float(u64),
+    Boolean(bool),
+    Timestamp(DateTime<Utc>),
+    Text(usize),
+}
+type Key = SmallVec<[KeyPart; 4]>;
+
+#[derive(Default)]
+struct Groups {
+    index: AHashMap<Key, usize>,
+    // Text IDs belong to this aggregation, never to a volume dictionary.
+    text_index: AHashMap<SmartString, usize>,
+    texts: Vec<SmartString>,
+    keys: Vec<Key>,
+    accumulators: Vec<Vec<Accumulator>>,
+    scratch: Key,
+    unsupported: bool,
+    // The legacy one-column primitive path groups floats by exact bits, unlike
+    // multi-column Value equality. Off-schema keys use the existing fallback;
+    // reproducing its mixed-type, first-arena-row policy here would be unstable.
+    single_type: Option<DataType>,
+}
+
+impl Groups {
+    fn part(&mut self, cell: Cell<'_>) -> KeyPart {
+        match cell {
+            Cell::Null => KeyPart::Null,
+            Cell::Integer(v) => KeyPart::Integer(v),
+            Cell::Float(v) if self.single_type.is_some() => KeyPart::Float(v.to_bits()),
+            Cell::Float(v) => {
+                let integer = v as i64;
+                if crate::core::value::cmp_i64_f64(integer, v) == Some(Ordering::Equal) {
+                    KeyPart::Integer(integer)
+                } else {
+                    KeyPart::Float(if v.is_nan() {
+                        f64::NAN.to_bits()
+                    } else {
+                        v.to_bits()
+                    })
+                }
+            }
+            Cell::Boolean(v) => KeyPart::Boolean(v),
+            Cell::Timestamp(v) => KeyPart::Timestamp(v),
+            Cell::Text(v) => {
+                let id = if let Some(&id) = self.text_index.get(v.as_str()) {
+                    id
+                } else {
+                    let id = self.texts.len();
+                    let text = v.clone();
+                    self.texts.push(text.clone());
+                    self.text_index.insert(text, id);
+                    id
+                };
+                KeyPart::Text(id)
+            }
+            Cell::Other(_) => {
+                self.unsupported = true;
+                KeyPart::Null
+            }
+        }
+    }
+    fn resolve(
+        &mut self,
+        cells: &Cells<'_, '_>,
+        columns: &[usize],
+        aggregate_count: usize,
+    ) -> usize {
+        if columns.is_empty() {
+            return 0;
+        }
+        self.scratch.clear();
+        for &column in columns {
+            let cell = cells.get(column);
+            if self
+                .single_type
+                .is_some_and(|expected| !matches!(cell, Cell::Null) && cell.data_type() != expected)
+            {
+                self.unsupported = true;
+                return 0;
+            }
+            let part = self.part(cell);
+            if self.unsupported {
+                return 0;
+            }
+            self.scratch.push(part);
+        }
+        if let Some(&index) = self.index.get(self.scratch.as_slice()) {
+            return index;
+        }
+        let index = self.keys.len();
+        self.keys.push(self.scratch.clone());
+        self.index.insert(self.scratch.clone(), index);
+        self.accumulators.push(
+            (0..aggregate_count)
+                .map(|_| Accumulator::default())
+                .collect(),
+        );
+        index
+    }
+}
+
+enum Column<'a> {
+    Borrowed(&'a ColumnData, usize),
+    Group(Arc<ColumnData>),
+}
+impl Column<'_> {
+    fn data(&self) -> (&ColumnData, usize) {
+        match self {
+            Self::Borrowed(column, offset) => (column, *offset),
+            Self::Group(column) => (column, 0),
+        }
+    }
+}
+
+struct GroupColumns<'a> {
+    segment: &'a ColdSegment,
+    group: usize,
+    count: usize,
+    columns: Vec<OnceCell<Column<'a>>>,
+}
+impl<'a> GroupColumns<'a> {
+    fn new(segment: &'a ColdSegment, group: usize, count: usize) -> Self {
+        Self {
+            segment,
+            group,
+            count,
+            columns: (0..segment.volume.columns.len())
+                .map(|_| OnceCell::new())
+                .collect(),
+        }
+    }
+    fn bind(&self, logical: usize) -> Result<()> {
+        let ColSource::Volume(physical) = self.segment.mapping.sources[logical] else {
+            return Ok(());
+        };
+        if self.columns[physical].get().is_some() {
+            return Ok(());
+        }
+        let source = &self.segment.volume.columns;
+        let column = if source.should_use_group_cache() {
+            Column::Group(
+                source
+                    .compressed_store()
+                    .ok_or_else(|| Error::internal("missing compressed group source"))?
+                    .group_column(physical, self.group)?,
+            )
+        } else {
+            Column::Borrowed(source.get(physical)?, self.group * ROW_GROUP_SIZE)
+        };
+        let (data, offset) = column.data();
+        if offset
+            .checked_add(self.count)
+            .is_none_or(|end| end > data.len())
+        {
+            return Err(Error::internal(
+                "captured aggregate column is shorter than row group",
+            ));
+        }
+        // OnceCell keeps existing references valid while binding more columns.
+        let _ = self.columns[physical].set(column);
+        Ok(())
+    }
+    fn dictionary_selection(
+        &self,
+        predicates: &[Option<DictionaryPredicate>],
+    ) -> Result<DictionarySelection<'_>> {
+        let mut filters: SmallVec<[DictFilter<'_>; DICTIONARY_PREFIX]> = SmallVec::new();
+        for predicate in predicates {
+            let predicate = predicate
+                .as_ref()
+                .ok_or_else(|| Error::internal("invalid dictionary equality prefix"))?;
+            // Missing targets prove the conjunction empty, including NULL rows.
+            let Some(target) = predicate.target else {
+                return Ok(DictionarySelection { filters: None });
+            };
+            let (column, offset) = self.bound_column(predicate.physical);
+            filters.push((column, offset, target));
+        }
+        // Sample the infallible equality prefix once per group without moving scalar predicates.
+        if filters.len() > 1 && self.count >= 128 {
+            let mut leading = 0;
+            let mut fewest = usize::MAX;
+            for (index, &(column, offset, target)) in filters.iter().enumerate() {
+                let (ids, nulls) = column
+                    .dict_ids()
+                    .ok_or_else(|| Error::internal("bound predicate has no dictionary"))?;
+                let end = offset
+                    .checked_add(64)
+                    .ok_or_else(|| Error::internal("captured dictionary sample offset overflow"))?;
+                let ids = ids
+                    .get(offset..end)
+                    .ok_or_else(|| Error::internal("captured dictionary sample exceeds column"))?;
+                let nulls = nulls.get(offset..end).ok_or_else(|| {
+                    Error::internal("captured dictionary sample exceeds null flags")
+                })?;
+                let matches = ids
+                    .iter()
+                    .zip(nulls)
+                    .filter(|&(id, null)| *id == target && !null)
+                    .count();
+                if matches < fewest {
+                    leading = index;
+                    fewest = matches;
+                }
+            }
+            filters.swap(0, leading);
+        }
+        Ok(DictionarySelection {
+            filters: Some(filters),
+        })
+    }
+
+    fn bound_column(&self, physical: usize) -> (&ColumnData, usize) {
+        let Some(column) = self.columns[physical].get() else {
+            unreachable!("required aggregate column is bound");
+        };
+        column.data()
+    }
+
+    fn get(&self, logical: usize, local: usize) -> Cell<'_> {
+        match &self.segment.mapping.sources[logical] {
+            ColSource::Default(value) => Cell::from_value(value),
+            ColSource::Volume(physical) => {
+                let (column, offset) = self.bound_column(*physical);
+                Cell::from_column(column, offset + local)
+            }
+        }
+    }
+
+    fn aggregate(&self, operation: AggregateOp, logical: usize) -> BoundAggregate<'_> {
+        let source = if operation == AggregateOp::CountStar {
+            AggregateSource::Constant(Cell::Null)
+        } else {
+            match &self.segment.mapping.sources[logical] {
+                ColSource::Default(value) => AggregateSource::Constant(Cell::from_value(value)),
+                ColSource::Volume(physical) => {
+                    let (column, offset) = self.bound_column(*physical);
+                    AggregateSource::Column(column, offset)
+                }
+            }
+        };
+        BoundAggregate { operation, source }
+    }
+}
+
+struct DictionarySelection<'a> {
+    // None proves the conjunction empty; Some([]) is the unfiltered case.
+    filters: Option<SmallVec<[DictFilter<'a>; DICTIONARY_PREFIX]>>,
+}
+impl DictionarySelection<'_> {
+    fn candidates(&self, start: usize, count: usize, out: &mut Vec<usize>) -> Result<()> {
+        out.clear();
+        let Some(filters) = &self.filters else {
+            return Ok(());
+        };
+        let window: SmallVec<[DictFilter<'_>; DICTIONARY_PREFIX]> = filters
+            .iter()
+            .map(|&(column, offset, target)| (column, offset + start, target))
+            .collect();
+        ColumnData::dict_matching_offsets(&window, count, out)
+            .ok_or_else(|| Error::internal("invalid captured dictionary predicate window"))
+    }
+}
+
+enum AggregateSource<'a> {
+    Column(&'a ColumnData, usize),
+    Constant(Cell<'a>),
+}
+
+struct BoundAggregate<'a> {
+    operation: AggregateOp,
+    source: AggregateSource<'a>,
+}
+
+impl BoundAggregate<'_> {
+    #[inline]
+    fn cell(&self, local: usize) -> Cell<'_> {
+        match self.source {
+            AggregateSource::Column(column, offset) => Cell::from_column(column, offset + local),
+            AggregateSource::Constant(cell) => cell,
+        }
+    }
+}
+
+enum Cells<'a, 'b> {
+    Hot(&'a Row, &'a [Value]),
+    Cold(&'a GroupColumns<'b>, usize),
+}
+impl Cells<'_, '_> {
+    fn get(&self, column: usize) -> Cell<'_> {
+        match self {
+            Self::Hot(row, defaults) => {
+                Cell::from_value(row.get(column).unwrap_or(&defaults[column]))
+            }
+            Self::Cold(columns, local) => columns.get(column, *local),
+        }
+    }
+}
+
+pub(crate) fn grouped(
+    schema: &Schema,
+    view: &CapturedHotView,
+    cold: ColdInput<'_>,
+    group_by: &[usize],
+    aggregates: &[(AggregateOp, usize)],
+) -> Result<Option<Vec<GroupedAggregateResult>>> {
+    if group_by.is_empty() {
+        return Ok(None);
+    }
+    run(schema, view, cold, group_by, aggregates, None)
+}
+
+pub(crate) fn filtered(
+    schema: &Schema,
+    view: &CapturedHotView,
+    cold: ColdInput<'_>,
+    aggregates: &[(AggregateOp, usize)],
+    expression: &dyn Expression,
+) -> Result<Option<Vec<Value>>> {
+    run(schema, view, cold, &[], aggregates, Some(expression))?
+        .map(|mut results| {
+            results
+                .pop()
+                .map(|result| result.aggregate_values)
+                .ok_or_else(|| Error::internal("global aggregate returned no group"))
+        })
+        .transpose()
+}
+
+fn run(
+    schema: &Schema,
+    view: &CapturedHotView,
+    cold: ColdInput<'_>,
+    group_by: &[usize],
+    aggregates: &[(AggregateOp, usize)],
+    expression: Option<&dyn Expression>,
+) -> Result<Option<Vec<GroupedAggregateResult>>> {
+    let mut predicates_bound = Vec::new();
+    if expression.is_some_and(|expression| !predicates(expression, schema, &mut predicates_bound)) {
+        return Ok(None);
+    }
+    if group_by.iter().any(|&column| {
+        schema
+            .columns
+            .get(column)
+            .is_none_or(|c| !scalar_type(c.data_type))
+    }) {
+        return Ok(None);
+    }
+    for &(operation, column) in aggregates {
+        if operation == AggregateOp::CountStar {
+            continue;
+        }
+        let Some(column) = schema.columns.get(column) else {
+            return Ok(None);
+        };
+        if match operation {
+            AggregateOp::Sum | AggregateOp::Avg => !matches!(
+                column.data_type,
+                DataType::Integer | DataType::Float | DataType::Boolean
+            ),
+            AggregateOp::Min | AggregateOp::Max => !scalar_type(column.data_type),
+            _ => false,
+        } {
+            return Ok(None);
+        }
+    }
+    let mut needed: SmallVec<[usize; 12]> = group_by.iter().copied().collect();
+    needed.extend(
+        aggregates
+            .iter()
+            .filter(|(operation, _)| *operation != AggregateOp::CountStar)
+            .map(|(_, column)| *column),
+    );
+    needed.extend(predicates_bound.iter().map(|p| p.column));
+    needed.sort_unstable();
+    needed.dedup();
+    // Schema evolution and unsupported physical representations are decided
+    // from metadata before any hot/cold accumulation has happened.
+    if let Some((generation, _)) = cold {
+        for segment in generation.segments.values() {
+            for &logical in &needed {
+                let Some(source) = segment.mapping.sources.get(logical) else {
+                    return Ok(None);
+                };
+                if let ColSource::Volume(physical) = source {
+                    if segment.volume.meta.column_types.get(*physical)
+                        != Some(&schema.columns[logical].data_type)
+                    {
+                        return Ok(None);
+                    }
+                }
+            }
+        }
+    }
+    let defaults: Vec<_> = schema
+        .columns
+        .iter()
+        .map(|column| {
+            column
+                .default_value
+                .clone()
+                .unwrap_or(Value::Null(column.data_type))
+        })
+        .collect();
+    let mut groups = Groups {
+        single_type: (group_by.len() == 1).then(|| schema.columns[group_by[0]].data_type),
+        ..Groups::default()
+    };
+    if group_by.is_empty() {
+        groups.keys.push(Key::new());
+        groups.index.insert(Key::new(), 0);
+        groups.accumulators.push(
+            (0..aggregates.len())
+                .map(|_| Accumulator::default())
+                .collect(),
+        );
+    }
+    let add = |groups: &mut Groups, index: usize, cells: &Cells<'_, '_>| {
+        for (accumulator, &(operation, column)) in
+            groups.accumulators[index].iter_mut().zip(aggregates)
+        {
+            let cell = if operation == AggregateOp::CountStar {
+                Cell::Null
+            } else {
+                cells.get(column)
+            };
+            if matches!(operation, AggregateOp::Min | AggregateOp::Max)
+                && matches!(cell, Cell::Other(_))
+            {
+                groups.unsupported = true;
+                return;
+            }
+            accumulator.add(operation, cell);
+        }
+    };
+    let mut predicate_error = None;
+    view.for_each_visible_until(|_, row| {
+        let cells = Cells::Hot(row, &defaults);
+        for predicate in &predicates_bound {
+            match predicate.matches(cells.get(predicate.column)) {
+                Ok(true) => (),
+                Ok(false) => return true,
+                Err(error) => {
+                    predicate_error = Some(error);
+                    return false;
+                }
+            }
+        }
+        let index = if group_by.is_empty() {
+            0
+        } else {
+            groups.resolve(&cells, group_by, aggregates.len())
+        };
+        if !groups.unsupported {
+            add(&mut groups, index, &cells);
+        }
+        !groups.unsupported
+    });
+    if let Some(error) = predicate_error {
+        return Err(error);
+    }
+    if groups.unsupported {
+        return Ok(None);
+    }
+    if let Some((generation, pending)) = cold {
+        let mut hidden = [0u64; ROW_GROUP_SIZE.div_ceil(64)];
+        let mut candidates = Vec::new();
+        for &id in &generation.segment_ids_newest_first {
+            let segment = generation.segments.get(&id).ok_or_else(|| {
+                Error::internal("captured aggregate generation is missing a segment")
+            })?;
+            let mut loaded = None;
+            for (group, ids) in segment
+                .volume
+                .meta
+                .row_ids
+                .chunks(ROW_GROUP_SIZE)
+                .enumerate()
+            {
+                view.mark_authoritative(ids, &mut hidden);
+                if segment.visible.is_some()
+                    || !pending.is_empty()
+                    || !generation.tombstones.is_empty()
+                {
+                    for (local, row_id) in ids.iter().enumerate() {
+                        if !segment.is_visible(group * ROW_GROUP_SIZE + local)
+                            || pending.contains(row_id)
+                            || generation.tombstones.get(row_id).is_some_and(|&sequence| {
+                                i64::try_from(sequence).is_ok_and(|sequence| {
+                                    view.epoch().admits_commit_sequence(sequence)
+                                })
+                            })
+                        {
+                            hidden[local / 64] |= 1 << (local % 64);
+                        }
+                    }
+                }
+                // mark_authoritative zeros unused tail bits. Inspect words,
+                // rather than every row, when no cold exclusions need merging.
+                if hidden[..ids.len().div_ceil(64)]
+                    .iter()
+                    .map(|bits| bits.count_ones() as usize)
+                    .sum::<usize>()
+                    == ids.len()
+                {
+                    continue;
+                }
+                let segment = match &mut loaded {
+                    Some(segment) => segment,
+                    slot @ None => slot.insert(generation.load_segment(id)?),
+                };
+                let columns = GroupColumns::new(segment, group, ids.len());
+                for predicate in &predicates_bound {
+                    columns.bind(predicate.column)?;
+                }
+                let dictionary_predicates: SmallVec<[Option<DictionaryPredicate>; 4]> =
+                    predicates_bound
+                        .iter()
+                        .map(|predicate| predicate.bind_dictionary(&columns))
+                        .collect();
+                // Only move a leading, infallible equality prefix into the
+                // batched selector. This preserves errors from earlier scalar
+                // predicates and keeps both selector scratch buffers bounded.
+                let dictionary_prefix = predicates_bound
+                    .iter()
+                    .zip(&dictionary_predicates)
+                    .take(DICTIONARY_PREFIX)
+                    .take_while(|(predicate, dictionary)| {
+                        predicate.operator == Operator::Eq && dictionary.is_some()
+                    })
+                    .count();
+                if dictionary_prefix != 0 && candidates.capacity() == 0 {
+                    candidates.reserve_exact(DICTIONARY_WINDOW);
+                }
+                let dictionary_selection =
+                    columns.dictionary_selection(&dictionary_predicates[..dictionary_prefix])?;
+                candidates.clear();
+                let mut candidate_position = 0;
+                let mut window_start = 0;
+                let mut window_end = 0;
+                let mut plain = 0;
+                let mut bound_aggregates: Option<SmallVec<[BoundAggregate<'_>; 4]>> = None;
+                // Dictionary identity is local to this bound group. Cache only
+                // its translation to globally canonical group indices.
+                let mut dictionary_groups: Vec<usize> = Vec::new();
+                let mut null_group = None;
+                'rows: loop {
+                    let local = if dictionary_prefix != 0 {
+                        while candidate_position == candidates.len() {
+                            if window_end == ids.len() {
+                                break 'rows;
+                            }
+                            window_start = window_end;
+                            window_end = (window_start + DICTIONARY_WINDOW).min(ids.len());
+                            dictionary_selection.candidates(
+                                window_start,
+                                window_end - window_start,
+                                &mut candidates,
+                            )?;
+                            candidate_position = 0;
+                        }
+                        let local = window_start + candidates[candidate_position];
+                        candidate_position += 1;
+                        local
+                    } else {
+                        if plain == ids.len() {
+                            break;
+                        }
+                        plain += 1;
+                        plain - 1
+                    };
+                    if hidden[local / 64] & (1 << (local % 64)) != 0 {
+                        continue;
+                    }
+                    for (predicate, dictionary) in predicates_bound
+                        .iter()
+                        .zip(&dictionary_predicates)
+                        .skip(dictionary_prefix)
+                    {
+                        if !predicate.matches_cold(&columns, local, dictionary.as_ref())? {
+                            continue 'rows;
+                        }
+                    }
+                    let bound = match &mut bound_aggregates {
+                        Some(bound) => bound,
+                        slot @ None => {
+                            for &column in &needed {
+                                columns.bind(column)?;
+                            }
+                            slot.insert(
+                                aggregates
+                                    .iter()
+                                    .map(|&(operation, column)| {
+                                        columns.aggregate(operation, column)
+                                    })
+                                    .collect(),
+                            )
+                        }
+                    };
+                    let cells = Cells::Cold(&columns, local);
+                    let mut cached_dictionary = None;
+                    if group_by.len() == 1 {
+                        if let ColSource::Volume(physical) =
+                            columns.segment.mapping.sources[group_by[0]]
+                        {
+                            let (data, offset) = columns.bound_column(physical);
+                            if let ColumnData::Dictionary {
+                                ids,
+                                dictionary,
+                                nulls,
+                            } = data
+                            {
+                                if dictionary.len() <= ROW_GROUP_SIZE {
+                                    if dictionary_groups.is_empty() {
+                                        dictionary_groups.resize(dictionary.len(), usize::MAX);
+                                    }
+                                    cached_dictionary = Some(if nulls[offset + local] {
+                                        None
+                                    } else {
+                                        Some(ids[offset + local] as usize)
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    let index = match cached_dictionary {
+                        Some(Some(dictionary_id)) => {
+                            let cached = dictionary_groups[dictionary_id];
+                            if cached != usize::MAX {
+                                cached
+                            } else {
+                                let index = groups.resolve(&cells, group_by, aggregates.len());
+                                dictionary_groups[dictionary_id] = index;
+                                index
+                            }
+                        }
+                        Some(None) => *null_group.get_or_insert_with(|| {
+                            groups.resolve(&cells, group_by, aggregates.len())
+                        }),
+                        None if group_by.is_empty() => 0,
+                        None => groups.resolve(&cells, group_by, aggregates.len()),
+                    };
+                    if groups.unsupported {
+                        return Ok(None);
+                    }
+                    for (accumulator, aggregate) in
+                        groups.accumulators[index].iter_mut().zip(bound.iter())
+                    {
+                        let cell = aggregate.cell(local);
+                        if matches!(aggregate.operation, AggregateOp::Min | AggregateOp::Max)
+                            && matches!(cell, Cell::Other(_))
+                        {
+                            return Ok(None);
+                        }
+                        accumulator.add(aggregate.operation, cell);
+                    }
+                    if groups.unsupported {
+                        return Ok(None);
+                    }
+                }
+            }
+        }
+    }
+    Ok(Some(
+        groups
+            .keys
+            .into_iter()
+            .zip(groups.accumulators)
+            .map(|(key, accumulators)| {
+                let group_values = key
+                    .into_iter()
+                    .zip(group_by)
+                    .map(|(part, &column)| match part {
+                        KeyPart::Null => Value::Null(schema.columns[column].data_type),
+                        KeyPart::Integer(v)
+                            if group_by.len() != 1
+                                && schema.columns[column].data_type == DataType::Float =>
+                        {
+                            Value::Float(v as f64)
+                        }
+                        KeyPart::Integer(v) => Value::Integer(v),
+                        KeyPart::Float(v) => Value::Float(f64::from_bits(v)),
+                        KeyPart::Boolean(v) => Value::Boolean(v),
+                        KeyPart::Timestamp(v) => Value::Timestamp(v),
+                        KeyPart::Text(v) => Value::Text(groups.texts[v].clone()),
+                    })
+                    .collect();
+                let aggregate_values = accumulators
+                    .into_iter()
+                    .zip(aggregates)
+                    .map(|(accumulator, &(operation, column))| {
+                        accumulator.finish(
+                            operation,
+                            schema
+                                .columns
+                                .get(column)
+                                .map_or(DataType::Null, |c| c.data_type),
+                            !group_by.is_empty(),
+                        )
+                    })
+                    .collect();
+                GroupedAggregateResult {
+                    group_values,
+                    aggregate_values,
+                }
+            })
+            .collect(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::manifest::{SegmentManager, SegmentMeta};
+    use super::super::table::SegmentedTable;
+    use super::super::writer::{ColumnMapping, VolumeBuilder};
+    use super::*;
+    use crate::core::{IsolationLevel, SchemaBuilder};
+    use crate::functions::aggregate::CompiledAggregate;
+    use crate::storage::expression::{AndExpr, ComparisonExpr, InListExpr};
+    use crate::storage::mvcc::registry::TransactionRegistry;
+    use crate::storage::mvcc::version_store::{RowVersion, TransactionVersionStore, VersionStore};
+    use crate::storage::mvcc::MVCCTable;
+    use crate::storage::traits::Table;
+
+    fn schema() -> Schema {
+        SchemaBuilder::new("aggregate")
+            .column("id", DataType::Integer, false, true)
+            .column("a", DataType::Text, true, false)
+            .column("b", DataType::Text, true, false)
+            .column("n", DataType::Integer, true, false)
+            .column("f", DataType::Float, true, false)
+            .column("flag", DataType::Boolean, true, false)
+            .column("time", DataType::Timestamp, true, false)
+            .build()
+    }
+
+    fn row(id: i64, a: &str, b: &str, n: i64) -> Row {
+        Row::from_values(vec![
+            Value::Integer(id),
+            Value::text(a),
+            Value::text(b),
+            Value::Integer(n),
+            Value::Float(n as f64 / 2.0),
+            Value::Boolean(n % 2 == 0),
+            Value::Timestamp(DateTime::from_timestamp(n % 10_000, 123).unwrap()),
+        ])
+    }
+
+    fn add_segment(
+        manager: &SegmentManager,
+        schema: &Schema,
+        id: u64,
+        rows: &[(i64, Row)],
+        warm: bool,
+    ) {
+        let mut builder = VolumeBuilder::new(schema);
+        for (id, row) in rows {
+            builder.add_row(*id, row);
+        }
+        let mut volume = builder.finish();
+        if warm {
+            let (_, compressed) = super::super::io::serialize_v4_public(&volume).unwrap();
+            volume.columns.attach_compressed_store(compressed);
+            volume = volume.to_warm().unwrap();
+        }
+        manager.register_segment(
+            id,
+            Arc::new(volume),
+            SegmentMeta {
+                segment_id: id,
+                file_path: format!("aggregate-{id}.vol").into(),
+                row_count: rows.len(),
+                min_row_id: rows.first().map_or(0, |(id, _)| *id),
+                max_row_id: rows.last().map_or(0, |(id, _)| *id),
+                schema_version: 0,
+                creation_lsn: 0,
+                seal_seq: 0,
+            },
+            Some(schema),
+        );
+    }
+
+    fn store(schema: &Schema) -> (Arc<TransactionRegistry>, Arc<VersionStore>) {
+        let registry = Arc::new(TransactionRegistry::new());
+        let store = Arc::new(VersionStore::with_visibility_checker(
+            "aggregate",
+            schema.clone(),
+            registry.clone(),
+        ));
+        (registry, store)
+    }
+
+    fn result_map(results: Vec<GroupedAggregateResult>) -> AHashMap<Vec<Value>, Vec<Value>> {
+        results
+            .into_iter()
+            .map(|result| (result.group_values, result.aggregate_values))
+            .collect()
+    }
+
+    fn reference(
+        rows: &[Row],
+        groups: &[usize],
+        operations: &[(AggregateOp, usize)],
+    ) -> AHashMap<Vec<Value>, Vec<Value>> {
+        let mut accumulators: AHashMap<Vec<Value>, Vec<CompiledAggregate>> = AHashMap::default();
+        for row in rows {
+            let key = groups.iter().map(|&column| row[column].clone()).collect();
+            let group = accumulators.entry(key).or_insert_with(|| {
+                operations
+                    .iter()
+                    .map(|&(operation, _)| match operation {
+                        AggregateOp::CountStar => CompiledAggregate::count_star(),
+                        AggregateOp::Count => CompiledAggregate::count(false),
+                        AggregateOp::Sum => CompiledAggregate::sum(false),
+                        AggregateOp::Avg => CompiledAggregate::avg(false),
+                        AggregateOp::Min => CompiledAggregate::min(),
+                        AggregateOp::Max => CompiledAggregate::max(),
+                    })
+                    .collect()
+            });
+            for (accumulator, &(_, column)) in group.iter_mut().zip(operations) {
+                accumulator.accumulate(&row[column]);
+            }
+        }
+        accumulators
+            .into_iter()
+            .map(|(key, group)| (key, group.iter().map(CompiledAggregate::result).collect()))
+            .collect()
+    }
+
+    #[test]
+    fn captured_aggregate_snapshot_overlap_own_overlay_and_dictionary_identity() {
+        let schema = schema();
+        let operations = [
+            (AggregateOp::CountStar, 0),
+            (AggregateOp::Count, 3),
+            (AggregateOp::Sum, 3),
+            (AggregateOp::Avg, 4),
+            (AggregateOp::Min, 3),
+            (AggregateOp::Max, 3),
+            (AggregateOp::Min, 1),
+            (AggregateOp::Max, 6),
+            (AggregateOp::Sum, 5),
+            (AggregateOp::Min, 5),
+        ];
+        for warm in [false, true] {
+            let manager = Arc::new(SegmentManager::new("aggregate", None));
+            // Dictionary ID zero names different strings in these volumes;
+            // repeated strings receive different IDs and must still merge.
+            add_segment(
+                &manager,
+                &schema,
+                1,
+                &[
+                    (1, row(1, "a", "x", 1)),
+                    (2, row(2, "b", "y", 2)),
+                    (3, row(3, "a", "y", 3)),
+                    (4, row(4, "b", "x", 4)),
+                    (5, row(5, "c", "x", 5)),
+                ],
+                warm,
+            );
+            let mut null = row(8, "a", "x", 8);
+            null.set(1, Value::Null(DataType::Text)).unwrap();
+            null.set(3, Value::Null(DataType::Integer)).unwrap();
+            add_segment(
+                &manager,
+                &schema,
+                2,
+                &[
+                    (5, row(5, "b", "y", 50)),
+                    (6, row(6, "a", "x", 6)),
+                    (7, row(7, "b", "x", 7)),
+                    (8, null.clone()),
+                ],
+                warm,
+            );
+            manager.set_seal_overlap(3);
+            let (registry, store) = store(&schema);
+            let (writer, _) = registry.begin_transaction();
+            registry.start_commit(writer);
+            store
+                .add_version(1, RowVersion::new(writer, row(1, "changed", "x", 10)))
+                .unwrap();
+            let mut deleted = RowVersion::new(writer, row(2, "b", "y", 2));
+            deleted.deleted_at_txn_id = writer;
+            store.add_version(2, deleted).unwrap();
+            registry.complete_commit(writer);
+            let (inflight, _) = registry.begin_transaction();
+            let inflight_sequence = registry.start_commit(inflight);
+            store
+                .add_version(3, RowVersion::new(inflight, row(3, "wrong", "wrong", 300)))
+                .unwrap();
+            let (reader, _) =
+                registry.begin_transaction_with_isolation(IsolationLevel::SnapshotIsolation);
+            manager.add_tombstones(&[3], inflight_sequence as u64);
+            manager.add_tombstones(&[7], registry.get_commit_sequence(writer).unwrap() as u64);
+            manager.add_pending_tombstone(reader, 4);
+            let mut local = TransactionVersionStore::new(store.clone(), reader);
+            local.put(6, row(6, "b", "y", 60), false).unwrap();
+            local.put(9, row(9, "a", "x", 9), false).unwrap();
+            let hot = MVCCTable::new(reader, store.clone(), local);
+            let mut table = SegmentedTable::new(Box::new(hot), manager.clone());
+            table
+                .set_read_epoch(registry.read_epoch_for_transaction(reader).unwrap())
+                .unwrap();
+            registry.complete_commit(inflight);
+            let expected = vec![
+                row(1, "changed", "x", 10),
+                row(3, "a", "y", 3),
+                row(5, "b", "y", 50),
+                row(6, "b", "y", 60),
+                null,
+                row(9, "a", "x", 9),
+            ];
+            for groups in [vec![1], vec![1, 2], vec![1, 2, 4, 5, 6], vec![5], vec![4]] {
+                let actual = table
+                    .compute_grouped_aggregates(&groups, &operations)
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(
+                    result_map(actual),
+                    reference(&expected, &groups, &operations),
+                    "warm={warm}, group={groups:?}"
+                );
+            }
+            let filter = AndExpr::new(vec![
+                Box::new(ComparisonExpr::eq("a", Value::text("a"))),
+                Box::new(ComparisonExpr::new("n", Operator::Gt, Value::Float(2.5))),
+            ]);
+            let actual = table
+                .compute_filtered_aggregates(&operations, &filter)
+                .unwrap()
+                .unwrap();
+            let expected_rows = [row(3, "a", "y", 3), row(9, "a", "x", 9)];
+            assert_eq!(
+                actual,
+                reference(&expected_rows, &[], &operations)
+                    .remove(&Vec::new())
+                    .unwrap()
+            );
+            // Frozen pending and generation remain authoritative after manager changes.
+            manager.rollback_pending_tombstones(reader);
+            manager.clear();
+            assert_eq!(
+                table
+                    .compute_filtered_aggregates(&operations, &filter)
+                    .unwrap()
+                    .unwrap(),
+                actual
+            );
+        }
+    }
+
+    #[test]
+    fn captured_aggregate_hot_only_numeric_boundaries_and_complete_filter_preflight() {
+        let schema = schema();
+        let (registry, store) = store(&schema);
+        let (writer, _) = registry.begin_transaction();
+        registry.start_commit(writer);
+        let mut first = row(1, "a", "x", i64::MAX);
+        first.set(4, Value::Float(f64::NAN)).unwrap();
+        let mut second = row(2, "a", "x", 2);
+        second.set(4, Value::Float(0.0)).unwrap();
+        let mut third = row(3, "a", "x", 3);
+        third.set(4, Value::Float(-0.0)).unwrap();
+        store
+            .add_version(1, RowVersion::new(writer, first))
+            .unwrap();
+        store
+            .add_version(2, RowVersion::new(writer, second))
+            .unwrap();
+        store
+            .add_version(3, RowVersion::new(writer, third))
+            .unwrap();
+        registry.complete_commit(writer);
+        let (reader, _) = registry.begin_transaction();
+        let mut hot = MVCCTable::new(
+            reader,
+            store.clone(),
+            TransactionVersionStore::new(store.clone(), reader),
+        );
+        hot.set_read_epoch(registry.capture_read_epoch()).unwrap();
+        let operations = [
+            (AggregateOp::Sum, 3),
+            (AggregateOp::Sum, 4),
+            (AggregateOp::Avg, 4),
+            (AggregateOp::Min, 4),
+            (AggregateOp::Max, 4),
+            (AggregateOp::Count, 4),
+        ];
+        let filter = ComparisonExpr::new("n", Operator::Gt, Value::Float(i64::MAX as f64));
+        assert_eq!(
+            hot.compute_filtered_aggregates(&[(AggregateOp::CountStar, 0)], &filter)
+                .unwrap(),
+            Some(vec![Value::Integer(0)]),
+            "exact integer/float comparison at 2^63"
+        );
+        let all = ComparisonExpr::new("id", Operator::Gt, Value::Integer(0));
+        assert_eq!(
+            hot.compute_filtered_aggregates(&operations, &all)
+                .unwrap()
+                .unwrap(),
+            vec![
+                Value::Float((i64::MAX as i128 + 5) as f64),
+                Value::Float(0.0),
+                Value::Float(0.0),
+                Value::Float(0.0),
+                Value::Float(0.0),
+                Value::Integer(3)
+            ]
+        );
+        let groups = hot
+            .compute_grouped_aggregates(&[4], &[(AggregateOp::CountStar, 0)])
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            groups.len(),
+            3,
+            "single-column float grouping preserves the legacy bit-pattern keys"
+        );
+        let unsupported = AndExpr::new(vec![
+            Box::new(all),
+            Box::new(InListExpr::new("id", vec![Value::Integer(1)])),
+        ]);
+        assert!(hot
+            .compute_filtered_aggregates(&operations, &unsupported)
+            .unwrap()
+            .is_none());
+        let unsupported_operator = ComparisonExpr::new("a", Operator::Like, Value::text("a%"));
+        assert!(hot
+            .compute_filtered_aggregates(&operations, &unsupported_operator)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn captured_sum_result_types_survive_layout_and_own_overlay_changes() {
+        fn assert_sum(actual: &Value, expected: &Value) {
+            match (actual, expected) {
+                (Value::Integer(a), Value::Integer(b)) => assert_eq!(a, b),
+                (Value::Float(a), Value::Float(b)) => assert_eq!(a, b),
+                (Value::Null(a), Value::Null(b)) => assert_eq!(a, b),
+                _ => panic!("SUM changed its result type: {actual:?}, expected {expected:?}"),
+            }
+        }
+        for (cold, warm) in [(false, false), (true, false), (true, true)] {
+            for own in [false, true] {
+                let schema = schema();
+                let (registry, store) = store(&schema);
+                let manager = Arc::new(SegmentManager::new("aggregate", None));
+                let mut null = row(5, "null", "same", 0);
+                null.set(3, Value::Null(DataType::Integer)).unwrap();
+                let seed = vec![
+                    (1, row(1, "plain", "same", 10)),
+                    (2, row(2, "plain", "same", 20)),
+                    (3, row(3, "overflow", "same", i64::MAX)),
+                    (4, row(4, "overflow", "same", 1)),
+                    (5, null),
+                ];
+                if cold {
+                    add_segment(&manager, &schema, 1, &seed[..2], warm);
+                    add_segment(&manager, &schema, 2, &seed[2..], warm);
+                } else {
+                    let (writer, _) = registry.begin_transaction();
+                    registry.start_commit(writer);
+                    for (id, value) in &seed {
+                        store
+                            .add_version(*id, RowVersion::new(writer, value.clone()))
+                            .unwrap();
+                    }
+                    registry.complete_commit(writer);
+                }
+                let (reader, _) = registry.begin_transaction();
+                let mut local = TransactionVersionStore::new(store.clone(), reader);
+                if own {
+                    local.put(1, row(1, "plain", "same", 11), false).unwrap();
+                    local.put(2, seed[1].1.clone(), true).unwrap();
+                    let mut mixed = row(6, "plain", "same", 0);
+                    mixed.set(3, Value::Float(0.5)).unwrap();
+                    local.put(6, mixed, false).unwrap();
+                }
+                let hot = MVCCTable::new(reader, store, local);
+                let mut table = SegmentedTable::new(Box::new(hot), manager);
+                table.set_read_epoch(registry.capture_read_epoch()).unwrap();
+                let groups = table
+                    .compute_grouped_aggregates(&[1], &[(AggregateOp::Sum, 3)])
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(groups.len(), 3);
+                for (name, global, grouped) in [
+                    (
+                        "plain",
+                        if own {
+                            Value::Float(11.5)
+                        } else {
+                            Value::Integer(30)
+                        },
+                        Value::Float(if own { 11.5 } else { 30.0 }),
+                    ),
+                    (
+                        "overflow",
+                        Value::Float(9_223_372_036_854_775_808.0),
+                        Value::Float(9_223_372_036_854_775_808.0),
+                    ),
+                    (
+                        "null",
+                        Value::Null(DataType::Float),
+                        Value::Null(DataType::Float),
+                    ),
+                ] {
+                    let result = groups
+                        .iter()
+                        .find(|g| g.group_values == [Value::text(name)])
+                        .unwrap();
+                    assert_sum(&result.aggregate_values[0], &grouped);
+                    let filter = ComparisonExpr::new("a", Operator::Eq, Value::text(name));
+                    let result = table
+                        .compute_filtered_aggregates(&[(AggregateOp::Sum, 3)], &filter)
+                        .unwrap()
+                        .unwrap();
+                    assert_sum(&result[0], &global);
+                }
+                let empty = ComparisonExpr::new("id", Operator::Lt, Value::Integer(0));
+                let result = table
+                    .compute_filtered_aggregates(&[(AggregateOp::Sum, 3)], &empty)
+                    .unwrap()
+                    .unwrap();
+                assert_sum(&result[0], &Value::Null(DataType::Float));
+            }
+        }
+    }
+
+    #[test]
+    fn captured_group_single_float_preserves_bits_across_hot_cold_overlap_and_own_rows() {
+        const NAN_A: u64 = 0x7ff8_0000_0000_0001;
+        const NAN_B: u64 = 0xfff8_0000_0000_0002;
+        fn floating(id: i64, bits: Option<u64>, weight: i64) -> Row {
+            let mut value = row(id, "same", "same", weight);
+            value
+                .set(
+                    4,
+                    bits.map_or(Value::Null(DataType::Float), |b| {
+                        Value::Float(f64::from_bits(b))
+                    }),
+                )
+                .unwrap();
+            value
+        }
+        fn bit_groups(
+            results: Vec<GroupedAggregateResult>,
+        ) -> std::collections::BTreeMap<Option<u64>, (i64, f64)> {
+            results
+                .into_iter()
+                .map(|result| {
+                    let key = match &result.group_values[..] {
+                        [Value::Float(v)] => Some(v.to_bits()),
+                        [Value::Null(DataType::Float)] => None,
+                        other => panic!("float group retained the wrong value type: {other:?}"),
+                    };
+                    let values = match result.aggregate_values[..] {
+                        [Value::Integer(count), Value::Float(sum)] => (count, sum),
+                        ref other => panic!("unexpected aggregates: {other:?}"),
+                    };
+                    (key, values)
+                })
+                .collect()
+        }
+        for (cold, warm, overlap) in [
+            (false, false, false),
+            (true, false, false),
+            (true, true, false),
+            (true, true, true),
+        ] {
+            let schema = schema();
+            let (registry, store) = store(&schema);
+            let manager = Arc::new(SegmentManager::new("aggregate", None));
+            let mut expected = vec![
+                floating(1, Some(0.0f64.to_bits()), 10),
+                floating(2, Some((-0.0f64).to_bits()), 20),
+                floating(3, Some(NAN_A), 30),
+                floating(4, Some(NAN_B), 40),
+                floating(5, Some(1.0f64.to_bits()), 50),
+                floating(6, Some(0.0f64.to_bits()), 60),
+                floating(7, Some(NAN_A), 70),
+                floating(8, None, 80),
+            ];
+            if cold {
+                let rows: Vec<_> = expected
+                    .iter()
+                    .enumerate()
+                    .map(|(i, row)| (i as i64 + 1, row.clone()))
+                    .collect();
+                add_segment(&manager, &schema, 1, &rows[..4], warm);
+                add_segment(&manager, &schema, 2, &rows[4..], warm);
+            } else {
+                let (writer, _) = registry.begin_transaction();
+                registry.start_commit(writer);
+                for (i, row) in expected.iter().enumerate() {
+                    store
+                        .add_version(i as i64 + 1, RowVersion::new(writer, row.clone()))
+                        .unwrap();
+                }
+                registry.complete_commit(writer);
+            }
+            if overlap {
+                let (writer, _) = registry.begin_transaction();
+                registry.start_commit(writer);
+                expected[0] = floating(1, Some((-0.0f64).to_bits()), 11);
+                store
+                    .add_version(1, RowVersion::new(writer, expected[0].clone()))
+                    .unwrap();
+                let mut deletion = RowVersion::new(writer, expected[3].clone());
+                deletion.deleted_at_txn_id = writer;
+                store.add_version(4, deletion).unwrap();
+                registry.complete_commit(writer);
+                expected.remove(3);
+                manager.set_seal_overlap(2);
+            }
+            let (reader, _) = registry.begin_transaction();
+            let mut local = TransactionVersionStore::new(store.clone(), reader);
+            if overlap {
+                let own = floating(9, Some(NAN_B), 90);
+                local.put(9, own.clone(), false).unwrap();
+                expected.push(own);
+                local
+                    .put(6, floating(6, Some(0.0f64.to_bits()), 60), true)
+                    .unwrap();
+                expected.retain(|row| row[0] != Value::Integer(6));
+            }
+            let hot = MVCCTable::new(reader, store.clone(), local);
+            let mut table = SegmentedTable::new(Box::new(hot), manager);
+            table.set_read_epoch(registry.capture_read_epoch()).unwrap();
+            // A later committed change must not rewrite the captured group key.
+            let (later, _) = registry.begin_transaction();
+            registry.start_commit(later);
+            store
+                .add_version(2, RowVersion::new(later, floating(2, Some(NAN_A), 2000)))
+                .unwrap();
+            registry.complete_commit(later);
+            let operations = [(AggregateOp::CountStar, 0), (AggregateOp::Sum, 3)];
+            let mut expected_bits = std::collections::BTreeMap::<Option<u64>, (i64, f64)>::new();
+            for row in &expected {
+                let key = match row[4] {
+                    Value::Float(v) => Some(v.to_bits()),
+                    Value::Null(_) => None,
+                    _ => unreachable!(),
+                };
+                let Value::Integer(weight) = row[3] else {
+                    unreachable!()
+                };
+                let group = expected_bits.entry(key).or_default();
+                group.0 += 1;
+                group.1 += weight as f64;
+            }
+            let actual = table
+                .compute_grouped_aggregates(&[4], &operations)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                actual.len(),
+                expected_bits.len(),
+                "cold={cold} warm={warm} overlap={overlap}"
+            );
+            assert_eq!(bit_groups(actual), expected_bits);
+            // Existing multi-key Value equality still merges signed zeros and
+            // NaN payloads. Comparing by Value is intentional only in this case.
+            let multi = table
+                .compute_grouped_aggregates(&[4, 1], &operations)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                result_map(multi),
+                reference(&expected, &[4, 1], &operations)
+            );
+        }
+    }
+
+    #[test]
+    fn captured_group_single_off_schema_keys_fall_back_but_multi_numeric_equality_remains() {
+        let schema = schema();
+        let (registry, store) = store(&schema);
+        let (writer, _) = registry.begin_transaction();
+        registry.start_commit(writer);
+        for (id, key) in [
+            Value::Integer(1),
+            Value::Float(1.0),
+            Value::Float(-0.0),
+            Value::Integer(0),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let mut data = row(id as i64 + 1, "same", "same", 1);
+            data.set(4, key).unwrap();
+            store
+                .add_version(id as i64 + 1, RowVersion::new(writer, data))
+                .unwrap();
+        }
+        registry.complete_commit(writer);
+        let view = CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        );
+        assert!(
+            grouped(&schema, &view, None, &[4], &[(AggregateOp::CountStar, 0)])
+                .unwrap()
+                .is_none()
+        );
+        let multi = grouped(
+            &schema,
+            &view,
+            None,
+            &[4, 1],
+            &[(AggregateOp::CountStar, 0)],
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(multi.len(), 2);
+        assert!(multi
+            .iter()
+            .all(|group| group.aggregate_values == [Value::Integer(2)]));
+        // Homogeneous primitive grouping emits the actual schema-compatible
+        // value type; Float(1.0) must not become Integer(1).
+        for (column, wanted) in [
+            (3, DataType::Integer),
+            (5, DataType::Boolean),
+            (6, DataType::Timestamp),
+        ] {
+            let groups = grouped(
+                &schema,
+                &view,
+                None,
+                &[column],
+                &[(AggregateOp::CountStar, 0)],
+            )
+            .unwrap()
+            .unwrap();
+            assert!(groups
+                .iter()
+                .all(|group| group.group_values[0].data_type() == wanted));
+        }
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[test]
+    fn captured_aggregate_visibility_precedes_io_and_late_binding_propagates_error() {
+        let _guard = crate::test_failpoints::FailpointGuard::new();
+        let schema = schema();
+        let (registry, store) = store(&schema);
+        let manager = SegmentManager::new("aggregate", None);
+        add_segment(&manager, &schema, 1, &[(1, row(1, "a", "x", 1))], true);
+        add_segment(&manager, &schema, 2, &[(2, row(2, "b", "y", 2))], true);
+        let (_, mut generation) = manager.capture_with_hot(|| ()).unwrap();
+        let view = CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        );
+        let pending = FxHashSet::default();
+        let filter = ComparisonExpr::new("id", Operator::Gt, Value::Integer(0));
+        let operations = [(AggregateOp::Sum, 3)];
+        // First volume predicate + aggregate succeeds. The later volume's
+        // aggregate read must fail the entire call, never return the prefix.
+        crate::test_failpoints::fail_cold_read_on(4);
+        let error = filtered(
+            &schema,
+            &view,
+            Some((&generation, &pending)),
+            &operations,
+            &filter,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("injected cold read failure"));
+        assert_eq!(
+            filtered(
+                &schema,
+                &view,
+                Some((&generation, &pending)),
+                &operations,
+                &filter
+            )
+            .unwrap(),
+            Some(vec![Value::Integer(3)])
+        );
+        // Five aggregates borrow the same physical input. Each volume still
+        // loads only its predicate and aggregate columns, once each.
+        crate::test_failpoints::fail_cold_read_on(5);
+        assert_eq!(
+            filtered(
+                &schema,
+                &view,
+                Some((&generation, &pending)),
+                &[
+                    (AggregateOp::Count, 3),
+                    (AggregateOp::Sum, 3),
+                    (AggregateOp::Avg, 3),
+                    (AggregateOp::Min, 3),
+                    (AggregateOp::Max, 3),
+                ],
+                &filter,
+            )
+            .unwrap(),
+            Some(vec![
+                Value::Integer(2),
+                Value::Integer(3),
+                Value::Float(1.5),
+                Value::Integer(1),
+                Value::Integer(2),
+            ])
+        );
+        assert!(crate::test_failpoints::check_cold_read().is_err());
+        let reject = ComparisonExpr::new("id", Operator::Lt, Value::Integer(0));
+        crate::test_failpoints::fail_cold_read_on(3);
+        assert_eq!(
+            filtered(
+                &schema,
+                &view,
+                Some((&generation, &pending)),
+                &operations,
+                &reject
+            )
+            .unwrap(),
+            Some(vec![Value::Null(DataType::Float)])
+        );
+        assert!(
+            generation.segments[&1].volume.columns.get(3).is_err(),
+            "rejected rows must not bind aggregate columns"
+        );
+        // A missing dictionary target also skips the aggregate read, even
+        // after both predicate groups have been decoded successfully.
+        crate::test_failpoints::fail_cold_read_on(3);
+        assert_eq!(
+            filtered(
+                &schema,
+                &view,
+                Some((&generation, &pending)),
+                &operations,
+                &ComparisonExpr::eq("a", Value::text("absent"))
+            )
+            .unwrap(),
+            Some(vec![Value::Null(DataType::Float)])
+        );
+        assert!(crate::test_failpoints::check_cold_read().is_err());
+        // Authority alone hides both metadata-only files. No backing exists,
+        // so any eager promotion here would fail.
+        drop(manager);
+        let hidden = Arc::get_mut(&mut generation).unwrap();
+        for segment in Arc::make_mut(&mut hidden.segments).values_mut() {
+            segment.volume = Arc::new(segment.volume.to_cold());
+        }
+        let pending: FxHashSet<_> = [1, 2].into_iter().collect();
+        crate::test_failpoints::fail_cold_read_on(1);
+        assert_eq!(
+            filtered(
+                &schema,
+                &view,
+                Some((&generation, &pending)),
+                &operations,
+                &filter
+            )
+            .unwrap(),
+            Some(vec![Value::Null(DataType::Float)])
+        );
+        assert!(crate::test_failpoints::check_cold_read().is_err());
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[test]
+    fn captured_aggregate_mapped_defaults_omit_physical_columns() {
+        let _guard = crate::test_failpoints::FailpointGuard::new();
+        let schema = schema();
+        let (registry, store) = store(&schema);
+        let manager = SegmentManager::new("aggregate", None);
+        add_segment(
+            &manager,
+            &schema,
+            1,
+            &[(1, row(1, "old", "x", 1)), (2, row(2, "old", "y", 2))],
+            true,
+        );
+        let (_, mut generation) = manager.capture_with_hot(|| ()).unwrap();
+        drop(manager);
+        let segments = Arc::get_mut(&mut generation).unwrap();
+        let segment = Arc::make_mut(&mut segments.segments).get_mut(&1).unwrap();
+        segment.mapping = ColumnMapping {
+            is_identity: false,
+            sources: (0..schema.columns.len())
+                .map(|column| {
+                    if column == 1 {
+                        ColSource::Default(Value::text("new"))
+                    } else if column == 3 {
+                        ColSource::Default(Value::Integer(7))
+                    } else {
+                        ColSource::Volume(column)
+                    }
+                })
+                .collect(),
+        };
+        let view = CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        );
+        let pending = FxHashSet::default();
+        crate::test_failpoints::fail_cold_read_on(1);
+        assert_eq!(
+            filtered(
+                &schema,
+                &view,
+                Some((&generation, &pending)),
+                &[(AggregateOp::Sum, 3)],
+                &ComparisonExpr::eq("a", Value::text("new"))
+            )
+            .unwrap(),
+            Some(vec![Value::Integer(14)])
+        );
+        let grouped = grouped(
+            &schema,
+            &view,
+            Some((&generation, &pending)),
+            &[1, 3],
+            &[(AggregateOp::CountStar, 0)],
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            grouped[0].group_values,
+            vec![Value::text("new"), Value::Integer(7)]
+        );
+        assert_eq!(grouped[0].aggregate_values, vec![Value::Integer(2)]);
+        assert!(crate::test_failpoints::check_cold_read().is_err());
+    }
+
+    #[test]
+    fn captured_aggregate_dictionary_windows_match_scalar_filters() {
+        let schema = schema();
+        let operations = [(AggregateOp::CountStar, 0), (AggregateOp::Sum, 3)];
+        for warm in [false, true] {
+            for length in [
+                7,
+                8,
+                9,
+                DICTIONARY_WINDOW - 1,
+                DICTIONARY_WINDOW,
+                DICTIONARY_WINDOW + 1,
+                DICTIONARY_WINDOW + 9,
+            ] {
+                let (registry, store) = store(&schema);
+                let manager = SegmentManager::new("aggregate", None);
+                // Dense leading blocks, a sparse tail, nulls and mismatching
+                // second keys all cross the selector's vector/window boundary.
+                let rows: Vec<_> = (1..=length)
+                    .map(|id| {
+                        let mut value = row(
+                            id as i64,
+                            if id < 512 || id % 31 == 0 { "a" } else { "b" },
+                            if id % 3 == 0 { "y" } else { "x" },
+                            id as i64,
+                        );
+                        if id % 19 == 0 {
+                            value.set(1, Value::Null(DataType::Text)).unwrap();
+                        }
+                        if id % 23 == 0 {
+                            value.set(2, Value::Null(DataType::Text)).unwrap();
+                        }
+                        (id as i64, value)
+                    })
+                    .collect();
+                add_segment(&manager, &schema, 1, &rows, warm);
+                let (_, generation) = manager.capture_with_hot(|| ()).unwrap();
+                let view = CapturedHotView::new(
+                    store.capture_hot_root(),
+                    registry.capture_read_epoch(),
+                    None,
+                );
+                let pending: FxHashSet<_> = rows
+                    .iter()
+                    .filter(|(id, _)| id % 17 == 0)
+                    .map(|(id, _)| *id)
+                    .collect();
+                for prefix in 0..=6 {
+                    for scalar_first in [false, true] {
+                        for target in ["a", "missing"] {
+                            let scalar = || {
+                                Box::new(ComparisonExpr::new("n", Operator::Gt, Value::Integer(4)))
+                                    as Box<dyn Expression>
+                            };
+                            let mut children: Vec<Box<dyn Expression>> = Vec::new();
+                            if scalar_first {
+                                children.push(scalar());
+                            }
+                            for index in 0..prefix {
+                                children.push(Box::new(ComparisonExpr::eq(
+                                    if index % 2 == 0 { "a" } else { "b" },
+                                    Value::text(if index % 2 == 0 { target } else { "x" }),
+                                )));
+                            }
+                            if !scalar_first {
+                                children.push(scalar());
+                            }
+                            children.push(Box::new(ComparisonExpr::new(
+                                "b",
+                                Operator::Ne,
+                                Value::text("y"),
+                            )));
+                            let mut expression = AndExpr::new(children);
+                            expression.prepare_for_schema(&schema);
+                            let matches: Vec<_> = rows
+                                .iter()
+                                .filter(|(id, row)| {
+                                    !pending.contains(id) && expression.evaluate(row).unwrap()
+                                })
+                                .collect();
+                            let expected = vec![
+                                Value::Integer(matches.len() as i64),
+                                if matches.is_empty() {
+                                    Value::Null(DataType::Float)
+                                } else {
+                                    Value::Integer(matches.iter().map(|(id, _)| *id).sum())
+                                },
+                            ];
+                            assert_eq!(filtered(&schema, &view, Some((&generation, &pending)),
+                                &operations, &expression).unwrap(), Some(expected),
+                                "warm={warm}, length={length}, prefix={prefix}, first={scalar_first}, target={target}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn dictionary_sample_is_only_a_hint_and_keeps_later_window_matches() {
+        let schema = schema();
+        for warm in [false, true] {
+            let (registry, store) = store(&schema);
+            let manager = SegmentManager::new("aggregate", None);
+            let rows: Vec<_> = (1..=DICTIONARY_WINDOW + 65)
+                .map(|id| {
+                    // The second target has zero sample hits but matches in
+                    // later windows. NULL has the target's dictionary ID on
+                    // some rows and must still be excluded.
+                    let mut value = row(
+                        id as i64,
+                        if id <= 64 || id % 3 == 0 { "a" } else { "b" },
+                        if id <= 64 { "y" } else { "x" },
+                        id as i64,
+                    );
+                    if id % 17 == 0 {
+                        value.set(2, Value::Null(DataType::Text)).unwrap();
+                    }
+                    (id as i64, value)
+                })
+                .collect();
+            add_segment(&manager, &schema, 1, &rows, warm);
+            let (_, generation) = manager.capture_with_hot(|| ()).unwrap();
+            let view = CapturedHotView::new(
+                store.capture_hot_root(),
+                registry.capture_read_epoch(),
+                None,
+            );
+            let pending = FxHashSet::from_iter([69, 1026]);
+            let mut expression = AndExpr::new(vec![
+                Box::new(ComparisonExpr::eq("a", Value::text("a"))),
+                Box::new(ComparisonExpr::eq("b", Value::text("x"))),
+            ]);
+            expression.prepare_for_schema(&schema);
+            let expected: Vec<_> = rows
+                .iter()
+                .filter(|(id, row)| !pending.contains(id) && expression.evaluate(row).unwrap())
+                .collect();
+            assert!(!expected.is_empty());
+            assert!(expected
+                .iter()
+                .any(|(id, _)| *id > DICTIONARY_WINDOW as i64));
+            assert_eq!(
+                filtered(
+                    &schema,
+                    &view,
+                    Some((&generation, &pending)),
+                    &[(AggregateOp::CountStar, 0), (AggregateOp::Sum, 3)],
+                    &expression,
+                )
+                .unwrap(),
+                Some(vec![
+                    Value::Integer(expected.len() as i64),
+                    Value::Integer(expected.iter().map(|(id, _)| *id).sum()),
+                ]),
+            );
+        }
+    }
+
+    #[test]
+    fn captured_aggregate_dictionary_selection_preserves_scalar_error_order() {
+        let schema = schema();
+        let (registry, store) = store(&schema);
+        let manager = SegmentManager::new("aggregate", None);
+        add_segment(&manager, &schema, 1, &[(1, row(1, "a", "x", 1))], true);
+        let (_, mut generation) = manager.capture_with_hot(|| ()).unwrap();
+        drop(manager);
+        let segment = Arc::make_mut(&mut Arc::get_mut(&mut generation).unwrap().segments)
+            .get_mut(&1)
+            .unwrap();
+        // A schema/default change can leave an incompatible runtime scalar.
+        // A rejecting later dictionary equality cannot conceal its error.
+        segment.mapping.sources[2] = ColSource::Default(Value::Integer(10));
+        let view = CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        );
+        let pending = FxHashSet::default();
+        for scalar_first in [true, false] {
+            let invalid = Box::new(ComparisonExpr::new("b", Operator::Ne, Value::text("10")))
+                as Box<dyn Expression>;
+            let reject =
+                Box::new(ComparisonExpr::eq("a", Value::text("absent"))) as Box<dyn Expression>;
+            let expression = AndExpr::new(if scalar_first {
+                vec![invalid, reject]
+            } else {
+                vec![reject, invalid]
+            });
+            let result = filtered(
+                &schema,
+                &view,
+                Some((&generation, &pending)),
+                &[(AggregateOp::CountStar, 0)],
+                &expression,
+            );
+            if scalar_first {
+                assert!(result.is_err());
+            } else {
+                assert_eq!(result.unwrap(), Some(vec![Value::Integer(0)]));
+            }
+        }
+    }
+
+    #[test]
+    fn captured_aggregate_reuses_authority_and_dictionary_state_across_groups() {
+        let schema = schema();
+        let (registry, store) = store(&schema);
+        let manager = SegmentManager::new("aggregate", None);
+        let rows: Vec<_> = (1..=ROW_GROUP_SIZE + 3)
+            .map(|id| {
+                (
+                    id as i64,
+                    row(id as i64, if id % 2 == 0 { "a" } else { "b" }, "x", 1),
+                )
+            })
+            .collect();
+        add_segment(&manager, &schema, 1, &rows, true);
+        let (_, generation) = manager.capture_with_hot(|| ()).unwrap();
+        let view = CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        );
+        let pending: FxHashSet<_> = (1..=ROW_GROUP_SIZE as i64 + 1).collect();
+        let result = grouped(
+            &schema,
+            &view,
+            Some((&generation, &pending)),
+            &[1],
+            &[(AggregateOp::CountStar, 0), (AggregateOp::Sum, 3)],
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            result_map(result),
+            [
+                (
+                    vec![Value::text("a")],
+                    vec![Value::Integer(1), Value::Integer(1)]
+                ),
+                (
+                    vec![Value::text("b")],
+                    vec![Value::Integer(1), Value::Integer(1)]
+                ),
+            ]
+            .into_iter()
+            .collect()
+        );
+        let empty_pending = FxHashSet::default();
+        let result = grouped(
+            &schema,
+            &view,
+            Some((&generation, &empty_pending)),
+            &[1, 2],
+            &[(AggregateOp::CountStar, 0)],
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            result_map(result),
+            [
+                (
+                    vec![Value::text("a"), Value::text("x")],
+                    vec![Value::Integer((ROW_GROUP_SIZE / 2 + 1) as i64)]
+                ),
+                (
+                    vec![Value::text("b"), Value::text("x")],
+                    vec![Value::Integer((ROW_GROUP_SIZE / 2 + 2) as i64)]
+                ),
+            ]
+            .into_iter()
+            .collect()
+        );
+    }
+
+    #[test]
+    fn captured_aggregate_changed_schema_preserves_hot_type_errors_and_fallback() {
+        let mut schema = schema();
+        schema
+            .modify_column("b", Some(DataType::Json), Some(true))
+            .unwrap();
+        let (registry, store) = store(&schema);
+        let (writer, _) = registry.begin_transaction();
+        registry.start_commit(writer);
+        let mut original = row(1, "a", "x", 10);
+        original.set(2, Value::json("{}")).unwrap();
+        store
+            .add_version(1, RowVersion::new(writer, original.clone()))
+            .unwrap();
+        registry.complete_commit(writer);
+        let (reader, _) = registry.begin_transaction();
+        let mut table = MVCCTable::new(
+            reader,
+            store.clone(),
+            TransactionVersionStore::new(store, reader),
+        );
+        table.modify_column("n", DataType::Text, true).unwrap();
+        table.modify_column("b", DataType::Text, true).unwrap();
+        table.set_read_epoch(registry.capture_read_epoch()).unwrap();
+        let mut predicate = ComparisonExpr::new("n", Operator::Ne, Value::text("10"));
+        predicate.prepare_for_schema(table.schema());
+        let expected = predicate.evaluate(&original).unwrap_err().to_string();
+        assert_eq!(
+            table
+                .compute_filtered_aggregates(&[(AggregateOp::CountStar, 0)], &predicate)
+                .unwrap_err()
+                .to_string(),
+            expected
+        );
+        assert!(
+            table
+                .compute_grouped_aggregates(&[2], &[(AggregateOp::CountStar, 0)])
+                .unwrap()
+                .is_none(),
+            "old extension payloads under a scalar schema require the generic path"
+        );
+        let all = ComparisonExpr::new("id", Operator::Gt, Value::Integer(0));
+        assert!(table
+            .compute_filtered_aggregates(&[(AggregateOp::Min, 2)], &all)
+            .unwrap()
+            .is_none());
+    }
+}

--- a/src/storage/volume/captured_scanner.rs
+++ b/src/storage/volume/captured_scanner.rs
@@ -1,0 +1,555 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Lazy cold iteration over one immutable table generation.
+
+use std::sync::Arc;
+
+use rustc_hash::FxHashSet;
+
+use crate::core::{DataType, Error, Operator, Result, Row, Schema, Value};
+use crate::storage::expression::Expression;
+use crate::storage::mvcc::version_store::{CapturedHotRow, CapturedHotView};
+use crate::storage::traits::Scanner;
+
+use super::manifest::{ColdGeneration, ColdSegment};
+use super::scanner::VolumeScanner;
+
+type MetadataComparisons = smallvec::SmallVec<[(usize, Operator, Value, Option<u64>); 4]>;
+
+/// Only the current volume is loaded. Metadata owners survive compaction and
+/// eviction; advancing never consults the mutable segment manager.
+pub(crate) struct CapturedColdScanner {
+    generation: Option<Arc<ColdGeneration>>,
+    view: Option<Arc<CapturedHotView>>,
+    pending: Option<Arc<FxHashSet<i64>>>,
+    columns: Vec<usize>,
+    filter: Option<Box<dyn Expression>>,
+    comparisons: MetadataComparisons,
+    // Only a single exact equality on the current INTEGER primary key.
+    pk_lookup: Option<(usize, i64)>,
+    remaining: usize,
+    active: Option<VolumeScanner>,
+    error: Option<Error>,
+    empty: Row,
+}
+
+impl CapturedColdScanner {
+    pub(crate) fn new(
+        generation: Arc<ColdGeneration>,
+        view: Arc<CapturedHotView>,
+        pending: Arc<FxHashSet<i64>>,
+        columns: Vec<usize>,
+        filter: Option<Box<dyn Expression>>,
+        schema: &Schema,
+    ) -> Self {
+        let remaining = generation.segment_ids_newest_first.len();
+        let pk_lookup = filter.as_ref().and_then(|filter| {
+            let (name, Operator::Eq, Value::Integer(id)) = filter.get_comparison_info()? else {
+                return None;
+            };
+            let mut primary = schema
+                .columns
+                .iter()
+                .enumerate()
+                .filter(|(_, c)| c.primary_key);
+            let (index, column) = primary.next()?;
+            (primary.next().is_none()
+                && column.data_type == DataType::Integer
+                && name.eq_ignore_ascii_case(&column.name))
+            .then_some((index, *id))
+        });
+        let comparisons = filter
+            .as_ref()
+            .map(|filter| {
+                filter
+                    .collect_comparisons()
+                    .into_iter()
+                    .filter_map(|(column, operator, value)| {
+                        let column = *schema.column_index_map().get(&column.to_lowercase())?;
+                        let hash = (operator == Operator::Eq)
+                            .then(|| super::column::ColumnBloomFilter::hash_value_static(value));
+                        Some((column, operator, value.clone(), hash))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Self {
+            generation: Some(generation),
+            view: Some(view),
+            pending: Some(pending),
+            columns,
+            filter,
+            comparisons,
+            pk_lookup,
+            remaining,
+            active: None,
+            error: None,
+            empty: Row::new(),
+        }
+    }
+
+    fn pruned(&self, segment: &ColdSegment) -> bool {
+        self.comparisons
+            .iter()
+            .any(|(logical, operator, value, hash)| {
+                let Some(super::writer::ColSource::Volume(physical)) =
+                    segment.mapping.sources.get(*logical)
+                else {
+                    return false;
+                };
+                let Some(zone) = segment.volume.meta.zone_maps.get(*physical) else {
+                    return false;
+                };
+                match operator {
+                    Operator::Eq => {
+                        !zone.may_contain_eq(value)
+                            || (segment.volume.meta.column_types.get(*physical).is_some_and(
+                                |&data_type| {
+                                    super::column::ColumnBloomFilter::equality_hash_compatible(
+                                        data_type, value,
+                                    )
+                                },
+                            ) && hash.is_some_and(|hash| {
+                                segment
+                                    .volume
+                                    .meta
+                                    .bloom_filters
+                                    .get(*physical)
+                                    .is_some_and(|bloom| !bloom.might_contain_hash(hash))
+                            }))
+                    }
+                    Operator::Gt | Operator::Gte => !zone.may_contain_gte(value),
+                    Operator::Lt | Operator::Lte => !zone.may_contain_lte(value),
+                    _ => false,
+                }
+            })
+    }
+
+    /// A metadata-only pass prevents reloading a completely hidden cold file.
+    /// One group of authority bits bounds scratch independently of table size.
+    pub(crate) fn visible_count(
+        segment: &ColdSegment,
+        generation: &ColdGeneration,
+        view: &CapturedHotView,
+        pending: &FxHashSet<i64>,
+        stop_after_first: bool,
+    ) -> usize {
+        if view.is_empty()
+            && pending.is_empty()
+            && generation.tombstones.is_empty()
+            && segment.visible.is_none()
+        {
+            return if stop_after_first {
+                usize::from(segment.volume.meta.row_count != 0)
+            } else {
+                segment.volume.meta.row_count
+            };
+        }
+        let mut count = 0;
+        Self::for_each_visible(segment, generation, view, pending, |_, _| {
+            count += 1;
+            !stop_after_first
+        });
+        count
+    }
+
+    pub(crate) fn for_each_visible(
+        segment: &ColdSegment,
+        generation: &ColdGeneration,
+        view: &CapturedHotView,
+        pending: &FxHashSet<i64>,
+        mut visit: impl FnMut(usize, i64) -> bool,
+    ) -> bool {
+        const GROUP: usize = super::column::ROW_GROUP_SIZE;
+        let mut bits = [0u64; GROUP.div_ceil(64)];
+        for (group, ids) in segment.volume.meta.row_ids.chunks(GROUP).enumerate() {
+            view.mark_authoritative(ids, &mut bits);
+            for (local, &id) in ids.iter().enumerate() {
+                if bits[local / 64] & (1 << (local % 64)) != 0
+                    || !segment.is_visible(group * GROUP + local)
+                    || pending.contains(&id)
+                    || generation.tombstones.get(&id).is_some_and(|&sequence| {
+                        i64::try_from(sequence)
+                            .is_ok_and(|sequence| view.epoch().admits_commit_sequence(sequence))
+                    })
+                {
+                    continue;
+                }
+                if !visit(group * GROUP + local, id) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    fn advance(&mut self) -> Result<bool> {
+        let (Some(generation), Some(view), Some(pending)) =
+            (&self.generation, &self.view, &self.pending)
+        else {
+            return Ok(false);
+        };
+        while self.remaining != 0 {
+            self.remaining -= 1;
+            let id = generation.segment_ids_newest_first[self.remaining];
+            let segment = generation.segments.get(&id).ok_or_else(|| {
+                Error::internal(format!("captured generation has no segment {id}"))
+            })?;
+            // Row IDs are the physical identity of a single INTEGER PK.
+            // A default or type-changed PK mapping cannot use that proof.
+            let point = self.pk_lookup.and_then(|(logical, row_id)| {
+                let super::writer::ColSource::Volume(physical) =
+                    segment.mapping.sources.get(logical)?
+                else {
+                    return None;
+                };
+                (segment.volume.meta.column_types.get(*physical) == Some(&DataType::Integer))
+                    .then(|| segment.volume.meta.row_ids.binary_search(&row_id))
+            });
+            let range = match point {
+                Some(Ok(index)) => {
+                    let row_id = segment.volume.meta.row_ids[index];
+                    // Resolve authority before opening a captured cold file,
+                    // even when unrelated rows in that file remain visible.
+                    if !matches!(view.row_state(row_id), CapturedHotRow::NoVisibleVersion)
+                        || !segment.is_visible(index)
+                        || pending.contains(&row_id)
+                        || generation.tombstones.get(&row_id).is_some_and(|&sequence| {
+                            i64::try_from(sequence)
+                                .is_ok_and(|sequence| view.epoch().admits_commit_sequence(sequence))
+                        })
+                    {
+                        continue;
+                    }
+                    Some((index, index + 1))
+                }
+                Some(Err(_)) => continue,
+                None => None,
+            };
+            if self.pruned(segment) {
+                continue;
+            }
+            if range.is_none()
+                && segment.volume.is_cold()
+                && Self::visible_count(segment, generation, view, pending, true) == 0
+            {
+                continue;
+            }
+            let loaded = generation.load_segment(id)?;
+            let mut scanner = if let Some((start, end)) = range {
+                VolumeScanner::with_range(loaded.volume, self.columns.clone(), start, end, None)
+            } else {
+                VolumeScanner::new(loaded.volume, self.columns.clone(), None)
+            };
+            scanner.set_skip_sets(generation.tombstones.clone(), pending.clone());
+            scanner.set_visibility_bitmap(loaded.visible);
+            scanner.set_column_mapping(loaded.mapping);
+            scanner.set_captured_visibility(view.clone(), pending.clone());
+            if let Some(filter) = &self.filter {
+                scanner.set_filter(filter.clone_box());
+            }
+            self.active = Some(scanner);
+            return Ok(true);
+        }
+        Ok(false)
+    }
+}
+
+impl Scanner for CapturedColdScanner {
+    fn next(&mut self) -> bool {
+        if self.error.is_some() {
+            return false;
+        }
+        loop {
+            if let Some(active) = &mut self.active {
+                if active.next() {
+                    return true;
+                }
+                if active.err().is_some() {
+                    return false;
+                }
+            }
+            self.active = None;
+            match self.advance() {
+                Ok(true) => (),
+                Ok(false) => {
+                    let _ = self.close();
+                    return false;
+                }
+                Err(error) => {
+                    self.error = Some(error);
+                    return false;
+                }
+            }
+        }
+    }
+    fn row(&self) -> &Row {
+        self.active.as_ref().map_or(&self.empty, Scanner::row)
+    }
+    fn current_row_id(&self) -> i64 {
+        self.active.as_ref().map_or(0, Scanner::current_row_id)
+    }
+    fn take_row(&mut self) -> Row {
+        self.active
+            .as_mut()
+            .map_or_else(Row::new, Scanner::take_row)
+    }
+    fn take_row_with_id(&mut self) -> (i64, Row) {
+        (self.current_row_id(), self.take_row())
+    }
+    fn err(&self) -> Option<&Error> {
+        self.error
+            .as_ref()
+            .or_else(|| self.active.as_ref().and_then(Scanner::err))
+    }
+    fn close(&mut self) -> Result<()> {
+        if let Some(active) = &mut self.active {
+            if self.error.is_none() {
+                self.error = active.err().cloned();
+            }
+            active.close()?;
+        }
+        self.active = None;
+        self.generation = None;
+        self.view = None;
+        self.pending = None;
+        self.filter = None;
+        self.comparisons = smallvec::SmallVec::new();
+        self.pk_lookup = None;
+        self.columns = Vec::new();
+        self.remaining = 0;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::SchemaBuilder;
+    use crate::storage::expression::ComparisonExpr;
+    use crate::storage::mvcc::version_store::{RowVersion, TransactionVersionStore, VersionStore};
+    use crate::storage::mvcc::{MVCCTable, TransactionRegistry};
+    use crate::storage::traits::Table;
+    use crate::storage::volume::manifest::{SegmentManager, SegmentMeta};
+    use crate::storage::volume::table::SegmentedTable;
+    use crate::storage::volume::writer::{ColSource, VolumeBuilder};
+
+    fn row(id: i64, n: i64) -> Row {
+        Row::from_values(vec![Value::Integer(id), Value::Integer(n)])
+    }
+    fn fixture() -> (
+        Schema,
+        Arc<TransactionRegistry>,
+        Arc<VersionStore>,
+        Arc<SegmentManager>,
+    ) {
+        let schema = SchemaBuilder::new("point")
+            .add_primary_key("id", DataType::Integer)
+            .add("n", DataType::Integer)
+            .build();
+        let registry = Arc::new(TransactionRegistry::new());
+        let store = Arc::new(VersionStore::with_visibility_checker(
+            "point",
+            schema.clone(),
+            registry.clone(),
+        ));
+        let manager = Arc::new(SegmentManager::new("point", None));
+        let mut builder = VolumeBuilder::new(&schema);
+        for id in 1..=6 {
+            builder.add_row(id, &row(id, id * 10));
+        }
+        manager.register_segment(
+            1,
+            Arc::new(builder.finish()),
+            SegmentMeta {
+                segment_id: 1,
+                file_path: "unopened-point.vol".into(),
+                row_count: 6,
+                min_row_id: 1,
+                max_row_id: 6,
+                schema_version: 0,
+                creation_lsn: 0,
+                seal_seq: 0,
+            },
+            Some(&schema),
+        );
+        (schema, registry, store, manager)
+    }
+    fn collect(scanner: &mut dyn Scanner) -> Result<Vec<(i64, Row)>> {
+        let mut rows = Vec::new();
+        while scanner.next() {
+            rows.push(scanner.take_row_with_id());
+        }
+        if let Some(error) = scanner.err() {
+            return Err(error.clone());
+        }
+        scanner.close()?;
+        Ok(rows)
+    }
+
+    #[test]
+    fn captured_pk_range_keeps_own_authority_and_frozen_sources() {
+        let (_, registry, store, manager) = fixture();
+        let (inflight, _) = registry.begin_transaction();
+        registry.start_commit(inflight);
+        store
+            .add_version(6, RowVersion::new(inflight, row(6, 600)))
+            .unwrap();
+        let (reader, _) = registry.begin_transaction();
+        let mut local = TransactionVersionStore::new(store.clone(), reader);
+        local.put(2, row(2, 200), false).unwrap();
+        local.put(3, row(3, 30), true).unwrap();
+        manager.add_pending_tombstone(reader, 4);
+        let hot = MVCCTable::new(reader, store.clone(), local);
+        let mut table = SegmentedTable::new(Box::new(hot), manager.clone());
+        table.set_read_epoch(registry.capture_read_epoch()).unwrap();
+        registry.complete_commit(inflight);
+        for (id, expected) in [
+            (1, Some(10)),
+            (2, Some(200)),
+            (3, None),
+            (4, None),
+            (6, Some(60)),
+            (99, None),
+        ] {
+            let filter = ComparisonExpr::eq("id", Value::Integer(id));
+            let mut scanner = table.scan(&[1], Some(&filter)).unwrap();
+            assert_eq!(
+                collect(&mut *scanner).unwrap(),
+                expected
+                    .into_iter()
+                    .map(|n| (id, Row::from_values(vec![Value::Integer(n)])))
+                    .collect::<Vec<_>>()
+            );
+        }
+        let filter = ComparisonExpr::eq("id", Value::Integer(5));
+        let mut scanner = table.scan(&[1], Some(&filter)).unwrap();
+        let (newer, _) = registry.begin_transaction();
+        registry.start_commit(newer);
+        store
+            .add_version(5, RowVersion::new(newer, row(5, 500)))
+            .unwrap();
+        registry.complete_commit(newer);
+        manager.rollback_pending_tombstones(reader);
+        manager.clear();
+        assert_eq!(
+            collect(&mut *scanner).unwrap(),
+            vec![(5, Row::from_values(vec![Value::Integer(50)]))]
+        );
+    }
+
+    #[test]
+    fn captured_pk_range_resolves_hidden_or_absent_before_cold_loading() {
+        let (schema, registry, store, manager) = fixture();
+        let (writer, _) = registry.begin_transaction();
+        registry.start_commit(writer);
+        store
+            .add_version(1, RowVersion::new(writer, row(1, 100)))
+            .unwrap();
+        let mut deleted = RowVersion::new(writer, row(2, 20));
+        deleted.deleted_at_txn_id = writer;
+        store.add_version(2, deleted).unwrap();
+        registry.complete_commit(writer);
+        manager.add_tombstones(&[4], registry.get_commit_sequence(writer).unwrap() as u64);
+        let (_, mut generation) = manager.capture_with_hot(|| ()).unwrap();
+        drop(manager);
+        let generation_mut = Arc::get_mut(&mut generation).unwrap();
+        let segment = Arc::make_mut(&mut generation_mut.segments)
+            .get_mut(&1)
+            .unwrap();
+        segment.volume = Arc::new(segment.volume.to_cold());
+        let view = Arc::new(CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        ));
+        let pending: Arc<FxHashSet<i64>> = Arc::new([3].into_iter().collect());
+        for id in [1, 2, 3, 4, 99, 6] {
+            let mut filter = ComparisonExpr::eq("id", Value::Integer(id));
+            filter.prepare_for_schema(&schema);
+            let mut scanner = CapturedColdScanner::new(
+                generation.clone(),
+                view.clone(),
+                pending.clone(),
+                vec![1],
+                Some(Box::new(filter)),
+                &schema,
+            );
+            assert_eq!(scanner.pk_lookup, Some((0, id)));
+            let result = collect(&mut scanner);
+            if id == 6 {
+                assert!(result.is_err(), "visible captured file failure propagates");
+            } else {
+                assert!(
+                    result.unwrap().is_empty(),
+                    "id {id} loaded a hidden or absent source"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn captured_pk_range_rejects_coercions_and_preserves_mapped_defaults() {
+        let (schema, registry, store, manager) = fixture();
+        let (_, mut generation) = manager.capture_with_hot(|| ()).unwrap();
+        let view = Arc::new(CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        ));
+        for (column, value, expected_id) in
+            [("n", Value::Integer(20), 2), ("id", Value::Float(2.0), 2)]
+        {
+            let mut filter = ComparisonExpr::eq(column, value);
+            filter.prepare_for_schema(&schema);
+            let mut scanner = CapturedColdScanner::new(
+                generation.clone(),
+                view.clone(),
+                Arc::default(),
+                vec![1],
+                Some(Box::new(filter)),
+                &schema,
+            );
+            assert!(scanner.pk_lookup.is_none());
+            assert_eq!(
+                collect(&mut scanner).unwrap(),
+                vec![(expected_id, Row::from_values(vec![Value::Integer(20)]))]
+            );
+        }
+        drop(manager);
+        let segment = Arc::make_mut(&mut Arc::get_mut(&mut generation).unwrap().segments)
+            .get_mut(&1)
+            .unwrap();
+        segment.mapping.is_identity = false;
+        segment.mapping.sources[0] = ColSource::Default(Value::Integer(7));
+        segment.mapping.sources[1] = ColSource::Default(Value::Integer(42));
+        let mut filter = ComparisonExpr::eq("id", Value::Integer(7));
+        filter.prepare_for_schema(&schema);
+        let mut scanner = CapturedColdScanner::new(
+            generation,
+            view,
+            Arc::default(),
+            vec![1],
+            Some(Box::new(filter)),
+            &schema,
+        );
+        assert_eq!(
+            collect(&mut scanner).unwrap(),
+            (1..=6)
+                .map(|id| (id, Row::from_values(vec![Value::Integer(42)])))
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/src/storage/volume/column.rs
+++ b/src/storage/volume/column.rs
@@ -674,6 +674,13 @@ pub struct ColumnBloomFilter {
 }
 
 impl ColumnBloomFilter {
+    /// V4 hashes include scalar type tags and raw floating bits. A negative
+    /// probe is conclusive only when SQL equality cannot cross those encodings.
+    #[inline]
+    pub(crate) fn equality_hash_compatible(data_type: DataType, value: &Value) -> bool {
+        data_type == value.data_type() && !matches!(value, Value::Float(value) if *value == 0.0)
+    }
+
     /// Estimate in-memory size of this bloom filter in bytes.
     pub fn memory_size(&self) -> usize {
         self.bits.len() * 8 + 8

--- a/src/storage/volume/io.rs
+++ b/src/storage/volume/io.rs
@@ -19,13 +19,373 @@
 //! corruption from crashes during writes.
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use crate::core::Result;
 
 use super::column::ROW_GROUP_SIZE;
 use super::format::{deserialize_volume_metadata, serialize_volume_metadata};
 use super::writer::{CompressedBlockStore, FrozenVolume, LazyColumns};
+
+/// Immutable identity plus a managed location, with no idle file descriptor.
+/// Residency transitions share this allocation. Only managed directory renames
+/// may change its location; every open still validates the captured identity.
+pub(crate) struct VolumeFile {
+    path: parking_lot::RwLock<PathBuf>,
+    identity: FileIdentity,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct FileIdentity {
+    device: u64,
+    #[cfg(not(windows))]
+    file: u64,
+    #[cfg(windows)]
+    file: [u8; 16],
+    length: u64,
+}
+
+impl FileIdentity {
+    fn capture(file: &std::fs::File) -> std::io::Result<Self> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let metadata = file.metadata()?;
+            Ok(Self {
+                device: metadata.dev(),
+                file: metadata.ino(),
+                length: metadata.len(),
+            })
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::AsRawHandle;
+            use windows_sys::Win32::Storage::FileSystem::{
+                FileIdInfo, GetFileInformationByHandleEx, FILE_ID_INFO,
+            };
+            let mut information = FILE_ID_INFO::default();
+            // SAFETY: File owns a valid live handle, and information points to
+            // writable, correctly aligned storage of exactly the advertised
+            // size for FileIdInfo. The synchronous API does not retain it.
+            let success = unsafe {
+                GetFileInformationByHandleEx(
+                    file.as_raw_handle(),
+                    FileIdInfo,
+                    (&mut information as *mut FILE_ID_INFO).cast(),
+                    std::mem::size_of::<FILE_ID_INFO>() as u32,
+                )
+            };
+            if success == 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            // ReFS needs the full 128-bit ID. Unsupported/unknown IDs must
+            // never collapse distinct files onto the same fallback identity.
+            let file_id = information.FileId.Identifier;
+            if file_id == [0; 16] || file_id == [u8::MAX; 16] {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    "filesystem did not provide a stable volume file identity",
+                ));
+            }
+            Ok(Self {
+                device: information.VolumeSerialNumber,
+                file: file_id,
+                length: file.metadata()?.len(),
+            })
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = file;
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "persistent volumes require stable file identities on this platform",
+            ))
+        }
+    }
+}
+
+impl VolumeFile {
+    fn from_file(path: &Path, file: &std::fs::File) -> std::io::Result<Arc<Self>> {
+        Ok(Arc::new(Self {
+            path: parking_lot::RwLock::new(path.to_path_buf()),
+            identity: FileIdentity::capture(file)?,
+        }))
+    }
+
+    fn open_reader(self: &Arc<Self>) -> std::io::Result<VolumeReadLease> {
+        // A managed rename holds the write guard through rename + path update.
+        // The active file handle then remains valid independently of the path.
+        let path = self.path.read();
+        let file = std::fs::File::open(&*path)?;
+        if FileIdentity::capture(&file)? != self.identity {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "captured volume file identity changed",
+            ));
+        }
+        Ok(VolumeReadLease {
+            file,
+            backing: self.clone(),
+        })
+    }
+}
+
+/// One decoder owns one open handle. Its backing owner also prevents a
+/// retirement sweep from unlinking the file until this read has completed.
+struct VolumeReadLease {
+    file: std::fs::File,
+    backing: Arc<VolumeFile>,
+}
+
+struct RetiredVolume {
+    backing: Weak<VolumeFile>,
+    path: PathBuf,
+    identity: FileIdentity,
+}
+
+/// Fully allocated before a destructive WAL operation. Linking this node after
+/// success is allocation-free; dropping an uncommitted node never schedules IO.
+pub(crate) struct PreparedRetirement {
+    entries: Vec<RetiredVolume>,
+    pub(crate) omitted_segment_ids: Vec<u64>,
+    pub(crate) next: Option<Box<PreparedRetirement>>,
+}
+
+impl PreparedRetirement {
+    /// Allocate every replacement before the directory is renamed. Parked
+    /// batches are owned by the manager until durable omission grants cleanup.
+    pub(crate) fn prepare_relocation(&self, old: &Path, new: &Path) -> Vec<Option<PathBuf>> {
+        self.entries
+            .iter()
+            .map(|entry| {
+                entry
+                    .path
+                    .strip_prefix(old)
+                    .ok()
+                    .map(|suffix| new.join(suffix))
+            })
+            .collect()
+    }
+
+    pub(crate) fn apply_relocation(&mut self, replacements: Vec<Option<PathBuf>>) {
+        debug_assert_eq!(self.entries.len(), replacements.len());
+        for (entry, replacement) in self.entries.iter_mut().zip(replacements) {
+            if let Some(replacement) = replacement {
+                entry.path = replacement;
+            }
+        }
+    }
+}
+
+impl Drop for PreparedRetirement {
+    fn drop(&mut self) {
+        // Repeated failed manifest writes can retain several exact batches.
+        // Release only metadata here, iteratively, without stack growth or IO.
+        let mut next = self.next.take();
+        while let Some(mut batch) = next {
+            next = batch.next.take();
+        }
+    }
+}
+
+#[derive(Default)]
+struct FileCatalog {
+    // One inline Weak for the normal one-descriptor case. Independent decodes
+    // registered in this engine remain aliases of the same physical identity.
+    live: rustc_hash::FxHashMap<FileIdentity, smallvec::SmallVec<[Weak<VolumeFile>; 1]>>,
+    pending: Vec<RetiredVolume>,
+    prepared: Option<Box<PreparedRetirement>>,
+}
+
+impl FileCatalog {
+    fn track(&mut self, backing: &Arc<VolumeFile>) {
+        let aliases = self.live.entry(backing.identity).or_default();
+        aliases.retain(|alias| alias.strong_count() != 0);
+        let weak = Arc::downgrade(backing);
+        if !aliases.iter().any(|alias| Weak::ptr_eq(alias, &weak)) {
+            aliases.push(weak);
+        }
+    }
+}
+
+/// Engine-owned deferred cleanup. Enqueue and sweep happen outside transfer
+/// fences; neither a generation nor a file descriptor performs I/O on Drop.
+/// Dropping the engine with live readers may leave an orphan for startup cleanup.
+#[derive(Default)]
+pub(crate) struct VolumeRetirementQueue {
+    catalog: parking_lot::Mutex<FileCatalog>,
+}
+
+impl VolumeRetirementQueue {
+    /// Register before publishing a volume into any manager generation. This
+    /// authority is independent of whether its file is eligible for deletion.
+    pub(crate) fn track(&self, backing: &Arc<VolumeFile>) {
+        self.catalog.lock().track(backing);
+    }
+
+    pub(crate) fn retire(&self, backing: &Arc<VolumeFile>) {
+        let mut catalog = self.catalog.lock();
+        catalog.track(backing);
+        catalog.pending.push(RetiredVolume {
+            backing: Arc::downgrade(backing),
+            path: backing.path.read().clone(),
+            identity: backing.identity,
+        });
+    }
+
+    pub(crate) fn prepare_retirement<'a>(
+        &self,
+        backings: impl Iterator<Item = &'a Arc<VolumeFile>>,
+    ) -> Box<PreparedRetirement> {
+        let mut catalog = self.catalog.lock();
+        let entries = backings
+            .map(|backing| {
+                catalog.track(backing);
+                RetiredVolume {
+                    backing: Arc::downgrade(backing),
+                    path: backing.path.read().clone(),
+                    identity: backing.identity,
+                }
+            })
+            .collect();
+        Box::new(PreparedRetirement {
+            entries,
+            omitted_segment_ids: Vec::new(),
+            next: None,
+        })
+    }
+
+    /// Exact batch eligibility is granted after truncate WAL and a durable
+    /// manifest image omitting its old identities. Storage already exists.
+    pub(crate) fn commit_retirement(&self, mut batch: Box<PreparedRetirement>) {
+        let mut catalog = self.catalog.lock();
+        batch.next = catalog.prepared.take();
+        catalog.prepared = Some(batch);
+    }
+
+    pub(crate) fn sweep(&self) {
+        let mut catalog = self.catalog.lock();
+        let FileCatalog {
+            live,
+            pending,
+            prepared,
+        } = &mut *catalog;
+        let keep = |entry: &RetiredVolume| {
+            if entry.backing.strong_count() != 0
+                || live
+                    .get(&entry.identity)
+                    .is_some_and(|aliases| aliases.iter().any(|alias| alias.strong_count() != 0))
+            {
+                return true;
+            }
+            // No strong owner can reappear after the count reaches zero.
+            // Never knowingly unlink a different file placed at the old path.
+            let file = match std::fs::File::open(&entry.path) {
+                Ok(file) => file,
+                Err(error) => return error.kind() != std::io::ErrorKind::NotFound,
+            };
+            let identity = FileIdentity::capture(&file);
+            drop(file);
+            match identity {
+                Ok(identity) if identity == entry.identity => {
+                    if let Err(error) = std::fs::remove_file(&entry.path) {
+                        return error.kind() != std::io::ErrorKind::NotFound;
+                    }
+                    if let Some(parent) = entry.path.parent() {
+                        let _ = std::fs::remove_dir(parent);
+                    }
+                    false
+                }
+                Ok(_) => false,
+                Err(_) => true,
+            }
+        };
+        pending.retain(keep);
+        let mut batches = prepared.take();
+        let mut retained = None;
+        while let Some(mut batch) = batches {
+            batches = batch.next.take();
+            batch.entries.retain(keep);
+            if !batch.entries.is_empty() {
+                batch.next = retained;
+                retained = Some(batch);
+            }
+        }
+        *prepared = retained;
+        live.retain(|_, aliases| {
+            aliases.retain(|alias| alias.strong_count() != 0);
+            !aliases.is_empty()
+        });
+        if pending.is_empty() {
+            pending.shrink_to_fit();
+        }
+    }
+
+    /// Serialize a managed parent rename with reader opens and retirement.
+    /// The caller serializes seal/compaction before collecting current volumes.
+    pub(crate) fn rename_directory(
+        &self,
+        old: &Path,
+        new: &Path,
+        current: &[Arc<FrozenVolume>],
+    ) -> std::io::Result<()> {
+        let mut catalog = self.catalog.lock();
+        for volume in current {
+            if let Some(backing) = volume.backing.get() {
+                catalog.track(backing);
+            }
+        }
+        let mut backings: Vec<_> = current
+            .iter()
+            .filter_map(|volume| volume.backing.get().cloned())
+            .chain(
+                catalog
+                    .live
+                    .values()
+                    .flat_map(|aliases| aliases.iter().filter_map(Weak::upgrade)),
+            )
+            .collect();
+        backings.sort_unstable_by_key(Arc::as_ptr);
+        backings.dedup_by(|left, right| Arc::ptr_eq(left, right));
+        let mut locations: Vec<_> = backings.iter().map(|file| file.path.write()).collect();
+        // Allocate replacement paths before changing anything on disk.
+        let replacements: Vec<_> = locations
+            .iter()
+            .map(|path| path.strip_prefix(old).ok().map(|suffix| new.join(suffix)))
+            .collect();
+        let FileCatalog {
+            pending, prepared, ..
+        } = &mut *catalog;
+        let mut entries: Vec<&mut RetiredVolume> = pending.iter_mut().collect();
+        let mut batch = prepared.as_mut();
+        while let Some(current) = batch {
+            entries.extend(current.entries.iter_mut());
+            batch = current.next.as_mut();
+        }
+        let retired_replacements: Vec<_> = entries
+            .iter()
+            .map(|entry| {
+                entry
+                    .path
+                    .strip_prefix(old)
+                    .ok()
+                    .map(|suffix| new.join(suffix))
+            })
+            .collect();
+        std::fs::rename(old, new)?;
+        for (path, replacement) in locations.iter_mut().zip(replacements) {
+            if let Some(replacement) = replacement {
+                **path = replacement;
+            }
+        }
+        for (entry, replacement) in entries.into_iter().zip(retired_replacements) {
+            if let Some(replacement) = replacement {
+                entry.path = replacement;
+            }
+        }
+        Ok(())
+    }
+}
 
 /// Volume file extension
 const VOLUME_EXT: &str = "vol";
@@ -75,18 +435,25 @@ pub fn write_volume_to_disk_opts(
     let (data, store) = serialize_v4_opts(volume, compress)
         .map_err(|e| crate::core::Error::internal(format!("V4 serialize failed: {}", e)))?;
 
-    {
+    let file = {
         use std::io::Write;
-        let mut f = std::fs::File::create(&tmp_path).map_err(|e| {
-            crate::core::Error::internal(format!("failed to create volume tmp file: {}", e))
-        })?;
+        let mut f = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp_path)
+            .map_err(|e| {
+                crate::core::Error::internal(format!("failed to create volume tmp file: {}", e))
+            })?;
         f.write_all(&data).map_err(|e| {
             crate::core::Error::internal(format!("failed to write volume file: {}", e))
         })?;
         f.sync_all().map_err(|e| {
             crate::core::Error::internal(format!("failed to fsync volume tmp file: {}", e))
         })?;
-    }
+        f
+    };
     drop(data);
 
     std::fs::rename(&tmp_path, &final_path).map_err(|e| {
@@ -99,6 +466,15 @@ pub fn write_volume_to_disk_opts(
             crate::core::Error::internal(format!("failed to fsync volume directory: {}", e))
         })?;
     }
+
+    // Capture the exact written handle; never reopen the published path here.
+    let backing = VolumeFile::from_file(&final_path, &file).map_err(|e| {
+        crate::core::Error::internal(format!("failed to bind written volume: {}", e))
+    })?;
+    drop(file);
+    // A volume is immutable. A later copy to another path cannot replace the
+    // backing already held by existing captured readers.
+    let _ = volume.backing.set(backing);
 
     Ok((final_path, store))
 }
@@ -196,23 +572,26 @@ fn serialize_v4_opts(
 /// CRC32 is computed incrementally as sections are read.
 /// Blocks are read one at a time into a reusable buffer and decompressed
 /// directly into final column vectors. No intermediate compressed storage.
-fn read_volume_v4(path: &Path) -> Result<FrozenVolume> {
+pub(crate) fn read_volume_file(backing: Arc<VolumeFile>) -> Result<FrozenVolume> {
+    let lease = backing.open_reader().map_err(|e| {
+        crate::core::Error::internal(format!("failed to open captured volume: {}", e))
+    })?;
+    read_volume_lease(lease)
+}
+
+fn read_volume_lease(lease: VolumeReadLease) -> Result<FrozenVolume> {
     use std::io::Read;
 
     let inv = |msg: &str| crate::core::Error::internal(format!("V4: {}", msg));
 
-    let file = std::fs::File::open(path)
-        .map_err(|e| crate::core::Error::internal(format!("V4 open {:?}: {}", path, e)))?;
-    let file_len = usize::try_from(
-        file.metadata()
-            .map_err(|e| crate::core::Error::internal(format!("V4 stat {:?}: {}", path, e)))?
-            .len(),
-    )
-    .map_err(|_| inv("file length exceeds address space"))?;
+    let file_len = usize::try_from(lease.backing.identity.length)
+        .map_err(|_| inv("file length exceeds address space"))?;
     if file_len < 24 {
         return Err(inv("file too small"));
     }
 
+    let VolumeReadLease { file, backing } = lease;
+    // Each decode owns its File, so the seek position cannot be shared.
     let mut reader = std::io::BufReader::new(file);
     let mut hasher = crc32fast::Hasher::new();
 
@@ -416,6 +795,7 @@ fn read_volume_v4(path: &Path) -> Result<FrozenVolume> {
     let columns = LazyColumns::deferred(store, col_data_types);
 
     Ok(FrozenVolume {
+        backing: std::sync::OnceLock::from(backing.clone()),
         columns,
         meta: Arc::new(super::writer::VolumeMeta {
             zone_maps: meta.zone_maps,
@@ -440,26 +820,13 @@ fn read_volume_v4(path: &Path) -> Result<FrozenVolume> {
 
 /// Read a frozen volume from disk. Only V4 (STV4) format is supported.
 pub fn read_volume_from_disk(path: &Path) -> Result<FrozenVolume> {
-    use std::io::Read;
-
-    let mut magic = [0u8; 4];
-    {
-        let mut f = std::fs::File::open(path).map_err(|e| {
-            crate::core::Error::internal(format!("failed to open volume {:?}: {}", path, e))
-        })?;
-        f.read_exact(&mut magic).map_err(|e| {
-            crate::core::Error::internal(format!("failed to read magic {:?}: {}", path, e))
-        })?;
-    }
-
-    if magic == V4_MAGIC {
-        read_volume_v4(path)
-    } else {
-        Err(crate::core::Error::internal(format!(
-            "unsupported volume format {:?}: expected STV4 magic, got {:?}",
-            path, magic
-        )))
-    }
+    let file = std::fs::File::open(path).map_err(|e| {
+        crate::core::Error::internal(format!("failed to open volume {:?}: {}", path, e))
+    })?;
+    let backing = VolumeFile::from_file(path, &file).map_err(|e| {
+        crate::core::Error::internal(format!("failed to bind volume {:?}: {}", path, e))
+    })?;
+    read_volume_lease(VolumeReadLease { file, backing })
 }
 
 /// List all volume files for a table, sorted by volume ID (oldest first).
@@ -801,6 +1168,280 @@ mod tests {
     use super::super::writer::VolumeBuilder;
     use super::*;
     use crate::core::{DataType, Row, SchemaBuilder, Value};
+
+    fn file_lease_fixture(dir: &Path, table: &str, id: u64, value: i64) -> (PathBuf, FrozenVolume) {
+        let schema = SchemaBuilder::new(table)
+            .column("id", DataType::Integer, false, true)
+            .build();
+        let mut builder = VolumeBuilder::new(&schema);
+        builder.add_row(1, &Row::from_values(vec![Value::Integer(value)]));
+        let volume = builder.finish();
+        let path = write_volume_to_disk(dir, table, id, &volume).unwrap();
+        (path, volume)
+    }
+
+    #[test]
+    fn captured_file_rejects_replacement_but_active_read_keeps_original() {
+        let dir = tempfile::tempdir().unwrap();
+        let (path, original) = file_lease_fixture(dir.path(), "captured", 1, 42);
+        let backing = original.backing.get().unwrap().clone();
+        let active = backing.open_reader().unwrap();
+        let (replacement, _) = file_lease_fixture(dir.path(), "replacement", 1, 99);
+        std::fs::rename(&replacement, &path).unwrap();
+        assert_eq!(
+            read_volume_from_disk(&path).unwrap().get_row(0).unwrap()[0],
+            Value::Integer(99)
+        );
+        assert!(read_volume_file(backing).is_err());
+        let old = read_volume_lease(active).unwrap();
+        assert_eq!(old.get_row(0).unwrap()[0], Value::Integer(42));
+    }
+
+    #[test]
+    fn captured_file_rejects_external_unlink_without_an_active_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let (path, volume) = file_lease_fixture(dir.path(), "unlinked", 1, 42);
+        std::fs::remove_file(path).unwrap();
+        assert!(volume.reload_from_backing().is_err());
+    }
+
+    #[test]
+    fn retirement_waits_for_last_reader_and_never_performs_io_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let (path, volume) = file_lease_fixture(dir.path(), "retired", 1, 42);
+        let queue = VolumeRetirementQueue::default();
+        let backing = volume.backing.get().unwrap().clone();
+        queue.retire(&backing);
+        let active = backing.open_reader().unwrap();
+        drop((volume, backing));
+        queue.sweep();
+        assert!(
+            path.exists(),
+            "an active decoder retains the identity lease"
+        );
+        let loaded = read_volume_lease(active).unwrap();
+        assert_eq!(loaded.get_row(0).unwrap()[0], Value::Integer(42));
+        queue.sweep();
+        assert!(
+            path.exists(),
+            "the decoded volume also retains its identity"
+        );
+        drop(loaded);
+        assert!(path.exists(), "Drop must not perform filesystem I/O");
+        queue.sweep();
+        assert!(!path.exists());
+        assert!(queue.catalog.lock().pending.is_empty());
+    }
+
+    #[test]
+    fn retirement_never_deletes_a_known_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let (path, volume) = file_lease_fixture(dir.path(), "replaced", 1, 42);
+        let original_inode = std::fs::File::open(&path).unwrap();
+        let queue = VolumeRetirementQueue::default();
+        queue.retire(volume.backing.get().unwrap());
+        drop(volume);
+        let (replacement, _) = file_lease_fixture(dir.path(), "replacement", 1, 99);
+        std::fs::rename(&replacement, &path).unwrap();
+        queue.sweep();
+        assert_eq!(
+            read_volume_from_disk(&path).unwrap().get_row(0).unwrap()[0],
+            Value::Integer(99)
+        );
+        assert!(queue.catalog.lock().pending.is_empty());
+        drop(original_inode);
+    }
+
+    #[test]
+    fn retirement_waits_for_independently_decoded_registered_aliases() {
+        let dir = tempfile::tempdir().unwrap();
+        let (path, first) = file_lease_fixture(dir.path(), "aliases", 1, 42);
+        let second = read_volume_from_disk(&path).unwrap();
+        assert!(!Arc::ptr_eq(
+            first.backing.get().unwrap(),
+            second.backing.get().unwrap()
+        ));
+        let queue = VolumeRetirementQueue::default();
+        queue.track(first.backing.get().unwrap());
+        queue.track(second.backing.get().unwrap());
+        queue.retire(first.backing.get().unwrap());
+        drop(first);
+        queue.sweep();
+        assert!(path.exists());
+        assert_eq!(
+            second.reload_from_backing().unwrap().get_row(0).unwrap()[0],
+            Value::Integer(42)
+        );
+        drop(second);
+        queue.sweep();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn engine_queue_drop_with_live_reader_leaves_a_safe_orphan() {
+        let dir = tempfile::tempdir().unwrap();
+        let (path, volume) = file_lease_fixture(dir.path(), "orphan", 1, 42);
+        let queue = VolumeRetirementQueue::default();
+        queue.retire(volume.backing.get().unwrap());
+        drop(queue);
+        assert_eq!(
+            volume.reload_from_backing().unwrap().get_row(0).unwrap()[0],
+            Value::Integer(42)
+        );
+        drop(volume);
+        assert!(
+            path.exists(),
+            "startup can later reclaim an unreferenced file"
+        );
+    }
+
+    #[test]
+    fn managed_directory_rename_updates_current_and_retired_readers() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_, live) = file_lease_fixture(dir.path(), "old", 1, 42);
+        let (_, retired) = file_lease_fixture(dir.path(), "old", 2, 99);
+        let live = Arc::new({
+            let cold = live.to_cold();
+            drop(live);
+            cold
+        });
+        let retired = Arc::new({
+            let cold = retired.to_cold();
+            drop(retired);
+            cold
+        });
+        let queue = VolumeRetirementQueue::default();
+        queue.retire(retired.backing.get().unwrap());
+        let old = dir.path().join("old");
+        let new = dir.path().join("new");
+        std::thread::scope(|scope| {
+            for volume in [&live, &retired] {
+                scope.spawn(move || {
+                    for _ in 0..100 {
+                        let loaded = volume.reload_from_backing().unwrap();
+                        assert!(Arc::ptr_eq(
+                            volume.backing.get().unwrap(),
+                            loaded.backing.get().unwrap()
+                        ));
+                    }
+                });
+            }
+            for _ in 0..10 {
+                queue
+                    .rename_directory(&old, &new, &[live.clone(), live.clone()])
+                    .unwrap();
+                queue
+                    .rename_directory(&new, &old, std::slice::from_ref(&live))
+                    .unwrap();
+            }
+        });
+        queue
+            .rename_directory(&old, &new, std::slice::from_ref(&live))
+            .unwrap();
+        assert_eq!(
+            retired.reload_from_backing().unwrap().get_row(0).unwrap()[0],
+            Value::Integer(99)
+        );
+        drop(retired);
+        queue.sweep();
+        assert!(!new.join("vol_0000000000000002.vol").exists());
+        assert!(new.join("vol_0000000000000001.vol").exists());
+    }
+
+    #[test]
+    fn failed_managed_rename_keeps_original_locations() {
+        let dir = tempfile::tempdir().unwrap();
+        let (path, live) = file_lease_fixture(dir.path(), "old", 1, 42);
+        let live = Arc::new(live);
+        let queue = VolumeRetirementQueue::default();
+        queue.retire(live.backing.get().unwrap());
+        assert!(queue
+            .rename_directory(
+                &dir.path().join("old"),
+                &dir.path().join("missing/new"),
+                std::slice::from_ref(&live)
+            )
+            .is_err());
+        assert_eq!(*live.backing.get().unwrap().path.read(), path);
+        assert_eq!(queue.catalog.lock().pending[0].path, path);
+        assert_eq!(
+            live.reload_from_backing().unwrap().get_row(0).unwrap()[0],
+            Value::Integer(42)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn idle_descriptor_count_does_not_grow_open_file_count() {
+        const CHILD_MARKER: &str = "STOOLAP_FILE_LEASE_FD_PROBE";
+        if std::env::var_os(CHILD_MARKER).is_none() {
+            // Other parallel unit tests may open files in this process.
+            // The child runs only this probe, so its FD delta is attributable.
+            let result = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "idle_descriptor_count_does_not_grow_open_file_count",
+                    "--test-threads=1",
+                    "--nocapture",
+                ])
+                .env(CHILD_MARKER, "1")
+                .output()
+                .unwrap();
+            assert!(
+                result.status.success(),
+                "{}\n{}",
+                String::from_utf8_lossy(&result.stdout),
+                String::from_utf8_lossy(&result.stderr)
+            );
+            return;
+        }
+        fn fd_count() -> usize {
+            std::fs::read_dir("/dev/fd").unwrap().count()
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let (path, _) = file_lease_fixture(dir.path(), "descriptors", 1, 42);
+        let before = fd_count();
+        let backings: Vec<_> = (0..512)
+            .map(|_| {
+                let file = std::fs::File::open(&path).unwrap();
+                VolumeFile::from_file(&path, &file).unwrap()
+            })
+            .collect();
+        assert!(
+            fd_count() <= before + 1,
+            "metadata identities do not retain descriptors"
+        );
+        let readers: Vec<_> = backings
+            .iter()
+            .take(8)
+            .map(|b| b.open_reader().unwrap())
+            .collect();
+        assert!(
+            fd_count() >= before + 8,
+            "only active reads open descriptors"
+        );
+        drop(readers);
+        assert!(fd_count() <= before + 1);
+        drop(backings);
+    }
+
+    #[test]
+    fn residency_reload_preserves_aliases_unique_cache_and_backing_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_, mut volume) = file_lease_fixture(dir.path(), "aliases", 1, 42);
+        volume.merge_column_rename("renamed", "id");
+        volume.prebuild_unique_index(&[0]).unwrap();
+        let cold = volume.to_cold();
+        let loaded = cold.reload_from_backing().unwrap();
+        assert!(Arc::ptr_eq(&cold.meta, &loaded.meta));
+        assert!(Arc::ptr_eq(&cold.unique_indices, &loaded.unique_indices));
+        assert!(Arc::ptr_eq(
+            cold.backing.get().unwrap(),
+            loaded.backing.get().unwrap()
+        ));
+        assert_eq!(loaded.column_index("renamed"), Some(0));
+        assert!(!loaded.unique_indices.read().is_empty());
+        assert_eq!(loaded.get_row(0).unwrap()[0], Value::Integer(42));
+    }
 
     #[test]
     fn malformed_v4_lengths_fail_before_allocating_or_decoding() {

--- a/src/storage/volume/manifest.rs
+++ b/src/storage/volume/manifest.rs
@@ -38,6 +38,93 @@ use crate::core::{Result, Value};
 
 use super::writer::FrozenVolume;
 
+type GenerationCache = Arc<parking_lot::Mutex<Option<Arc<ColdGeneration>>>>;
+
+/// Every mutation invalidates the cached generation while still owning the
+/// source write lock. Readers validate revisions with all source locks held.
+struct GenerationSource<T> {
+    value: RwLock<T>,
+    revision: std::sync::atomic::AtomicU64,
+    cache: GenerationCache,
+}
+
+impl<T> GenerationSource<T> {
+    fn new(value: T, cache: &GenerationCache) -> Self {
+        Self {
+            value: RwLock::new(value),
+            revision: std::sync::atomic::AtomicU64::new(0),
+            cache: cache.clone(),
+        }
+    }
+    fn read(&self) -> parking_lot::RwLockReadGuard<'_, T> {
+        self.value.read()
+    }
+    fn write(&self) -> GenerationWriteGuard<'_, T> {
+        let guard = self.value.write();
+        // The cache is not a reader. Drop its aliases before exposing mutable
+        // access so Arc::make_mut only copies for actual captured readers.
+        let retired = self.cache.lock().take();
+        drop(retired);
+        GenerationWriteGuard {
+            guard,
+            source: self,
+        }
+    }
+    fn revision(&self) -> u64 {
+        self.revision.load(std::sync::atomic::Ordering::Acquire)
+    }
+}
+
+/// A write guard that retires cached read metadata before publishing its change.
+pub struct GenerationWriteGuard<'a, T> {
+    guard: parking_lot::RwLockWriteGuard<'a, T>,
+    source: &'a GenerationSource<T>,
+}
+
+impl<T> std::ops::Deref for GenerationWriteGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.guard
+    }
+}
+impl<T> std::ops::DerefMut for GenerationWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.guard
+    }
+}
+impl<T> Drop for GenerationWriteGuard<'_, T> {
+    fn drop(&mut self) {
+        self.source
+            .revision
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
+    }
+}
+
+/// Immutable cold authority and file handles for one captured table view.
+/// Preparing this descriptor never reloads columns. An absent manifest member
+/// is an error; a reader never switches to a newer manager generation.
+pub struct ColdGeneration {
+    pub(crate) segment_ids_newest_first: Vec<u64>,
+    pub(crate) segments: Arc<FxHashMap<u64, ColdSegment>>,
+    pub(crate) tombstones: Arc<FxHashMap<i64, u64>>,
+    revisions: [u64; 3],
+}
+
+impl ColdGeneration {
+    /// Load only the selected captured file, outside the transfer fence.
+    pub(crate) fn load_segment(&self, id: u64) -> Result<ColdSegment> {
+        let segment = self.segments.get(&id).ok_or_else(|| {
+            crate::core::Error::internal(format!("captured generation has no segment {id}"))
+        })?;
+        if !segment.volume.is_cold() {
+            return Ok(segment.clone());
+        }
+        let mut loaded = segment.clone();
+        loaded.volume = Arc::new(segment.volume.reload_from_backing()?);
+        Ok(loaded)
+    }
+}
+
 /// A cold segment: immutable volume + pre-computed column mapping.
 /// The mapping is computed once at registration (seal/compaction/load) and
 /// recomputed on ALTER TABLE. No per-scan computation, no lock contention.
@@ -645,15 +732,18 @@ pub struct SegmentManager {
     /// Table name.
     table_name: SmartString,
     /// The manifest (source of truth for segment state).
-    manifest: RwLock<TableManifest>,
+    manifest: GenerationSource<TableManifest>,
     /// Loaded segments with pre-computed column mappings, keyed by segment_id.
     /// CoW via Arc: readers clone the Arc (O(1) atomic increment, ~5ns),
     /// writers clone the inner map, modify, and swap the Arc.
     /// The ColumnMapping is computed once at registration and recomputed on ALTER TABLE.
     /// This eliminates per-scan compute_column_mapping overhead and lock contention.
-    segments: RwLock<Arc<FxHashMap<u64, ColdSegment>>>,
+    segments: GenerationSource<Arc<FxHashMap<u64, ColdSegment>>>,
     /// Base directory for volume files (None for memory-only databases).
     volume_dir: Option<PathBuf>,
+    /// Engine-owned identity authority, independent of current manifest membership.
+    file_catalog: Arc<super::io::VolumeRetirementQueue>,
+    truncate_retirements: parking_lot::Mutex<Option<Box<super::io::PreparedRetirement>>>,
     /// Fast atomic flag: true if any segments are loaded.
     has_segments_flag: std::sync::atomic::AtomicBool,
     /// Current eviction epoch. Updated by evict_idle_volumes.
@@ -669,7 +759,8 @@ pub struct SegmentManager {
     /// membership, not mutate. Writers swap the Arc on mutation.
     /// The commit_seq enables snapshot isolation: a snapshot at begin_seq=N
     /// only sees tombstones with commit_seq <= N.
-    tombstones: RwLock<Arc<FxHashMap<i64, u64>>>,
+    tombstones: GenerationSource<Arc<FxHashMap<i64, u64>>>,
+    generation_cache: GenerationCache,
     /// Per-transaction pending tombstones: txn_id → list of cold row_ids to tombstone.
     /// Applied to the shared tombstone set on commit, discarded on rollback.
     /// This lives on the SegmentManager (not SegmentedTable) because the commit
@@ -711,7 +802,149 @@ pub struct SegmentManager {
     _hot_object_charge: MemoryCharge,
 }
 
+/// Prepared allocations and exact old ownership for one physical truncate.
+/// The namespace and registry admission reservations keep these sources stable.
+pub(crate) struct PreparedColdTruncate {
+    pub(crate) old_segments: Arc<FxHashMap<u64, ColdSegment>>,
+    empty_segments: Arc<FxHashMap<u64, ColdSegment>>,
+    empty_tombstones: Arc<FxHashMap<i64, u64>>,
+    empty_transaction_generations: HotTxnMap<u64>,
+    retired_cache: Option<Arc<ColdGeneration>>,
+}
+
+pub(crate) struct RetiredColdTruncate {
+    _segments: Arc<FxHashMap<u64, ColdSegment>>,
+    _tombstones: Arc<FxHashMap<i64, u64>>,
+    _manifest_segments: Vec<SegmentMeta>,
+    _manifest_tombstones: Vec<(i64, u64)>,
+    _cache: Option<Arc<ColdGeneration>>,
+    _transaction_generations: HotTxnMap<u64>,
+}
+
 impl SegmentManager {
+    fn prepare_cold_generation(&self) -> Result<Arc<ColdGeneration>> {
+        if let Some(generation) = self.generation_cache.lock().clone() {
+            return Ok(generation);
+        }
+        // This metadata preparation happens before the transfer fence. No
+        // column access, path reopen or decompression is allowed here.
+        let manifest = self.manifest.read();
+        let segments = self.segments.read();
+        let tombstones = self.tombstones.read();
+        let mut cache = self.generation_cache.lock();
+        if let Some(generation) = cache.as_ref() {
+            return Ok(generation.clone());
+        }
+        let mut ids = Vec::with_capacity(manifest.segments.len());
+        for meta in manifest.segments.iter().rev() {
+            if !segments.contains_key(&meta.segment_id) {
+                return Err(crate::core::Error::internal(format!(
+                    "table '{}': manifest segment {} has no captured backing",
+                    self.table_name, meta.segment_id,
+                )));
+            }
+            ids.push(meta.segment_id);
+        }
+        let generation = Arc::new(ColdGeneration {
+            segment_ids_newest_first: ids,
+            segments: segments.clone(),
+            tombstones: tombstones.clone(),
+            revisions: [
+                self.manifest.revision(),
+                self.segments.revision(),
+                self.tombstones.revision(),
+            ],
+        });
+        *cache = Some(generation.clone());
+        Ok(generation)
+    }
+
+    /// Capture hot authority and cold identity in one brief transfer-fence hold.
+    /// The callback must only clone an already-owned hot root: no I/O, filtering,
+    /// allocation or budget wait may happen inside this callback.
+    pub(crate) fn capture_with_hot<T>(
+        &self,
+        mut capture_hot: impl FnMut() -> T,
+    ) -> Result<(T, Arc<ColdGeneration>)> {
+        for _attempt in 0..3 {
+            let generation = self.prepare_cold_generation()?;
+            if let Some(captured) = self.capture_prepared_with_hot(generation, &mut capture_hot) {
+                return Ok(captured);
+            }
+        }
+        Err(crate::core::Error::internal(
+            "retryable read conflict: cold generation changed during three capture attempts",
+        ))
+    }
+
+    /// Only physical membership/mapping changes require another preparation.
+    /// A fixed ReadEpoch filters sequenced DML; its shared fence need only
+    /// exclude physical hot/cold transfers, not other ordinary DML readers.
+    fn capture_prepared_with_hot<T>(
+        &self,
+        mut generation: Arc<ColdGeneration>,
+        capture_hot: &mut impl FnMut() -> T,
+    ) -> Option<(T, Arc<ColdGeneration>)> {
+        loop {
+            // Declare retired ownership before the fence, including for unwind:
+            // destroying a last tombstone-map owner must happen after unlocking.
+            let mut retired_tombstones = None;
+            let captured = {
+                let _fence = self.acquire_seal_read();
+                let manifest = self.manifest.read();
+                let segments = self.segments.read();
+                let tombstones = self.tombstones.read();
+                let revisions = [
+                    self.manifest.revision(),
+                    self.segments.revision(),
+                    self.tombstones.revision(),
+                ];
+                // Manifest tombstone writes also advance its broad revision.
+                // When that changes, compare the actual ordered membership;
+                // segments revision separately protects mappings and backings.
+                if generation.revisions[1] != revisions[1]
+                    || (generation.revisions[0] != revisions[0]
+                        && (generation.segment_ids_newest_first.len() != manifest.segments.len()
+                            || generation
+                                .segment_ids_newest_first
+                                .iter()
+                                .copied()
+                                .ne(manifest.segments.iter().rev().map(|meta| meta.segment_id))))
+                {
+                    return None;
+                }
+                let ready = if generation.revisions == revisions {
+                    true
+                } else if let Some(private) = Arc::get_mut(&mut generation) {
+                    retired_tombstones = Some(std::mem::replace(
+                        &mut private.tombstones,
+                        Arc::clone(&tombstones),
+                    ));
+                    private.revisions = revisions;
+                    true
+                } else {
+                    false
+                };
+                // Preserve the source-lock -> hot-root lock order boundary.
+                drop((manifest, segments, tombstones));
+                ready.then(&mut *capture_hot)
+            };
+            drop(retired_tombstones);
+            if let Some(hot) = captured {
+                return Some((hot, generation));
+            }
+            // Shared old readers retain their immutable generation. Prepare a
+            // private shell outside the fence; later tombstone churn needs only
+            // an Arc swap into it, not another allocation or bounded retry.
+            generation = Arc::new(ColdGeneration {
+                segment_ids_newest_first: generation.segment_ids_newest_first.clone(),
+                segments: Arc::clone(&generation.segments),
+                tombstones: Arc::clone(&generation.tombstones),
+                revisions: generation.revisions,
+            });
+        }
+    }
+
     /// Create a new segment manager for a table.
     pub fn new(table_name: &str, volume_dir: Option<PathBuf>) -> Self {
         Self::new_in(table_name, volume_dir, MemoryAccount::new())
@@ -722,31 +955,26 @@ impl SegmentManager {
         volume_dir: Option<PathBuf>,
         memory: MemoryAccount,
     ) -> Self {
-        Self {
-            table_name: SmartString::from(table_name).into_hot(&memory),
-            manifest: RwLock::new(TableManifest::new(table_name)),
-            segments: RwLock::new(Arc::new(FxHashMap::default())),
+        Self::new_with_file_catalog_in(
+            table_name,
             volume_dir,
-            has_segments_flag: std::sync::atomic::AtomicBool::new(false),
-            has_cold: std::sync::atomic::AtomicBool::new(false),
-            current_eviction_epoch: std::sync::atomic::AtomicU64::new(0),
-            reloading: parking_lot::Mutex::new(()),
-            tombstones: RwLock::new(Arc::new(FxHashMap::default())),
-            pending_txn_tombstones: RwLock::new(hot_txn_map(&memory)),
-            pending_tombstone_undo: RwLock::new(hot_txn_map(&memory)),
-            published_tombstone_undo: RwLock::new(hot_txn_map(&memory)),
-            cached_deduped_count: std::sync::atomic::AtomicU64::new(u64::MAX),
-            seal_fence: RwLock::new(()),
-            visibility_seen: parking_lot::Mutex::new(rustc_hash::FxHashSet::default()),
-            seal_generation: std::sync::atomic::AtomicU64::new(0),
-            txn_seal_gens: parking_lot::Mutex::new(hot_txn_map(&memory)),
-            seal_overlap_count: std::sync::atomic::AtomicUsize::new(0),
-            _hot_object_charge: MemoryCharge::conservative(
-                &memory,
-                std::mem::size_of::<Self>() + 4 * std::mem::size_of::<usize>(),
-            ),
-            hot_memory: memory,
-        }
+            Arc::new(super::io::VolumeRetirementQueue::default()),
+            memory,
+        )
+    }
+
+    pub(crate) fn new_with_file_catalog_in(
+        table_name: &str,
+        volume_dir: Option<PathBuf>,
+        file_catalog: Arc<super::io::VolumeRetirementQueue>,
+        memory: MemoryAccount,
+    ) -> Self {
+        Self::from_manifest_with_file_catalog_in(
+            TableManifest::new(table_name),
+            volume_dir,
+            file_catalog,
+            memory,
+        )
     }
 
     /// Create from an existing manifest loaded from disk.
@@ -759,18 +987,36 @@ impl SegmentManager {
         volume_dir: Option<PathBuf>,
         memory: MemoryAccount,
     ) -> Self {
-        let table_name = manifest.table_name.clone();
+        Self::from_manifest_with_file_catalog_in(
+            manifest,
+            volume_dir,
+            Arc::new(super::io::VolumeRetirementQueue::default()),
+            memory,
+        )
+    }
+
+    fn from_manifest_with_file_catalog_in(
+        manifest: TableManifest,
+        volume_dir: Option<PathBuf>,
+        file_catalog: Arc<super::io::VolumeRetirementQueue>,
+        memory: MemoryAccount,
+    ) -> Self {
+        let generation_cache = Arc::new(parking_lot::Mutex::new(None));
+        let table_name = manifest.table_name.clone().into_hot(&memory);
         let tombstone_map: FxHashMap<i64, u64> = manifest.tombstones.iter().copied().collect();
         Self {
-            table_name: table_name.into_hot(&memory),
-            manifest: RwLock::new(manifest),
-            segments: RwLock::new(Arc::new(FxHashMap::default())),
+            table_name,
+            manifest: GenerationSource::new(manifest, &generation_cache),
+            segments: GenerationSource::new(Arc::new(FxHashMap::default()), &generation_cache),
             volume_dir,
+            file_catalog,
+            truncate_retirements: parking_lot::Mutex::new(None),
             has_segments_flag: std::sync::atomic::AtomicBool::new(false),
             has_cold: std::sync::atomic::AtomicBool::new(false),
             current_eviction_epoch: std::sync::atomic::AtomicU64::new(0),
             reloading: parking_lot::Mutex::new(()),
-            tombstones: RwLock::new(Arc::new(tombstone_map)),
+            tombstones: GenerationSource::new(Arc::new(tombstone_map), &generation_cache),
+            generation_cache,
             pending_txn_tombstones: RwLock::new(hot_txn_map(&memory)),
             pending_tombstone_undo: RwLock::new(hot_txn_map(&memory)),
             published_tombstone_undo: RwLock::new(hot_txn_map(&memory)),
@@ -1544,16 +1790,17 @@ impl SegmentManager {
     /// Reload cold volumes (metadata-only, in segments map) from disk.
     /// Replaces them in-place with full deferred volumes.
     fn reload_cold_volumes(&self, ids: Vec<u64>) {
-        let vol_dir = match &self.volume_dir {
-            Some(d) => d,
-            None => return,
-        };
         let mut reloaded = Vec::new();
         let mut failed = Vec::new();
         for &id in &ids {
-            let filename = format!("vol_{:016x}.vol", id);
-            let full_path = vol_dir.join(self.table_name.as_str()).join(filename);
-            match crate::storage::volume::io::read_volume_from_disk(&full_path) {
+            let source = {
+                let segments = self.segments.read();
+                segments.get(&id).map(|segment| segment.volume.clone())
+            };
+            let Some(source) = source else {
+                continue;
+            };
+            match source.reload_from_backing() {
                 Ok(volume) => {
                     reloaded.push((id, Arc::new(volume)));
                 }
@@ -1576,10 +1823,6 @@ impl SegmentManager {
         let mut new_map = (**segments).clone();
         for (id, volume) in reloaded {
             if let Some(cs) = new_map.get_mut(&id) {
-                if !cs.volume.unique_indices.read().is_empty() {
-                    *volume.unique_indices.write() =
-                        std::mem::take(&mut *cs.volume.unique_indices.write());
-                }
                 volume.mark_accessed();
                 cs.volume = volume;
             }
@@ -1638,6 +1881,9 @@ impl SegmentManager {
         meta: SegmentMeta,
         schema: Option<&crate::core::Schema>,
     ) {
+        if let Some(backing) = volume.backing.get() {
+            self.file_catalog.track(backing);
+        }
         // Both manifest and segments must be updated atomically under write locks.
         // The bitmap computation runs inside the critical section — this is safe
         // because the segments write lock only blocks other writers (readers clone
@@ -1709,6 +1955,9 @@ impl SegmentManager {
         drop(manifest);
 
         if let Some(schema_version) = seg_schema_version {
+            if let Some(backing) = volume.backing.get() {
+                self.file_catalog.track(backing);
+            }
             let cold = ColdSegment {
                 mapping: super::writer::ColumnMapping {
                     sources: (0..volume.columns.len())
@@ -1865,7 +2114,7 @@ impl SegmentManager {
     }
 
     /// Get write access to the tombstone map (for seal cleanup).
-    pub fn tombstones_write(&self) -> parking_lot::RwLockWriteGuard<'_, Arc<FxHashMap<i64, u64>>> {
+    pub fn tombstones_write(&self) -> GenerationWriteGuard<'_, Arc<FxHashMap<i64, u64>>> {
         self.tombstones.write()
     }
 
@@ -2350,15 +2599,21 @@ impl SegmentManager {
     /// a later INSERT within the same txn cannot hide an earlier seal.
     #[inline]
     pub fn record_txn_seal_generation(&self, txn_id: i64) {
-        let gen = self.seal_generation();
+        self.record_txn_seal_generation_at(txn_id, self.seal_generation());
+    }
+
+    /// Remember the generation captured before statement staging. Recording a
+    /// later current generation could hide a seal that raced with that staging.
+    #[inline]
+    pub fn record_txn_seal_generation_at(&self, txn_id: i64, generation: u64) {
         let mut map = self.txn_seal_gens.lock();
         match map.entry(txn_id) {
             HashEntry::Occupied(entry) => {
                 let mut existing = entry.into_mut();
-                *existing = (*existing).min(gen);
+                *existing = (*existing).min(generation);
             }
             HashEntry::Vacant(entry) => {
-                entry.insert(gen);
+                entry.insert(generation);
             }
         }
     }
@@ -2503,6 +2758,63 @@ impl SegmentManager {
             .load(std::sync::atomic::Ordering::Acquire)
     }
 
+    /// All node/list storage was prepared before WAL. Eligibility remains
+    /// blocked until this manager persists an image omitting the exact old IDs.
+    pub(crate) fn park_truncate_retirement(&self, mut batch: Box<super::io::PreparedRetirement>) {
+        let mut pending = self.truncate_retirements.lock();
+        batch.next = pending.take();
+        *pending = Some(batch);
+    }
+
+    /// Relocate even batches whose old files are not yet eligible for deletion.
+    /// Lock order matches durable promotion: parked batches, then file catalog.
+    /// No manifest or transfer-fence guard is held during filesystem operations.
+    pub(crate) fn rename_volume_directory(
+        &self,
+        old: &Path,
+        new: &Path,
+        current: &[Arc<FrozenVolume>],
+    ) -> std::io::Result<()> {
+        let mut pending = self.truncate_retirements.lock();
+        let mut batch = pending.as_ref();
+        let mut replacements = Vec::new();
+        while let Some(current) = batch {
+            replacements.push(current.prepare_relocation(old, new));
+            batch = current.next.as_ref();
+        }
+        self.file_catalog.rename_directory(old, new, current)?;
+        let mut batch = pending.as_mut();
+        for replacement in replacements {
+            let Some(current) = batch else {
+                unreachable!("parked retirement list remains locked");
+            };
+            current.apply_relocation(replacement);
+            batch = current.next.as_mut();
+        }
+        Ok(())
+    }
+
+    fn release_truncate_retirements(&self, durable: &TableManifest) {
+        let mut pending = self.truncate_retirements.lock();
+        let mut next = pending.take();
+        let mut blocked = None;
+        while let Some(mut batch) = next {
+            next = batch.next.take();
+            if batch.omitted_segment_ids.iter().all(|id| {
+                !durable
+                    .segments
+                    .iter()
+                    .any(|segment| segment.segment_id == *id)
+            }) {
+                self.file_catalog.commit_retirement(batch);
+            } else {
+                batch.next = blocked;
+                blocked = Some(batch);
+            }
+        }
+        *pending = blocked;
+    }
+
     /// Persist the manifest to disk (includes tombstones).
     pub fn persist(&self) -> Result<()> {
         self.persist_manifest_only()
@@ -2511,6 +2823,7 @@ impl SegmentManager {
     /// Persist only the manifest.
     pub fn persist_manifest_only(&self) -> Result<()> {
         let Some(ref vol_dir) = self.volume_dir else {
+            self.release_truncate_retirements(&self.manifest.read());
             return Ok(());
         };
 
@@ -2521,7 +2834,9 @@ impl SegmentManager {
         })?;
 
         let manifest_path = table_dir.join("manifest.bin");
-        self.manifest.read().write_to_disk(&manifest_path)?;
+        let image = self.manifest.read();
+        image.write_to_disk(&manifest_path)?;
+        self.release_truncate_retirements(&image);
 
         Ok(())
     }
@@ -2546,17 +2861,100 @@ impl SegmentManager {
         volume_dir: &Path,
         memory: MemoryAccount,
     ) -> Result<Option<Self>> {
+        Self::load_from_disk_with_file_catalog_in(
+            table_name,
+            volume_dir,
+            Arc::new(super::io::VolumeRetirementQueue::default()),
+            memory,
+        )
+    }
+
+    pub(crate) fn load_from_disk_with_file_catalog_in(
+        table_name: &str,
+        volume_dir: &Path,
+        file_catalog: Arc<super::io::VolumeRetirementQueue>,
+        memory: MemoryAccount,
+    ) -> Result<Option<Self>> {
         let table_dir = volume_dir.join(table_name);
         let manifest_path = table_dir.join("manifest.bin");
-
         if !manifest_path.exists() {
             return Ok(None);
         }
-
         let manifest = TableManifest::read_from_disk(&manifest_path)?;
-        let manager = Self::from_manifest_in(manifest, Some(volume_dir.to_path_buf()), memory);
-
+        let manager = Self::from_manifest_with_file_catalog_in(
+            manifest,
+            Some(volume_dir.to_path_buf()),
+            file_catalog,
+            memory,
+        );
         Ok(Some(manager))
+    }
+
+    /// No column decoding or filesystem IO. All missing-manifest and pending
+    /// mutation errors are reported before the truncate WAL is written.
+    pub(crate) fn prepare_truncate(&self) -> Result<PreparedColdTruncate> {
+        if self
+            .pending_txn_tombstones
+            .read()
+            .values()
+            .any(|rows| !rows.is_empty())
+            || !self.pending_tombstone_undo.read().is_empty()
+            || !self.published_tombstone_undo.read().is_empty()
+        {
+            return Err(crate::core::Error::TableHasActiveTransactions);
+        }
+        let old_segments = Arc::clone(&*self.segments.read());
+        for segment in &self.manifest.read().segments {
+            if !old_segments.contains_key(&segment.segment_id) {
+                return Err(crate::core::Error::internal(
+                    "TRUNCATE manifest segment is not loaded",
+                ));
+            }
+        }
+        Ok(PreparedColdTruncate {
+            old_segments,
+            empty_segments: Arc::new(FxHashMap::default()),
+            empty_tombstones: Arc::new(FxHashMap::default()),
+            empty_transaction_generations: hot_txn_map(&self.hot_memory),
+            retired_cache: self.generation_cache.lock().take(),
+        })
+    }
+
+    /// Call only after WAL success while the transfer fence is held. No
+    /// allocation, budget admission, storage reads, or ownership destruction.
+    pub(crate) fn apply_truncate(&self, prepared: PreparedColdTruncate) -> RetiredColdTruncate {
+        let (manifest_segments, manifest_tombstones) = {
+            let mut manifest = self.manifest.write();
+            (
+                std::mem::take(&mut manifest.segments),
+                std::mem::take(&mut manifest.tombstones),
+            )
+        };
+        let segments = std::mem::replace(&mut *self.segments.write(), prepared.empty_segments);
+        let tombstones =
+            std::mem::replace(&mut *self.tombstones.write(), prepared.empty_tombstones);
+        let transaction_generations = std::mem::replace(
+            &mut *self.txn_seal_gens.lock(),
+            prepared.empty_transaction_generations,
+        );
+        self.cached_deduped_count
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+        self.has_segments_flag
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        self.has_cold
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        self.seal_overlap_count
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+        self.seal_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
+        RetiredColdTruncate {
+            _segments: segments,
+            _tombstones: tombstones,
+            _manifest_segments: manifest_segments,
+            _manifest_tombstones: manifest_tombstones,
+            _cache: prepared.retired_cache,
+            _transaction_generations: transaction_generations,
+        }
     }
 
     /// Remove all segments and tombstones (for DROP TABLE / TRUNCATE).
@@ -2622,6 +3020,9 @@ impl SegmentManager {
         new_meta: SegmentMeta,
         old_segment_ids: &[u64],
     ) {
+        if let Some(backing) = new_volume.backing.get() {
+            self.file_catalog.track(backing);
+        }
         // Atomic: manifest + segments updated under both write locks.
         // Bitmap computation runs inside — safe because writers are serialized.
         {
@@ -2677,6 +3078,11 @@ impl SegmentManager {
         new_volumes: Vec<(u64, Arc<FrozenVolume>, SegmentMeta)>,
         old_segment_ids: &[u64],
     ) {
+        for (_, volume, _) in &new_volumes {
+            if let Some(backing) = volume.backing.get() {
+                self.file_catalog.track(backing);
+            }
+        }
         if new_volumes.is_empty() {
             self.replace_segments_atomic_remove_only(old_segment_ids);
             return;
@@ -2831,7 +3237,7 @@ impl SegmentManager {
         // Serialize reloads — prevents concurrent stampede on the same volume.
         // Second thread re-checks the fast path after acquiring the guard.
         let _guard = self.reloading.lock();
-        {
+        let source = {
             let segs = self.segments.read();
             match segs.get(&seg_id) {
                 None => return Ok(None),
@@ -2839,32 +3245,15 @@ impl SegmentManager {
                     cs.volume.mark_accessed();
                     return Ok(Some(Arc::clone(&cs.volume)));
                 }
-                Some(_) => {}
-            }
-        }
-        let vol_dir = self
-            .volume_dir
-            .as_ref()
-            .ok_or_else(|| crate::core::Error::Internal {
-                message: format!(
-                    "table '{}': cold segment {} has no volume directory to reload from",
-                    self.table_name, seg_id
-                ),
-            })?;
-        let filename = format!("vol_{:016x}.vol", seg_id);
-        let full_path = vol_dir.join(self.table_name.as_str()).join(filename);
-        let volume = match crate::storage::volume::io::read_volume_from_disk(&full_path) {
-            Ok(v) => Arc::new(v),
-            Err(e) => {
-                return Err(crate::core::Error::Internal {
-                    message: format!(
-                        "table '{}': failed to reload cold volume seg={}: {}; \
-                         refusing to serve partial data",
-                        self.table_name, seg_id, e
-                    ),
-                });
+                Some(cs) => cs.volume.clone(),
             }
         };
+        let volume = Arc::new(source.reload_from_backing().map_err(|error| {
+            crate::core::Error::internal(format!(
+                "table '{}': failed to reload cold volume seg={}: {}; refusing to serve partial data",
+                self.table_name, seg_id, error
+            ))
+        })?);
         volume.mark_accessed();
         let mut segments = self.segments.write();
         let mut new_map = (**segments).clone();
@@ -2874,9 +3263,6 @@ impl SegmentManager {
             None => return Ok(None),
             Some(cs) => cs,
         };
-        if !cs.volume.unique_indices.read().is_empty() {
-            *volume.unique_indices.write() = std::mem::take(&mut *cs.volume.unique_indices.write());
-        }
         cs.volume = Arc::clone(&volume);
         let still_cold = new_map.values().any(|cs| cs.volume.is_cold());
         *segments = Arc::new(new_map);
@@ -2888,7 +3274,7 @@ impl SegmentManager {
     }
 
     /// Get the manifest for writing (e.g., to allocate segment IDs).
-    pub fn manifest_mut(&self) -> parking_lot::RwLockWriteGuard<'_, TableManifest> {
+    pub fn manifest_mut(&self) -> GenerationWriteGuard<'_, TableManifest> {
         self.manifest.write()
     }
 
@@ -2987,6 +3373,328 @@ fn read_i64(data: &[u8], pos: &mut usize) -> std::io::Result<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cold_generation_capture_does_not_wait_for_shared_dml_fence() {
+        let manager = Arc::new(SegmentManager::new("shared_capture", None));
+        let paused_dml = manager.acquire_seal_read();
+        let other = manager.clone();
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            sender.send(other.capture_with_hot(|| 7)).unwrap();
+        });
+        let result = receiver.recv_timeout(std::time::Duration::from_secs(2));
+        drop(paused_dml);
+        reader.join().unwrap();
+        let (hot, generation) = result
+            .expect("a reader must not wait for an ordinary DML shared fence")
+            .unwrap();
+        assert_eq!(hot, 7);
+        assert!(generation.segment_ids_newest_first.is_empty());
+    }
+
+    #[test]
+    fn cold_generation_refreshes_tombstones_but_revalidates_order_and_mapping() {
+        use crate::core::{DataType, Row, SchemaBuilder, Value};
+        let manager = SegmentManager::new("refresh_capture", None);
+        let schema = SchemaBuilder::new("refresh_capture")
+            .column("id", DataType::Integer, false, true)
+            .build();
+        for id in 1..=2 {
+            let mut builder = super::super::writer::VolumeBuilder::new(&schema);
+            builder.add_row(id, &Row::from_values(vec![Value::Integer(id)]));
+            manager.register_segment(
+                id as u64,
+                Arc::new(builder.finish()),
+                SegmentMeta {
+                    segment_id: id as u64,
+                    file_path: PathBuf::new(),
+                    row_count: 1,
+                    min_row_id: id,
+                    max_row_id: id,
+                    creation_lsn: 1,
+                    seal_seq: 0,
+                    schema_version: 0,
+                },
+                Some(&schema),
+            );
+        }
+        for sequence in 1..=8 {
+            let old_reader = manager.prepare_cold_generation().unwrap();
+            // Force mutation between the real preparation and capture paths;
+            // retaining this reader also forces private-shell allocation.
+            manager.add_tombstones(&[sequence], sequence as u64);
+            let (_, current) = manager
+                .capture_prepared_with_hot(old_reader.clone(), &mut || {
+                    assert!(manager.manifest.value.try_write().is_some());
+                    assert!(manager.segments.value.try_write().is_some());
+                    assert!(manager.tombstones.value.try_write().is_some());
+                })
+                .expect("tombstone churn does not invalidate physical membership");
+            assert_eq!(current.segment_ids_newest_first, [2, 1]);
+            assert_eq!(current.tombstones.len(), sequence as usize);
+            assert_eq!(current.tombstones.get(&sequence), Some(&(sequence as u64)));
+            assert_eq!(old_reader.tombstones.len(), sequence as usize - 1);
+        }
+        let old_order = manager.prepare_cold_generation().unwrap();
+        manager.manifest.write().segments.swap(0, 1);
+        assert!(manager
+            .capture_prepared_with_hot(old_order, &mut || panic!("stale membership"))
+            .is_none());
+        let (_, reordered) = manager.capture_with_hot(|| ()).unwrap();
+        assert_eq!(reordered.segment_ids_newest_first, [1, 2]);
+        {
+            let mut segments = manager.segments.write();
+            Arc::make_mut(&mut *segments)
+                .get_mut(&1)
+                .unwrap()
+                .schema_version = 1;
+        }
+        assert!(manager
+            .capture_prepared_with_hot(reordered, &mut || panic!("stale mapping"))
+            .is_none());
+    }
+
+    #[test]
+    fn idle_generation_cache_does_not_force_tombstone_cow() {
+        let manager = SegmentManager::new("idle_cache", None);
+        manager.add_tombstones(&[1], 1);
+        let pointer = Arc::as_ptr(&*manager.tombstones.read());
+        for sequence in 2..=8 {
+            let (_, generation) = manager.capture_with_hot(|| ()).unwrap();
+            drop(generation);
+            manager.add_tombstones(&[1], sequence);
+            assert_eq!(
+                Arc::as_ptr(&*manager.tombstones.read()),
+                pointer,
+                "an idle metadata cache is not a live snapshot reader"
+            );
+        }
+        let (_, active) = manager.capture_with_hot(|| ()).unwrap();
+        manager.add_tombstones(&[1], 9);
+        assert_ne!(Arc::as_ptr(&*manager.tombstones.read()), pointer);
+        assert_eq!(active.tombstones.get(&1), Some(&8));
+    }
+
+    #[test]
+    fn cold_generation_captures_without_loading_and_retires_stale_cache_owners() {
+        use crate::core::{DataType, Row, SchemaBuilder, Value};
+        let schema = SchemaBuilder::new("generation")
+            .column("id", DataType::Integer, false, true)
+            .build();
+        let mut builder = super::super::writer::VolumeBuilder::new(&schema);
+        builder.add_row(1, &Row::from_values(vec![Value::Integer(42)]));
+        let volume = builder.finish();
+        let dir = tempfile::tempdir().unwrap();
+        let path =
+            super::super::io::write_volume_to_disk(dir.path(), "generation", 1, &volume).unwrap();
+        let manager = SegmentManager::new("generation", Some(dir.path().to_path_buf()));
+        manager.register_segment(
+            1,
+            Arc::new(volume.to_cold()),
+            SegmentMeta {
+                segment_id: 1,
+                file_path: path.clone(),
+                row_count: 1,
+                min_row_id: 1,
+                max_row_id: 1,
+                creation_lsn: 1,
+                seal_seq: 0,
+                schema_version: 0,
+            },
+            Some(&schema),
+        );
+        let (hot_marker, captured) = manager
+            .capture_with_hot(|| {
+                assert!(manager.seal_fence.try_write().is_none());
+                7
+            })
+            .unwrap();
+        assert_eq!(hot_marker, 7);
+        assert!(manager.seal_fence.try_write().is_some());
+        assert!(captured.segments[&1].volume.is_cold());
+        assert_eq!(captured.segment_ids_newest_first, vec![1]);
+        let (_, same) = manager.capture_with_hot(|| ()).unwrap();
+        assert!(Arc::ptr_eq(&captured, &same));
+        drop(same);
+        let old = Arc::downgrade(&captured);
+        manager.add_tombstones(&[1], 9);
+        let (_, newer) = manager.capture_with_hot(|| ()).unwrap();
+        assert!(!Arc::ptr_eq(&captured, &newer));
+        assert!(captured.tombstones.is_empty());
+        assert_eq!(newer.tombstones.get(&1), Some(&9));
+
+        // Durable compaction retires the file, but captured readers retain it.
+        let retirements = super::super::io::VolumeRetirementQueue::default();
+        manager.replace_segments_atomic_remove_only(&[1]);
+        retirements.retire(captured.segments[&1].volume.backing.get().unwrap());
+        retirements.sweep();
+        assert!(path.exists());
+        let loaded = captured.load_segment(1).unwrap();
+        assert_eq!(loaded.volume.get_row(0).unwrap()[0], Value::Integer(42));
+        drop(captured);
+        assert!(
+            old.upgrade().is_none(),
+            "the manager cache must not retain retired generations"
+        );
+        drop((loaded, newer, volume));
+        assert!(path.exists(), "final-owner Drop performs no filesystem I/O");
+        retirements.sweep();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn cold_generation_rejects_missing_members_and_missing_backings() {
+        use crate::core::{DataType, Row, SchemaBuilder, Value};
+        let schema = SchemaBuilder::new("missing")
+            .column("id", DataType::Integer, false, true)
+            .build();
+        let mut builder = super::super::writer::VolumeBuilder::new(&schema);
+        builder.add_row(1, &Row::from_values(vec![Value::Integer(1)]));
+        let manager = SegmentManager::new("missing", None);
+        let meta = SegmentMeta {
+            segment_id: 1,
+            file_path: PathBuf::from("missing.vol"),
+            row_count: 1,
+            min_row_id: 1,
+            max_row_id: 1,
+            creation_lsn: 0,
+            seal_seq: 0,
+            schema_version: 0,
+        };
+        manager.manifest_mut().add_segment(meta.clone());
+        assert!(manager.capture_with_hot(|| ()).is_err());
+        manager.register_segment(1, Arc::new(builder.finish().to_cold()), meta, Some(&schema));
+        let (_, generation) = manager.capture_with_hot(|| ()).unwrap();
+        assert!(generation.load_segment(1).is_err());
+    }
+
+    #[test]
+    fn failed_manifest_publication_keeps_old_identity_in_rename_catalog() {
+        use crate::core::{DataType, Row, SchemaBuilder, Value};
+        let directory = tempfile::tempdir().unwrap();
+        let schema = SchemaBuilder::new("before")
+            .column("id", DataType::Integer, false, true)
+            .build();
+        let mut builder = super::super::writer::VolumeBuilder::new(&schema);
+        builder.add_row(1, &Row::from_values(vec![Value::Integer(42)]));
+        let volume = builder.finish();
+        let path =
+            super::super::io::write_volume_to_disk(directory.path(), "before", 1, &volume).unwrap();
+        let catalog = Arc::new(super::super::io::VolumeRetirementQueue::default());
+        let manager = SegmentManager::new_with_file_catalog_in(
+            "before",
+            Some(directory.path().to_path_buf()),
+            catalog.clone(),
+            MemoryAccount::new(),
+        );
+        manager.register_segment(
+            1,
+            Arc::new(volume.to_cold()),
+            SegmentMeta {
+                segment_id: 1,
+                file_path: path,
+                row_count: 1,
+                min_row_id: 1,
+                max_row_id: 1,
+                creation_lsn: 1,
+                seal_seq: 0,
+                schema_version: 0,
+            },
+            Some(&schema),
+        );
+        manager.persist_manifest_only().unwrap();
+        let (_, captured) = manager.capture_with_hot(|| ()).unwrap();
+        drop(volume);
+        manager.replace_segments_atomic_remove_only(&[1]);
+        std::fs::create_dir(directory.path().join("before/manifest.manifest.tmp")).unwrap();
+        assert!(manager.persist_manifest_only().is_err());
+        assert!(manager.segments_raw().is_empty());
+        // The old identity is neither current nor eligible for deletion.
+        catalog
+            .rename_directory(
+                &directory.path().join("before"),
+                &directory.path().join("after"),
+                &[],
+            )
+            .unwrap();
+        assert_eq!(
+            captured.load_segment(1).unwrap().volume.get_row(0).unwrap()[0],
+            Value::Integer(42)
+        );
+        drop(captured);
+        catalog.sweep();
+        assert!(directory
+            .path()
+            .join("after/vol_0000000000000001.vol")
+            .exists());
+    }
+
+    #[test]
+    fn both_manager_reload_paths_preserve_the_captured_identity_and_metadata() {
+        use crate::core::{DataType, Row, SchemaBuilder, Value};
+        for bulk in [false, true] {
+            let directory = tempfile::tempdir().unwrap();
+            let schema = SchemaBuilder::new("reload")
+                .column("before", DataType::Integer, false, true)
+                .build();
+            let mut builder = super::super::writer::VolumeBuilder::new(&schema);
+            builder.add_row(1, &Row::from_values(vec![Value::Integer(42)]));
+            let mut volume = builder.finish();
+            let path =
+                super::super::io::write_volume_to_disk(directory.path(), "reload", 1, &volume)
+                    .unwrap();
+            volume.merge_column_rename("after", "before");
+            volume.prebuild_unique_index(&[0]).unwrap();
+            let manager = SegmentManager::new("reload", Some(directory.path().to_path_buf()));
+            manager.register_segment(
+                1,
+                Arc::new(volume.to_cold()),
+                SegmentMeta {
+                    segment_id: 1,
+                    file_path: path.clone(),
+                    row_count: 1,
+                    min_row_id: 1,
+                    max_row_id: 1,
+                    creation_lsn: 1,
+                    seal_seq: 0,
+                    schema_version: 0,
+                },
+                Some(&schema),
+            );
+            let (_, captured) = manager.capture_with_hot(|| ()).unwrap();
+            let loaded = if bulk {
+                manager.reload_cold_volumes(vec![1]);
+                manager.segments_raw()[&1].volume.clone()
+            } else {
+                manager.ensure_volume(1).unwrap().unwrap()
+            };
+            assert!(!loaded.is_cold());
+            assert!(Arc::ptr_eq(
+                volume.backing.get().unwrap(),
+                loaded.backing.get().unwrap()
+            ));
+            assert!(Arc::ptr_eq(&volume.meta, &loaded.meta));
+            assert!(Arc::ptr_eq(&volume.unique_indices, &loaded.unique_indices));
+            assert_eq!(loaded.column_index("after"), Some(0));
+            let retirements = super::super::io::VolumeRetirementQueue::default();
+            retirements.retire(loaded.backing.get().unwrap());
+            manager.clear();
+            drop((loaded, volume));
+            retirements.sweep();
+            assert!(
+                path.exists(),
+                "the earlier generation still owns the same identity"
+            );
+            assert_eq!(
+                captured.load_segment(1).unwrap().volume.get_row(0).unwrap()[0],
+                Value::Integer(42)
+            );
+            drop(captured);
+            retirements.sweep();
+            assert!(!path.exists());
+        }
+    }
 
     #[test]
     fn test_manifest_new() {
@@ -3663,6 +4371,33 @@ mod tests {
 #[cfg(test)]
 mod publication_undo_tests {
     use super::*;
+
+    #[test]
+    fn truncate_retires_generation_capacity_and_keeps_the_replacement_accounted() {
+        let account = MemoryAccount::new();
+        let initial = account.snapshot().accounted_bytes;
+        let manager = SegmentManager::new_in("truncate_memory", None, account.child());
+        let empty = account.snapshot().retained_bytes;
+        for txn in 1..=128 {
+            manager.record_txn_seal_generation_at(txn, 9);
+        }
+        let grown = account.snapshot().retained_bytes;
+        assert!(grown > empty);
+        let prepared = manager.prepare_truncate().unwrap();
+        let fence = manager.acquire_seal_write();
+        let retired = manager.apply_truncate(prepared);
+        drop(fence);
+        assert_eq!(manager.get_txn_seal_generation(1), None);
+        assert_eq!(account.snapshot().retained_bytes, grown);
+        manager.record_txn_seal_generation_at(1000, 10);
+        let both = account.snapshot().retained_bytes;
+        assert!(both > grown, "the replacement map must remain attached");
+        drop(retired);
+        assert_eq!(account.snapshot().retained_bytes, both - (grown - empty));
+        assert_eq!(manager.get_txn_seal_generation(1000), Some(10));
+        drop(manager);
+        assert_eq!(account.snapshot().accounted_bytes, initial);
+    }
 
     #[test]
     fn reopened_manager_keeps_pending_hot_bytes_in_its_engine_origin() {

--- a/src/storage/volume/mod.rs
+++ b/src/storage/volume/mod.rs
@@ -57,6 +57,8 @@
 //!   uses hot buffer + frozen volumes. The executor sees the same Table/Scanner
 //!   traits regardless.
 
+pub(crate) mod captured_aggregate;
+pub(crate) mod captured_scanner;
 pub mod column;
 pub mod format;
 pub mod group_cache;

--- a/src/storage/volume/scanner.rs
+++ b/src/storage/volume/scanner.rs
@@ -26,6 +26,7 @@
 use std::sync::Arc;
 
 use crate::core::{Error, Result, Row, Value};
+use crate::storage::mvcc::version_store::CapturedHotView;
 use crate::storage::traits::Scanner;
 
 use super::writer::FrozenVolume;
@@ -78,6 +79,18 @@ impl GroupColumnCache {
     }
 }
 
+/// Statement visibility is resolved once for the requested part of each row
+/// group, before any predicate column is loaded. Boxing keeps legacy scanners
+/// at one pointer of overhead; the bitmap never grows with table cardinality.
+struct CapturedVisibility {
+    view: Arc<CapturedHotView>,
+    pending: Arc<rustc_hash::FxHashSet<i64>>,
+    hidden: smallvec::SmallVec<[u64; 4]>,
+    group: Option<usize>,
+    start: usize,
+    all_hidden: bool,
+}
+
 /// Scanner over a frozen volume that implements the `Scanner` trait.
 ///
 /// Reconstructs rows lazily from column-major data, projecting only
@@ -89,6 +102,9 @@ pub struct VolumeScanner {
     volume: Arc<FrozenVolume>,
     /// Column indices to project (empty = all columns)
     project_cols: Vec<usize>,
+    /// An empty projection requests every logical schema column, including
+    /// columns added after this physical volume was written.
+    projects_all_columns: bool,
     /// Pre-computed flag: true when project_cols is an identity mapping over
     /// all volume columns. Avoids recomputing this check on every row.
     is_full_projection: bool,
@@ -166,9 +182,102 @@ pub struct VolumeScanner {
     group_candidates: Vec<usize>,
     /// The group `group_candidates` was computed for
     candidates_group: Option<usize>,
+    captured_visibility: Option<Box<CapturedVisibility>>,
 }
 
 impl VolumeScanner {
+    /// Bind a fixed statement before installing its filter or starting the
+    /// scan. The view supplies the same epoch for hot rows and tombstones.
+    /// Pending deletes are the transaction's frozen statement overlay.
+    pub fn set_captured_visibility(
+        &mut self,
+        view: Arc<CapturedHotView>,
+        pending: Arc<rustc_hash::FxHashSet<i64>>,
+    ) {
+        // Short ranges, especially a primary-key point read, need only their
+        // own bits. Larger scans reuse at most one physical group's bitmap.
+        let words = self
+            .end_idx
+            .saturating_sub(self.current_idx)
+            .min(super::column::ROW_GROUP_SIZE)
+            .div_ceil(64);
+        let mut hidden = smallvec::SmallVec::new();
+        hidden.resize(words, 0);
+        self.captured_visibility = Some(Box::new(CapturedVisibility {
+            view,
+            pending,
+            hidden,
+            group: None,
+            start: 0,
+            all_hidden: false,
+        }));
+        // Preserve a previously selected reverse direction. Captured scans
+        // cannot eagerly inspect dictionary columns in later hidden groups.
+        self.ordered_walk = true;
+        self.matching_indices = None;
+        self.match_idx = 0;
+        self.next_group_boundary = 0;
+        self.candidates_group = None;
+        self.group_candidates.clear();
+    }
+
+    /// Returns true when every requested row in this group is hidden. The
+    /// initial bounds remain valid as the forward/reverse cursor advances.
+    fn prepare_captured_group(&mut self, group: usize, lo: usize, hi: usize) -> bool {
+        let Some(policy) = &mut self.captured_visibility else {
+            return false;
+        };
+        if policy.group == Some(group) {
+            return policy.all_hidden;
+        }
+        let ids = &self.volume.meta.row_ids[lo..hi];
+        policy.view.mark_authoritative(ids, &mut policy.hidden);
+        policy.start = lo;
+        policy.group = Some(group);
+        if self.visibility_bitmap.is_none()
+            && policy.pending.is_empty()
+            && self
+                .committed_tombstones
+                .as_ref()
+                .is_none_or(|tombstones| tombstones.is_empty())
+        {
+            // The authority writer clears unused tail bits; counting bounded
+            // words avoids another row pass when cold exclusions are absent.
+            policy.all_hidden = policy.hidden[..ids.len().div_ceil(64)]
+                .iter()
+                .map(|bits| bits.count_ones() as usize)
+                .sum::<usize>()
+                == ids.len();
+            return policy.all_hidden;
+        }
+        policy.all_hidden = true;
+        for (local, &id) in ids.iter().enumerate() {
+            let global = lo + local;
+            let hidden = self.visibility_bitmap.as_ref().is_some_and(|bitmap| {
+                bitmap
+                    .get(global / 64)
+                    .is_some_and(|word| word & (1u64 << (global % 64)) == 0)
+            }) || policy.pending.contains(&id)
+                || self
+                    .committed_tombstones
+                    .as_ref()
+                    .is_some_and(|tombstones| {
+                        tombstones.get(&id).is_some_and(|&sequence| {
+                            i64::try_from(sequence).is_ok_and(|sequence| {
+                                policy.view.epoch().admits_commit_sequence(sequence)
+                            })
+                        })
+                    });
+            let bit = 1u64 << (local % 64);
+            let word = &mut policy.hidden[local / 64];
+            if hidden {
+                *word |= bit;
+            }
+            policy.all_hidden &= *word & bit != 0;
+        }
+        policy.all_hidden
+    }
+
     /// Rows in the volume's order, from the start (ascending) or from the end
     /// (descending), without the eager dictionary pre-scan over the range
     pub fn set_ordered_walk(&mut self, ascending: bool) {
@@ -242,6 +351,14 @@ impl VolumeScanner {
             let idx = self.end_idx - 1;
             let group_idx = idx / super::column::ROW_GROUP_SIZE;
             let group_start = group_idx * super::column::ROW_GROUP_SIZE;
+            if self.prepare_captured_group(
+                group_idx,
+                group_start.max(self.current_idx),
+                self.end_idx,
+            ) {
+                self.end_idx = group_start.max(self.current_idx);
+                continue;
+            }
             let cached = self.group_cache.as_ref().map(|c| c.group_idx);
             if cached != Some(group_idx) {
                 if let Some(ref skips) = self.row_group_skips {
@@ -258,7 +375,12 @@ impl VolumeScanner {
                     }
                 }
             }
-            if !self.dict_filters.is_empty() && self.candidates_group != Some(group_idx) {
+            // Captured scans test visibility before even dictionary predicates.
+            // Legacy reverse scans can batch candidates for the whole group.
+            if self.captured_visibility.is_none()
+                && !self.dict_filters.is_empty()
+                && self.candidates_group != Some(group_idx)
+            {
                 let lo = group_start.max(self.current_idx);
                 match self.dictionary_candidates(lo, self.end_idx)? {
                     Some(candidates) => {
@@ -283,14 +405,14 @@ impl VolumeScanner {
             } else {
                 idx
             };
+            self.end_idx = idx;
+            if self.should_skip_row(idx) {
+                continue;
+            }
             if self.past_stop_key(idx)? {
                 self.end_idx = self.current_idx;
                 self.has_current = false;
                 return Ok(false);
-            }
-            self.end_idx = idx;
-            if self.should_skip_row(idx) {
-                continue;
             }
             if self.candidates_group != Some(group_idx)
                 && !self.dict_filters.is_empty()
@@ -324,6 +446,7 @@ impl VolumeScanner {
         project_cols: Vec<usize>,
         _delete_vector: Option<()>,
     ) -> Self {
+        let projects_all_columns = project_cols.is_empty();
         let project = if project_cols.is_empty() {
             (0..volume.columns.len()).collect()
         } else {
@@ -336,6 +459,7 @@ impl VolumeScanner {
             end_idx: volume.meta.row_count,
             volume,
             project_cols: project,
+            projects_all_columns,
             is_full_projection,
             current_idx: 0,
             current_row: Row::new(),
@@ -361,6 +485,7 @@ impl VolumeScanner {
             stop_key: None,
             group_candidates: Vec::new(),
             candidates_group: None,
+            captured_visibility: None,
         };
         if !s.is_full_projection && s.volume.columns.should_use_group_cache() {
             let mut mask = vec![false; s.volume.columns.len()];
@@ -382,6 +507,7 @@ impl VolumeScanner {
         end_idx: usize,
         _delete_vector: Option<()>,
     ) -> Self {
+        let projects_all_columns = project_cols.is_empty();
         let project = if project_cols.is_empty() {
             (0..volume.columns.len()).collect()
         } else {
@@ -392,6 +518,7 @@ impl VolumeScanner {
         let mut s = Self {
             volume,
             project_cols: project,
+            projects_all_columns,
             is_full_projection,
             current_idx: start_idx,
             end_idx,
@@ -418,6 +545,7 @@ impl VolumeScanner {
             stop_key: None,
             group_candidates: Vec::new(),
             candidates_group: None,
+            captured_visibility: None,
         };
         if !s.is_full_projection && s.volume.columns.should_use_group_cache() {
             let mut mask = vec![false; s.volume.columns.len()];
@@ -462,6 +590,7 @@ impl VolumeScanner {
     pub fn empty() -> Self {
         Self {
             volume: Arc::new(FrozenVolume {
+                backing: std::sync::OnceLock::new(),
                 columns: super::writer::LazyColumns::empty(),
                 meta: Arc::new(super::writer::VolumeMeta {
                     zone_maps: Vec::new(),
@@ -481,6 +610,7 @@ impl VolumeScanner {
                 last_access_epoch: std::sync::atomic::AtomicU64::new(0),
             }),
             project_cols: Vec::new(),
+            projects_all_columns: true,
             is_full_projection: true,
             current_idx: 0,
             end_idx: 0,
@@ -507,6 +637,7 @@ impl VolumeScanner {
             stop_key: None,
             group_candidates: Vec::new(),
             candidates_group: None,
+            captured_visibility: None,
         }
     }
 
@@ -525,7 +656,12 @@ impl VolumeScanner {
     ) -> Result<()> {
         // Extract dictionary filters for fast pre-filtering.
         // Uses CompressedBlockStore's shared dict when available (no column decompression).
-        let comparisons = filter.collect_comparisons();
+        // Apply logical schema mapping before physical dictionary pruning.
+        let comparisons = if self.column_mapping.is_some() {
+            Vec::new()
+        } else {
+            filter.collect_comparisons()
+        };
         // Only use CompressedBlockStore for dict lookup / group scan when
         // columns are NOT already loaded (deferred volumes from disk).
         // After seal/compaction, eager() pre-loads all OnceLock
@@ -541,7 +677,18 @@ impl VolumeScanner {
             }
             if let Value::Text(s) = value {
                 if let Some(col_idx) = self.volume.column_index(col_name) {
-                    let dict_id = if let Some(st) = store {
+                    let dict_id = if self.captured_visibility.is_some() {
+                        // Optional dictionary narrowing must not force a
+                        // column read before this group's authority mask.
+                        let Some(dictionary) = self.volume.columns.get_column_dictionary(col_idx)
+                        else {
+                            continue;
+                        };
+                        dictionary
+                            .iter()
+                            .position(|value| value.as_str() == s.as_str())
+                            .map(|index| index as u32)
+                    } else if let Some(st) = store {
                         st.dict_lookup(col_idx, s.as_str())
                     } else {
                         self.volume.columns.get(col_idx)?.dict_lookup(s.as_str())
@@ -725,10 +872,9 @@ impl VolumeScanner {
         let mut filter_cols = Vec::new();
         if filter.collect_column_indices(&mut filter_cols) {
             let num_cols = self.volume.columns.len();
-            // Use the larger of volume columns and mapping sources length
-            // to handle schema-evolved volumes.
+            // Filter and projection positions address the logical schema.
             let mask_len = if let Some(ref m) = self.column_mapping {
-                m.sources.len().max(num_cols)
+                m.sources.len()
             } else {
                 num_cols
             };
@@ -847,11 +993,56 @@ impl VolumeScanner {
     }
 
     /// Set a precomputed column mapping for schema-evolved volumes.
-    /// Only stores it if the mapping is non-identity (avoids overhead
-    /// when the volume matches the current schema).
+    /// Install before the filter or iteration. Projection and filter masks use
+    /// logical positions; decompression maps
+    /// those positions back to physical columns when loading a group.
     pub fn set_column_mapping(&mut self, mapping: super::writer::ColumnMapping) {
-        if !mapping.is_identity {
-            self.column_mapping = Some(mapping);
+        if mapping.sources.iter().any(|source| {
+            matches!(source,
+            super::writer::ColSource::Volume(index) if *index >= self.volume.columns.len())
+        }) {
+            self.error = Some(Error::internal("volume column mapping index out of bounds"));
+            self.has_current = false;
+            return;
+        }
+        let logical_columns = mapping.sources.len();
+        if mapping.is_identity
+            && self.column_mapping.is_none()
+            && logical_columns == self.volume.columns.len()
+        {
+            return;
+        }
+        if self.projects_all_columns && self.project_cols.len() != logical_columns {
+            self.project_cols = (0..logical_columns).collect();
+        }
+        self.is_full_projection =
+            Self::compute_is_full_projection(&self.project_cols, logical_columns);
+        self.column_mapping = (!mapping.is_identity).then_some(mapping);
+        self.group_cache = None;
+        self.next_group_boundary = 0;
+        self.dict_filters.clear();
+        self.typed_predicates.clear();
+        self.matching_indices = None;
+        self.match_idx = 0;
+        self.row_group_skips = None;
+        self.group_candidates.clear();
+        self.candidates_group = None;
+        let mut references = Vec::new();
+        if self
+            .filter
+            .as_ref()
+            .is_some_and(|filter| !filter.collect_column_indices(&mut references))
+            || (self.filter.is_none() && self.is_full_projection)
+        {
+            self.needed_cols = None;
+        } else {
+            let mut mask = vec![false; logical_columns];
+            for &index in self.project_cols.iter().chain(&references) {
+                if let Some(needed) = mask.get_mut(index) {
+                    *needed = true;
+                }
+            }
+            self.needed_cols = Some(mask);
         }
     }
 
@@ -888,7 +1079,30 @@ impl VolumeScanner {
         let group_start = group_idx * super::column::ROW_GROUP_SIZE;
 
         let mut columns: Vec<Option<Arc<super::column::ColumnData>>> = vec![None; col_count];
-        if let Some(ref needed) = self.needed_cols {
+        if let Some(mapping) = &self.column_mapping {
+            for (logical, source) in mapping.sources.iter().enumerate() {
+                if self
+                    .needed_cols
+                    .as_ref()
+                    .is_some_and(|needed| !needed.get(logical).copied().unwrap_or(false))
+                {
+                    continue;
+                }
+                let super::writer::ColSource::Volume(ci) = *source else {
+                    continue;
+                };
+                if columns[ci].is_some() {
+                    continue;
+                }
+                match store.group_column(ci, group_idx) {
+                    Ok(column) => columns[ci] = Some(column),
+                    Err(error) => {
+                        self.error = Some(error.into());
+                        return;
+                    }
+                }
+            }
+        } else if let Some(ref needed) = self.needed_cols {
             for (ci, &need) in needed.iter().enumerate() {
                 if need && ci < col_count && group_idx < store.num_groups(ci) {
                     match store.group_column(ci, group_idx) {
@@ -931,6 +1145,11 @@ impl VolumeScanner {
     /// the row should be skipped.
     #[inline(always)]
     fn should_skip_row(&self, idx: usize) -> bool {
+        if let Some(policy) = &self.captured_visibility {
+            debug_assert_eq!(policy.group, Some(idx / super::column::ROW_GROUP_SIZE));
+            let local = idx - policy.start;
+            return policy.hidden[local / 64] & (1u64 << (local % 64)) != 0;
+        }
         // Check pre-computed inter-volume visibility bitmap first (O(1) bit check).
         // A clear bit means a newer volume owns this row_id — skip without materialization.
         if let Some(ref bm) = self.visibility_bitmap {
@@ -974,9 +1193,12 @@ impl VolumeScanner {
     /// rejects the row.
     #[inline(always)]
     fn materialize_row(&mut self, idx: usize) -> Result<bool> {
-        // Per-group cache path: only when no schema mapping is needed.
-        // Schema-evolved volumes require column_mapping which remaps positions.
-        if self.group_cache.is_some() && self.column_mapping.is_none() {
+        // Both paths use already-loaded group columns. Schema mappings resolve
+        // logical positions without reloading entire physical columns.
+        if self.group_cache.is_some() && self.column_mapping.is_some() {
+            return self.materialize_mapped_row_from_cache(idx);
+        }
+        if self.group_cache.is_some() {
             return self.materialize_row_from_cache(idx);
         }
 
@@ -989,7 +1211,7 @@ impl VolumeScanner {
                 (None, Some(mapping)) => self.volume.get_row_mapped(idx, mapping)?,
                 (None, None) => self.volume.get_row(idx)?,
             };
-            if !filter.evaluate_fast(&full_row) {
+            if !filter.evaluate(&full_row)? {
                 return Ok(false);
             }
             if self.is_full_projection {
@@ -1024,6 +1246,39 @@ impl VolumeScanner {
     }
 
     /// Build a row from the per-group column cache (avoids full-column decompression).
+    fn materialize_mapped_row_from_cache(&mut self, idx: usize) -> Result<bool> {
+        let mapping = self
+            .column_mapping
+            .as_ref()
+            .ok_or_else(|| crate::core::Error::internal("mapped cache path has no mapping"))?;
+        let mut values = Vec::with_capacity(mapping.sources.len());
+        for (logical, source) in mapping.sources.iter().enumerate() {
+            let needed = self
+                .needed_cols
+                .as_ref()
+                .is_none_or(|mask| mask.get(logical).copied().unwrap_or(false));
+            let value = match source {
+                super::writer::ColSource::Volume(physical) => {
+                    if needed {
+                        let (column, local) = self.col_and_idx(*physical, idx)?;
+                        column.get_value(local)
+                    } else {
+                        Value::Null(self.volume.columns.data_type(*physical))
+                    }
+                }
+                super::writer::ColSource::Default(value) => {
+                    if needed {
+                        value.clone()
+                    } else {
+                        Value::Null(value.data_type())
+                    }
+                }
+            };
+            values.push(value);
+        }
+        self.finish_cached_row(Row::from_values(values))
+    }
+
     fn materialize_row_from_cache(&mut self, idx: usize) -> Result<bool> {
         let col_count = self.volume.columns.len();
         let mut values = Vec::with_capacity(col_count);
@@ -1039,11 +1294,16 @@ impl VolumeScanner {
                 values.push(Value::Null(self.volume.columns.data_type(ci)));
             }
         }
-        let full_row = Row::from_values(values);
+        self.finish_cached_row(Row::from_values(values))
+    }
+
+    fn finish_cached_row(&mut self, full_row: Row) -> Result<bool> {
         if self
             .filter
             .as_ref()
-            .is_some_and(|filter| !filter.evaluate_fast(&full_row))
+            .map(|filter| filter.evaluate(&full_row))
+            .transpose()?
+            .is_some_and(|matched| !matched)
         {
             return Ok(false);
         }
@@ -1092,6 +1352,12 @@ impl VolumeScanner {
                     }
                 };
 
+                let gi = idx / super::column::ROW_GROUP_SIZE;
+                self.prepare_captured_group(
+                    gi,
+                    gi * super::column::ROW_GROUP_SIZE,
+                    ((gi + 1) * super::column::ROW_GROUP_SIZE).min(self.end_idx),
+                );
                 if self.should_skip_row(idx) {
                     continue;
                 }
@@ -1131,6 +1397,15 @@ impl VolumeScanner {
                 self.next_group_boundary =
                     ((group_idx + 1) * super::column::ROW_GROUP_SIZE).min(self.end_idx);
 
+                if self.prepare_captured_group(
+                    group_idx,
+                    self.current_idx,
+                    self.next_group_boundary,
+                ) {
+                    self.current_idx = self.next_group_boundary;
+                    continue;
+                }
+
                 // Zone map skip
                 if let Some(ref skips) = self.row_group_skips {
                     if group_idx < skips.len() && skips[group_idx] {
@@ -1149,15 +1424,15 @@ impl VolumeScanner {
                 }
             }
 
+            if self.should_skip_row(self.current_idx) {
+                self.current_idx += 1;
+                continue;
+            }
+
             if self.stop_key.is_some() && self.past_stop_key(self.current_idx)? {
                 self.current_idx = self.end_idx;
                 self.has_current = false;
                 return Ok(false);
-            }
-
-            if self.should_skip_row(self.current_idx) {
-                self.current_idx += 1;
-                continue;
             }
 
             let idx = self.current_idx;
@@ -1208,6 +1483,22 @@ impl Scanner for VolumeScanner {
 
     fn close(&mut self) -> Result<()> {
         self.has_current = false;
+        if let Some(policy) = self.captured_visibility.take() {
+            // A closed scanner can remain allocated. Release its captured
+            // owners and buffers, then the epoch, and never resume the cursor.
+            self.current_idx = self.end_idx;
+            self.matching_indices = None;
+            self.match_idx = 0;
+            self.group_cache = None;
+            self.group_candidates = Vec::new();
+            self.candidates_group = None;
+            self.visibility_bitmap = None;
+            self.pending_cold_deletes = None;
+            self.committed_tombstones = None;
+            self.filter = None;
+            self.current_row = Row::new();
+            drop(policy);
+        }
         Ok(())
     }
 
@@ -1407,6 +1698,420 @@ mod tests {
     use super::super::writer::VolumeBuilder;
     use super::*;
     use crate::core::{DataType, SchemaBuilder};
+    use crate::storage::expression::{ComparisonExpr, Expression};
+    use crate::storage::mvcc::registry::TransactionRegistry;
+    use crate::storage::mvcc::version_store::{RowVersion, VersionStore};
+
+    fn captured_store() -> (Arc<TransactionRegistry>, VersionStore) {
+        let registry = Arc::new(TransactionRegistry::new());
+        let schema = SchemaBuilder::new("test")
+            .column("id", DataType::Integer, false, true)
+            .column("name", DataType::Text, false, false)
+            .column("price", DataType::Float, false, false)
+            .build();
+        let store = VersionStore::with_visibility_checker("test", schema, registry.clone());
+        (registry, store)
+    }
+
+    fn scan_ids(scanner: &mut VolumeScanner) -> Vec<i64> {
+        let mut ids = Vec::new();
+        while scanner.next() {
+            ids.push(scanner.current_rid);
+        }
+        assert!(scanner.err().is_none(), "{:?}", scanner.err());
+        ids
+    }
+
+    #[test]
+    fn mapped_projection_keeps_added_defaults_and_explicit_physical_width_prefix() {
+        use super::super::writer::{ColSource, ColumnMapping};
+        let (registry, store) = captured_store();
+        let view = Arc::new(CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        ));
+        let old_schema = SchemaBuilder::new("test")
+            .column("id", DataType::Integer, false, true)
+            .column("g", DataType::Integer, false, false)
+            .build();
+        let schema = SchemaBuilder::new("test")
+            .column("id", DataType::Integer, false, true)
+            .column("g", DataType::Integer, false, false)
+            .column("added", DataType::Integer, false, false)
+            .build();
+        let mut builder = VolumeBuilder::new(&old_schema);
+        builder.add_row(
+            1,
+            &Row::from_values(vec![Value::Integer(1), Value::Integer(20)]),
+        );
+        let mut volume = builder.finish();
+        let (_, compressed) = super::super::io::serialize_v4_public(&volume).unwrap();
+        volume.columns.attach_compressed_store(compressed);
+        let warm = Arc::new(volume.to_warm().unwrap());
+        let eager = Arc::new(volume);
+        let mapping = ColumnMapping {
+            sources: vec![
+                ColSource::Volume(0),
+                ColSource::Volume(1),
+                ColSource::Default(Value::Integer(7)),
+            ],
+            is_identity: false,
+        };
+        for volume in [eager, warm] {
+            for columns in [vec![], vec![0, 1], vec![0, 1, 2], vec![2], vec![2, 0]] {
+                for filtered in [false, true] {
+                    let mut scanner = VolumeScanner::new(volume.clone(), columns.clone(), None);
+                    scanner.set_column_mapping(mapping.clone());
+                    scanner.set_captured_visibility(view.clone(), Arc::default());
+                    if filtered {
+                        let mut filter = ComparisonExpr::eq("id", Value::Integer(1));
+                        filter.prepare_for_schema(&schema);
+                        scanner.set_filter(Box::new(filter));
+                    }
+                    assert!(scanner.next(), "{:?}", scanner.err());
+                    let values = [Value::Integer(1), Value::Integer(20), Value::Integer(7)];
+                    let expected = if columns.is_empty() {
+                        values.to_vec()
+                    } else {
+                        columns.iter().map(|&index| values[index].clone()).collect()
+                    };
+                    assert_eq!(scanner.row(), &Row::from_values(expected));
+                    assert!(!scanner.next());
+                    assert!(scanner.err().is_none());
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[test]
+    fn mapped_default_filter_does_not_read_dropped_or_omitted_physical_columns() {
+        use super::super::writer::{ColSource, ColumnMapping};
+        let _guard = crate::test_failpoints::FailpointGuard::new();
+        let (registry, store) = captured_store();
+        let view = Arc::new(CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        ));
+        let mut volume = Arc::try_unwrap(make_test_volume()).ok().unwrap();
+        let (_, compressed) = super::super::io::serialize_v4_public(&volume).unwrap();
+        volume.columns.attach_compressed_store(compressed);
+        let warm = Arc::new(volume.to_warm().unwrap());
+        let schema = SchemaBuilder::new("test")
+            .column("name", DataType::Text, false, false)
+            .column("price", DataType::Float, false, false)
+            .build();
+        let mapping = ColumnMapping {
+            sources: vec![
+                ColSource::Default(Value::text("replacement")),
+                ColSource::Volume(2),
+            ],
+            is_identity: false,
+        };
+        for ascending in [true, false] {
+            let mut scanner = VolumeScanner::new(warm.clone(), vec![0], None);
+            scanner.set_column_mapping(mapping.clone());
+            scanner.set_captured_visibility(view.clone(), Arc::default());
+            scanner.set_ordered_walk(ascending);
+            let mut filter = ComparisonExpr::eq("name", Value::text("replacement"));
+            filter.prepare_for_schema(&schema);
+            crate::test_failpoints::fail_cold_read_on(1);
+            scanner.set_filter(Box::new(filter));
+            let mut count = 0;
+            while scanner.next() {
+                assert_eq!(
+                    scanner.row(),
+                    &Row::from_values(vec![Value::text("replacement")])
+                );
+                count += 1;
+            }
+            assert_eq!(count, 5);
+            assert!(scanner.err().is_none(), "{:?}", scanner.err());
+            let mut required = VolumeScanner::new(warm.clone(), vec![2], None);
+            assert!(
+                !required.next(),
+                "the first physical access must retain the fault"
+            );
+            assert!(required.err().is_some());
+        }
+    }
+
+    #[test]
+    fn captured_authority_precedes_filters_and_keeps_invisible_hot_fallback() {
+        let (registry, store) = captured_store();
+        let (committed, _) = registry.begin_transaction();
+        registry.start_commit(committed);
+        store
+            .add_version(1, RowVersion::new(committed, Row::new()))
+            .unwrap();
+        let mut deleted = RowVersion::new(committed, Row::new());
+        deleted.deleted_at_txn_id = committed;
+        store.add_version(2, deleted).unwrap();
+        registry.complete_commit(committed);
+        let (inflight, _) = registry.begin_transaction();
+        registry.start_commit(inflight);
+        store
+            .add_version(3, RowVersion::new(inflight, Row::new()))
+            .unwrap();
+        let epoch = registry.capture_read_epoch();
+        let view = Arc::new(CapturedHotView::new(store.capture_hot_root(), epoch, None));
+        registry.complete_commit(inflight);
+        let pending: Arc<rustc_hash::FxHashSet<i64>> = Arc::new([4].into_iter().collect());
+        let volume = make_test_volume();
+
+        for start in 0..=5 {
+            for end in start..=5 {
+                for ascending in [true, false] {
+                    let mut scanner =
+                        VolumeScanner::with_range(volume.clone(), vec![], start, end, None);
+                    scanner.set_ordered_walk(ascending);
+                    scanner.set_captured_visibility(view.clone(), pending.clone());
+                    let mut expected: Vec<i64> = [3, 5]
+                        .into_iter()
+                        .filter(|id| start < *id as usize && (*id as usize - 1) < end)
+                        .collect();
+                    if !ascending {
+                        expected.reverse();
+                    }
+                    assert_eq!(scan_ids(&mut scanner), expected);
+                }
+            }
+        }
+
+        // The old cold value matches "apple", but visible hot authority must
+        // suppress it even though the replacement hot row does not match.
+        for ascending in [true, false] {
+            let mut scanner = VolumeScanner::new(volume.clone(), vec![], None);
+            scanner.set_captured_visibility(view.clone(), pending.clone());
+            scanner.set_ordered_walk(ascending);
+            let mut filter = ComparisonExpr::eq("name", Value::text("apple"));
+            filter.prepare_for_schema(&store.schema());
+            scanner.set_filter(Box::new(filter));
+            assert!(scan_ids(&mut scanner).is_empty());
+            assert!(scanner.matching_indices.is_none());
+        }
+
+        // An excluded tombstone remains invisible after its publisher commits.
+        let tombstones: Arc<rustc_hash::FxHashMap<i64, u64>> = Arc::new(
+            [
+                (3, registry.get_commit_sequence(inflight).unwrap() as u64),
+                (5, registry.get_commit_sequence(committed).unwrap() as u64),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let mut scanner = VolumeScanner::new(volume.clone(), vec![], None);
+        scanner.set_captured_visibility(view.clone(), pending.clone());
+        scanner.set_skip_sets(tombstones.clone(), pending.clone());
+        assert_eq!(scan_ids(&mut scanner), vec![3]);
+
+        let mut scanner = VolumeScanner::new(volume, vec![], None);
+        scanner.set_captured_visibility(view, pending.clone());
+        scanner.set_skip_sets(tombstones, pending);
+        scanner.set_visibility_bitmap(Some(Arc::new(vec![!(1u64 << 2)])));
+        assert!(scan_ids(&mut scanner).is_empty());
+    }
+
+    #[test]
+    fn captured_hidden_range_never_loads_columns_or_stop_keys() {
+        let (registry, store) = captured_store();
+        let (txn, _) = registry.begin_transaction();
+        registry.start_commit(txn);
+        for id in [2, 3] {
+            store
+                .add_version(id, RowVersion::new(txn, Row::new()))
+                .unwrap();
+        }
+        registry.complete_commit(txn);
+        let view = Arc::new(CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        ));
+        // A metadata-only volume has no column source. Any attempted column
+        // access fails, including optional dictionary resolution in set_filter.
+        let volume = Arc::new(make_test_volume().to_cold());
+        for ascending in [true, false] {
+            let mut scanner = VolumeScanner::with_range(volume.clone(), vec![], 1, 3, None);
+            scanner.set_ordered_walk(ascending);
+            scanner.set_captured_visibility(view.clone(), Arc::default());
+            scanner.set_stop_key(0, &Value::Integer(2), ascending);
+            let mut filter = ComparisonExpr::eq("name", Value::text("banana"));
+            filter.prepare_for_schema(&store.schema());
+            scanner.set_filter(Box::new(filter));
+            assert!(scan_ids(&mut scanner).is_empty());
+        }
+        let mut visible = VolumeScanner::new(volume, vec![], None);
+        visible.set_captured_visibility(view, Arc::default());
+        assert!(!visible.next());
+        assert!(
+            visible.err().is_some(),
+            "visible cold access must still fail"
+        );
+    }
+
+    #[test]
+    fn captured_close_releases_epoch_and_stops_without_discarding_error() {
+        let (registry, store) = captured_store();
+        for reverse in [false, true] {
+            for unreadable in [false, true] {
+                assert_eq!(registry.oldest_retention_horizon(), None);
+                let epoch = registry.capture_read_epoch();
+                let horizon = epoch.retention_horizon();
+                let view = Arc::new(CapturedHotView::new(store.capture_hot_root(), epoch, None));
+                let volume = make_test_volume();
+                let volume = if unreadable {
+                    Arc::new(volume.to_cold())
+                } else {
+                    volume
+                };
+                let mut scanner = VolumeScanner::new(volume, vec![], None);
+                scanner.set_captured_visibility(view, Arc::default());
+                scanner.set_ordered_walk(!reverse);
+                assert_eq!(registry.oldest_retention_horizon(), Some(horizon));
+                assert_eq!(scanner.next(), !unreadable);
+                let error = scanner.err().map(ToString::to_string);
+                scanner.close().unwrap();
+                assert_eq!(registry.oldest_retention_horizon(), None);
+                assert!(scanner.captured_visibility.is_none());
+                assert!(!scanner.next(), "closed object must not resume scanning");
+                assert_eq!(scanner.err().map(ToString::to_string), error);
+                scanner.close().unwrap();
+                assert!(!scanner.next());
+            }
+        }
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[test]
+    fn captured_hidden_warm_group_skips_dictionary_prescan_and_decompression() {
+        let _guard = crate::test_failpoints::FailpointGuard::new();
+        let (registry, store) = captured_store();
+        let view = Arc::new(CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        ));
+        let mut volume = Arc::try_unwrap(make_test_volume()).ok().unwrap();
+        let (_, compressed) = super::super::io::serialize_v4_public(&volume).unwrap();
+        volume.columns.attach_compressed_store(compressed);
+        let warm = Arc::new(volume.to_warm().unwrap());
+        assert!(warm.columns.should_use_group_cache());
+        for ascending in [true, false] {
+            let mut scanner = VolumeScanner::new(warm.clone(), vec![], None);
+            scanner.set_captured_visibility(view.clone(), Arc::new((1..=5).collect()));
+            scanner.set_ordered_walk(ascending);
+            let mut filter = ComparisonExpr::eq("name", Value::text("apple"));
+            filter.prepare_for_schema(&store.schema());
+            crate::test_failpoints::fail_cold_read_on(1);
+            scanner.set_filter(Box::new(filter));
+            assert!(scan_ids(&mut scanner).is_empty());
+            // No masked access consumed the fault, and a required access
+            // remains fallible rather than treating unreadable data as empty.
+            let mut visible = VolumeScanner::new(warm.clone(), vec![], None);
+            visible.set_captured_visibility(view.clone(), Arc::default());
+            assert!(!visible.next());
+            assert!(visible.err().is_some());
+        }
+    }
+
+    #[test]
+    fn captured_point_range_bounds_authority_work_with_many_hot_rows() {
+        let (registry, store) = captured_store();
+        let schema = SchemaBuilder::new("point")
+            .column("id", DataType::Integer, false, true)
+            .build();
+        let target = 2048usize;
+        let mut builder = VolumeBuilder::with_capacity(&schema, 4096);
+        let (writer, _) = registry.begin_transaction();
+        registry.start_commit(writer);
+        for id in 0..4096 {
+            let row = Row::from_values(vec![Value::Integer(id as i64)]);
+            builder.add_row(id as i64, &row);
+            if id != target {
+                store
+                    .add_version(id as i64, RowVersion::new(writer, row))
+                    .unwrap();
+            }
+        }
+        registry.complete_commit(writer);
+        let view = Arc::new(CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        ));
+        assert!(!view.is_empty());
+        let volume = Arc::new(builder.finish());
+        for ascending in [true, false] {
+            let mut scanner =
+                VolumeScanner::with_range(volume.clone(), vec![0], target, target + 1, None);
+            scanner.set_captured_visibility(view.clone(), Arc::default());
+            scanner.set_ordered_walk(ascending);
+            let mut filter = ComparisonExpr::eq("id", Value::Integer(target as i64));
+            filter.prepare_for_schema(&schema);
+            scanner.set_filter(Box::new(filter));
+            assert_eq!(
+                scanner.captured_visibility.as_ref().unwrap().hidden.len(),
+                1
+            );
+            assert!(scanner.next(), "{:?}", scanner.err());
+            assert_eq!(scanner.current_row_id(), target as i64);
+            let policy = scanner.captured_visibility.as_ref().unwrap();
+            assert_eq!(
+                policy.start, target,
+                "authority begins at the requested point, not the physical group"
+            );
+            assert_eq!(policy.hidden[0], 0);
+            assert_eq!(
+                policy.hidden.len(),
+                1,
+                "a point needs only its own mask word"
+            );
+            assert!(!scanner.next());
+            assert!(scanner.err().is_none());
+        }
+    }
+
+    #[test]
+    fn captured_visibility_reuses_bounded_mask_across_group_and_word_boundaries() {
+        let (registry, store) = captured_store();
+        let view = Arc::new(CapturedHotView::new(
+            store.capture_hot_root(),
+            registry.capture_read_epoch(),
+            None,
+        ));
+        let schema = SchemaBuilder::new("large")
+            .column("id", DataType::Integer, false, true)
+            .build();
+        let count = super::super::column::ROW_GROUP_SIZE + 65;
+        let mut builder = VolumeBuilder::with_capacity(&schema, count);
+        for id in 0..count {
+            builder.add_row(
+                id as i64,
+                &Row::from_values(vec![Value::Integer(id as i64)]),
+            );
+        }
+        let volume = Arc::new(builder.finish());
+        let survivors = [0, 63, 64, count - 66, count - 65, count - 1];
+        let pending: Arc<rustc_hash::FxHashSet<i64>> = Arc::new(
+            (0..count)
+                .filter(|id| !survivors.contains(id))
+                .map(|id| id as i64)
+                .collect(),
+        );
+        for ascending in [true, false] {
+            let mut scanner = VolumeScanner::with_range(volume.clone(), vec![], 1, count, None);
+            scanner.set_captured_visibility(view.clone(), pending.clone());
+            scanner.set_ordered_walk(ascending);
+            let mut expected: Vec<i64> = survivors[1..].iter().map(|id| *id as i64).collect();
+            if !ascending {
+                expected.reverse();
+            }
+            assert_eq!(scan_ids(&mut scanner), expected);
+        }
+    }
 
     fn make_test_volume() -> Arc<FrozenVolume> {
         let schema = SchemaBuilder::new("test")

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -26,7 +26,7 @@
 //! This is the Table trait implementation that makes the executor unaware
 //! of whether data lives in memory or frozen segments.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -178,6 +178,9 @@ pub struct SegmentedTable {
     /// preserving the snapshot's point-in-time view of cold data.
     /// None for auto-commit transactions (all tombstones visible).
     snapshot_seq: Option<u64>,
+    read_epoch: Option<crate::storage::mvcc::registry::ReadEpoch>,
+    cold_generation: Option<Arc<super::manifest::ColdGeneration>>,
+    captured_pending: OnceLock<Arc<FxHashSet<i64>>>,
 }
 
 impl SegmentedTable {
@@ -187,6 +190,9 @@ impl SegmentedTable {
             hot,
             segment_mgr,
             snapshot_seq: None,
+            read_epoch: None,
+            cold_generation: None,
+            captured_pending: OnceLock::new(),
         }
     }
 
@@ -201,6 +207,9 @@ impl SegmentedTable {
             hot,
             segment_mgr,
             snapshot_seq: Some(snapshot_seq),
+            read_epoch: None,
+            cold_generation: None,
+            captured_pending: OnceLock::new(),
         }
     }
 
@@ -210,6 +219,9 @@ impl SegmentedTable {
             segment_mgr: Arc::new(SegmentManager::new("", None)),
             hot,
             snapshot_seq: None,
+            read_epoch: None,
+            cold_generation: None,
+            captured_pending: OnceLock::new(),
         }
     }
 
@@ -218,11 +230,409 @@ impl SegmentedTable {
     /// hot rows in between. None once segments exist. Readers that merge hot
     /// and cold values hold the fence for their whole body instead.
     fn unsealed<T>(&self, f: impl FnOnce(&dyn Table) -> T) -> Option<T> {
+        if let Some(generation) = &self.cold_generation {
+            return generation
+                .segment_ids_newest_first
+                .is_empty()
+                .then(|| f(&*self.hot));
+        }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         if self.segment_mgr.has_segments() {
             return None;
         }
         Some(f(&*self.hot))
+    }
+
+    fn captured_pending(&self) -> &Arc<FxHashSet<i64>> {
+        self.captured_pending.get_or_init(|| {
+            let mut pending = FxHashSet::default();
+            self.segment_mgr
+                .insert_pending_tombstones_into(self.txn_id(), &mut pending);
+            Arc::new(pending)
+        })
+    }
+
+    fn captured_scan(
+        &self,
+        columns: &[usize],
+        filter: Option<&dyn Expression>,
+    ) -> Result<Option<Box<dyn Scanner>>> {
+        let Some(generation) = &self.cold_generation else {
+            return Ok(None);
+        };
+        let Some(view) = self.hot.captured_hot_view() else {
+            return Err(crate::core::Error::internal(
+                "captured cold generation has no hot view",
+            ));
+        };
+        if generation.segment_ids_newest_first.is_empty() {
+            return self.hot.scan(columns, filter).map(Some);
+        }
+        let prepared = filter.map(|filter| {
+            let mut filter = filter.clone_box();
+            filter.prepare_for_schema(self.hot.schema());
+            filter
+        });
+        let hot = self.hot.scan(columns, prepared.as_deref())?;
+        let columns = if columns.is_empty() {
+            (0..self.hot.schema().columns.len()).collect()
+        } else {
+            columns.to_vec()
+        };
+        let cold = super::captured_scanner::CapturedColdScanner::new(
+            generation.clone(),
+            view,
+            self.captured_pending().clone(),
+            columns,
+            prepared,
+            self.hot.schema(),
+        );
+        Ok(Some(Box::new(super::scanner::MergingScanner::new(vec![
+            Box::new(cold),
+            hot,
+        ]))))
+    }
+
+    fn collect_captured(
+        &self,
+        filter: Option<&dyn Expression>,
+        limit: usize,
+        offset: usize,
+    ) -> Result<RowVec> {
+        let mut result = RowVec::new();
+        if limit == 0 {
+            return Ok(result);
+        }
+        let mut scanner = self
+            .captured_scan(&[], filter)?
+            .ok_or_else(|| crate::core::Error::internal("missing captured table view"))?;
+        let mut skipped = 0;
+        while scanner.next() {
+            if skipped < offset {
+                skipped += 1;
+                continue;
+            }
+            result.push(scanner.take_row_with_id());
+            if result.len() == limit {
+                break;
+            }
+        }
+        if let Some(error) = scanner.err() {
+            return Err(error.clone());
+        }
+        scanner.close()?;
+        Ok(result)
+    }
+
+    fn captured_row(&self, row_id: i64) -> Result<Option<Row>> {
+        use crate::storage::mvcc::version_store::CapturedHotRow;
+        let generation = self
+            .cold_generation
+            .as_ref()
+            .ok_or_else(|| crate::core::Error::internal("missing captured cold generation"))?;
+        let view = self.hot.captured_hot_view().ok_or_else(|| {
+            crate::core::Error::internal("captured cold generation has no hot view")
+        })?;
+        match view.row_state(row_id) {
+            CapturedHotRow::Value(source) => {
+                let schema = self.hot.schema();
+                let mut row = source.clone();
+                if row.len() < schema.columns.len() {
+                    for column in &schema.columns[row.len()..] {
+                        row.push(
+                            column
+                                .default_value
+                                .clone()
+                                .unwrap_or_else(|| Value::null(column.data_type)),
+                        );
+                    }
+                } else if row.len() > schema.columns.len() {
+                    row.truncate(schema.columns.len());
+                }
+                return Ok(Some(row));
+            }
+            CapturedHotRow::Deleted => return Ok(None),
+            CapturedHotRow::NoVisibleVersion => (),
+        }
+        let Some((id, index)) = self.captured_cold_location(row_id)? else {
+            return Ok(None);
+        };
+        let loaded = generation.load_segment(id)?;
+        let row = if loaded.mapping.is_identity {
+            loaded.volume.get_row(index)?
+        } else {
+            loaded.volume.get_row_mapped(index, &loaded.mapping)?
+        };
+        Ok(Some(row))
+    }
+
+    /// Metadata-only cold identity lookup; caller resolves hot authority first.
+    fn captured_cold_location(&self, row_id: i64) -> Result<Option<(u64, usize)>> {
+        let generation = self
+            .cold_generation
+            .as_ref()
+            .ok_or_else(|| crate::core::Error::internal("missing captured cold generation"))?;
+        if self.captured_pending().contains(&row_id)
+            || self.is_row_tombstoned(&generation.tombstones, row_id)
+        {
+            return Ok(None);
+        }
+        for &id in &generation.segment_ids_newest_first {
+            let segment = generation.segments.get(&id).ok_or_else(|| {
+                crate::core::Error::internal(format!("captured generation has no segment {id}"))
+            })?;
+            if let Ok(index) = segment.volume.meta.row_ids.binary_search(&row_id) {
+                if !segment.is_visible(index) {
+                    continue;
+                }
+                return Ok(Some((id, index)));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Aggregate one logical column without constructing rows or loading other
+    /// columns. Fully visible immutable volumes can answer from captured stats.
+    fn captured_column_stats(
+        &self,
+        column: usize,
+    ) -> Result<Option<super::stats::ColumnAggregateStats>> {
+        use super::writer::ColSource;
+        let Some(schema_column) = self.hot.schema().columns.get(column) else {
+            return Ok(None);
+        };
+        let Some(generation) = &self.cold_generation else {
+            return Ok(None);
+        };
+        let view = self.hot.captured_hot_view().ok_or_else(|| {
+            crate::core::Error::internal("captured cold generation has no hot view")
+        })?;
+        let pending = self.captured_pending();
+        let default = schema_column
+            .default_value
+            .clone()
+            .unwrap_or_else(|| Value::null(schema_column.data_type));
+        let mut stats = super::stats::ColumnAggregateStats::default();
+        view.for_each_visible(|_, row| stats.accumulate(row.get(column).unwrap_or(&default)));
+        for &id in &generation.segment_ids_newest_first {
+            let segment = generation.segments.get(&id).ok_or_else(|| {
+                crate::core::Error::internal(format!("captured generation has no segment {id}"))
+            })?;
+            let count = super::captured_scanner::CapturedColdScanner::visible_count(
+                segment, generation, &view, pending, false,
+            );
+            if count == 0 {
+                continue;
+            }
+            let default_source = ColSource::Default(default.clone());
+            let physical = match segment
+                .mapping
+                .sources
+                .get(column)
+                .unwrap_or(&default_source)
+            {
+                ColSource::Default(value) => {
+                    let mut contribution = super::stats::ColumnAggregateStats::default();
+                    contribution.accumulate(value);
+                    contribution.sum_int *= count as i128;
+                    contribution.sum_float *= count as f64;
+                    contribution.numeric_count *= count as u64;
+                    contribution.non_null_count *= count as u64;
+                    stats.merge(&contribution);
+                    continue;
+                }
+                ColSource::Volume(physical) => *physical,
+            };
+            // Older volumes predate Boolean SUM stats. Their Boolean values
+            // must still be read; all other fully visible stats are compatible.
+            if count == segment.volume.meta.row_count
+                && schema_column.data_type != DataType::Boolean
+            {
+                if let Some(contribution) = segment.volume.meta.stats.columns.get(physical) {
+                    stats.merge(contribution);
+                    continue;
+                }
+            }
+            let loaded = generation.load_segment(id)?;
+            let grouped = loaded.volume.columns.should_use_group_cache();
+            let store = grouped
+                .then(|| loaded.volume.columns.compressed_store())
+                .flatten();
+            let mut cached_group = None;
+            let mut error = None;
+            super::captured_scanner::CapturedColdScanner::for_each_visible(
+                segment,
+                generation,
+                &view,
+                pending,
+                |index, _| {
+                    let outcome = (|| -> Result<()> {
+                        let (data, local) = if let Some(store) = store {
+                            let group = index / super::column::ROW_GROUP_SIZE;
+                            if cached_group
+                                .as_ref()
+                                .is_some_and(|(cached, _)| *cached != group)
+                            {
+                                cached_group = None;
+                            }
+                            let cached = match &mut cached_group {
+                                Some(cached) => cached,
+                                slot @ None => {
+                                    slot.insert((group, store.group_column(physical, group)?))
+                                }
+                            };
+                            (cached.1.as_ref(), index % super::column::ROW_GROUP_SIZE)
+                        } else {
+                            (loaded.volume.columns.get(physical)?, index)
+                        };
+                        stats.accumulate(&data.get_value(local));
+                        Ok(())
+                    })();
+                    if let Err(failure) = outcome {
+                        error = Some(failure);
+                        return false;
+                    }
+                    true
+                },
+            );
+            if let Some(error) = error {
+                return Err(error);
+            }
+        }
+        Ok(Some(stats))
+    }
+
+    fn captured_top_k(
+        &self,
+        filter: Option<&dyn Expression>,
+        column_name: &str,
+        ascending: bool,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Option<RowVec>> {
+        let Some(generation) = &self.cold_generation else {
+            return Ok(None);
+        };
+        let schema = self.hot.schema();
+        let Some((column, definition)) = schema.find_column(column_name) else {
+            return Ok(None);
+        };
+        if definition.nullable || definition.data_type == DataType::Float {
+            return Ok(None);
+        }
+        if limit == 0 {
+            return Ok(Some(RowVec::new()));
+        }
+        let view = self.hot.captured_hot_view().ok_or_else(|| {
+            crate::core::Error::internal("captured cold generation has no hot view")
+        })?;
+        let pending = self.captured_pending();
+        let mut ordered = Vec::with_capacity(generation.segment_ids_newest_first.len());
+        for &id in &generation.segment_ids_newest_first {
+            let segment = generation.segments.get(&id).ok_or_else(|| {
+                crate::core::Error::internal(format!("captured generation has no segment {id}"))
+            })?;
+            let (physical, bound) = match segment.mapping.sources.get(column) {
+                Some(super::writer::ColSource::Volume(physical)) => {
+                    let Some(zone) = segment.volume.meta.zone_maps.get(*physical) else {
+                        return Ok(None);
+                    };
+                    if zone.null_count != 0 {
+                        return Ok(None);
+                    }
+                    (
+                        Some(*physical),
+                        if ascending {
+                            zone.min.clone()
+                        } else {
+                            zone.max.clone()
+                        },
+                    )
+                }
+                Some(super::writer::ColSource::Default(value)) => (None, value.clone()),
+                None => (None, self.column_default(column)),
+            };
+            if bound.is_null() && segment.volume.meta.row_count != 0 {
+                return Ok(None);
+            }
+            ordered.push((id, physical, bound));
+        }
+        ordered.sort_unstable_by(|a, b| {
+            if ascending {
+                a.2.cmp(&b.2)
+            } else {
+                b.2.cmp(&a.2)
+            }
+        });
+        let needed = limit.saturating_add(offset);
+        let Some(hot_rows) = self
+            .hot
+            .scan_top_k(filter, column_name, ascending, needed, 0)?
+        else {
+            return Ok(None);
+        };
+        let mut keep = TopK::new(needed, column, ascending);
+        for (id, row) in hot_rows {
+            keep.offer(id, row);
+        }
+        let prepared = filter.map(|filter| {
+            let mut filter = filter.clone_box();
+            filter.prepare_for_schema(schema);
+            filter
+        });
+        let columns: Vec<_> = (0..schema.columns.len()).collect();
+        for (id, physical, bound) in ordered {
+            if keep.cannot_improve(&bound) {
+                break;
+            }
+            let segment = &generation.segments[&id];
+            if super::captured_scanner::CapturedColdScanner::visible_count(
+                segment, generation, &view, pending, true,
+            ) == 0
+            {
+                continue;
+            }
+            let loaded = generation.load_segment(id)?;
+            let sorted = physical.is_none_or(|physical| loaded.volume.is_sorted(physical));
+            let mut scanner = VolumeScanner::new(loaded.volume, columns.clone(), None);
+            scanner.set_column_mapping(loaded.mapping);
+            scanner.set_visibility_bitmap(loaded.visible);
+            scanner.set_skip_sets(generation.tombstones.clone(), pending.clone());
+            scanner.set_captured_visibility(view.clone(), pending.clone());
+            if sorted {
+                scanner.set_ordered_walk(ascending);
+            }
+            if let Some(filter) = &prepared {
+                scanner.set_filter(filter.clone_box());
+            }
+            if sorted {
+                if let (Some(physical), Some(worst)) = (physical, keep.worst_key()) {
+                    scanner.set_stop_key(physical, worst, ascending);
+                }
+            }
+            while scanner.next() {
+                if sorted
+                    && scanner
+                        .row()
+                        .get(column)
+                        .is_some_and(|key| keep.cannot_improve(key))
+                {
+                    break;
+                }
+                let (id, row) = scanner.take_row_with_id();
+                keep.offer(id, row);
+                if sorted {
+                    if let (Some(physical), Some(worst)) = (physical, keep.worst_key()) {
+                        scanner.set_stop_key(physical, worst, ascending);
+                    }
+                }
+            }
+            if let Some(error) = scanner.err() {
+                return Err(error.clone());
+            }
+            scanner.close()?;
+        }
+        Ok(Some(keep.into_rows(offset)))
     }
 
     /// Get the transaction ID for per-txn tombstone tracking.
@@ -237,6 +647,10 @@ impl SegmentedTable {
     /// so the original cold row remains visible to the older snapshot.
     #[inline]
     fn is_tombstone_visible(&self, commit_seq: u64) -> bool {
+        if let Some(epoch) = &self.read_epoch {
+            return i64::try_from(commit_seq)
+                .is_ok_and(|sequence| epoch.admits_commit_sequence(sequence));
+        }
         self.snapshot_seq.is_none_or(|ss| commit_seq <= ss)
     }
 
@@ -1103,6 +1517,338 @@ impl SegmentedTable {
         Ok(rows)
     }
 
+    /// DML reads current own writes but never freezes the complete transaction
+    /// overlay. Global authority comes exclusively from the bound hot root.
+    fn captured_dml_hot_authority(&self, row_id: i64) -> Result<bool> {
+        self.hot
+            .captured_mutation_has_hot_authority(row_id)
+            .ok_or_else(|| {
+                crate::core::Error::internal("captured cold DML has no bound hot authority")
+            })
+    }
+
+    /// Preload selected old rows from retained file handles before changing any
+    /// write set. Phase 6 replaces this statement staging with bounded preflight.
+    fn captured_cold_dml_targets(
+        &self,
+        row_ids: Option<&[i64]>,
+        predicate: Option<&dyn Expression>,
+    ) -> Result<Vec<(u64, i64, Row)>> {
+        let generation = self
+            .cold_generation
+            .as_ref()
+            .ok_or_else(|| crate::core::Error::internal("cold DML has no bound generation"))?;
+        let mut targets = Vec::new();
+        if generation.segment_ids_newest_first.is_empty() {
+            return Ok(targets);
+        }
+        // Keep a PK predicate on the point path even when immutable files exist.
+        let point_id = predicate.and_then(|expression| {
+            let (name, operator, value) = expression.get_comparison_info()?;
+            let keys = self.hot.schema().primary_key_indices();
+            if keys.len() != 1 || operator != crate::core::Operator::Eq {
+                return None;
+            }
+            let column = &self.hot.schema().columns[keys[0]];
+            if column.data_type != DataType::Integer || !column.name.eq_ignore_ascii_case(name) {
+                return None;
+            }
+            match value {
+                Value::Integer(id) => Some([*id]),
+                _ => None,
+            }
+        });
+        let row_ids = row_ids.or_else(|| point_id.as_ref().map(|ids| ids.as_slice()));
+        let eligible = |row_id| -> Result<bool> {
+            Ok(!self.captured_dml_hot_authority(row_id)?
+                && !self.is_row_tombstoned(&generation.tombstones, row_id)
+                && !self.segment_mgr.is_pending_tombstone(self.txn_id(), row_id))
+        };
+        if let Some(row_ids) = row_ids {
+            // One retained loaded segment per visited file, with no whole-table
+            // scan or full own-write overlay for a point mutation.
+            let mut loaded: smallvec::SmallVec<[(u64, super::manifest::ColdSegment); 1]> =
+                smallvec::SmallVec::new();
+            for &row_id in row_ids {
+                if !eligible(row_id)? {
+                    continue;
+                }
+                for &id in &generation.segment_ids_newest_first {
+                    let segment = generation.segments.get(&id).ok_or_else(|| {
+                        crate::core::Error::internal(format!(
+                            "captured generation has no segment {id}"
+                        ))
+                    })?;
+                    let Ok(offset) = segment.volume.meta.row_ids.binary_search(&row_id) else {
+                        continue;
+                    };
+                    if !segment.is_visible(offset) {
+                        continue;
+                    }
+                    let position = match loaded.iter().position(|(loaded_id, _)| *loaded_id == id) {
+                        Some(position) => position,
+                        None => {
+                            loaded.push((id, generation.load_segment(id)?));
+                            loaded.len() - 1
+                        }
+                    };
+                    let segment = &loaded[position].1;
+                    let row = segment.volume.get_row_mapped(offset, &segment.mapping)?;
+                    if let Some(predicate) = predicate {
+                        if !predicate.evaluate(&row)? {
+                            break;
+                        }
+                    }
+                    targets.push((id, row_id, row));
+                    break;
+                }
+            }
+            return Ok(targets);
+        }
+        let comparisons = predicate
+            .map(|expr| expr.collect_comparisons())
+            .unwrap_or_default();
+        let hashes = Self::precompute_bloom_hashes(&comparisons);
+        for &id in &generation.segment_ids_newest_first {
+            let segment = generation.segments.get(&id).ok_or_else(|| {
+                crate::core::Error::internal(format!("captured generation has no segment {id}"))
+            })?;
+            // Prune resident metadata through the captured logical mapping before loading payloads.
+            let pruned = comparisons
+                .iter()
+                .zip(&hashes)
+                .any(|(&(name, operator, value), hash)| {
+                    let Some((logical, _)) = self.hot.schema().find_column(name) else {
+                        return false;
+                    };
+                    let Some(super::writer::ColSource::Volume(physical)) =
+                        segment.mapping.sources.get(logical)
+                    else {
+                        return false;
+                    };
+                    let Some(zone) = segment.volume.meta.zone_maps.get(*physical) else {
+                        return false;
+                    };
+                    match operator {
+                        crate::core::Operator::Eq => {
+                            !zone.may_contain_eq(value)
+                                || hash.is_some_and(|hash| {
+                                    segment.volume.meta.column_types.get(*physical).is_some_and(
+                                    |&data_type| {
+                                        super::column::ColumnBloomFilter::equality_hash_compatible(
+                                            data_type, value,
+                                        )
+                                    },
+                                ) && segment
+                                    .volume
+                                    .meta
+                                    .bloom_filters
+                                    .get(*physical)
+                                    .is_some_and(|bloom| !bloom.might_contain_hash(hash))
+                                })
+                        }
+                        crate::core::Operator::Gt | crate::core::Operator::Gte => {
+                            !zone.may_contain_gte(value)
+                        }
+                        crate::core::Operator::Lt | crate::core::Operator::Lte => {
+                            !zone.may_contain_lte(value)
+                        }
+                        _ => false,
+                    }
+                });
+            if pruned {
+                continue;
+            }
+            let mut loaded = None;
+            for (offset, &row_id) in segment.volume.meta.row_ids.iter().enumerate() {
+                if !segment.is_visible(offset) || !eligible(row_id)? {
+                    continue;
+                }
+                let loaded = match &loaded {
+                    Some(loaded) => loaded,
+                    None => loaded.insert(generation.load_segment(id)?),
+                };
+                let row = loaded.volume.get_row_mapped(offset, &loaded.mapping)?;
+                if let Some(predicate) = predicate {
+                    if !predicate.evaluate(&row)? {
+                        continue;
+                    }
+                }
+                targets.push((id, row_id, row));
+            }
+        }
+        Ok(targets)
+    }
+
+    /// The row claim excludes competing row publishers; the caller also holds
+    /// the short transfer fence while checking source identity and publishing
+    /// its staged hot write. All checks here are resident metadata only.
+    fn validate_captured_cold_source(&self, row_id: i64, source: u64) -> Result<()> {
+        self.hot.validate_cold_mutation(row_id)?;
+        let conflict = || {
+            crate::core::Error::internal(format!(
+                "write conflict: cold row {row_id} changed after the statement read epoch"
+            ))
+        };
+        let manifest = self.segment_mgr.manifest();
+        let segments = self.segment_mgr.segments_raw();
+        if self.segment_mgr.tombstone_set_arc().contains_key(&row_id) {
+            return Err(conflict());
+        }
+        for meta in manifest.segments.iter().rev() {
+            let segment = segments.get(&meta.segment_id).ok_or_else(conflict)?;
+            if let Ok(offset) = segment.volume.meta.row_ids.binary_search(&row_id) {
+                if segment.is_visible(offset) {
+                    return if meta.segment_id == source {
+                        Ok(())
+                    } else {
+                        Err(conflict())
+                    };
+                }
+            }
+        }
+        Err(conflict())
+    }
+
+    fn validate_cold_constraint_snapshot(
+        &self,
+        snapshot: Option<&super::manifest::StatementSnapshot>,
+    ) -> Result<()> {
+        if let Some(snapshot) = snapshot {
+            if !Arc::ptr_eq(&snapshot.segs, &self.segment_mgr.segments_raw())
+                || !Arc::ptr_eq(&snapshot.tombstones, &self.segment_mgr.tombstone_set_arc())
+            {
+                return Err(crate::core::Error::internal(
+                    "write conflict: cold constraints changed during statement preflight",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn captured_update(
+        &mut self,
+        row_ids: Option<&[i64]>,
+        predicate: Option<&dyn Expression>,
+        setter: &mut dyn FnMut(Row) -> Result<(Row, bool)>,
+    ) -> Result<i32> {
+        let generation = self.segment_mgr.seal_generation();
+        let targets = self.captured_cold_dml_targets(row_ids, predicate)?;
+        let constraints = if !targets.is_empty() && self.hot.has_unique_non_pk_indexes() {
+            Some(self.segment_mgr.statement_snapshot()?)
+        } else {
+            None
+        };
+        let mut count = if let Some(ids) = row_ids {
+            // Unknown IDs must not become phantom writes. A captured Deleted
+            // still routes hot so the underlying DML can return zero.
+            let mut hot_ids: smallvec::SmallVec<[i64; 1]> = smallvec::SmallVec::new();
+            for &id in ids {
+                if self.captured_dml_hot_authority(id)? {
+                    hot_ids.push(id);
+                }
+            }
+            if hot_ids.is_empty() {
+                0
+            } else {
+                self.hot.update_by_row_ids(&hot_ids, setter)?
+            }
+        } else {
+            self.hot.update(predicate, setter)?
+        };
+        let has_int_pk = self
+            .hot
+            .schema()
+            .columns
+            .iter()
+            .any(|column| column.primary_key && column.data_type == DataType::Integer);
+        for (source, row_id, old_row) in targets {
+            let (new_row, changed) = setter(old_row.clone())?;
+            if !changed {
+                continue;
+            }
+            if constraints.is_some() {
+                self.check_cold_unique_for_update(&new_row, row_id, constraints.as_ref())?;
+            }
+            self.hot.try_claim_row(row_id)?;
+            let manager = self.segment_mgr.clone();
+            let _fence = manager.acquire_seal_read();
+            self.validate_captured_cold_source(row_id, source)?;
+            self.validate_cold_constraint_snapshot(constraints.as_ref())?;
+            if has_int_pk {
+                self.hot.insert_discard(old_row)?;
+                let mut staged = Some(new_row);
+                let changed = self.hot.update_by_row_ids(&[row_id], &mut |_| {
+                    staged
+                        .take()
+                        .map(|row| (row, true))
+                        .ok_or_else(|| crate::core::Error::internal("cold mutation applied twice"))
+                })?;
+                if changed != 1 {
+                    return Err(crate::core::Error::internal(
+                        "write conflict: mirrored cold update lost its target",
+                    ));
+                }
+            } else {
+                self.hot.insert_discard(new_row)?;
+            }
+            manager.add_pending_tombstone(self.txn_id(), row_id);
+            count += 1;
+        }
+        if count != 0 {
+            self.segment_mgr
+                .record_txn_seal_generation_at(self.txn_id(), generation);
+        }
+        Ok(count)
+    }
+
+    fn captured_delete(
+        &mut self,
+        row_ids: Option<&[i64]>,
+        predicate: Option<&dyn Expression>,
+    ) -> Result<i32> {
+        let generation = self.segment_mgr.seal_generation();
+        let targets = self.captured_cold_dml_targets(row_ids, predicate)?;
+        let mut count = if let Some(ids) = row_ids {
+            let mut hot_ids: smallvec::SmallVec<[i64; 1]> = smallvec::SmallVec::new();
+            for &id in ids {
+                if self.captured_dml_hot_authority(id)? {
+                    hot_ids.push(id);
+                }
+            }
+            if hot_ids.is_empty() {
+                0
+            } else {
+                self.hot.delete_by_row_ids(&hot_ids)?
+            }
+        } else {
+            self.hot.delete(predicate)?
+        };
+        let has_int_pk = self
+            .hot
+            .schema()
+            .columns
+            .iter()
+            .any(|column| column.primary_key && column.data_type == DataType::Integer);
+        for (source, row_id, _) in targets {
+            self.hot.try_claim_row(row_id)?;
+            let manager = self.segment_mgr.clone();
+            let _fence = manager.acquire_seal_read();
+            self.validate_captured_cold_source(row_id, source)?;
+            if has_int_pk && self.hot.delete_by_row_ids(&[row_id])? != 1 {
+                return Err(crate::core::Error::internal(
+                    "write conflict: cold delete lost its target",
+                ));
+            }
+            manager.add_pending_tombstone(self.txn_id(), row_id);
+            count += 1;
+        }
+        if count != 0 {
+            self.segment_mgr
+                .record_txn_seal_generation_at(self.txn_id(), generation);
+        }
+        Ok(count)
+    }
     /// Find a non-tombstoned, non-hot-shadowed row in the retained volume snapshot.
     /// Use segment bounds and binary search; propagate identity or column read errors.
     fn find_segment_row_in(
@@ -1313,6 +2059,33 @@ impl SegmentedTable {
 }
 
 impl Table for SegmentedTable {
+    fn begin_logical_mutation(
+        &self,
+    ) -> Option<crate::storage::mvcc::registry::LogicalMutationGuard> {
+        self.hot.begin_logical_mutation()
+    }
+
+    fn set_read_epoch(&mut self, epoch: crate::storage::mvcc::registry::ReadEpoch) -> Result<()> {
+        if self
+            .read_epoch
+            .as_ref()
+            .is_some_and(|current| current.same_epoch(&epoch))
+        {
+            return Ok(());
+        }
+        let (root, generation) = self
+            .segment_mgr
+            .capture_with_hot(|| self.hot.capture_hot_root())?;
+        self.hot.set_read_epoch(epoch.clone())?;
+        if let Some(root) = root {
+            self.hot.replace_hot_root(root)?;
+        }
+        self.cold_generation = Some(generation);
+        self.captured_pending.take();
+        self.snapshot_seq = Some(epoch.cutoff() as u64);
+        self.read_epoch = Some(epoch);
+        Ok(())
+    }
     // =========================================================================
     // Metadata
     // =========================================================================
@@ -1356,6 +2129,7 @@ impl Table for SegmentedTable {
         default_expr: Option<String>,
         default_value: Option<Value>,
     ) -> Result<()> {
+        let _logical_change = self.hot.begin_logical_mutation();
         self.hot.create_column_with_default_value(
             name,
             column_type,
@@ -1366,6 +2140,7 @@ impl Table for SegmentedTable {
     }
 
     fn drop_column(&mut self, name: &str) -> Result<()> {
+        let _logical_change = self.hot.begin_logical_mutation();
         self.hot.drop_column(name)
     }
 
@@ -1415,6 +2190,9 @@ impl Table for SegmentedTable {
         where_expr: Option<&dyn Expression>,
         setter: &mut dyn FnMut(Row) -> Result<(Row, bool)>,
     ) -> Result<i32> {
+        if self.cold_generation.is_some() {
+            return self.captured_update(None, where_expr, setter);
+        }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         // Capture a verified all-warm segment snapshot BEFORE mutating the
         // hot buffer and use it for the entire statement: eviction CoWs
@@ -1556,6 +2334,9 @@ impl Table for SegmentedTable {
         row_ids: &[i64],
         setter: &mut dyn FnMut(Row) -> Result<(Row, bool)>,
     ) -> Result<i32> {
+        if self.cold_generation.is_some() {
+            return self.captured_update(Some(row_ids), None, setter);
+        }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         // Capture a verified all-warm segment snapshot BEFORE mutating the
         // hot buffer and use it for the entire statement: eviction CoWs
@@ -1655,6 +2436,9 @@ impl Table for SegmentedTable {
     }
 
     fn delete_by_row_ids(&mut self, row_ids: &[i64]) -> Result<i32> {
+        if self.cold_generation.is_some() {
+            return self.captured_delete(Some(row_ids), None);
+        }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         // Capture a verified all-warm segment snapshot BEFORE mutating the
         // hot buffer and use it for the entire statement: eviction CoWs
@@ -1704,6 +2488,30 @@ impl Table for SegmentedTable {
     }
 
     fn get_active_row_ids(&self) -> Result<Vec<i64>> {
+        if let Some(generation) = &self.cold_generation {
+            let view = self.hot.captured_hot_view().ok_or_else(|| {
+                crate::core::Error::internal("captured cold generation has no hot view")
+            })?;
+            let pending = self.captured_pending();
+            let mut ids = Vec::new();
+            for &id in generation.segment_ids_newest_first.iter().rev() {
+                let segment = generation.segments.get(&id).ok_or_else(|| {
+                    crate::core::Error::internal(format!("captured generation has no segment {id}"))
+                })?;
+                super::captured_scanner::CapturedColdScanner::for_each_visible(
+                    segment,
+                    generation,
+                    &view,
+                    pending,
+                    |_, row_id| {
+                        ids.push(row_id);
+                        true
+                    },
+                );
+            }
+            view.for_each_visible(|id, _| ids.push(id));
+            return Ok(ids);
+        }
         let hot_ids = self.hot.get_active_row_ids()?;
 
         if !self.segment_mgr.has_segments() {
@@ -1740,6 +2548,9 @@ impl Table for SegmentedTable {
     }
 
     fn delete(&mut self, where_expr: Option<&dyn Expression>) -> Result<i32> {
+        if self.cold_generation.is_some() {
+            return self.captured_delete(None, where_expr);
+        }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         // Capture a verified all-warm segment snapshot BEFORE mutating the
         // hot buffer and use it for the entire statement: eviction CoWs
@@ -1922,12 +2733,13 @@ impl Table for SegmentedTable {
     }
 
     fn truncate(&mut self) -> Result<i32> {
-        let _seal_guard = self.segment_mgr.acquire_seal_read();
-        let seg_rows = self.segment_mgr.total_row_count() as i32;
-        // Clear pending tombstones for this txn (segments are being dropped)
-        self.segment_mgr.rollback_pending_tombstones(self.txn_id());
-        self.segment_mgr.clear();
-        Ok(self.hot.truncate()? + seg_rows)
+        // The engine coordinator owns maintenance/registry ordering, WAL, and
+        // both hot/cold publication. Never hold a seal read guard over WAL.
+        let rows = self.hot.truncate_with_outer_epoch(&mut self.read_epoch)?;
+        self.cold_generation = None;
+        self.captured_pending.take();
+        self.snapshot_seq = None;
+        Ok(rows)
     }
 
     // =========================================================================
@@ -1939,6 +2751,9 @@ impl Table for SegmentedTable {
         column_indices: &[usize],
         where_expr: Option<&dyn Expression>,
     ) -> Result<Box<dyn Scanner>> {
+        if let Some(scanner) = self.captured_scan(column_indices, where_expr)? {
+            return Ok(scanner);
+        }
         if let Some(result) = self.unsealed(|hot| hot.scan(column_indices, where_expr)) {
             return result;
         }
@@ -1972,6 +2787,9 @@ impl Table for SegmentedTable {
     }
 
     fn collect_all_rows(&self, where_expr: Option<&dyn Expression>) -> Result<RowVec> {
+        if self.cold_generation.is_some() {
+            return self.collect_captured(where_expr, usize::MAX, 0);
+        }
         if let Some(result) = self.unsealed(|hot| hot.collect_all_rows(where_expr)) {
             return result;
         }
@@ -1998,6 +2816,9 @@ impl Table for SegmentedTable {
     }
 
     fn collect_all_rows_unsorted(&self) -> Result<RowVec> {
+        if self.cold_generation.is_some() {
+            return self.collect_captured(None, usize::MAX, 0);
+        }
         if let Some(result) = self.unsealed(|hot| hot.collect_all_rows_unsorted()) {
             return result;
         }
@@ -2020,6 +2841,15 @@ impl Table for SegmentedTable {
     }
 
     fn collect_rows_by_ids(&self, row_ids: &[i64]) -> Result<RowVec> {
+        if self.cold_generation.is_some() {
+            let mut rows = RowVec::with_capacity(row_ids.len());
+            for &id in row_ids {
+                if let Some(row) = self.captured_row(id)? {
+                    rows.push((id, row));
+                }
+            }
+            return Ok(rows);
+        }
         if let Some(result) = self.unsealed(|hot| hot.collect_rows_by_ids(row_ids)) {
             return result;
         }
@@ -2078,6 +2908,22 @@ impl Table for SegmentedTable {
         filter: &dyn Expression,
         buffer: &mut RowVec,
     ) -> Result<()> {
+        if self.cold_generation.is_some() {
+            let prepared = (!filter.is_prepared()).then(|| {
+                let mut prepared = filter.clone_box();
+                prepared.prepare_for_schema(self.hot.schema());
+                prepared
+            });
+            let filter = prepared.as_deref().unwrap_or(filter);
+            for &id in row_ids {
+                if let Some(row) = self.captured_row(id)? {
+                    if filter.evaluate(&row)? {
+                        buffer.push((id, row));
+                    }
+                }
+            }
+            return Ok(());
+        }
         if let Some(result) =
             self.unsealed(|hot| hot.fetch_rows_by_ids_into(row_ids, filter, buffer))
         {
@@ -2131,6 +2977,9 @@ impl Table for SegmentedTable {
         limit: usize,
         offset: usize,
     ) -> Result<RowVec> {
+        if self.cold_generation.is_some() {
+            return self.collect_captured(where_expr, limit, offset);
+        }
         if let Some(result) =
             self.unsealed(|hot| hot.collect_rows_with_limit(where_expr, limit, offset))
         {
@@ -2244,6 +3093,9 @@ impl Table for SegmentedTable {
         limit: usize,
         offset: usize,
     ) -> Result<RowVec> {
+        if self.cold_generation.is_some() {
+            return self.collect_captured(where_expr, limit, offset);
+        }
         if let Some(result) =
             self.unsealed(|hot| hot.collect_rows_with_limit_unordered(where_expr, limit, offset))
         {
@@ -2384,6 +3236,15 @@ impl Table for SegmentedTable {
         }) {
             return result;
         }
+        if self.read_epoch.is_some() {
+            if let Some(column) = self.hot.schema().columns.get(sort_col_idx) {
+                if let Some(rows) =
+                    self.captured_top_k(None, &column.name, ascending, limit, offset)?
+                {
+                    return Ok(rows.into_iter().map(|(_, row)| row).collect());
+                }
+            }
+        }
         // Collect all merged rows, sort, take limit
         let mut rows = self.collect_all_rows(None)?;
         rows.sort_by(|(_, a), (_, b)| {
@@ -2410,6 +3271,19 @@ impl Table for SegmentedTable {
     }
 
     fn has_row_id(&self, row_id: i64) -> Result<bool> {
+        if self.cold_generation.is_some() {
+            use crate::storage::mvcc::version_store::CapturedHotRow;
+            let view = self.hot.captured_hot_view().ok_or_else(|| {
+                crate::core::Error::internal("captured cold generation has no hot view")
+            })?;
+            return match view.row_state(row_id) {
+                CapturedHotRow::Value(_) => Ok(true),
+                CapturedHotRow::Deleted => Ok(false),
+                CapturedHotRow::NoVisibleVersion => {
+                    Ok(self.captured_cold_location(row_id)?.is_some())
+                }
+            };
+        }
         if self.hot.has_row_id(row_id)? {
             return Ok(true);
         }
@@ -2437,6 +3311,22 @@ impl Table for SegmentedTable {
     // =========================================================================
 
     fn row_count(&self) -> Result<usize> {
+        if let Some(generation) = &self.cold_generation {
+            let view = self.hot.captured_hot_view().ok_or_else(|| {
+                crate::core::Error::internal("captured cold generation has no hot view")
+            })?;
+            let mut count = self.hot.row_count()?;
+            let pending = self.captured_pending();
+            for &id in &generation.segment_ids_newest_first {
+                let segment = generation.segments.get(&id).ok_or_else(|| {
+                    crate::core::Error::internal(format!("captured generation has no segment {id}"))
+                })?;
+                count += super::captured_scanner::CapturedColdScanner::visible_count(
+                    segment, generation, &view, pending, false,
+                );
+            }
+            return Ok(count);
+        }
         // Snapshot isolation: deduped_row_count and the fast path subtract ALL
         // tombstones, but a snapshot may not see newer ones. Use full scan.
         if self.snapshot_seq.is_some() {
@@ -2462,6 +3352,9 @@ impl Table for SegmentedTable {
     }
 
     fn fast_row_count(&self) -> Result<Option<usize>> {
+        if self.cold_generation.is_some() {
+            return self.row_count().map(Some);
+        }
         // Snapshot isolation: deduped_row_count subtracts ALL tombstones, but
         // this snapshot may not see newer tombstones. Fall back to scan which
         // correctly filters by snapshot_seq.
@@ -2488,6 +3381,11 @@ impl Table for SegmentedTable {
     // =========================================================================
 
     fn sum_column(&self, col_idx: usize) -> Result<Option<(f64, usize)>> {
+        if self.cold_generation.is_some() {
+            return Ok(self
+                .captured_column_stats(col_idx)?
+                .map(|stats| (stats.sum_as_f64(), stats.numeric_count as usize)));
+        }
         // Snapshot isolation: cold aggregation uses tombstones without snapshot
         // filtering. Bail so the executor falls back to full scan.
         if self.snapshot_seq.is_some() {
@@ -2636,6 +3534,11 @@ impl Table for SegmentedTable {
     }
 
     fn min_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
+        if self.cold_generation.is_some() {
+            return Ok(self
+                .captured_column_stats(col_idx)?
+                .map(|stats| (!stats.min.is_null()).then_some(stats.min)));
+        }
         if self.snapshot_seq.is_some() {
             return Ok(None);
         }
@@ -2942,6 +3845,11 @@ impl Table for SegmentedTable {
     }
 
     fn max_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
+        if self.cold_generation.is_some() {
+            return Ok(self
+                .captured_column_stats(col_idx)?
+                .map(|stats| (!stats.max.is_null()).then_some(stats.max)));
+        }
         if self.snapshot_seq.is_some() {
             return Ok(None);
         }
@@ -3242,6 +4150,11 @@ impl Table for SegmentedTable {
     // =========================================================================
 
     fn get_partition_count(&self, column_name: &str) -> Result<Option<usize>> {
+        if self.read_epoch.is_some() {
+            return Ok(self
+                .get_partition_values(column_name)?
+                .map(|values| values.into_iter().filter(|value| !value.is_null()).count()));
+        }
         if self.snapshot_seq.is_some() {
             return Ok(None);
         }
@@ -3316,6 +4229,33 @@ impl Table for SegmentedTable {
     }
 
     fn get_partition_values(&self, column_name: &str) -> Result<Option<Vec<Value>>> {
+        if let Some(generation) = &self.cold_generation {
+            let schema = self.hot.schema();
+            let Some((column, _)) = schema.find_column(column_name) else {
+                return Ok(None);
+            };
+            let view = self.hot.captured_hot_view().ok_or_else(|| {
+                crate::core::Error::internal("captured distinct generation has no hot view")
+            })?;
+            return super::captured_aggregate::grouped(
+                schema,
+                &view,
+                Some((generation, self.captured_pending())),
+                &[column],
+                &[],
+            )?
+            .map(|groups| {
+                groups
+                    .into_iter()
+                    .map(|group| {
+                        group.group_values.into_iter().next().ok_or_else(|| {
+                            crate::core::Error::internal("distinct group has no key")
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose();
+        }
         if self.snapshot_seq.is_some() {
             return Ok(None);
         }
@@ -3386,6 +4326,15 @@ impl Table for SegmentedTable {
     }
 
     fn compute_distinct_values(&self, col_idx: usize) -> Result<Option<Vec<Value>>> {
+        if self.read_epoch.is_some() {
+            let Some(column) = self.hot.schema().columns.get(col_idx) else {
+                return Ok(None);
+            };
+            return Ok(self.get_partition_values(&column.name)?.map(|mut values| {
+                values.retain(|value| !value.is_null());
+                values
+            }));
+        }
         // Bail for snapshot isolation — tombstone visibility is snapshot-dependent
         if self.snapshot_seq.is_some() {
             return Ok(None);
@@ -3713,6 +4662,9 @@ impl Table for SegmentedTable {
         }) {
             return result;
         }
+        if self.read_epoch.is_some() {
+            return self.captured_top_k(None, column_name, ascending, limit, offset);
+        }
 
         // Snapshot isolation: the merge path doesn't filter by snapshot_seq.
         // Fall back to the full scan + sort path which handles MVCC correctly.
@@ -3936,10 +4888,19 @@ impl Table for SegmentedTable {
     // =========================================================================
 
     fn close(&mut self) -> Result<()> {
-        self.hot.close()
+        self.hot.close()?;
+        let txn_id = self.txn_id();
+        self.segment_mgr.rollback_pending_tombstones(txn_id);
+        self.segment_mgr.clear_txn_seal_generation(txn_id);
+        self.cold_generation = None;
+        self.read_epoch = None;
+        self.captured_pending.take();
+        self.snapshot_seq = None;
+        Ok(())
     }
 
     fn commit(&mut self) -> Result<()> {
+        let _logical_change = self.hot.begin_logical_mutation();
         self.hot.commit()?;
         // Apply pending tombstones to the shared tombstone set.
         // commit_seq=0 means "always visible to all snapshots". This is safe because
@@ -3988,6 +4949,9 @@ impl Table for SegmentedTable {
         limit: usize,
         offset: usize,
     ) -> Result<Option<RowVec>> {
+        if self.cold_generation.is_some() {
+            return self.captured_top_k(where_expr, column_name, ascending, limit, offset);
+        }
         if self.snapshot_seq.is_some() {
             return Ok(None);
         }
@@ -4369,6 +5333,9 @@ impl Table for SegmentedTable {
     }
 
     fn get_index_min_value(&self, column_name: &str) -> Option<Value> {
+        if self.cold_generation.is_some() {
+            return None;
+        }
         if let Some(result) = self.unsealed(|hot| hot.get_index_min_value(column_name)) {
             return result;
         }
@@ -4410,6 +5377,9 @@ impl Table for SegmentedTable {
     }
 
     fn get_index_max_value(&self, column_name: &str) -> Option<Value> {
+        if self.cold_generation.is_some() {
+            return None;
+        }
         if let Some(result) = self.unsealed(|hot| hot.get_index_max_value(column_name)) {
             return result;
         }
@@ -4455,10 +5425,12 @@ impl Table for SegmentedTable {
     // =========================================================================
 
     fn rename_column(&mut self, old_name: &str, new_name: &str) -> Result<()> {
+        let _logical_change = self.hot.begin_logical_mutation();
         self.hot.rename_column(old_name, new_name)
     }
 
     fn modify_column(&mut self, name: &str, column_type: DataType, nullable: bool) -> Result<()> {
+        let _logical_change = self.hot.begin_logical_mutation();
         self.hot.modify_column(name, column_type, nullable)
     }
 
@@ -4639,6 +5611,18 @@ impl Table for SegmentedTable {
         aggregates: &[(AggregateOp, usize)],
         where_expr: &dyn Expression,
     ) -> Result<Option<Vec<Value>>> {
+        if let Some(generation) = &self.cold_generation {
+            let view = self.hot.captured_hot_view().ok_or_else(|| {
+                crate::core::Error::internal("captured aggregate has no hot view")
+            })?;
+            return super::captured_aggregate::filtered(
+                self.hot.schema(),
+                &view,
+                Some((generation, self.captured_pending())),
+                aggregates,
+                where_expr,
+            );
+        }
         // Bail out: snapshot isolation requires tombstone filtering by snapshot_seq
         if self.snapshot_seq.is_some() {
             return Ok(None);
@@ -5525,6 +6509,18 @@ impl Table for SegmentedTable {
         group_by_indices: &[usize],
         aggregates: &[(AggregateOp, usize)],
     ) -> Result<Option<Vec<GroupedAggregateResult>>> {
+        if let Some(generation) = &self.cold_generation {
+            let view = self.hot.captured_hot_view().ok_or_else(|| {
+                crate::core::Error::internal("captured aggregate has no hot view")
+            })?;
+            return super::captured_aggregate::grouped(
+                self.hot.schema(),
+                &view,
+                Some((generation, self.captured_pending())),
+                group_by_indices,
+                aggregates,
+            );
+        }
         if self.snapshot_seq.is_some() {
             return Ok(None);
         }
@@ -6373,6 +7369,250 @@ mod tests {
             None,
         );
         mgr
+    }
+
+    /// Minimal test table for the hot buffer
+    #[test]
+    fn captured_merge_preserves_authority_and_generation_after_mutation() {
+        use crate::core::Operator;
+        use crate::storage::expression::ComparisonExpr;
+        use crate::storage::mvcc::version_store::{
+            RowVersion, TransactionVersionStore, VersionStore,
+        };
+        use crate::storage::mvcc::{MVCCTable, TransactionRegistry};
+
+        let schema = SchemaBuilder::new("test")
+            .column("id", DataType::Integer, false, true)
+            .column("g", DataType::Integer, false, false)
+            .build();
+        let row = |id, value| Row::from_values(vec![Value::Integer(id), Value::Integer(value)]);
+        let manager = make_segment_mgr(
+            &schema,
+            &[
+                (1, row(1, 10)),
+                (2, row(2, 10)),
+                (3, row(3, 30)),
+                (4, row(4, 40)),
+            ],
+        );
+        let registry = Arc::new(TransactionRegistry::new());
+        let store = Arc::new(VersionStore::with_visibility_checker(
+            "test",
+            schema,
+            registry.clone(),
+        ));
+        let (committed, _) = registry.begin_transaction();
+        registry.start_commit(committed);
+        store
+            .add_version(1, RowVersion::new(committed, row(1, 20)))
+            .unwrap();
+        let mut deleted = RowVersion::new(committed, row(2, 10));
+        deleted.deleted_at_txn_id = committed;
+        store.add_version(2, deleted).unwrap();
+        registry.complete_commit(committed);
+        let (inflight, _) = registry.begin_transaction();
+        registry.start_commit(inflight);
+        store
+            .add_version(3, RowVersion::new(inflight, row(3, 300)))
+            .unwrap();
+        let (reader, _) = registry.begin_transaction();
+        let hot = MVCCTable::new(
+            reader,
+            store.clone(),
+            TransactionVersionStore::new(store.clone(), reader),
+        );
+        let mut table = SegmentedTable::new(Box::new(hot), manager.clone());
+        manager.add_pending_tombstone(reader, 4);
+        table.set_read_epoch(registry.capture_read_epoch()).unwrap();
+        registry.complete_commit(inflight);
+        assert_eq!(table.row_count().unwrap(), 2);
+        assert_eq!(table.sum_column(1).unwrap(), Some((50.0, 2)));
+        assert_eq!(table.min_column(1).unwrap(), Some(Some(Value::Integer(20))));
+        assert_eq!(table.max_column(1).unwrap(), Some(Some(Value::Integer(30))));
+        assert_eq!(
+            table
+                .collect_rows_by_ids(&[1, 2, 3, 4])
+                .unwrap()
+                .into_iter()
+                .collect::<Vec<_>>(),
+            vec![(1, row(1, 20)), (3, row(3, 30))]
+        );
+        let filter = ComparisonExpr::new("g", Operator::Eq, Value::Integer(10));
+        assert!(
+            table.collect_all_rows(Some(&filter)).unwrap().is_empty(),
+            "a hot value rejected by the predicate and a hot delete must both shadow old cold rows"
+        );
+        for (value, expected_id) in [(20, 1), (30, 3)] {
+            let filter = ComparisonExpr::new("g", Operator::Eq, Value::Integer(value));
+            let rows = table.collect_all_rows(Some(&filter)).unwrap();
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].0, expected_id);
+        }
+        for projection in [
+            vec![0],
+            vec![1],
+            vec![1, 0],
+            vec![0, 0, 1],
+            vec![0, 1],
+            vec![],
+        ] {
+            for filter in [
+                None,
+                Some(ComparisonExpr::new("id", Operator::Eq, Value::Integer(1))),
+            ] {
+                let mut scanner = table
+                    .scan(&projection, filter.as_ref().map(|f| f as &dyn Expression))
+                    .unwrap();
+                let mut actual = Vec::new();
+                while scanner.next() {
+                    actual.push(scanner.take_row_with_id());
+                }
+                assert!(scanner.err().is_none());
+                actual.sort_by_key(|(id, _)| *id);
+                let expected: Vec<_> = [(1, row(1, 20)), (3, row(3, 30))]
+                    .into_iter()
+                    .filter(|(id, _)| filter.is_none() || *id == 1)
+                    .map(|(id, row)| {
+                        let row = if projection.is_empty() {
+                            row
+                        } else {
+                            Row::from_values(
+                                projection
+                                    .iter()
+                                    .map(|&column| row[column].clone())
+                                    .collect(),
+                            )
+                        };
+                        (id, row)
+                    })
+                    .collect();
+                assert_eq!(
+                    actual,
+                    expected,
+                    "projection {projection:?}, filtered {}",
+                    filter.is_some()
+                );
+            }
+        }
+        let mut scanner = table.scan(&[1], None).unwrap();
+        manager.rollback_pending_tombstones(reader);
+        manager.clear();
+        store
+            .add_version(1, RowVersion::new(inflight, row(1, 999)))
+            .unwrap();
+        let mut actual = Vec::new();
+        while scanner.next() {
+            actual.push(scanner.take_row_with_id());
+        }
+        assert!(scanner.err().is_none(), "{:?}", scanner.err());
+        actual.sort_by_key(|(id, _)| *id);
+        assert_eq!(
+            actual,
+            vec![
+                (1, Row::from_values(vec![Value::Integer(20)])),
+                (3, Row::from_values(vec![Value::Integer(30)]))
+            ]
+        );
+        assert_eq!(table.collect_rows_with_limit(None, 1, 1).unwrap().len(), 1);
+        assert!(table
+            .collect_rows_with_limit(None, 0, usize::MAX)
+            .unwrap()
+            .is_empty());
+        let old_epoch = table.read_epoch.clone().unwrap();
+        manager.manifest_mut().segments.push(SegmentMeta {
+            segment_id: 999,
+            file_path: PathBuf::from("missing.vol"),
+            row_count: 1,
+            min_row_id: 1,
+            max_row_id: 1,
+            schema_version: 0,
+            creation_lsn: 0,
+            seal_seq: 0,
+        });
+        assert!(table.set_read_epoch(registry.capture_read_epoch()).is_err());
+        table.set_read_epoch(old_epoch).unwrap();
+        assert_eq!(
+            table.collect_rows_by_ids(&[1]).unwrap()[0].1,
+            row(1, 20),
+            "a failed rebind must retain the previous hot and cold generation together"
+        );
+    }
+
+    #[test]
+    fn captured_merge_skips_hidden_cold_file_and_keeps_load_error_sticky() {
+        use crate::storage::mvcc::version_store::{
+            RowVersion, TransactionVersionStore, VersionStore,
+        };
+        use crate::storage::mvcc::{MVCCTable, TransactionRegistry};
+        let schema = SchemaBuilder::new("test")
+            .column("id", DataType::Integer, false, true)
+            .build();
+        let row = Row::from_values(vec![Value::Integer(1)]);
+        let source = make_segment_mgr(&schema, &[(1, row.clone())]);
+        let cold = Arc::new(source.segments_raw()[&1].volume.to_cold());
+        let meta = source.manifest().segments[0].clone();
+        let manager = Arc::new(SegmentManager::new("test", None));
+        manager.register_segment(1, cold, meta, None);
+        let registry = Arc::new(TransactionRegistry::new());
+        let store = Arc::new(VersionStore::with_visibility_checker(
+            "test",
+            schema,
+            registry.clone(),
+        ));
+        let (reader, _) = registry.begin_transaction();
+        let make_hot = || {
+            MVCCTable::new(
+                reader,
+                store.clone(),
+                TransactionVersionStore::new(store.clone(), reader),
+            )
+        };
+        let mut visible = SegmentedTable::new(Box::new(make_hot()), manager.clone());
+        visible
+            .set_read_epoch(registry.capture_read_epoch())
+            .unwrap();
+        assert!(visible.has_row_id(1).unwrap());
+        assert_eq!(visible.get_active_row_ids().unwrap(), vec![1]);
+        assert_eq!(visible.row_count().unwrap(), 1);
+        assert_eq!(visible.sum_column(0).unwrap(), Some((1.0, 1)));
+        assert_eq!(
+            visible.min_column(0).unwrap(),
+            Some(Some(Value::Integer(1)))
+        );
+        let nonmatching = crate::storage::expression::ComparisonExpr::eq("id", Value::Integer(99));
+        assert!(
+            visible
+                .collect_all_rows(Some(&nonmatching))
+                .unwrap()
+                .is_empty(),
+            "metadata pruning must run before loading a cold file"
+        );
+        let mut scanner = visible.scan(&[], None).unwrap();
+        assert!(!scanner.next());
+        assert!(scanner
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("no captured file backing"));
+        assert!(!scanner.next());
+        assert!(scanner.err().is_some());
+        scanner.close().unwrap();
+        assert!(!scanner.next());
+        assert!(scanner.err().is_some());
+        let (writer, _) = registry.begin_transaction();
+        registry.start_commit(writer);
+        store.add_version(1, RowVersion::new(writer, row)).unwrap();
+        registry.complete_commit(writer);
+        let mut hidden = SegmentedTable::new(Box::new(make_hot()), manager);
+        hidden
+            .set_read_epoch(registry.capture_read_epoch())
+            .unwrap();
+        let rows = hidden.collect_all_rows(None).unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "a wholly shadowed cold file requires no backing read"
+        );
     }
 
     /// Minimal test table for the hot buffer

--- a/src/storage/volume/writer.rs
+++ b/src/storage/volume/writer.rs
@@ -1191,6 +1191,9 @@ impl VolumeMeta {
 /// This is the in-memory representation. Serialization to/from disk
 /// is handled by io.rs (V4 format).
 pub struct FrozenVolume {
+    /// Shared file identity/retention lease, without an idle file descriptor.
+    /// Set before publication and preserved across every residency transition.
+    pub(crate) backing: std::sync::OnceLock<Arc<super::io::VolumeFile>>,
     /// Column data stored as typed arrays with lazy decompression
     pub columns: LazyColumns,
     /// Shared metadata (zone maps, bloom filters, stats, row IDs, etc.)
@@ -1646,6 +1649,7 @@ impl VolumeBuilder {
         };
 
         FrozenVolume {
+            backing: std::sync::OnceLock::new(),
             columns: LazyColumns::eager(columns, column_types.clone()),
             meta: Arc::new(VolumeMeta {
                 zone_maps: self.zone_maps,
@@ -2053,12 +2057,25 @@ impl FrozenVolume {
         !self.columns.is_eager() && !self.columns.has_compressed_store()
     }
 
+    /// Reload this exact captured identity, retaining runtime schema aliases
+    /// and the existing unique-index cache. Called outside transfer fences.
+    pub(crate) fn reload_from_backing(&self) -> crate::core::Result<FrozenVolume> {
+        let backing = self.backing.get().ok_or_else(|| {
+            crate::core::Error::internal("cold volume has no captured file backing")
+        })?;
+        let mut loaded = super::io::read_volume_file(backing.clone())?;
+        loaded.meta = self.meta.clone();
+        loaded.unique_indices = self.unique_indices.clone();
+        Ok(loaded)
+    }
+
     /// Create a warm-tier volume: shares metadata via Arc (zero copy),
     /// shares compressed store via Arc, drops decompressed columns.
     /// Scanners use per-group decompression from RAM (~1ms per column per group).
     pub fn to_warm(&self) -> Option<FrozenVolume> {
         let store = self.columns.compressed_store_arc()?.clone();
         Some(FrozenVolume {
+            backing: self.backing.clone(),
             columns: LazyColumns::deferred_shared(store, self.meta.column_types.clone()),
             meta: Arc::clone(&self.meta),
             unique_indices: Arc::clone(&self.unique_indices),
@@ -2074,6 +2091,7 @@ impl FrozenVolume {
     /// Must reload from disk to scan.
     pub fn to_cold(&self) -> FrozenVolume {
         FrozenVolume {
+            backing: self.backing.clone(),
             columns: LazyColumns::metadata_only(self.meta.column_types.clone()),
             meta: Arc::clone(&self.meta),
             unique_indices: Arc::clone(&self.unique_indices),

--- a/tests/captured_hot_allocation_test.rs
+++ b/tests/captured_hot_allocation_test.rs
@@ -1,0 +1,455 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A counting System allocator cannot coexist with the library's optional
+// mimalloc global allocator. Run this regression with --no-default-features.
+#![cfg(not(feature = "mimalloc"))]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::sync::Arc;
+
+use stoolap::common::CowBTree;
+use stoolap::core::{Row, SchemaBuilder, Value};
+use stoolap::storage::mvcc::version_store::{CapturedHotView, RowVersion, VersionStore};
+use stoolap::storage::mvcc::TransactionRegistry;
+
+thread_local! {
+    static COUNTING: Cell<bool> = const { Cell::new(false) };
+    static CALLS: Cell<usize> = const { Cell::new(0) };
+    static REQUESTED_BYTES: Cell<usize> = const { Cell::new(0) };
+}
+
+struct CountingAllocator;
+
+fn count_call(bytes: usize) {
+    if COUNTING.try_with(Cell::get).unwrap_or(false) {
+        let _ = CALLS.try_with(|calls| calls.set(calls.get() + 1));
+        let _ = REQUESTED_BYTES.try_with(|requested| requested.set(requested.get() + bytes));
+    }
+}
+
+// SAFETY: Allocation ownership, alignment, and layouts are delegated unchanged
+// to System. Thread-local counters do not allocate or access the allocation.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        count_call(layout.size());
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        count_call(layout.size());
+        unsafe { System.alloc_zeroed(layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        count_call(size);
+        unsafe { System.realloc(ptr, layout, size) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn allocation_calls<T>(operation: impl FnOnce() -> T) -> (T, usize) {
+    struct StopCounting;
+    impl Drop for StopCounting {
+        fn drop(&mut self) {
+            COUNTING.with(|counting| counting.set(false));
+        }
+    }
+    CALLS.with(|calls| calls.set(0));
+    REQUESTED_BYTES.with(|bytes| bytes.set(0));
+    COUNTING.with(|counting| counting.set(true));
+    let stop = StopCounting;
+    let value = operation();
+    drop(stop);
+    (value, CALLS.with(Cell::get))
+}
+
+#[test]
+fn cold_point_visibility_allocates_only_a_small_range_mask() {
+    use stoolap::core::DataType;
+    use stoolap::storage::traits::Scanner;
+    use stoolap::storage::volume::scanner::VolumeScanner;
+    use stoolap::storage::volume::writer::VolumeBuilder;
+
+    let schema = SchemaBuilder::new("mask_allocations")
+        .add_primary_key("id", DataType::Integer)
+        .build();
+    let registry = Arc::new(TransactionRegistry::new());
+    let store =
+        VersionStore::with_visibility_checker("mask_allocations", schema.clone(), registry.clone());
+    let view = Arc::new(CapturedHotView::new(
+        store.capture_hot_root(),
+        registry.capture_read_epoch(),
+        None,
+    ));
+    let mut builder = VolumeBuilder::new(&schema);
+    for id in 0..20_000 {
+        builder.add_row(id, &Row::from(vec![Value::Integer(id)]));
+    }
+    let volume = Arc::new(builder.finish());
+    for rows in [1, 64, 256, 257, 20_000] {
+        let mut scanner = VolumeScanner::with_range(volume.clone(), vec![0], 0, rows, None);
+        let pending = Arc::default();
+        let (_, calls) =
+            allocation_calls(|| scanner.set_captured_visibility(view.clone(), pending));
+        let bytes = REQUESTED_BYTES.with(Cell::get);
+        if rows <= 256 {
+            assert_eq!(calls, 1, "short ranges have no separately allocated bitmap");
+            assert!(bytes <= 256, "short range requested {bytes} bytes");
+        } else {
+            assert_eq!(calls, 2, "large scans allocate one reusable bitmap");
+            assert!(bytes <= 8192 + 256, "group mask requested {bytes} bytes");
+        }
+        assert!(scanner.next());
+        assert_eq!(scanner.current_row_id(), 0);
+        scanner.close().unwrap();
+    }
+}
+
+#[test]
+fn multilevel_tree_clone_and_bidirectional_walks_do_not_allocate() {
+    let mut tree = CowBTree::new();
+    // Non-monotonic insertion and subsequent deletion exercise split, merge,
+    // and range boundary paths across several levels, rather than a leaf root.
+    for n in 0..30_000 {
+        let id = (n * 7919) % 30_000 - 15_000;
+        tree.insert(id, id);
+    }
+    for id in (-15_000..15_000).step_by(3) {
+        tree.remove(id);
+    }
+    let expected: i64 = tree.values().copied().sum();
+    let expected_range: i64 = tree.range(-10_000..=10_000).map(|(_, value)| *value).sum();
+    let ((all, range), calls) = allocation_calls(|| {
+        let snapshot = tree.clone();
+        (
+            snapshot.iter().map(|(_, value)| *value).sum::<i64>(),
+            snapshot
+                .range(-10_000..=10_000)
+                .map(|(_, value)| *value)
+                .sum::<i64>(),
+        )
+    });
+    assert_eq!((all, range), (expected, expected_range));
+    assert_eq!(calls, 0);
+    let ((all, range), calls) = allocation_calls(|| {
+        let snapshot = tree.clone();
+        (
+            snapshot.iter_rev().map(|(_, value)| *value).sum::<i64>(),
+            snapshot
+                .range_rev(-10_000..=10_000)
+                .map(|(_, value)| *value)
+                .sum::<i64>(),
+        )
+    });
+    assert_eq!((all, range), (expected, expected_range));
+    assert_eq!(calls, 0);
+}
+
+#[test]
+fn captured_root_clone_and_visible_callbacks_do_not_allocate() {
+    let registry = Arc::new(TransactionRegistry::new());
+    let store = VersionStore::with_visibility_checker(
+        "allocation_test",
+        SchemaBuilder::new("allocation_test").build(),
+        registry.clone(),
+    );
+    let (txn, _) = registry.begin_transaction();
+    registry.start_commit(txn);
+    store
+        .add_versions_batch(
+            (0..20_000)
+                .map(|id| {
+                    (
+                        id,
+                        RowVersion::new(txn, Row::from(vec![Value::Integer(id)])),
+                    )
+                })
+                .collect(),
+        )
+        .unwrap();
+    registry.complete_commit(txn);
+    let epoch = registry.capture_read_epoch();
+    let ((count, sum, stopped_count, version_count, authority), calls) = allocation_calls(|| {
+        let root = store.capture_hot_root();
+        let mut version_count = 0;
+        root.for_each_visible_version_until(&epoch, |_, _| {
+            version_count += 1;
+            true
+        });
+        let view = CapturedHotView::new(root, epoch.clone(), None);
+        let mut authority = [u64::MAX];
+        view.mark_authoritative(&[7, 9999, 20_000], &mut authority);
+        let cloned = view.clone();
+        let mut count = 0;
+        cloned.for_each_visible(|_, _| count += 1);
+        let mut sum = 0;
+        view.for_each_visible_range_until(100..200, |id, _| {
+            sum += id;
+            true
+        });
+        let mut stopped_count = 0;
+        view.for_each_visible_until(|_, _| {
+            stopped_count += 1;
+            stopped_count < 7
+        });
+        (count, sum, stopped_count, version_count, authority)
+    });
+    assert_eq!(
+        (count, sum, stopped_count),
+        (20_000, (100..200).sum::<i64>(), 7)
+    );
+    assert_eq!(version_count, 20_000);
+    assert_eq!(authority, [0b11]);
+    assert_eq!(calls, 0);
+    let mut reverse = [0i64; 7];
+    let (_, calls) = allocation_calls(|| {
+        let view = CapturedHotView::new(store.capture_hot_root(), epoch.clone(), None);
+        let mut count = 0;
+        view.for_each_visible_range_rev_until(100..200, |id, _| {
+            reverse[count] = id;
+            count += 1;
+            count < reverse.len()
+        });
+    });
+    assert_eq!(reverse, [199, 198, 197, 196, 195, 194, 193]);
+    assert_eq!(calls, 0);
+}
+
+#[test]
+fn point_update_does_not_copy_a_large_prior_write_set() {
+    use stoolap::core::DataType;
+    use stoolap::storage::expression::ComparisonExpr;
+    use stoolap::storage::mvcc::table::MVCCTable;
+    use stoolap::storage::mvcc::TransactionVersionStore;
+    use stoolap::storage::traits::Table;
+
+    let registry = Arc::new(TransactionRegistry::new());
+    let schema = SchemaBuilder::new("point_update")
+        .add_primary_key("id", DataType::Integer)
+        .add("value", DataType::Integer)
+        .build();
+    let store = Arc::new(VersionStore::with_visibility_checker(
+        "point_update",
+        schema,
+        registry.clone(),
+    ));
+    let (creator, _) = registry.begin_transaction();
+    store
+        .add_version(
+            1,
+            RowVersion::new(
+                creator,
+                Row::from(vec![Value::Integer(1), Value::Integer(10)]),
+            ),
+        )
+        .unwrap();
+    registry.commit_transaction(creator);
+    let (txn, _) = registry.begin_transaction();
+    let mut local = TransactionVersionStore::new(store.clone(), txn);
+    for id in 2..20_002 {
+        local
+            .put(
+                id,
+                Row::from(vec![Value::Integer(id), Value::Integer(id)]),
+                false,
+            )
+            .unwrap();
+    }
+    let mut table = MVCCTable::new(txn, store, local);
+    table
+        .set_read_epoch(registry.read_epoch_for_transaction(txn).unwrap())
+        .unwrap();
+    let pk = ComparisonExpr::eq("id", Value::Integer(1));
+    let (result, calls) = allocation_calls(|| table.update(Some(&pk), &mut |row| Ok((row, false))));
+    assert_eq!(result.unwrap(), 0);
+    assert_eq!(
+        calls, 0,
+        "a point UPDATE must not freeze/copy 20,000 unrelated own writes"
+    );
+    let mut table = stoolap::storage::volume::table::SegmentedTable::hot_only(Box::new(table));
+    table
+        .set_read_epoch(registry.read_epoch_for_transaction(txn).unwrap())
+        .unwrap();
+    let (result, calls) = allocation_calls(|| table.update(Some(&pk), &mut |row| Ok((row, false))));
+    assert_eq!(result.unwrap(), 0);
+    assert_eq!(
+        calls, 0,
+        "the cold DML wrapper must preserve the allocation-free hot point path"
+    );
+}
+
+#[test]
+fn captured_aggregates_allocate_per_group_not_per_input_row() {
+    use stoolap::core::DataType;
+    use stoolap::storage::expression::ComparisonExpr;
+    use stoolap::storage::mvcc::version_store::{AggregateOp, TransactionVersionStore};
+    use stoolap::storage::mvcc::MVCCTable;
+    use stoolap::storage::traits::Table;
+    use stoolap::storage::volume::manifest::{SegmentManager, SegmentMeta};
+    use stoolap::storage::volume::table::SegmentedTable;
+    use stoolap::storage::volume::writer::VolumeBuilder;
+
+    fn fixture(count: i64, cold: bool) -> Box<dyn Table> {
+        let schema = SchemaBuilder::new("aggregate_allocations")
+            .add_primary_key("id", DataType::Integer)
+            .add("a", DataType::Text)
+            .add("b", DataType::Text)
+            .add("n", DataType::Integer)
+            .add("unread_payload", DataType::Text)
+            .build();
+        let registry = Arc::new(TransactionRegistry::new());
+        let store = Arc::new(VersionStore::with_visibility_checker(
+            "aggregate_allocations",
+            schema.clone(),
+            registry.clone(),
+        ));
+        let (writer, _) = registry.begin_transaction();
+        let mut volume = VolumeBuilder::new(&schema);
+        let text_a = Value::text("a grouping string that exceeds the inline string representation");
+        let text_b =
+            Value::text("another grouping string that exceeds the inline string representation");
+        let payload = Value::text("z".repeat(4096));
+        for id in 1..=count {
+            let row = Row::from(vec![
+                Value::Integer(id),
+                text_a.clone(),
+                text_b.clone(),
+                Value::Integer(id),
+                payload.clone(),
+            ]);
+            if cold {
+                volume.add_row(id, &row);
+            } else {
+                store.add_version(id, RowVersion::new(writer, row)).unwrap();
+            }
+        }
+        registry.commit_transaction(writer);
+        let (reader, _) = registry.begin_transaction();
+        let hot = MVCCTable::new(
+            reader,
+            store.clone(),
+            TransactionVersionStore::new(store, reader),
+        );
+        let mut table: Box<dyn Table> = if cold {
+            let manager = Arc::new(SegmentManager::new("aggregate_allocations", None));
+            manager.register_segment(
+                1,
+                Arc::new(volume.finish()),
+                SegmentMeta {
+                    segment_id: 1,
+                    file_path: "aggregate-allocations.vol".into(),
+                    row_count: count as usize,
+                    min_row_id: 1,
+                    max_row_id: count,
+                    schema_version: 0,
+                    creation_lsn: 0,
+                    seal_seq: 0,
+                },
+                Some(&schema),
+            );
+            Box::new(SegmentedTable::new(Box::new(hot), manager))
+        } else {
+            Box::new(hot)
+        };
+        table.set_read_epoch(registry.capture_read_epoch()).unwrap();
+        table
+    }
+
+    for cold in [false, true] {
+        let operations = [(AggregateOp::CountStar, 0), (AggregateOp::Sum, 3)];
+        let filter = ComparisonExpr::eq(
+            "a",
+            Value::text("a grouping string that exceeds the inline string representation"),
+        );
+        let measure = |count| {
+            let table = fixture(count, cold);
+            // Bind the immutable view once; subsequent aggregates share it.
+            table
+                .compute_grouped_aggregates(&[1], &operations)
+                .unwrap()
+                .unwrap();
+            let ((single, composite, filtered), calls) = allocation_calls(|| {
+                (
+                    table
+                        .compute_grouped_aggregates(&[1], &operations)
+                        .unwrap()
+                        .unwrap(),
+                    // The longer key also verifies that spilled scratch is reused.
+                    table
+                        .compute_grouped_aggregates(&[1, 2, 1, 2, 1], &operations)
+                        .unwrap()
+                        .unwrap(),
+                    table
+                        .compute_filtered_aggregates(&operations, &filter)
+                        .unwrap()
+                        .unwrap(),
+                )
+            });
+            assert_eq!(single.len(), 1);
+            assert_eq!(composite.len(), 1);
+            assert_eq!(filtered[0], Value::Integer(count));
+            calls
+        };
+        let small = measure(10);
+        let large = measure(20_000);
+        assert_eq!(
+            large, small,
+            "cold={cold}: row materialization or key allocation grew with input length"
+        );
+    }
+}
+
+#[test]
+fn statement_result_close_and_exhaustion_release_epoch_without_allocating() {
+    use stoolap::executor::Executor;
+    let db = stoolap::Database::open("memory://").unwrap();
+    let executor = Executor::new(db.engine().clone());
+    for close in [true, false] {
+        // Warm result caches and the thread's reusable row-buffer pool before
+        // measuring cleanup of an otherwise identical real SQL result.
+        for _ in 0..2 {
+            let mut result = executor.execute("SELECT 1 AS value").unwrap();
+            assert!(result.next());
+            if close {
+                result.close().unwrap();
+            } else {
+                assert!(!result.next());
+            }
+        }
+        let mut result = executor.execute("SELECT 1 AS value").unwrap();
+        assert!(result.next());
+        assert!(db.engine().registry().has_retention_obligations());
+        let (_, calls) = allocation_calls(|| {
+            if close {
+                result.close().unwrap();
+            } else {
+                assert!(!result.next());
+            }
+        });
+        assert_eq!(
+            calls, 0,
+            "close={close}: terminal cleanup must not allocate a replacement result"
+        );
+        assert_eq!(db.engine().registry().oldest_retention_horizon(), None);
+        assert_eq!(result.columns(), &["value"]);
+        assert_eq!(result.exact_len(), Some(0));
+        assert!(!result.next());
+        assert!(result.last_error().is_none());
+    }
+}

--- a/tests/captured_ordered_reads_test.rs
+++ b/tests/captured_ordered_reads_test.rs
@@ -1,0 +1,551 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, RwLock};
+use stoolap::common::CompactArc;
+use stoolap::core::{DataType, Error, Result, Row, RowVec, Schema, SchemaBuilder, Value};
+use stoolap::storage::expression::{ComparisonExpr, Expression};
+use stoolap::storage::mvcc::{
+    table::MVCCTable, RowVersion, TransactionRegistry, TransactionVersionStore, VersionStore,
+};
+use stoolap::storage::traits::Table;
+use stoolap::storage::volume::{
+    manifest::{SegmentManager, SegmentMeta},
+    table::SegmentedTable,
+    writer::VolumeBuilder,
+};
+
+fn row(id: i64, value: i64) -> Row {
+    Row::from(vec![id.into(), value.into()])
+}
+fn schema() -> Schema {
+    SchemaBuilder::new("ordered")
+        .column("id", DataType::Integer, false, true)
+        .column("g", DataType::Integer, false, false)
+        .build()
+}
+fn publish(registry: &TransactionRegistry, store: &VersionStore, values: &[(i64, i64)]) {
+    let (id, _) = registry.begin_transaction();
+    registry.start_commit(id);
+    store
+        .add_versions_batch(
+            values
+                .iter()
+                .map(|&(key, value)| (key, RowVersion::new(id, row(key, value))))
+                .collect(),
+        )
+        .unwrap();
+    registry.complete_commit(id);
+}
+fn hot_fixture() -> MVCCTable {
+    let registry = Arc::new(TransactionRegistry::new());
+    let store = Arc::new(VersionStore::with_visibility_checker(
+        "ordered",
+        schema(),
+        registry.clone(),
+    ));
+    publish(
+        &registry,
+        &store,
+        &[(i64::MIN, 30), (-7, 10), (0, 20), (3, 40), (i64::MAX, 10)],
+    );
+    let epoch = registry.capture_read_epoch();
+    let (txn, _) = registry.begin_transaction();
+    let mut local = TransactionVersionStore::new(store.clone(), txn);
+    local.put(0, row(0, 5), false).unwrap();
+    local.put(3, row(3, 40), true).unwrap();
+    local.put(5, row(5, 10), false).unwrap();
+    // The root is deliberately bound only after these unrelated commits.
+    publish(&registry, &store, &[(-7, 99), (99, 1)]);
+    let mut table = MVCCTable::new(txn, store, local);
+    table.set_read_epoch(epoch).unwrap();
+    table
+}
+fn canonical_hot() -> Vec<(i64, i64)> {
+    vec![(i64::MIN, 30), (-7, 10), (0, 5), (5, 10), (i64::MAX, 10)]
+}
+fn pairs(rows: RowVec) -> Vec<(i64, i64)> {
+    rows.into_iter()
+        .map(|(id, row)| {
+            let Value::Integer(value) = row.get(1).unwrap() else {
+                panic!("integer expected")
+            };
+            (id, *value)
+        })
+        .collect()
+}
+fn model(
+    mut rows: Vec<(i64, i64)>,
+    ascending: bool,
+    limit: usize,
+    offset: usize,
+) -> Vec<(i64, i64)> {
+    rows.sort_by_key(|&(id, value)| (value, id));
+    if !ascending {
+        rows.reverse();
+    }
+    rows.into_iter().skip(offset).take(limit).collect()
+}
+
+#[test]
+fn captured_hot_ordered_and_top_k_match_frozen_canonical_rows() {
+    let table = hot_fixture();
+    let mut filter = ComparisonExpr::gte("g", 10.into());
+    filter.prepare_for_schema(table.schema());
+    for ascending in [true, false] {
+        for limit in [0, 1, 3, 20] {
+            for offset in [0, 1, 4, 9] {
+                let expected = model(canonical_hot(), ascending, limit, offset);
+                assert_eq!(
+                    pairs(
+                        table
+                            .scan_top_k(None, "g", ascending, limit, offset)
+                            .unwrap()
+                            .unwrap()
+                    ),
+                    expected
+                );
+                assert_eq!(
+                    pairs(
+                        table
+                            .collect_rows_ordered_by_index("g", ascending, limit, offset)
+                            .unwrap()
+                            .unwrap()
+                    ),
+                    expected
+                );
+                let sorted = table
+                    .collect_rows_sorted_with_limit(1, ascending, limit, offset)
+                    .unwrap();
+                let expected_rows: Vec<_> = expected.iter().map(|&(id, g)| row(id, g)).collect();
+                assert_eq!(sorted, expected_rows);
+                let qualifying = canonical_hot()
+                    .into_iter()
+                    .filter(|&(_, g)| g >= 10)
+                    .collect();
+                assert_eq!(
+                    pairs(
+                        table
+                            .scan_top_k(Some(&filter), "g", ascending, limit, offset)
+                            .unwrap()
+                            .unwrap()
+                    ),
+                    model(qualifying, ascending, limit, offset)
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn captured_pk_keysets_handle_extreme_ids_own_rows_and_reverse_bounds() {
+    let table = hot_fixture();
+    for ascending in [true, false] {
+        for bound in [
+            None,
+            Some(i64::MIN),
+            Some(-7),
+            Some(0),
+            Some(5),
+            Some(i64::MAX),
+        ] {
+            for inclusive in [false, true] {
+                for limit in [0, 1, 3, 20] {
+                    let mut expected: Vec<_> = canonical_hot()
+                        .into_iter()
+                        .filter(|&(id, _)| {
+                            bound.is_none_or(|b| if inclusive { id >= b } else { id > b })
+                        })
+                        .collect();
+                    if !ascending {
+                        expected.reverse();
+                    }
+                    expected.truncate(limit);
+                    let (after, from) = if inclusive {
+                        (None, bound)
+                    } else {
+                        (bound, None)
+                    };
+                    assert_eq!(
+                        pairs(
+                            table
+                                .collect_rows_pk_keyset(after, from, ascending, limit)
+                                .unwrap()
+                        ),
+                        expected,
+                        "ascending={ascending} bound={bound:?} inclusive={inclusive} limit={limit}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn cold_fixture() -> SegmentedTable {
+    let registry = Arc::new(TransactionRegistry::new());
+    let old = schema();
+    let mut current = SchemaBuilder::new("ordered")
+        .column("id", DataType::Integer, false, true)
+        .column("g", DataType::Integer, false, false)
+        .column("extra", DataType::Integer, false, false)
+        .build();
+    current.columns[1].default_value = Some(99.into());
+    current.columns[2].default_value = Some(77.into());
+    let manager = Arc::new(SegmentManager::new("ordered", None));
+    let mut builder = VolumeBuilder::new(&old);
+    for (id, g) in [(-10, 100), (2, -100), (8, 5)] {
+        builder.add_row(id, &row(id, g));
+    }
+    manager.register_segment(
+        1,
+        Arc::new(builder.finish()),
+        SegmentMeta {
+            segment_id: 1,
+            file_path: "captured-order.vol".into(),
+            row_count: 3,
+            min_row_id: -10,
+            max_row_id: 8,
+            creation_lsn: 0,
+            seal_seq: 0,
+            schema_version: 0,
+        },
+        Some(&old),
+    );
+    manager.record_column_drop("g", 1);
+    manager.invalidate_mappings(&current);
+    let store = Arc::new(VersionStore::with_visibility_checker(
+        "ordered",
+        current,
+        registry.clone(),
+    ));
+    publish(&registry, &store, &[(0, 10), (2, 20)]);
+    let epoch = registry.capture_read_epoch();
+    let (txn, _) = registry.begin_transaction();
+    let local = CompactArc::new(RwLock::new(TransactionVersionStore::new(
+        store.clone(),
+        txn,
+    )));
+    local.write().unwrap().put(8, row(8, 30), false).unwrap();
+    publish(&registry, &store, &[(0, 1000), (9, 1)]);
+    let mut table = SegmentedTable::new(
+        Box::new(MVCCTable::new_with_shared_store(txn, store, local)),
+        manager,
+    );
+    table.set_read_epoch(epoch).unwrap();
+    table
+}
+
+#[test]
+fn captured_cold_hot_ordering_projection_defaults_and_stats_share_authority() {
+    let table = cold_fixture();
+    let expected = vec![(-10, 99), (0, 10), (2, 20), (8, 30)];
+    for ascending in [true, false] {
+        for limit in [0, 1, 3, 20] {
+            for offset in [0, 1, 3, 8] {
+                let rows = table
+                    .scan_top_k(None, "g", ascending, limit, offset)
+                    .unwrap()
+                    .unwrap();
+                for (_, row) in &rows {
+                    assert_eq!(row.get(2), Some(&77.into()));
+                }
+                assert_eq!(
+                    pairs(rows),
+                    model(expected.clone(), ascending, limit, offset)
+                );
+            }
+        }
+    }
+    let mut filter = ComparisonExpr::eq("g", 99.into());
+    filter.prepare_for_schema(table.schema());
+    let mut scanner = table.scan(&[2, 0], Some(&filter)).unwrap();
+    let mut projected = Vec::new();
+    while scanner.next() {
+        projected.push(scanner.take_row());
+    }
+    assert!(scanner.err().is_none());
+    assert_eq!(projected, vec![Row::from(vec![77.into(), (-10).into()])]);
+    assert_eq!(table.sum_column(1).unwrap(), Some((159.0, 4)));
+    assert_eq!(table.min_column(1).unwrap(), Some(Some(Value::Integer(10))));
+    assert_eq!(table.max_column(1).unwrap(), Some(Some(Value::Integer(99))));
+}
+
+fn cold_only_fixture() -> SegmentedTable {
+    cold_scalar_fixture(DataType::Integer, Value::Integer(10))
+}
+
+fn cold_scalar_fixture(data_type: DataType, value: Value) -> SegmentedTable {
+    let registry = Arc::new(TransactionRegistry::new());
+    let schema = SchemaBuilder::new("ordered")
+        .column("id", DataType::Integer, false, true)
+        .column("g", data_type, false, false)
+        .build();
+    let manager = Arc::new(SegmentManager::new("ordered", None));
+    let mut builder = VolumeBuilder::new(&schema);
+    builder.add_row(1, &Row::from(vec![1.into(), value]));
+    manager.register_segment(
+        1,
+        Arc::new(builder.finish()),
+        SegmentMeta {
+            segment_id: 1,
+            file_path: "cold-only.vol".into(),
+            row_count: 1,
+            min_row_id: 1,
+            max_row_id: 1,
+            creation_lsn: 0,
+            seal_seq: 0,
+            schema_version: 0,
+        },
+        Some(&schema),
+    );
+    let store = Arc::new(VersionStore::with_visibility_checker(
+        "ordered",
+        schema,
+        registry.clone(),
+    ));
+    let (txn, _) = registry.begin_transaction();
+    let local = TransactionVersionStore::new(store.clone(), txn);
+    let mut table = SegmentedTable::new(Box::new(MVCCTable::new(txn, store, local)), manager);
+    table.set_read_epoch(registry.capture_read_epoch()).unwrap();
+    table
+}
+
+#[derive(Clone, Debug)]
+struct FailingPredicate;
+impl Expression for FailingPredicate {
+    fn evaluate(&self, _: &Row) -> Result<bool> {
+        Err(Error::internal("captured predicate read failure"))
+    }
+    fn evaluate_fast(&self, _: &Row) -> bool {
+        false
+    }
+    fn with_aliases(&self, _: &rustc_hash::FxHashMap<String, String>) -> Box<dyn Expression> {
+        Box::new(self.clone())
+    }
+    fn prepare_for_schema(&mut self, _: &Schema) {}
+    fn is_prepared(&self) -> bool {
+        true
+    }
+    fn clone_box(&self) -> Box<dyn Expression> {
+        Box::new(self.clone())
+    }
+}
+
+#[test]
+fn captured_scanner_and_top_k_preserve_fallible_predicate_errors() {
+    let tables: Vec<Box<dyn Table>> = vec![
+        Box::new(hot_fixture()),
+        Box::new(cold_fixture()),
+        Box::new(cold_only_fixture()),
+    ];
+    for (kind, table) in tables.into_iter().enumerate() {
+        for (route, result) in [
+            ("all", table.collect_all_rows(Some(&FailingPredicate))),
+            (
+                "limit",
+                table.collect_rows_with_limit(Some(&FailingPredicate), 20, 0),
+            ),
+            (
+                "unordered",
+                table.collect_rows_with_limit_unordered(Some(&FailingPredicate), 20, 0),
+            ),
+            ("fetch", table.fetch_rows_by_ids(&[0, 1], &FailingPredicate)),
+        ] {
+            let error = match result {
+                Err(error) => error,
+                Ok(rows) => panic!("table={kind} route={route} returned {} rows", rows.len()),
+            };
+            assert!(error
+                .to_string()
+                .contains("captured predicate read failure"));
+        }
+        let error = table
+            .scan_top_k(Some(&FailingPredicate), "g", true, 20, 0)
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("captured predicate read failure"));
+        let mut scanner = table.scan(&[0, 1], Some(&FailingPredicate)).unwrap();
+        while scanner.next() {}
+        assert!(scanner
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("captured predicate read failure"));
+        assert!(!scanner.next());
+        assert!(
+            scanner.err().is_some(),
+            "end-of-stream must preserve the error"
+        );
+        scanner.close().unwrap();
+        assert!(scanner.err().is_some(), "close must preserve the error");
+    }
+}
+
+#[test]
+fn cold_metadata_pruning_preserves_cross_numeric_and_signed_zero_equality() {
+    for (data_type, stored, compared) in [
+        (DataType::Integer, Value::Integer(10), Value::Float(10.0)),
+        (DataType::Float, Value::Float(10.0), Value::Integer(10)),
+        (DataType::Float, Value::Float(0.0), Value::Float(-0.0)),
+        (DataType::Float, Value::Float(-0.0), Value::Float(0.0)),
+    ] {
+        let table = cold_scalar_fixture(data_type, stored.clone());
+        let mut predicate = ComparisonExpr::eq("g", compared);
+        predicate.prepare_for_schema(table.schema());
+        let expected = Row::from(vec![1.into(), stored]);
+        assert!(predicate.evaluate(&expected).unwrap());
+        let rows = table.collect_all_rows(Some(&predicate)).unwrap();
+        assert_eq!(rows.len(), 1, "physical type {data_type:?}");
+        assert_eq!(rows[0].1, expected);
+    }
+}
+
+#[test]
+fn captured_dictionary_partitions_merge_nulls_and_authoritative_versions() {
+    let registry = Arc::new(TransactionRegistry::new());
+    let schema = SchemaBuilder::new("partitions")
+        .column("id", DataType::Integer, false, true)
+        .column("label", DataType::Text, true, false)
+        .build();
+    let make_row = |id: i64, text: Option<&str>| {
+        Row::from(vec![
+            id.into(),
+            text.map(Value::text).unwrap_or(Value::Null(DataType::Text)),
+        ])
+    };
+    let manager = Arc::new(SegmentManager::new("partitions", None));
+    for (segment_id, mut values) in [
+        (1, vec![(1, Some("a")), (2, None), (3, Some("b"))]),
+        (2, vec![(4, Some("b")), (5, Some("a")), (6, None)]),
+    ] {
+        let first = segment_id as i64 * 100;
+        values.extend((first..first + 32).map(|id| (id, Some("a"))));
+        let mut builder = VolumeBuilder::new(&schema);
+        for &(id, text) in &values {
+            builder.add_row(id, &make_row(id, text));
+        }
+        let volume = Arc::new(builder.finish());
+        assert!(
+            matches!(
+                volume.columns.get(1).unwrap(),
+                stoolap::storage::volume::column::ColumnData::Dictionary { .. }
+            ),
+            "each file must exercise its own dictionary IDs"
+        );
+        manager.register_segment(
+            segment_id,
+            volume,
+            SegmentMeta {
+                segment_id,
+                file_path: format!("dictionary-{segment_id}.vol").into(),
+                row_count: values.len(),
+                min_row_id: values[0].0,
+                max_row_id: values[values.len() - 1].0,
+                creation_lsn: 0,
+                seal_seq: 0,
+                schema_version: 0,
+            },
+            Some(&schema),
+        );
+    }
+    let store = Arc::new(VersionStore::with_visibility_checker(
+        "partitions",
+        schema,
+        registry.clone(),
+    ));
+    let (creator, _) = registry.begin_transaction();
+    registry.start_commit(creator);
+    store
+        .add_versions_batch(vec![
+            (1, RowVersion::new(creator, make_row(1, Some("c")))),
+            (7, RowVersion::new(creator, make_row(7, None))),
+        ])
+        .unwrap();
+    registry.complete_commit(creator);
+    let epoch = registry.capture_read_epoch();
+    let (txn, _) = registry.begin_transaction();
+    let mut local = TransactionVersionStore::new(store.clone(), txn);
+    local.put(3, make_row(3, Some("a")), false).unwrap();
+    local.put(4, make_row(4, Some("b")), true).unwrap();
+    local.put(8, make_row(8, Some("d")), false).unwrap();
+    let (later, _) = registry.begin_transaction();
+    registry.start_commit(later);
+    store
+        .add_versions_batch(vec![
+            (5, RowVersion::new(later, make_row(5, Some("later")))),
+            (9, RowVersion::new(later, make_row(9, Some("later")))),
+        ])
+        .unwrap();
+    registry.complete_commit(later);
+    let hot = MVCCTable::new(txn, store, local);
+    let mut table = SegmentedTable::new(Box::new(hot), manager);
+    table.set_read_epoch(epoch).unwrap();
+    let partitions = table.get_partition_values("label").unwrap().unwrap();
+    let mut logical: Vec<Option<String>> = partitions
+        .into_iter()
+        .map(|value| match value {
+            Value::Null(_) => None,
+            Value::Text(text) => Some(text.to_string()),
+            value => panic!("unexpected partition {value:?}"),
+        })
+        .collect();
+    logical.sort();
+    assert_eq!(
+        logical,
+        vec![None, Some("a".into()), Some("c".into()), Some("d".into())]
+    );
+    assert_eq!(table.get_partition_count("label").unwrap(), Some(3));
+    let mut distinct = table.compute_distinct_values(1).unwrap().unwrap();
+    distinct.sort();
+    assert_eq!(
+        distinct,
+        vec![Value::text("a"), Value::text("c"), Value::text("d")]
+    );
+}
+
+#[test]
+fn closing_captured_table_releases_its_lease_but_not_a_live_result() {
+    let registry = Arc::new(TransactionRegistry::new());
+    let store = Arc::new(VersionStore::with_visibility_checker(
+        "ordered",
+        schema(),
+        registry.clone(),
+    ));
+    publish(&registry, &store, &[(1, 10), (2, 20)]);
+    let (txn, _) = registry.begin_transaction();
+    let local = TransactionVersionStore::new(store.clone(), txn);
+    let mut table = SegmentedTable::hot_only(Box::new(MVCCTable::new(txn, store, local)));
+    table.set_read_epoch(registry.capture_read_epoch()).unwrap();
+    let mut scanner = table.scan(&[], None).unwrap();
+    registry.abort_transaction(txn);
+    registry.acknowledge_rollback(txn);
+    table.close().unwrap();
+    assert!(
+        registry.oldest_retention_horizon().is_some(),
+        "the independently owned scanner must retain its epoch"
+    );
+    let mut actual = Vec::new();
+    while scanner.next() {
+        actual.push(scanner.take_row());
+    }
+    assert!(scanner.err().is_none());
+    assert_eq!(actual, vec![row(1, 10), row(2, 20)]);
+    scanner.close().unwrap();
+    assert_eq!(
+        registry.oldest_retention_horizon(),
+        None,
+        "table and completed scanner must release their lease"
+    );
+}

--- a/tests/captured_sum_type_test.rs
+++ b/tests/captured_sum_type_test.rs
@@ -1,0 +1,81 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Result types must survive captured hot/cold grouping and SQL wrappers.
+
+use stoolap::{Database, Value};
+
+#[test]
+fn grouped_sum_float_type_is_stable_for_views_derived_tables_and_own_writes() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open(&format!(
+        "file://{}?checkpoint_interval=3600",
+        dir.path().display()
+    ))
+    .unwrap();
+    db.execute(
+        "CREATE TABLE totals (id INTEGER PRIMARY KEY, category TEXT, amount INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO totals VALUES (1, 'plain', 10), (2, 'plain', 20), (3, 'null', NULL), (4, 'overflow', 9223372036854775807), (5, 'overflow', 1)", ()).unwrap();
+    db.execute("CREATE VIEW grouped_totals AS SELECT category, SUM(amount) AS total FROM totals GROUP BY category", ()).unwrap();
+    for stage in ["hot", "cold", "own"] {
+        match stage {
+            "cold" => {
+                db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+            }
+            "own" => {
+                db.execute("BEGIN", ()).unwrap();
+                db.execute("UPDATE totals SET amount = 11 WHERE id = 1", ())
+                    .unwrap();
+                db.execute("INSERT INTO totals VALUES (6, 'plain', 1)", ())
+                    .unwrap();
+            }
+            _ => (),
+        }
+        for sql in [
+            "SELECT category, SUM(amount) FROM totals GROUP BY category",
+            "SELECT category, total FROM grouped_totals",
+            "SELECT category, total FROM (SELECT category, SUM(amount) AS total FROM totals GROUP BY category) AS grouped",
+        ] {
+            let mut count = 0;
+            for row in db.query(sql, ()).unwrap() {
+                let row = row.unwrap();
+                let category = row.get::<String>(0).unwrap();
+                let actual = row.get_value(1).unwrap();
+                match category.as_str() {
+                    "plain" => assert!(matches!(actual, Value::Float(v) if *v == if stage == "own" { 32.0 } else { 30.0 }), "{stage}: {sql}: {actual:?}"),
+                    "overflow" => assert!(matches!(actual, Value::Float(v) if *v == 9_223_372_036_854_775_808.0), "{stage}: {sql}: {actual:?}"),
+                    "null" => assert!(matches!(actual, Value::Null(_)), "{stage}: {sql}: {actual:?}"),
+                    _ => panic!("unexpected group {category}"),
+                }
+                count += 1;
+            }
+            assert_eq!(count, 3, "{stage}: {sql}");
+        }
+        let mut rows = db
+            .query(
+                "SELECT SUM(amount) FROM totals WHERE category = 'plain'",
+                (),
+            )
+            .unwrap();
+        let row = rows.next().unwrap().unwrap();
+        assert!(
+            matches!(row.get_value(0), Some(Value::Integer(v)) if *v == if stage == "own" { 32 } else { 30 }),
+            "filtered global SUM must keep integer narrowing: {stage}"
+        );
+    }
+    db.execute("ROLLBACK", ()).unwrap();
+}

--- a/tests/cold_read_error_test.rs
+++ b/tests/cold_read_error_test.rs
@@ -157,11 +157,20 @@ fn cold_error_after_scan_progress_discards_rows_and_aggregate() {
     let _guard = test_failpoints::FailpointGuard::new();
     let (_dir, dsn) = fixture();
     let db = Database::open(&dsn).unwrap();
+    db.execute(
+        "INSERT INTO items VALUES (7, 'c', 70, 'seven'), (8, 'c', 80, 'eight')",
+        (),
+    )
+    .unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    assert_eq!(db.engine().volume_stats().len(), 2);
     for (sql, nth) in [
-        ("SELECT id, amount, code FROM items ORDER BY id", 7),
-        // The SUM column is bound once; later predicate reads still follow
-        // rows already accumulated and must discard that partial aggregate.
-        ("SELECT SUM(amount) FROM items WHERE amount >= 10", 5),
+        // Each volume binds four projected columns; the fifth read belongs
+        // to the second volume after the first has contributed visible rows.
+        ("SELECT id, amount, code FROM items ORDER BY id", 5),
+        // Predicate and SUM share the amount column. The second binding is
+        // in the next volume, after the first partial aggregate was accumulated.
+        ("SELECT SUM(amount) FROM items WHERE amount >= 10", 2),
     ] {
         let expected = rows(&db, sql).unwrap();
         test_failpoints::fail_cold_read_on(nth);

--- a/tests/current_index_population_test.rs
+++ b/tests/current_index_population_test.rs
@@ -1,0 +1,505 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+use stoolap::core::{DataType, IndexType, Row, SchemaBuilder, Value};
+use stoolap::storage::index::HnswIndex;
+use stoolap::storage::mvcc::{
+    persistence::IndexMetadata, table::MVCCTable, RowVersion, TransactionRegistry,
+    TransactionVersionStore, VersionStore,
+};
+use stoolap::storage::traits::Table;
+use stoolap::{Database, IsolationLevel};
+
+fn memory_db() -> Database {
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    Database::open(&format!(
+        "memory://canonical_index_{}",
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ))
+    .unwrap()
+}
+
+#[test]
+fn sql_index_build_uses_current_rows_without_advancing_its_old_snapshot() {
+    for (suffix, columns, keys) in [
+        ("", "g", vec![20.into()]),
+        (" USING HASH", "g", vec![20.into()]),
+        (" USING BITMAP", "g", vec![20.into()]),
+        (" USING BTREE", "g", vec![20.into()]),
+        ("", "g, id", vec![20.into(), 1.into()]),
+    ] {
+        let db = memory_db();
+        db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, g INTEGER)", ())
+            .unwrap();
+        db.execute("INSERT INTO t VALUES (1, 10), (2, 11)", ())
+            .unwrap();
+        let mut old = db
+            .begin_with_isolation(IsolationLevel::SnapshotIsolation)
+            .unwrap();
+        assert_eq!(
+            old.query_one::<i64, _>("SELECT g FROM t WHERE id = 1", ())
+                .unwrap(),
+            10
+        );
+        db.execute("UPDATE t SET g = 20 WHERE id = 1", ()).unwrap();
+        db.execute("DELETE FROM t WHERE id = 2", ()).unwrap();
+        db.execute("INSERT INTO t VALUES (3, 30)", ()).unwrap();
+        let table = db.engine().get_table_for_txn(old.id(), "t").unwrap();
+        let index_type = match suffix {
+            " USING HASH" => Some(IndexType::Hash),
+            " USING BITMAP" => Some(IndexType::Bitmap),
+            " USING BTREE" => Some(IndexType::BTree),
+            _ => None,
+        };
+        let column_names: Vec<_> = columns.split(", ").collect();
+        table
+            .create_index_with_type("idx_g", &column_names, false, index_type)
+            .unwrap();
+        let index = db
+            .engine()
+            .get_version_store("t")
+            .unwrap()
+            .get_index("idx_g")
+            .unwrap();
+        assert_eq!(
+            index.get_row_ids_equal(&keys).as_slice(),
+            &[1],
+            "{suffix} {columns}"
+        );
+        let mut stale = keys.clone();
+        stale[0] = 10.into();
+        assert!(index.get_row_ids_equal(&stale).is_empty());
+        assert_eq!(
+            old.query_one::<i64, _>("SELECT g FROM t WHERE id = 1", ())
+                .unwrap(),
+            10
+        );
+        assert_eq!(
+            old.query_one::<i64, _>("SELECT COUNT(*) FROM t", ())
+                .unwrap(),
+            2
+        );
+        old.rollback().unwrap();
+    }
+}
+
+#[test]
+fn sql_default_columns_populate_all_native_index_builders() {
+    for (suffix, columns, keys) in [
+        ("", "g", vec![77.into()]),
+        (" USING HASH", "g", vec![77.into()]),
+        (" USING BITMAP", "g", vec![77.into()]),
+        (" USING BTREE", "g", vec![77.into()]),
+        ("", "g, id", vec![77.into(), 1.into()]),
+    ] {
+        let db = memory_db();
+        db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", ())
+            .unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).unwrap();
+        db.execute("ALTER TABLE t ADD COLUMN g INTEGER DEFAULT 77", ())
+            .unwrap();
+        db.execute(&format!("CREATE INDEX idx_g ON t({columns}){suffix}"), ())
+            .unwrap();
+        let index = db
+            .engine()
+            .get_version_store("t")
+            .unwrap()
+            .get_index("idx_g")
+            .unwrap();
+        assert_eq!(
+            index.get_row_ids_equal(&keys).as_slice(),
+            &[1],
+            "{suffix} {columns}"
+        );
+        assert_eq!(
+            db.query_one::<i64, _>("SELECT g FROM t WHERE id = 1", ())
+                .unwrap(),
+            77
+        );
+    }
+}
+
+fn publish(registry: &TransactionRegistry, store: &VersionStore, row_id: i64, row: Row) {
+    let (id, _) = registry.begin_transaction();
+    registry.start_commit(id);
+    store.add_version(row_id, RowVersion::new(id, row)).unwrap();
+    registry.complete_commit(id);
+}
+
+fn integer_store() -> (Arc<TransactionRegistry>, Arc<VersionStore>) {
+    let registry = Arc::new(TransactionRegistry::new());
+    let schema = SchemaBuilder::new("t")
+        .add_primary_key("id", DataType::Integer)
+        .add("g", DataType::Integer)
+        .build();
+    let store = Arc::new(VersionStore::with_visibility_checker(
+        "t",
+        schema,
+        registry.clone(),
+    ));
+    (registry, store)
+}
+
+#[test]
+fn public_btree_and_multi_helpers_use_current_defaulted_keys() {
+    for multi in [false, true] {
+        let (registry, store) = integer_store();
+        publish(&registry, &store, 1, Row::from(vec![1.into(), 10.into()]));
+        let (old, _) = registry.begin_transaction_with_isolation(IsolationLevel::SnapshotIsolation);
+        let mut table = MVCCTable::new(
+            old,
+            store.clone(),
+            TransactionVersionStore::new(store.clone(), old),
+        );
+        table
+            .create_column_with_default_value(
+                "d",
+                DataType::Integer,
+                false,
+                Some("77".into()),
+                Some(77.into()),
+            )
+            .unwrap();
+        publish(&registry, &store, 1, Row::from(vec![1.into(), 20.into()]));
+        let keys = if multi {
+            table
+                .create_multi_column_index("idx", &["d", "g"], false)
+                .unwrap();
+            vec![77.into(), 20.into()]
+        } else {
+            table.create_btree_index("d", false, Some("idx")).unwrap();
+            vec![77.into()]
+        };
+        assert_eq!(
+            store
+                .get_index("idx")
+                .unwrap()
+                .get_row_ids_equal(&keys)
+                .as_slice(),
+            &[1]
+        );
+        assert_eq!(
+            store.get_visible_version(1, old).unwrap().data.get(1),
+            Some(&10.into())
+        );
+    }
+}
+
+#[test]
+fn hnsw_build_uses_current_vector_and_defaulted_payload() {
+    let db = memory_db();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v VECTOR(2))", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, '[1, 0]')", ())
+        .unwrap();
+    let mut old = db
+        .begin_with_isolation(IsolationLevel::SnapshotIsolation)
+        .unwrap();
+    db.execute("UPDATE t SET v = '[9, 0]' WHERE id = 1", ())
+        .unwrap();
+    db.engine()
+        .get_table_for_txn(old.id(), "t")
+        .unwrap()
+        .create_hnsw_index(
+            "idx_v",
+            "v",
+            false,
+            16,
+            64,
+            32,
+            stoolap::storage::index::HnswDistanceMetric::L2,
+        )
+        .unwrap();
+    let index = db
+        .engine()
+        .get_version_store("t")
+        .unwrap()
+        .get_index("idx_v")
+        .unwrap();
+    let hnsw = index.as_any().downcast_ref::<HnswIndex>().unwrap();
+    let query: Vec<u8> = [9.0_f32, 0.0]
+        .into_iter()
+        .flat_map(f32::to_le_bytes)
+        .collect();
+    assert_eq!(hnsw.search_nearest(&query, 1, 16), vec![(1, 0.0)]);
+    old.rollback().unwrap();
+
+    // Public generic HNSW construction shares the native builder, while SQL
+    // WITH parameters uses the dedicated HNSW builder exercised above.
+    let registry = Arc::new(TransactionRegistry::new());
+    let mut schema = SchemaBuilder::new("v")
+        .add_primary_key("id", DataType::Integer)
+        .add("v", DataType::Vector)
+        .build();
+    schema.columns[1].vector_dimensions = 2;
+    schema.columns[1].default_value = Some(Value::vector(vec![9.0, 0.0]));
+    let store = Arc::new(VersionStore::with_visibility_checker(
+        "v",
+        schema,
+        registry.clone(),
+    ));
+    publish(&registry, &store, 1, Row::from(vec![1.into()]));
+    let (txn, _) = registry.begin_transaction();
+    let table = MVCCTable::new(
+        txn,
+        store.clone(),
+        TransactionVersionStore::new(store.clone(), txn),
+    );
+    table
+        .create_index_with_type("idx", &["v"], false, Some(IndexType::Hnsw))
+        .unwrap();
+    let index = store.get_index("idx").unwrap();
+    let hnsw = index.as_any().downcast_ref::<HnswIndex>().unwrap();
+    assert_eq!(hnsw.search_nearest(&query, 1, 16), vec![(1, 0.0)]);
+}
+
+#[test]
+fn unresolved_applied_publisher_excludes_builder_until_terminal_outcome() {
+    for commit in [false, true] {
+        let (registry, store) = integer_store();
+        publish(&registry, &store, 1, Row::from(vec![1.into(), 10.into()]));
+        let (writer_id, _) = registry.begin_transaction();
+        let mut writer = TransactionVersionStore::new(store.clone(), writer_id);
+        writer
+            .put(1, Row::from(vec![1.into(), 20.into()]), false)
+            .unwrap();
+        registry.start_commit(writer_id);
+        writer.prepare_publication().unwrap();
+        writer.apply_prepared_publication().unwrap();
+        let (builder_id, _) = registry.begin_transaction();
+        let builder = MVCCTable::new(
+            builder_id,
+            store.clone(),
+            TransactionVersionStore::new(store.clone(), builder_id),
+        );
+        assert!(builder.create_index("idx", &["g"], false).is_err());
+        assert!(store.get_index("idx").is_none());
+        if commit {
+            registry.complete_commit(writer_id);
+        } else {
+            registry.abort_transaction(writer_id);
+        }
+        writer.finish_publication(commit).unwrap();
+        builder.create_index("idx", &["g"], false).unwrap();
+        let expected = if commit { 20 } else { 10 };
+        assert_eq!(
+            store
+                .get_index("idx")
+                .unwrap()
+                .get_row_ids_equal(&[expected.into()])
+                .as_slice(),
+            &[1]
+        );
+    }
+}
+
+#[test]
+fn uncommitted_insert_is_not_installed_in_shared_index_and_commit_adds_it() {
+    for commit in [false, true] {
+        let db = memory_db();
+        db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, g INTEGER)", ())
+            .unwrap();
+        let mut txn = db.begin().unwrap();
+        txn.execute("INSERT INTO t VALUES (1, 10)", ()).unwrap();
+        db.engine()
+            .get_table_for_txn(txn.id(), "t")
+            .unwrap()
+            .create_index("idx", &["g"], false)
+            .unwrap();
+        let index = db
+            .engine()
+            .get_version_store("t")
+            .unwrap()
+            .get_index("idx")
+            .unwrap();
+        assert!(index.get_row_ids_equal(&[10.into()]).is_empty());
+        if commit {
+            txn.commit().unwrap();
+        } else {
+            txn.rollback().unwrap();
+        }
+        assert_eq!(
+            index.get_row_ids_equal(&[10.into()]).as_slice(),
+            if commit { &[1][..] } else { &[][..] }
+        );
+    }
+}
+
+fn metadata(multi: bool, unique: bool) -> IndexMetadata {
+    IndexMetadata {
+        name: "idx".into(),
+        table_name: "t".into(),
+        column_names: if multi {
+            vec!["g".into(), "id".into()]
+        } else {
+            vec!["g".into()]
+        },
+        column_ids: if multi { vec![1, 0] } else { vec![1] },
+        data_types: if multi {
+            vec![DataType::Integer; 2]
+        } else {
+            vec![DataType::Integer]
+        },
+        is_unique: unique,
+        index_type: IndexType::Hash,
+        hnsw_m: None,
+        hnsw_ef_construction: None,
+        hnsw_ef_search: None,
+        hnsw_distance_metric: None,
+    }
+}
+
+#[test]
+fn recovery_population_projects_defaults_and_propagates_unique_errors() {
+    for deferred in [false, true] {
+        for multi in [false, true] {
+            let (registry, store) = integer_store();
+            let (txn, _) = registry.begin_transaction();
+            let mut table = MVCCTable::new(
+                txn,
+                store.clone(),
+                TransactionVersionStore::new(store.clone(), txn),
+            );
+            table.drop_column("g").unwrap();
+            table
+                .create_column_with_default_value(
+                    "g",
+                    DataType::Integer,
+                    false,
+                    Some("77".into()),
+                    Some(77.into()),
+                )
+                .unwrap();
+            publish(&registry, &store, 1, Row::from(vec![1.into()]));
+            store
+                .create_index_from_metadata(&metadata(multi, false), deferred)
+                .unwrap();
+            if deferred {
+                store.populate_all_indexes().unwrap();
+            }
+            let keys = if multi {
+                vec![77.into(), 1.into()]
+            } else {
+                vec![77.into()]
+            };
+            assert_eq!(
+                store
+                    .get_index("idx")
+                    .unwrap()
+                    .get_row_ids_equal(&keys)
+                    .as_slice(),
+                &[1]
+            );
+        }
+        let (registry, store) = integer_store();
+        publish(&registry, &store, 1, Row::from(vec![1.into(), 10.into()]));
+        publish(&registry, &store, 2, Row::from(vec![2.into(), 10.into()]));
+        let build = store.create_index_from_metadata(&metadata(false, true), deferred);
+        if deferred {
+            build.unwrap();
+            assert!(
+                store.populate_all_indexes().is_err(),
+                "startup must not accept incomplete unique index"
+            );
+        } else {
+            assert!(build.is_err());
+            assert!(store.get_index("idx").is_none());
+        }
+    }
+}
+
+#[test]
+fn direct_local_commit_must_reach_registry_outcome_before_index_build() {
+    for delete in [false, true] {
+        for start_before_apply in [false, true] {
+            let (registry, store) = integer_store();
+            publish(&registry, &store, 0, Row::from(vec![0.into(), 99.into()]));
+            publish(&registry, &store, 1, Row::from(vec![1.into(), 10.into()]));
+            let (writer_id, _) = registry.begin_transaction();
+            let mut writer = TransactionVersionStore::new(store.clone(), writer_id);
+            writer
+                .put(1, Row::from(vec![1.into(), 20.into()]), delete)
+                .unwrap();
+            if start_before_apply {
+                registry.start_commit(writer_id);
+            }
+            // The public local-store API releases its catalog lease here, but
+            // the caller has not yet published the registry outcome.
+            writer.commit().unwrap();
+            let (builder_id, _) = registry.begin_transaction();
+            let table = MVCCTable::new(
+                builder_id,
+                store.clone(),
+                TransactionVersionStore::new(store.clone(), builder_id),
+            );
+            let error = table.create_index("idx", &["g"], true).unwrap_err();
+            assert!(error.to_string().contains("unresolved row mutation"));
+            assert!(
+                store.get_index("idx").is_none(),
+                "a valid prefix must not install a partial index"
+            );
+            if !start_before_apply {
+                registry.start_commit(writer_id);
+            }
+            registry.complete_commit(writer_id);
+            // An unrelated in-flight commit does not block the per-table check.
+            let (unrelated, _) = registry.begin_transaction();
+            registry.start_commit(unrelated);
+            table.create_index("idx", &["g"], true).unwrap();
+            let index = store.get_index("idx").unwrap();
+            assert_eq!(index.get_row_ids_equal(&[99.into()]).as_slice(), &[0]);
+            assert!(index.get_row_ids_equal(&[10.into()]).is_empty());
+            assert_eq!(
+                index.get_row_ids_equal(&[20.into()]).as_slice(),
+                if delete { &[][..] } else { &[1][..] }
+            );
+            registry.abort_transaction(unrelated);
+        }
+    }
+}
+
+#[test]
+fn visible_creator_with_unresolved_distinct_deleter_blocks_index_build() {
+    let (registry, store) = integer_store();
+    publish(&registry, &store, 1, Row::from(vec![1.into(), 10.into()]));
+    let epoch = registry.capture_read_epoch();
+    let mut deleted = store
+        .capture_hot_root()
+        .visible_version(1, &epoch)
+        .unwrap()
+        .clone();
+    let (deleter, _) = registry.begin_transaction();
+    deleted.deleted_at_txn_id = deleter;
+    store.add_version(1, deleted).unwrap();
+    let (builder, _) = registry.begin_transaction();
+    let table = MVCCTable::new(
+        builder,
+        store.clone(),
+        TransactionVersionStore::new(store.clone(), builder),
+    );
+    assert!(table.create_index("idx", &["g"], false).is_err());
+    registry.start_commit(deleter);
+    assert!(table.create_index("idx", &["g"], false).is_err());
+    registry.complete_commit(deleter);
+    table.create_index("idx", &["g"], false).unwrap();
+    assert!(store
+        .get_index("idx")
+        .unwrap()
+        .get_row_ids_equal(&[10.into()])
+        .is_empty());
+}

--- a/tests/fixed_epoch_cold_dml_test.rs
+++ b/tests/fixed_epoch_cold_dml_test.rs
@@ -1,0 +1,436 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, RwLock};
+use stoolap::common::CompactArc;
+use stoolap::core::{DataType, Row, Schema, SchemaBuilder, Value};
+use stoolap::storage::expression::{ComparisonExpr, Expression};
+use stoolap::storage::mvcc::{
+    table::MVCCTable, RowVersion, TransactionRegistry, TransactionVersionStore, VersionStore,
+};
+use stoolap::storage::traits::Table;
+use stoolap::storage::volume::{
+    manifest::{SegmentManager, SegmentMeta},
+    table::SegmentedTable,
+    writer::VolumeBuilder,
+};
+
+fn row(id: i64, g: i64) -> Row {
+    Row::from(vec![id.into(), g.into()])
+}
+fn meta(id: u64, rows: &[(i64, i64)]) -> SegmentMeta {
+    SegmentMeta {
+        segment_id: id,
+        file_path: format!("{id}.vol").into(),
+        row_count: rows.len(),
+        min_row_id: rows.first().unwrap().0,
+        max_row_id: rows.last().unwrap().0,
+        creation_lsn: 0,
+        seal_seq: 0,
+        schema_version: 0,
+    }
+}
+fn volume(
+    schema: &Schema,
+    rows: &[(i64, i64)],
+) -> Arc<stoolap::storage::volume::writer::FrozenVolume> {
+    let mut builder = VolumeBuilder::new(schema);
+    for &(id, g) in rows {
+        builder.add_row(id, &row(id, g));
+    }
+    Arc::new(builder.finish())
+}
+fn register(manager: &SegmentManager, schema: &Schema, id: u64, rows: &[(i64, i64)]) {
+    manager.register_segment(id, volume(schema, rows), meta(id, rows), Some(schema));
+}
+struct Fixture {
+    registry: Arc<TransactionRegistry>,
+    store: Arc<VersionStore>,
+    manager: Arc<SegmentManager>,
+    local: CompactArc<RwLock<TransactionVersionStore>>,
+    table: SegmentedTable,
+    txn: i64,
+}
+fn fixture() -> Fixture {
+    let registry = Arc::new(TransactionRegistry::new());
+    let schema = SchemaBuilder::new("t")
+        .add_primary_key("id", DataType::Integer)
+        .add("g", DataType::Integer)
+        .build();
+    let store = Arc::new(VersionStore::with_visibility_checker(
+        "t",
+        schema.clone(),
+        registry.clone(),
+    ));
+    let manager = Arc::new(SegmentManager::new("t", None));
+    register(&manager, &schema, 1, &[(1, 10), (2, 20)]);
+    let epoch = registry.capture_read_epoch();
+    let (txn, _) = registry.begin_transaction();
+    let local = CompactArc::new(RwLock::new(TransactionVersionStore::new(
+        store.clone(),
+        txn,
+    )));
+    let hot = MVCCTable::new_with_shared_store(txn, store.clone(), local.clone());
+    let mut table = SegmentedTable::new(Box::new(hot), manager.clone());
+    table.set_read_epoch(epoch).unwrap();
+    Fixture {
+        registry,
+        store,
+        manager,
+        local,
+        table,
+        txn,
+    }
+}
+fn condition(table: &SegmentedTable, by_id: bool) -> Box<dyn Expression> {
+    let mut expression = if by_id {
+        ComparisonExpr::eq("id", 1.into())
+    } else {
+        ComparisonExpr::eq("g", 10.into())
+    };
+    expression.prepare_for_schema(table.schema());
+    Box::new(expression)
+}
+fn change(
+    f: &mut Fixture,
+    mode: usize,
+    delete: bool,
+    seen: &mut Vec<Value>,
+) -> stoolap::core::Result<i32> {
+    let expression = condition(&f.table, mode == 0);
+    if delete {
+        if mode == 2 {
+            f.table.delete_by_row_ids(&[1])
+        } else {
+            f.table.delete(Some(expression.as_ref()))
+        }
+    } else {
+        let mut setter = |mut value: Row| {
+            seen.push(value.get(1).unwrap().clone());
+            value.set(1, 11.into())?;
+            Ok((value, true))
+        };
+        if mode == 2 {
+            f.table.update_by_row_ids(&[1], &mut setter)
+        } else {
+            f.table.update(Some(expression.as_ref()), &mut setter)
+        }
+    }
+}
+
+#[test]
+fn captured_cold_dml_excludes_later_segments_and_keeps_own_changes() {
+    for delete in [false, true] {
+        for mode in 0..3 {
+            let mut f = fixture();
+            register(&f.manager, &f.store.schema(), 2, &[(3, 10)]);
+            let mut seen = Vec::new();
+            assert_eq!(change(&mut f, mode, delete, &mut seen).unwrap(), 1);
+            assert!(f.manager.is_pending_tombstone(f.txn, 1));
+            assert!(!f.manager.is_pending_tombstone(f.txn, 3));
+            if !delete {
+                assert_eq!(seen, vec![Value::Integer(10)]);
+                let mut observed = Vec::new();
+                assert_eq!(
+                    f.table
+                        .update_by_row_ids(&[1], &mut |value| {
+                            observed.push(value.get(1).unwrap().clone());
+                            Ok((value, false))
+                        })
+                        .unwrap(),
+                    0
+                );
+                assert_eq!(observed, vec![Value::Integer(11)]);
+            } else {
+                assert_eq!(f.table.delete_by_row_ids(&[1]).unwrap(), 0);
+            }
+            assert!(f.local.read().unwrap().get_local_version(3).is_none());
+        }
+    }
+}
+
+#[test]
+fn captured_cold_dml_rejects_new_hot_authority_before_mirroring() {
+    for delete in [false, true] {
+        for mode in 0..3 {
+            let mut f = fixture();
+            let (writer, _) = f.registry.begin_transaction();
+            f.registry.start_commit(writer);
+            f.store
+                .add_version(1, RowVersion::new(writer, row(1, 99)))
+                .unwrap();
+            f.registry.complete_commit(writer);
+            let mut seen = Vec::new();
+            let error = change(&mut f, mode, delete, &mut seen).unwrap_err();
+            assert!(error.to_string().contains("write conflict"), "{error}");
+            if !delete {
+                assert_eq!(seen, vec![Value::Integer(10)]);
+            }
+            assert!(!f.local.read().unwrap().has_local_changes());
+            assert!(!f.manager.is_pending_tombstone(f.txn, 1));
+        }
+    }
+}
+
+#[test]
+fn captured_cold_dml_rejects_later_tombstone_and_replaced_source() {
+    for replace in [false, true] {
+        for delete in [false, true] {
+            for mode in 0..3 {
+                let mut f = fixture();
+                if replace {
+                    let rows = [(1, 99), (2, 20)];
+                    f.manager.replace_segments_atomic(
+                        2,
+                        volume(&f.store.schema(), &rows),
+                        meta(2, &rows),
+                        &[1],
+                    );
+                } else {
+                    let (writer, _) = f.registry.begin_transaction();
+                    let sequence = f.registry.start_commit(writer);
+                    f.registry.complete_commit(writer);
+                    f.manager.add_tombstones(&[1], sequence as u64);
+                }
+                let mut seen = Vec::new();
+                let error = change(&mut f, mode, delete, &mut seen).unwrap_err();
+                assert!(error.to_string().contains("write conflict"), "{error}");
+                if !delete {
+                    assert_eq!(seen, vec![Value::Integer(10)]);
+                }
+                assert!(!f.local.read().unwrap().has_local_changes());
+                assert!(!f.manager.is_pending_tombstone(f.txn, 1));
+            }
+        }
+    }
+}
+
+#[test]
+fn captured_delete_of_unknown_ids_does_not_create_phantom_writes() {
+    let mut f = fixture();
+    assert_eq!(f.table.delete_by_row_ids(&[999]).unwrap(), 0);
+    assert!(!f.local.read().unwrap().has_local_changes());
+    assert!(f.manager.get_pending_tombstones(f.txn).is_empty());
+}
+
+#[test]
+fn cold_dml_setter_runs_outside_transfer_fence_and_keeps_earliest_generation() {
+    let mut f = fixture();
+    let manager = f.manager.clone();
+    let schema = f.store.schema();
+    let old_generation = manager.seal_generation();
+    assert_eq!(
+        f.table
+            .update_by_row_ids(&[1], &mut |mut value| {
+                // This would deadlock if user code were invoked under seal_read. A
+                // separate new row leaves the selected source identity authoritative.
+                let _fence = manager.acquire_seal_write();
+                register(&manager, &schema, 2, &[(3, 30)]);
+                value.set(1, 11.into())?;
+                Ok((value, true))
+            })
+            .unwrap(),
+        1
+    );
+    assert!(manager.seal_generation() > old_generation);
+    assert_eq!(manager.get_txn_seal_generation(f.txn), Some(old_generation));
+    manager.record_txn_seal_generation(f.txn);
+    assert_eq!(manager.get_txn_seal_generation(f.txn), Some(old_generation));
+}
+
+fn unique_g(f: &Fixture) {
+    use stoolap::storage::index::HashIndex;
+    f.store
+        .add_index(
+            "u_g".into(),
+            Arc::new(HashIndex::new(
+                "u_g".into(),
+                "t".into(),
+                vec!["g".into()],
+                vec![1],
+                vec![DataType::Integer],
+                true,
+                0,
+            )),
+        )
+        .unwrap();
+}
+
+#[test]
+fn captured_cold_update_checks_current_unique_keys_and_revalidates_preflight() {
+    for concurrent_segment in [false, true] {
+        let mut f = fixture();
+        unique_g(&f);
+        let manager = f.manager.clone();
+        let schema = f.store.schema();
+        let error = f
+            .table
+            .update_by_row_ids(&[1], &mut |mut value| {
+                if concurrent_segment {
+                    let _fence = manager.acquire_seal_write();
+                    register(&manager, &schema, 2, &[(3, 50)]);
+                }
+                value.set(
+                    1,
+                    if concurrent_segment {
+                        50.into()
+                    } else {
+                        20.into()
+                    },
+                )?;
+                Ok((value, true))
+            })
+            .unwrap_err();
+        if concurrent_segment {
+            assert!(error.to_string().contains("write conflict"), "{error}");
+        } else {
+            assert!(
+                matches!(error, stoolap::core::Error::UniqueConstraint { .. }),
+                "{error}"
+            );
+        }
+        assert!(!f.local.read().unwrap().has_local_changes());
+        assert!(!f.manager.is_pending_tombstone(f.txn, 1));
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FailingPredicate;
+impl Expression for FailingPredicate {
+    fn evaluate(&self, _: &Row) -> stoolap::core::Result<bool> {
+        Err(stoolap::core::Error::internal(
+            "cold target expression failed",
+        ))
+    }
+    fn evaluate_fast(&self, _: &Row) -> bool {
+        false
+    }
+    fn with_aliases(&self, _: &rustc_hash::FxHashMap<String, String>) -> Box<dyn Expression> {
+        Box::new(self.clone())
+    }
+    fn prepare_for_schema(&mut self, _: &Schema) {}
+    fn is_prepared(&self) -> bool {
+        true
+    }
+    fn clone_box(&self) -> Box<dyn Expression> {
+        Box::new(self.clone())
+    }
+}
+
+#[test]
+fn captured_cold_predicate_errors_cannot_become_successful_partial_dml() {
+    for delete in [false, true] {
+        let mut f = fixture();
+        let result = if delete {
+            f.table.delete(Some(&FailingPredicate))
+        } else {
+            f.table
+                .update(Some(&FailingPredicate), &mut |row| Ok((row, true)))
+        };
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("cold target expression failed"));
+        assert!(!f.local.read().unwrap().has_local_changes());
+        assert!(f.manager.get_pending_tombstones(f.txn).is_empty());
+    }
+}
+
+#[test]
+fn cold_dml_pruning_uses_readded_columns_default_mapping() {
+    for delete in [false, true] {
+        let dir = tempfile::tempdir().unwrap();
+        let db = stoolap::Database::open(&format!(
+            "file://{}?checkpoint_interval=3600",
+            dir.path().display()
+        ))
+        .unwrap();
+        db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, g INTEGER)", ())
+            .unwrap();
+        db.execute("INSERT INTO t VALUES (1, 10), (2, 20)", ())
+            .unwrap();
+        db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        db.execute("ALTER TABLE t DROP COLUMN g", ()).unwrap();
+        db.execute("ALTER TABLE t ADD COLUMN g INTEGER DEFAULT 99", ())
+            .unwrap();
+        assert_eq!(
+            db.query_one::<i64, _>("SELECT COUNT(*) FROM t WHERE g = 99", ())
+                .unwrap(),
+            2
+        );
+        let affected = if delete {
+            db.execute("DELETE FROM t WHERE g = 99", ()).unwrap()
+        } else {
+            db.execute("UPDATE t SET g = 100 WHERE g = 99", ()).unwrap()
+        };
+        assert_eq!(
+            affected, 2,
+            "old physical g zone maps must not prune current default g"
+        );
+        assert_eq!(
+            db.query_one::<i64, _>("SELECT COUNT(*) FROM t WHERE g = 99", ())
+                .unwrap(),
+            0
+        );
+    }
+}
+
+#[test]
+fn cold_dml_bloom_pruning_preserves_numeric_equivalence() {
+    for delete in [false, true] {
+        for (data_type, stored, compared) in [
+            (DataType::Integer, Value::Integer(10), Value::Float(10.0)),
+            (DataType::Float, Value::Float(10.0), Value::Integer(10)),
+            (DataType::Float, Value::Float(0.0), Value::Float(-0.0)),
+            (DataType::Float, Value::Float(-0.0), Value::Float(0.0)),
+        ] {
+            let registry = Arc::new(TransactionRegistry::new());
+            let schema = SchemaBuilder::new("t")
+                .column("id", DataType::Integer, false, true)
+                .column("g", data_type, false, false)
+                .build();
+            let manager = Arc::new(SegmentManager::new("t", None));
+            let mut builder = VolumeBuilder::new(&schema);
+            let expected = Row::from(vec![1.into(), stored]);
+            builder.add_row(1, &expected);
+            manager.register_segment(
+                1,
+                Arc::new(builder.finish()),
+                meta(1, &[(1, 10)]),
+                Some(&schema),
+            );
+            let store = Arc::new(VersionStore::with_visibility_checker(
+                "t",
+                schema,
+                registry.clone(),
+            ));
+            let (txn, _) = registry.begin_transaction();
+            let local = TransactionVersionStore::new(store.clone(), txn);
+            let mut table =
+                SegmentedTable::new(Box::new(MVCCTable::new(txn, store, local)), manager);
+            table.set_read_epoch(registry.capture_read_epoch()).unwrap();
+            let mut predicate = ComparisonExpr::eq("g", compared);
+            predicate.prepare_for_schema(table.schema());
+            assert!(predicate.evaluate(&expected).unwrap());
+            let changed = if delete {
+                table.delete(Some(&predicate)).unwrap()
+            } else {
+                table
+                    .update(Some(&predicate), &mut |row| Ok((row, true)))
+                    .unwrap()
+            };
+            assert_eq!(changed, 1, "delete={delete}, physical type {data_type:?}");
+        }
+    }
+}

--- a/tests/fixed_epoch_dml_targets_test.rs
+++ b/tests/fixed_epoch_dml_targets_test.rs
@@ -1,0 +1,260 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, RwLock};
+use stoolap::common::CompactArc;
+use stoolap::core::{DataType, Error, Row, SchemaBuilder, Value};
+use stoolap::storage::expression::{AndExpr, ComparisonExpr, Expression};
+use stoolap::storage::mvcc::registry::ReadEpoch;
+use stoolap::storage::mvcc::table::MVCCTable;
+use stoolap::storage::mvcc::{
+    RowVersion, TransactionRegistry, TransactionVersionStore, VersionStore,
+};
+use stoolap::storage::traits::Table;
+
+fn row(id: i64, g: i64) -> Row {
+    Row::from(vec![Value::Integer(id), Value::Integer(g)])
+}
+
+fn fixture() -> (Arc<TransactionRegistry>, Arc<VersionStore>, ReadEpoch) {
+    let registry = Arc::new(TransactionRegistry::new());
+    let schema = SchemaBuilder::new("t")
+        .add_primary_key("id", DataType::Integer)
+        .add("g", DataType::Integer)
+        .build();
+    let store = Arc::new(VersionStore::with_visibility_checker(
+        "t",
+        schema,
+        registry.clone(),
+    ));
+    publish(&registry, &store, &[(1, 10), (2, 20)]);
+    let epoch = registry.capture_read_epoch();
+    (registry, store, epoch)
+}
+
+fn publish(registry: &TransactionRegistry, store: &VersionStore, rows: &[(i64, i64)]) {
+    let (txn, _) = registry.begin_transaction();
+    registry.start_commit(txn);
+    store
+        .add_versions_batch(
+            rows.iter()
+                .map(|&(id, g)| (id, RowVersion::new(txn, row(id, g))))
+                .collect(),
+        )
+        .unwrap();
+    registry.complete_commit(txn);
+}
+
+fn bind(registry: &TransactionRegistry, store: Arc<VersionStore>, epoch: ReadEpoch) -> MVCCTable {
+    let (txn, _) = registry.begin_transaction();
+    let local = CompactArc::new(RwLock::new(TransactionVersionStore::new(
+        store.clone(),
+        txn,
+    )));
+    let mut table = MVCCTable::new_with_shared_store(txn, store, local);
+    table.set_read_epoch(epoch).unwrap();
+    table
+}
+
+fn predicate(mode: usize, table: &MVCCTable) -> Option<Box<dyn Expression>> {
+    let mut expression: Box<dyn Expression> = match mode {
+        0 => Box::new(ComparisonExpr::eq("id", Value::Integer(1))),
+        1 => Box::new(AndExpr::and(
+            Box::new(ComparisonExpr::gte("id", Value::Integer(1))),
+            Box::new(ComparisonExpr::lt("id", Value::Integer(2))),
+        )),
+        2 => return None,
+        _ => Box::new(ComparisonExpr::eq("g", Value::Integer(10))),
+    };
+    expression.prepare_for_schema(&table.version_store().schema());
+    Some(expression)
+}
+
+#[test]
+fn update_pk_range_ids_and_scan_keep_captured_originals() {
+    for mode in 0..4 {
+        let (registry, store, epoch) = fixture();
+        publish(&registry, &store, &[(1, 99), (2, 99)]);
+        let mut table = bind(&registry, store, epoch);
+        let expression = predicate(mode, &table);
+        let mut seen = Vec::new();
+        let mut setter = |mut value: Row| {
+            seen.push(value.get(1).unwrap().clone());
+            value.set(1, Value::Integer(11))?;
+            Ok((value, true))
+        };
+        let count = if mode == 2 {
+            table.update_by_row_ids(&[1], &mut setter).unwrap()
+        } else {
+            table.update(expression.as_deref(), &mut setter).unwrap()
+        };
+        assert_eq!(count, 1, "target mode {mode}");
+        assert_eq!(seen, vec![Value::Integer(10)], "target mode {mode}");
+        let local = table.txn_versions().read().unwrap();
+        let (_, _, original) = local.iter_local_with_old().next().unwrap();
+        assert_eq!(original, Some(&row(1, 10)));
+        assert!(
+            local.detect_conflicts_safe().is_err(),
+            "captured creator must not be replaced with latest creator in mode {mode}"
+        );
+    }
+}
+
+#[test]
+fn delete_pk_range_ids_and_scan_keep_captured_originals() {
+    for mode in 0..4 {
+        let (registry, store, epoch) = fixture();
+        publish(&registry, &store, &[(1, 99), (2, 99)]);
+        let mut table = bind(&registry, store, epoch);
+        let expression = predicate(mode, &table);
+        let count = if mode == 2 {
+            table.delete_by_row_ids(&[1]).unwrap()
+        } else {
+            table.delete(expression.as_deref()).unwrap()
+        };
+        assert_eq!(count, 1, "target mode {mode}");
+        let local = table.txn_versions().read().unwrap();
+        let (_, deleted, original) = local.iter_local_with_old().next().unwrap();
+        assert!(deleted.is_deleted());
+        assert_eq!(original, Some(&row(1, 10)));
+        assert!(
+            local.detect_conflicts_safe().is_err(),
+            "captured creator must survive mode {mode}"
+        );
+    }
+}
+
+#[test]
+fn dml_full_scan_uses_latest_own_writes_before_global_predicate() {
+    let (registry, store, epoch) = fixture();
+    let mut table = bind(&registry, store, epoch);
+    {
+        let mut local = table.txn_versions().write().unwrap();
+        local.put(1, row(1, 30), false).unwrap();
+        local.put(2, row(2, 20), true).unwrap();
+        local.put(3, row(3, 30), false).unwrap();
+    }
+    let mut g30 = ComparisonExpr::eq("g", Value::Integer(30));
+    g30.prepare_for_schema(&table.version_store().schema());
+    assert_eq!(
+        table
+            .update(Some(&g30), &mut |mut value| {
+                value.set(1, Value::Integer(31))?;
+                Ok((value, true))
+            })
+            .unwrap(),
+        2
+    );
+    let mut g10 = ComparisonExpr::eq("g", Value::Integer(10));
+    g10.prepare_for_schema(&table.version_store().schema());
+    assert_eq!(table.delete(Some(&g10)).unwrap(), 0);
+    let mut g31 = ComparisonExpr::eq("g", Value::Integer(31));
+    g31.prepare_for_schema(&table.version_store().schema());
+    assert_eq!(table.delete(Some(&g31)).unwrap(), 2);
+    assert_eq!(table.delete_by_row_ids(&[1, 2, 3]).unwrap(), 0);
+}
+
+#[test]
+fn captured_update_setter_failure_does_not_stage_a_prefix() {
+    let (registry, store, epoch) = fixture();
+    let mut table = bind(&registry, store, epoch);
+    let mut calls = 0;
+    let result = table.update(None, &mut |mut value| {
+        calls += 1;
+        if calls == 2 {
+            return Err(Error::internal("setter failed"));
+        }
+        value.set(1, Value::Integer(99))?;
+        Ok((value, true))
+    });
+    assert!(result.is_err());
+    assert_eq!(calls, 2);
+    assert!(!table.txn_versions().read().unwrap().has_local_changes());
+}
+
+#[test]
+fn captured_value_rejects_a_later_distinct_committed_deleter() {
+    for delete in [false, true] {
+        let (registry, store, epoch) = fixture();
+        let creator = store.get_latest_version_id(1).unwrap();
+        let (deleter, _) = registry.begin_transaction();
+        registry.start_commit(deleter);
+        let mut deletion = RowVersion::new(creator, row(1, 10));
+        deletion.deleted_at_txn_id = deleter;
+        store.add_version(1, deletion).unwrap();
+        registry.complete_commit(deleter);
+        let mut table = bind(&registry, store, epoch);
+        let pk = ComparisonExpr::eq("id", Value::Integer(1));
+        let selected = if delete {
+            table.delete(Some(&pk)).unwrap()
+        } else {
+            table
+                .update(Some(&pk), &mut |mut value| {
+                    value.set(1, Value::Integer(11))?;
+                    Ok((value, true))
+                })
+                .unwrap()
+        };
+        assert_eq!(
+            selected, 1,
+            "invisible deletion still exposes the old value"
+        );
+        assert!(
+            table
+                .txn_versions()
+                .read()
+                .unwrap()
+                .detect_conflicts_safe()
+                .is_err(),
+            "a committed deletion must conflict even when its creator stayed unchanged"
+        );
+    }
+}
+
+#[test]
+fn aborted_distinct_deleter_keeps_the_visible_original_for_index_undo() {
+    let (registry, store, epoch) = fixture();
+    let creator = store.get_latest_version_id(1).unwrap();
+    let (deleter, _) = registry.begin_transaction();
+    registry.start_commit(deleter);
+    let mut deletion = RowVersion::new(creator, row(1, 10));
+    deletion.deleted_at_txn_id = deleter;
+    store.add_version(1, deletion).unwrap();
+    // The captured tree owns the excluded deletion head even after undo puts
+    // the original value back into the live store.
+    let mut table = bind(&registry, store.clone(), epoch);
+    registry.abort_transaction(deleter);
+    store
+        .add_version(1, RowVersion::new(creator, row(1, 10)))
+        .unwrap();
+    registry.acknowledge_rollback(deleter);
+    let pk = ComparisonExpr::eq("id", Value::Integer(1));
+    assert_eq!(
+        table
+            .update(Some(&pk), &mut |mut value| {
+                value.set(1, Value::Integer(11))?;
+                Ok((value, true))
+            })
+            .unwrap(),
+        1
+    );
+    let local = table.txn_versions().read().unwrap();
+    assert!(local.detect_conflicts_safe().is_ok());
+    let (_, _, original) = local.iter_local_with_old().next().unwrap();
+    assert_eq!(
+        original,
+        Some(&row(1, 10)),
+        "old index keys belong to the visible value, despite the raw captured marker"
+    );
+}

--- a/tests/fixed_epoch_seal_retention_test.rs
+++ b/tests/fixed_epoch_seal_retention_test.rs
@@ -1,0 +1,64 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use stoolap::executor::{ExecutionContext, Executor};
+use stoolap::storage::traits::QueryResult;
+use stoolap::{Database, Value};
+
+fn collect(mut result: Box<dyn QueryResult>) -> Vec<Vec<Value>> {
+    let mut values = Vec::new();
+    while result.next() {
+        values.push(result.take_row().as_slice().to_vec());
+    }
+    assert!(result.last_error().is_none());
+    values
+}
+
+#[test]
+fn delayed_table_binding_keeps_epoch_across_a_later_seal() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open(&format!(
+        "file://{}?checkpoint_interval=3600",
+        dir.path().display()
+    ))
+    .unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, g INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10), (3, 30)", ())
+        .unwrap();
+    let executor = Executor::new(db.engine().clone());
+    // No Table or hot root has been captured yet; the external epoch alone
+    // owns the right to bind this table later at the earlier cutoff.
+    let context =
+        ExecutionContext::new().with_read_epoch(db.engine().registry().capture_read_epoch());
+    db.execute("UPDATE t SET g = 20 WHERE id = 1", ()).unwrap();
+    db.execute("INSERT INTO t VALUES (2, 20)", ()).unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    assert_eq!(
+        collect(
+            executor
+                .execute_with_context("SELECT id, g FROM t ORDER BY id", &context)
+                .unwrap()
+        ),
+        vec![
+            vec![Value::Integer(1), Value::Integer(10)],
+            vec![Value::Integer(3), Value::Integer(30)],
+        ]
+    );
+    assert!(db
+        .engine()
+        .volume_stats()
+        .iter()
+        .any(|volume| volume.0 == "t"));
+}

--- a/tests/group_by_expression_aggregate_test.rs
+++ b/tests/group_by_expression_aggregate_test.rs
@@ -181,3 +181,73 @@ fn test_signed_zero_group_membership_is_stable_per_shape() {
     assert_eq!(groups("SELECT v, COUNT(*) FROM t GROUP BY v"), 3);
     assert_eq!(groups("SELECT v, SUM(w * 1) FROM t GROUP BY v"), 3);
 }
+
+#[test]
+fn signed_zero_and_nan_payload_groups_survive_cold_and_updated_row_paths() {
+    use std::collections::BTreeMap;
+    const NAN_A: u64 = 0x7ff8_0000_0000_0001;
+    const NAN_B: u64 = 0xfff8_0000_0000_0002;
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open(&format!(
+        "file://{}?checkpoint_interval=3600",
+        dir.path().display()
+    ))
+    .unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, k FLOAT, w INTEGER)",
+        (),
+    )
+    .unwrap();
+    let insert = db.prepare("INSERT INTO t VALUES ($1, $2, 1)").unwrap();
+    let mut values = vec![
+        Some(0.0f64.to_bits()),
+        Some((-0.0f64).to_bits()),
+        Some(NAN_A),
+        Some(NAN_B),
+        Some(0.0f64.to_bits()),
+        Some(NAN_A),
+        Some(1.0f64.to_bits()),
+        None,
+    ];
+    for (id, bits) in values.iter().enumerate() {
+        insert
+            .execute((id as i64 + 1, bits.map(f64::from_bits)))
+            .unwrap();
+    }
+    for stage in ["hot", "cold", "updated"] {
+        if stage == "cold" {
+            db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        }
+        if stage == "updated" {
+            db.execute("UPDATE t SET k = $1 WHERE id = 2", (f64::from_bits(NAN_B),))
+                .unwrap();
+            db.execute("UPDATE t SET k = $1 WHERE id = 4", (0.0f64,))
+                .unwrap();
+            insert.execute((9i64, -0.0f64)).unwrap();
+            values[1] = Some(NAN_B);
+            values[3] = Some(0.0f64.to_bits());
+            values.push(Some((-0.0f64).to_bits()));
+        }
+        let mut expected = BTreeMap::<Option<u64>, i64>::new();
+        for bits in &values {
+            *expected.entry(*bits).or_default() += 1;
+        }
+        for aggregate in ["SUM(w)", "COUNT(*)", "SUM(w * 1)"] {
+            let query = format!("SELECT k, {aggregate} FROM t GROUP BY k");
+            let mut result = Vec::new();
+            for row in db.query(&query, ()).unwrap() {
+                let row = row.unwrap();
+                result.push((
+                    row.get::<Option<f64>>(0).unwrap().map(f64::to_bits),
+                    row.get::<i64>(1).unwrap(),
+                ));
+            }
+            assert_eq!(result.len(), expected.len(), "{stage}: {aggregate}");
+            assert_eq!(
+                result.into_iter().collect::<BTreeMap<_, _>>(),
+                expected,
+                "{stage}: {aggregate}"
+            );
+        }
+    }
+}

--- a/tests/hot_index_top_k_test.rs
+++ b/tests/hot_index_top_k_test.rs
@@ -319,14 +319,22 @@ fn test_snapshot_orders_by_the_values_it_sees() {
     check(&db, "WHERE g = 'a' AND k = 'k3'", true, 3, 0);
 }
 
-/// Runs the first checkpoint from inside the WHERE, at the point where a
-/// concurrent seal can run: after the table saw no volumes, before the hot
-/// index is walked
+/// Runs the first checkpoint from inside the WHERE. The legacy index path
+/// inspects comparison metadata; a captured scan instead evaluates the frozen
+/// hot rows. Both hooks exercise the same first-seal interleaving.
 #[derive(Clone)]
 struct SealInsideWhere {
     inner: ComparisonExpr,
     db: Database,
     fired: Arc<AtomicBool>,
+}
+
+impl SealInsideWhere {
+    fn seal_once(&self) {
+        if !self.fired.swap(true, Ordering::SeqCst) {
+            self.db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        }
+    }
 }
 
 impl std::fmt::Debug for SealInsideWhere {
@@ -337,9 +345,11 @@ impl std::fmt::Debug for SealInsideWhere {
 
 impl Expression for SealInsideWhere {
     fn evaluate(&self, row: &Row) -> Result<bool> {
+        self.seal_once();
         self.inner.evaluate(row)
     }
     fn evaluate_fast(&self, row: &Row) -> bool {
+        self.seal_once();
         self.inner.evaluate_fast(row)
     }
     fn with_aliases(&self, _: &rustc_hash::FxHashMap<String, String>) -> Box<dyn Expression> {
@@ -355,9 +365,7 @@ impl Expression for SealInsideWhere {
         Box::new(self.clone())
     }
     fn get_comparison_info(&self) -> Option<(&str, Operator, &Value)> {
-        if !self.fired.swap(true, Ordering::SeqCst) {
-            self.db.execute("PRAGMA CHECKPOINT", ()).unwrap();
-        }
+        self.seal_once();
         self.inner.get_comparison_info()
     }
 }

--- a/tests/index_optimizer_test.rs
+++ b/tests/index_optimizer_test.rs
@@ -913,3 +913,91 @@ fn test_in_list_pk_decision_follows_the_extracted_list() {
         vec![8]
     );
 }
+
+#[test]
+fn test_ordered_storage_scan_does_not_order_by_a_shadowed_select_alias() {
+    let db = Database::open("memory://ordered_shadowed_alias").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER NOT NULL)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE INDEX t_n ON t(n)", ()).unwrap();
+    db.execute("INSERT INTO t VALUES (1, 1), (2, 2), (3, 3)", ())
+        .unwrap();
+    for (query, expected) in [
+        ("SELECT -n AS n FROM t ORDER BY n ASC LIMIT 2", vec![-3, -2]),
+        (
+            "SELECT -n AS n FROM t ORDER BY n DESC LIMIT 1 OFFSET 1",
+            vec![-2],
+        ),
+        ("SELECT id AS n FROM t ORDER BY n DESC LIMIT 2", vec![3, 2]),
+        ("SELECT n AS n FROM t ORDER BY n DESC LIMIT 2", vec![3, 2]),
+        (
+            "SELECT -id AS id FROM t WHERE id > 0 ORDER BY id ASC LIMIT 2",
+            vec![-3, -2],
+        ),
+    ] {
+        let actual: Vec<i64> = db
+            .query(query, ())
+            .unwrap()
+            .map(|row| row.unwrap().get(0).unwrap())
+            .collect();
+        assert_eq!(actual, expected, "{query}");
+    }
+}
+
+#[test]
+fn test_captured_float_window_preserves_order_limit_and_future_dependencies() {
+    use std::sync::Arc;
+    use stoolap::executor::{ExecutionContext, Executor};
+    use stoolap::storage::mvcc::engine::MVCCEngine;
+    use stoolap::Value;
+
+    let engine = Arc::new(MVCCEngine::in_memory());
+    engine.open_engine().unwrap();
+    let executor = Executor::new(engine.clone());
+    executor
+        .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, price FLOAT NOT NULL)")
+        .unwrap();
+    executor
+        .execute("CREATE INDEX t_price ON t(price)")
+        .unwrap();
+    executor
+        .execute("INSERT INTO t VALUES (1, 30.0), (2, 10.0), (3, 20.0)")
+        .unwrap();
+    executor
+        .execute_with_params(
+            "INSERT INTO t VALUES (4, $1)",
+            smallvec::smallvec![Value::Float(f64::NAN)],
+        )
+        .unwrap();
+    let ctx = ExecutionContext::new().with_read_epoch(engine.registry().capture_read_epoch());
+    executor.execute("UPDATE t SET price = -price").unwrap();
+    executor
+        .execute("INSERT INTO t VALUES (5, -100.0)")
+        .unwrap();
+    for (query, expected) in [
+        (
+            "SELECT id, ROW_NUMBER() OVER (ORDER BY price) FROM t LIMIT 2 OFFSET 1",
+            vec![(3, 2), (1, 3)],
+        ),
+        (
+            "SELECT id, ROW_NUMBER() OVER (ORDER BY price DESC) FROM t LIMIT 2",
+            vec![(4, 1), (1, 2)],
+        ),
+        (
+            "SELECT id, LEAD(id) OVER (ORDER BY price) FROM t LIMIT 2",
+            vec![(2, 3), (3, 1)],
+        ),
+    ] {
+        let mut result = executor.execute_with_context(query, &ctx).unwrap();
+        let mut actual = Vec::new();
+        while result.next() {
+            let row = result.take_row();
+            actual.push((row[0].as_int64().unwrap(), row[1].as_int64().unwrap()));
+        }
+        assert!(result.last_error().is_none());
+        assert_eq!(actual, expected, "{query}");
+    }
+}

--- a/tests/query_cache_test.rs
+++ b/tests/query_cache_test.rs
@@ -16,6 +16,47 @@
 
 use stoolap::Database;
 
+#[test]
+fn committed_changes_from_another_executor_cannot_reuse_old_rows() {
+    use std::sync::Arc;
+    use stoolap::executor::Executor;
+
+    let db =
+        Database::open("memory://committed_changes_from_another_executor_cannot_reuse_old_rows")
+            .unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10), (2, 20)", ())
+        .unwrap();
+    let reader = Executor::new(Arc::clone(db.engine()));
+    let writer = Executor::new(Arc::clone(db.engine()));
+    let values = || {
+        let mut result = reader.execute("SELECT * FROM t WHERE id > 0").unwrap();
+        let mut rows = Vec::new();
+        while result.next() {
+            let row = result.row();
+            rows.push((
+                row.get(0).unwrap().as_int64().unwrap(),
+                row.get(1).unwrap().as_int64().unwrap(),
+            ));
+        }
+        assert!(result.last_error().is_none());
+        result.close().unwrap();
+        rows.sort_unstable();
+        rows
+    };
+    assert_eq!(values(), vec![(1, 10), (2, 20)]);
+    assert_eq!(values(), vec![(1, 10), (2, 20)]);
+    assert_eq!(reader.semantic_cache_stats().exact_hits, 1);
+    writer.execute("INSERT INTO t VALUES (3, 30)").unwrap();
+    assert_eq!(values(), vec![(1, 10), (2, 20), (3, 30)]);
+    writer.execute("UPDATE t SET v=99 WHERE id=1").unwrap();
+    assert_eq!(values(), vec![(1, 99), (2, 20), (3, 30)]);
+    writer.execute("DELETE FROM t WHERE id=2").unwrap();
+    assert_eq!(values(), vec![(1, 99), (3, 30)]);
+    assert_eq!(reader.semantic_cache_stats().exact_hits, 1);
+}
+
 /// Tests basic query cache functionality
 #[test]
 fn test_query_cache_basic() {

--- a/tests/returning_atomicity_test.rs
+++ b/tests/returning_atomicity_test.rs
@@ -1,0 +1,145 @@
+// Copyright 2026 Stoolap Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use stoolap::Database;
+
+#[test]
+fn returning_reports_affected_rows_for_dml_and_prepared_insert() {
+    let db = Database::open_in_memory().unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER)", ())
+        .unwrap();
+    assert_eq!(
+        db.execute(
+            "INSERT INTO t VALUES (1, 10), (2, 20), (3, 30) RETURNING id",
+            ()
+        )
+        .unwrap(),
+        3
+    );
+    assert_eq!(
+        db.prepare("INSERT INTO t VALUES ($1, $2) RETURNING id")
+            .unwrap()
+            .execute((4i64, 40i64))
+            .unwrap(),
+        1
+    );
+    let mut tx = db.begin().unwrap();
+    assert_eq!(
+        tx.execute("UPDATE t SET n=n+1 WHERE id<=3 RETURNING id, n", ())
+            .unwrap(),
+        3
+    );
+    let mut rows = tx
+        .query("DELETE FROM t WHERE id<=3 RETURNING id", ())
+        .unwrap();
+    assert_eq!(rows.rows_affected(), 3);
+    assert_eq!(
+        rows.by_ref()
+            .collect::<stoolap::Result<Vec<_>>>()
+            .unwrap()
+            .len(),
+        3
+    );
+    assert_eq!(rows.rows_affected(), 3);
+    drop(rows);
+    assert_eq!(
+        tx.execute("DELETE FROM t WHERE id<=3 RETURNING id", ())
+            .unwrap(),
+        0
+    );
+    tx.rollback().unwrap();
+    assert_eq!(
+        db.execute(
+            "INSERT INTO t VALUES (1, 100) ON CONFLICT DO NOTHING RETURNING id",
+            ()
+        )
+        .unwrap(),
+        0
+    );
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM t", ())
+            .unwrap(),
+        4
+    );
+}
+
+#[test]
+fn returning_projection_failure_rolls_back_before_commit_and_reopen() {
+    for cold in [false, true] {
+        let dir = tempfile::tempdir().unwrap();
+        let dsn = format!(
+            "file://{}?checkpoint_interval=3600&sync_mode=full",
+            dir.path().display()
+        );
+        let db = Database::open(&dsn).unwrap();
+        db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER)", ())
+            .unwrap();
+        db.execute("INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)", ())
+            .unwrap();
+        if cold {
+            db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        }
+        for explicit in [false, true] {
+            for sql in [
+                "INSERT INTO t VALUES (4, 40), (5, 50) RETURNING 'x' REGEXP CASE WHEN id=5 THEN '[' ELSE 'x' END",
+                "INSERT INTO t VALUES (4, 40), (5, 50) ON CONFLICT DO NOTHING RETURNING 'x' REGEXP CASE WHEN id=5 THEN '[' ELSE 'x' END",
+                "INSERT INTO t SELECT id+3, n FROM t WHERE id<=2 RETURNING 'x' REGEXP CASE WHEN id=5 THEN '[' ELSE 'x' END",
+                "INSERT INTO t SELECT id+3, n FROM t WHERE id<=2 ON CONFLICT DO NOTHING RETURNING 'x' REGEXP CASE WHEN id=5 THEN '[' ELSE 'x' END",
+                "UPDATE t SET n=n+100 WHERE id<=3 RETURNING 'x' REGEXP CASE WHEN id=3 THEN '[' ELSE 'x' END",
+                "DELETE FROM t WHERE id<=3 RETURNING 'x' REGEXP CASE WHEN id=3 THEN '[' ELSE 'x' END",
+            ] {
+                if explicit {
+                    let mut tx = db.begin().unwrap();
+                    tx.execute("INSERT INTO t VALUES (99, 99)", ()).unwrap();
+                    assert!(tx.execute(sql, ()).is_err(), "{sql}");
+                    assert_eq!(
+                        tx.query_one::<i64, _>("SELECT COUNT(*) FROM t", ())
+                            .unwrap(),
+                        4
+                    );
+                    assert_eq!(
+                        tx.query_one::<i64, _>("SELECT SUM(n) FROM t WHERE id<=3", ())
+                            .unwrap(),
+                        60
+                    );
+                    tx.commit().unwrap();
+                    assert_eq!(
+                        db.query_one::<i64, _>("SELECT n FROM t WHERE id=99", ())
+                            .unwrap(),
+                        99
+                    );
+                    db.execute("DELETE FROM t WHERE id=99", ()).unwrap();
+                } else {
+                    assert!(db.execute(sql, ()).is_err(), "{sql}");
+                }
+                assert_eq!(
+                    db.query_one::<i64, _>("SELECT COUNT(*) FROM t", ())
+                        .unwrap(),
+                    3
+                );
+                assert_eq!(
+                    db.query_one::<i64, _>("SELECT SUM(n) FROM t", ()).unwrap(),
+                    60
+                );
+            }
+        }
+        // A compile-time RETURNING error is also pre-commit.
+        assert!(db
+            .execute("DELETE FROM t RETURNING missing_column", ())
+            .is_err());
+        drop(db);
+        let reopened = Database::open(&dsn).unwrap();
+        assert_eq!(
+            reopened
+                .query_one::<i64, _>("SELECT COUNT(*) FROM t", ())
+                .unwrap(),
+            3
+        );
+        assert_eq!(
+            reopened
+                .query_one::<i64, _>("SELECT SUM(n) FROM t", ())
+                .unwrap(),
+            60
+        );
+    }
+}

--- a/tests/semantic_cache_provenance_test.rs
+++ b/tests/semantic_cache_provenance_test.rs
@@ -1,0 +1,319 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use stoolap::core::{Row, Value};
+use stoolap::executor::semantic_cache::{CacheLookupResult, SemanticCache};
+use stoolap::executor::{ExecutionContext, Executor};
+use stoolap::storage::mvcc::{RowVersion, TransactionVersionStore, RECOVERY_TRANSACTION_ID};
+use stoolap::storage::traits::{Engine, QueryResult};
+use stoolap::{Database, IsolationLevel};
+
+const QUERY: &str = "SELECT * FROM t WHERE id > 0";
+
+fn drain(mut result: Box<dyn QueryResult>) -> Vec<Row> {
+    let mut rows = Vec::new();
+    while result.next() {
+        rows.push(result.row().clone());
+    }
+    assert!(result.last_error().is_none());
+    result.close().unwrap();
+    rows
+}
+fn values(executor: &Executor) -> Vec<(i64, i64)> {
+    let mut rows: Vec<_> = drain(executor.execute(QUERY).unwrap())
+        .iter()
+        .map(|row| {
+            (
+                row.get(0).and_then(Value::as_int64).unwrap(),
+                row.get(1).and_then(Value::as_int64).unwrap(),
+            )
+        })
+        .collect();
+    rows.sort_unstable();
+    rows
+}
+fn fixture() -> (Database, Executor, Executor) {
+    fixture_from(Database::open_in_memory().unwrap())
+}
+fn fixture_from(db: Database) -> (Database, Executor, Executor) {
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10), (2, 20)", ())
+        .unwrap();
+    let reader = Executor::new(Arc::clone(db.engine()));
+    let writer = Executor::new(Arc::clone(db.engine()));
+    (db, reader, writer)
+}
+
+#[test]
+fn cross_executor_truncate_invalidates_before_explicit_transaction_finishes() {
+    for cold in [false, true] {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, reader, writer) = if cold {
+            fixture_from(
+                Database::open(&format!(
+                    "file://{}?checkpoint_interval=3600",
+                    dir.path().display()
+                ))
+                .unwrap(),
+            )
+        } else {
+            fixture()
+        };
+        if cold {
+            db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+            assert_eq!(db.engine().get_version_store("t").unwrap().row_count(), 0);
+        }
+        assert_eq!(values(&reader), vec![(1, 10), (2, 20)]);
+        assert_eq!(values(&reader), vec![(1, 10), (2, 20)]);
+        writer.execute("BEGIN").unwrap();
+        writer.execute("TRUNCATE TABLE t").unwrap();
+        assert!(
+            values(&reader).is_empty(),
+            "TRUNCATE is visible before COMMIT"
+        );
+        writer.execute("ROLLBACK").unwrap();
+        assert!(values(&reader).is_empty());
+        writer.execute("INSERT INTO t VALUES (1, 77)").unwrap();
+        assert_eq!(values(&reader), vec![(1, 77)]);
+    }
+}
+
+#[test]
+fn cold_default_mapping_and_same_name_recreation_change_cache_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let (db, reader, writer) = fixture_from(
+        Database::open(&format!(
+            "file://{}?checkpoint_interval=3600",
+            dir.path().display()
+        ))
+        .unwrap(),
+    );
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    assert_eq!(db.engine().get_version_store("t").unwrap().row_count(), 0);
+    assert_eq!(values(&reader), vec![(1, 10), (2, 20)]);
+    assert_eq!(values(&reader), vec![(1, 10), (2, 20)]);
+    writer.execute("ALTER TABLE t DROP COLUMN v").unwrap();
+    writer
+        .execute("ALTER TABLE t ADD COLUMN v INTEGER DEFAULT 99")
+        .unwrap();
+    assert_eq!(values(&reader), vec![(1, 99), (2, 99)]);
+    writer.execute("DROP TABLE t").unwrap();
+    writer
+        .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)")
+        .unwrap();
+    writer.execute("INSERT INTO t VALUES (1, 77)").unwrap();
+    assert_eq!(values(&reader), vec![(1, 77)]);
+}
+
+#[test]
+fn a_finished_old_scan_inserted_after_invalidation_keeps_its_original_proof() {
+    let (db, reader, writer) = fixture();
+    let epoch = db.engine().capture_read_epoch().unwrap().unwrap();
+    let ctx = ExecutionContext::new().with_read_epoch(epoch.clone());
+    let old_rows = drain(reader.execute_with_context(QUERY, &ctx).unwrap());
+    let proof = db.engine().cache_provenance(&epoch).unwrap();
+    let cache = SemanticCache::new();
+    let columns = vec!["id".to_owned(), "v".to_owned()];
+    writer.execute("INSERT INTO t VALUES (3,30)").unwrap();
+    cache.invalidate_table("t");
+    // The producer resumes after invalidation. Its rows still belong to epoch.
+    cache.insert_with_provenance("t", columns.clone(), old_rows, None, proof);
+    let fresh = db.engine().capture_read_epoch().unwrap().unwrap();
+    let fresh_proof = db.engine().cache_provenance(&fresh).unwrap();
+    assert!(matches!(
+        cache.lookup_with_provenance("t", &columns, None, fresh_proof),
+        CacheLookupResult::Miss
+    ));
+    assert!(matches!(
+        cache.lookup("t", &columns, None),
+        CacheLookupResult::Miss
+    ));
+    assert!(db.engine().cache_provenance(&epoch).is_none());
+    assert_eq!(
+        drain(reader.execute_with_context(QUERY, &ctx).unwrap()).len(),
+        2
+    );
+    assert_eq!(values(&reader).len(), 3);
+}
+
+#[test]
+fn supplied_snapshot_and_private_transaction_reads_do_not_use_shared_results() {
+    let (db, reader, writer) = fixture();
+    assert_eq!(values(&reader).len(), 2);
+    assert_eq!(values(&reader).len(), 2);
+    let mut snapshot = db
+        .engine()
+        .begin_transaction_with_level(IsolationLevel::SnapshotIsolation)
+        .unwrap();
+    let epoch = snapshot.capture_read_epoch().unwrap().unwrap();
+    let ctx = ExecutionContext::new().with_read_epoch(epoch);
+    writer.execute("INSERT INTO t VALUES (3,30)").unwrap();
+    assert_eq!(
+        drain(reader.execute_with_context(QUERY, &ctx).unwrap()).len(),
+        2
+    );
+    assert_eq!(reader.semantic_cache_stats().exact_hits, 1);
+    snapshot.rollback().unwrap();
+    writer.execute("BEGIN").unwrap();
+    writer.execute("INSERT INTO t VALUES (4,40)").unwrap();
+    assert_eq!(values(&writer).len(), 4);
+    writer.execute("ROLLBACK").unwrap();
+    assert_eq!(values(&reader).len(), 3);
+}
+
+#[test]
+fn direct_cold_table_commit_invalidates_before_registry_terminal_outcome() {
+    let dir = tempfile::tempdir().unwrap();
+    let (db, reader, _writer) = fixture_from(
+        Database::open(&format!(
+            "file://{}?checkpoint_interval=3600",
+            dir.path().display()
+        ))
+        .unwrap(),
+    );
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    assert_eq!(db.engine().get_version_store("t").unwrap().row_count(), 0);
+    assert_eq!(values(&reader).len(), 2);
+    assert_eq!(values(&reader).len(), 2);
+    let mut tx = db.engine().begin_transaction().unwrap();
+    let mut table = tx.get_table("t").unwrap();
+    assert_eq!(table.delete_by_row_ids(&[1]).unwrap(), 1);
+    table.commit().unwrap(); // The public compatibility path publishes source 0.
+    assert_eq!(values(&reader), vec![(2, 20)]);
+    tx.commit().unwrap();
+    assert_eq!(values(&reader), vec![(2, 20)]);
+}
+
+#[cfg(feature = "test-failpoints")]
+#[test]
+fn failed_multi_table_publication_does_not_cache_partial_cold_tombstones() {
+    let _guard = stoolap::test_failpoints::FailpointGuard::new();
+    let dir = tempfile::tempdir().unwrap();
+    let (db, reader, writer) = fixture_from(
+        Database::open(&format!(
+            "file://{}?checkpoint_interval=3600",
+            dir.path().display()
+        ))
+        .unwrap(),
+    );
+    db.execute(
+        "CREATE TABLE other_t (id INTEGER PRIMARY KEY, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO other_t VALUES (1,10)", ()).unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    assert_eq!(db.engine().get_version_store("t").unwrap().row_count(), 0);
+    assert_eq!(values(&reader).len(), 2);
+    assert_eq!(values(&reader).len(), 2);
+    writer.execute("BEGIN").unwrap();
+    writer.execute("DELETE FROM t WHERE id=1").unwrap();
+    writer
+        .execute("UPDATE other_t SET v=90 WHERE id=1")
+        .unwrap();
+    stoolap::test_failpoints::fail_table_publish_on(2);
+    assert!(writer.execute("COMMIT").is_err());
+    assert_eq!(values(&reader), vec![(1, 10), (2, 20)]);
+    assert_eq!(values(&reader), vec![(1, 10), (2, 20)]);
+    writer.execute("INSERT INTO t VALUES (3,30)").unwrap();
+    assert_eq!(values(&reader).len(), 3);
+}
+
+#[test]
+fn public_already_visible_version_ingress_invalidates_cached_results() {
+    for operation in 0..4 {
+        let (db, reader, _writer) = fixture();
+        assert_eq!(values(&reader), vec![(1, 10), (2, 20)]);
+        assert_eq!(values(&reader), vec![(1, 10), (2, 20)]);
+        let epoch = db.engine().capture_read_epoch().unwrap().unwrap();
+        assert!(db.engine().cache_provenance(&epoch).is_some());
+        let store = db.engine().get_version_store("t").unwrap();
+        let version = RowVersion::new(
+            RECOVERY_TRANSACTION_ID,
+            Row::from_values(vec![Value::Integer(3), Value::Integer(30)]),
+        );
+        match operation {
+            0 => store.add_version(3, version),
+            1 => store.add_version_single(3, version),
+            2 => store.add_versions_batch(vec![(3, version)]),
+            3 => store.apply_recovered_version(3, version),
+            _ => unreachable!(),
+        }
+        .unwrap();
+        assert!(db.engine().cache_provenance(&epoch).is_none());
+        let expected = vec![(1, 10), (2, 20), (3, 30)];
+        assert_eq!(values(&reader), expected, "operation {operation}");
+        assert_eq!(values(&Executor::new(Arc::clone(db.engine()))), expected);
+        assert_eq!(reader.semantic_cache_stats().exact_hits, 1);
+    }
+}
+
+#[test]
+fn public_recovery_delete_and_physical_removal_invalidate_cached_results() {
+    for physical_remove in [false, true] {
+        let (db, reader, _writer) = fixture();
+        assert_eq!(values(&reader), vec![(1, 10), (2, 20)]);
+        assert_eq!(values(&reader), vec![(1, 10), (2, 20)]);
+        let epoch = db.engine().capture_read_epoch().unwrap().unwrap();
+        assert!(db.engine().cache_provenance(&epoch).is_some());
+        let store = db.engine().get_version_store("t").unwrap();
+        if physical_remove {
+            let (_, snapshot) = store.extract_for_seal(RECOVERY_TRANSACTION_ID);
+            let (removed, _, skipped) = store.remove_sealed_rows(&[1], &snapshot);
+            assert_eq!(removed, 1);
+            assert!(skipped.is_empty());
+            store.subtract_committed_row_count(removed);
+        } else {
+            store.mark_deleted(1, RECOVERY_TRANSACTION_ID).unwrap();
+        }
+        assert!(db.engine().cache_provenance(&epoch).is_none());
+        assert_eq!(values(&reader), vec![(2, 20)]);
+        assert_eq!(
+            values(&Executor::new(Arc::clone(db.engine()))),
+            vec![(2, 20)]
+        );
+    }
+}
+
+#[test]
+fn public_transaction_publication_and_undo_invalidate_already_visible_creator() {
+    let (db, reader, _writer) = fixture();
+    assert_eq!(values(&reader), vec![(1, 10), (2, 20)]);
+    assert_eq!(values(&reader), vec![(1, 10), (2, 20)]);
+    let epoch = db.engine().capture_read_epoch().unwrap().unwrap();
+    let store = db.engine().get_version_store("t").unwrap();
+    // Public low-level TVS callers can reuse a committed creator; no future
+    // registry terminal transition will invalidate a previously captured proof.
+    let creator = store.get_latest_version_id(1).unwrap();
+    let mut local = TransactionVersionStore::new(store, creator);
+    local
+        .put(
+            3,
+            Row::from_values(vec![Value::Integer(3), Value::Integer(30)]),
+            false,
+        )
+        .unwrap();
+    local.prepare_publication().unwrap();
+    local.apply_prepared_publication().unwrap();
+    assert!(db.engine().cache_provenance(&epoch).is_none());
+    assert_eq!(values(&reader), vec![(1, 10), (2, 20), (3, 30)]);
+    assert_eq!(values(&reader), vec![(1, 10), (2, 20), (3, 30)]);
+    let after_apply = db.engine().capture_read_epoch().unwrap().unwrap();
+    assert!(db.engine().cache_provenance(&after_apply).is_some());
+    local.finish_publication(false).unwrap();
+    assert!(db.engine().cache_provenance(&after_apply).is_none());
+    assert_eq!(values(&reader), vec![(1, 10), (2, 20)]);
+}

--- a/tests/statement_read_epoch_test.rs
+++ b/tests/statement_read_epoch_test.rs
@@ -1,0 +1,190 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Fixed statement visibility across compiled, generic, and correlated reads.
+
+use std::sync::Arc;
+use stoolap::executor::{ExecutionContext, Executor};
+use stoolap::storage::mvcc::engine::MVCCEngine;
+use stoolap::storage::traits::QueryResult;
+use stoolap::Value;
+
+fn setup() -> (Arc<MVCCEngine>, Executor) {
+    let engine = Arc::new(MVCCEngine::in_memory());
+    engine.open_engine().unwrap();
+    let executor = Executor::new(engine.clone());
+    executor
+        .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, g INTEGER)")
+        .unwrap();
+    executor.execute("CREATE INDEX t_g ON t(g)").unwrap();
+    executor
+        .execute("CREATE TABLE outer_keys (id INTEGER PRIMARY KEY, g INTEGER)")
+        .unwrap();
+    executor
+        .execute("INSERT INTO t VALUES (1, 10), (2, 10)")
+        .unwrap();
+    executor
+        .execute("INSERT INTO outer_keys VALUES (1, 10), (2, 20)")
+        .unwrap();
+    (engine, executor)
+}
+
+fn rows(mut result: Box<dyn QueryResult>) -> Vec<Vec<Value>> {
+    let mut rows = Vec::new();
+    while result.next() {
+        rows.push(result.take_row().as_slice().to_vec());
+    }
+    assert!(result.last_error().is_none());
+    rows
+}
+
+#[test]
+fn fixed_epoch_covers_cached_plan_compiled_pk_and_aggregate() {
+    #[cfg(feature = "test-failpoints")]
+    let _guard = stoolap::test_failpoints::FailpointGuard::new();
+    let (engine, executor) = setup();
+    let plan = executor
+        .get_or_create_plan("SELECT * FROM t WHERE id = 1")
+        .unwrap();
+    drop(
+        executor
+            .execute_with_cached_plan(&plan, &ExecutionContext::new())
+            .unwrap(),
+    );
+    drop(executor.execute("SELECT COUNT(*) FROM t").unwrap());
+    let ctx = ExecutionContext::new().with_read_epoch(engine.registry().capture_read_epoch());
+    executor
+        .execute("UPDATE t SET g = 20 WHERE id = 1")
+        .unwrap();
+    executor.execute("DELETE FROM t WHERE id = 2").unwrap();
+    executor
+        .execute("INSERT INTO t VALUES (3, 30), (4, 40)")
+        .unwrap();
+    assert_eq!(
+        rows(executor.execute_with_cached_plan(&plan, &ctx).unwrap()),
+        vec![vec![Value::Integer(1), Value::Integer(10)]]
+    );
+    assert_eq!(
+        rows(
+            executor
+                .execute_with_context("SELECT COUNT(*) FROM t", &ctx)
+                .unwrap()
+        ),
+        vec![vec![Value::Integer(2)]]
+    );
+    assert_eq!(
+        rows(
+            executor
+                .execute_with_context("SELECT id, g FROM t ORDER BY id", &ctx)
+                .unwrap()
+        ),
+        vec![
+            vec![Value::Integer(1), Value::Integer(10)],
+            vec![Value::Integer(2), Value::Integer(10)]
+        ]
+    );
+    assert_eq!(
+        rows(executor.execute("SELECT COUNT(*) FROM t").unwrap()),
+        vec![vec![Value::Integer(3)]]
+    );
+}
+
+#[test]
+fn fixed_epoch_keeps_old_secondary_keys_for_correlated_and_anti_reads() {
+    #[cfg(feature = "test-failpoints")]
+    let _guard = stoolap::test_failpoints::FailpointGuard::new();
+    let (engine, executor) = setup();
+    let ctx = ExecutionContext::new().with_read_epoch(engine.registry().capture_read_epoch());
+    executor.execute("UPDATE t SET g = 20").unwrap();
+    assert_eq!(
+        rows(
+            executor
+                .execute_with_context("SELECT g, COUNT(*) FROM t GROUP BY g ORDER BY g", &ctx)
+                .unwrap()
+        ),
+        vec![vec![Value::Integer(10), Value::Integer(2)]]
+    );
+    assert_eq!(
+        rows(
+            executor
+                .execute_with_context(
+                    "SELECT o.id, t.id FROM outer_keys o JOIN t ON o.g = t.g ORDER BY o.id, t.id",
+                    &ctx
+                )
+                .unwrap()
+        ),
+        vec![
+            vec![Value::Integer(1), Value::Integer(1)],
+            vec![Value::Integer(1), Value::Integer(2)]
+        ]
+    );
+
+    assert_eq!(rows(executor.execute_with_context("SELECT id FROM outer_keys o WHERE EXISTS (SELECT 1 FROM t WHERE t.g = o.g) ORDER BY id", &ctx).unwrap()), vec![vec![Value::Integer(1)]]);
+    assert_eq!(rows(executor.execute_with_context("SELECT o.id, (SELECT COUNT(*) FROM t WHERE t.g = o.g) AS n FROM outer_keys o ORDER BY o.id", &ctx).unwrap()), vec![vec![Value::Integer(1), Value::Integer(2)], vec![Value::Integer(2), Value::Integer(0)]]);
+    assert_eq!(rows(executor.execute_with_context("SELECT id FROM outer_keys o WHERE NOT EXISTS (SELECT 1 FROM t WHERE t.g = o.g) ORDER BY id", &ctx).unwrap()), vec![vec![Value::Integer(2)]]);
+}
+
+#[test]
+fn fixed_epoch_dml_does_not_select_later_matching_rows() {
+    #[cfg(feature = "test-failpoints")]
+    let _guard = stoolap::test_failpoints::FailpointGuard::new();
+    let (engine, executor) = setup();
+    let ctx = ExecutionContext::new().with_read_epoch(engine.registry().capture_read_epoch());
+    executor.execute("UPDATE t SET g = 20").unwrap();
+    let updated = executor
+        .execute_with_context("UPDATE t SET g = 99 WHERE g = 20", &ctx)
+        .unwrap();
+    assert_eq!(updated.rows_affected(), 0);
+    let deleted = executor
+        .execute_with_context("DELETE FROM t WHERE g = 20", &ctx)
+        .unwrap();
+    assert_eq!(deleted.rows_affected(), 0);
+    assert_eq!(
+        rows(executor.execute("SELECT g FROM t ORDER BY id").unwrap()),
+        vec![vec![Value::Integer(20)], vec![Value::Integer(20)]]
+    );
+}
+
+#[cfg(feature = "test-failpoints")]
+#[test]
+fn failed_commit_acknowledges_only_after_all_table_undo_and_retained_epoch_release() {
+    use stoolap::storage::traits::Engine;
+    let _guard = stoolap::test_failpoints::FailpointGuard::new();
+    let (engine, executor) = setup();
+    let transaction = engine.begin_transaction().unwrap();
+    let txn_id = transaction.id();
+    executor.install_transaction(transaction);
+    executor.execute("UPDATE t SET g = 99").unwrap();
+    executor.execute("UPDATE outer_keys SET g = 99").unwrap();
+    // This root could have been captured during failed publication. Its
+    // lease must keep the aborted marker even after complete successful undo.
+    let lease = engine.registry().capture_read_epoch();
+    stoolap::test_failpoints::fail_table_publish_on(2);
+    assert!(executor.execute("COMMIT").is_err());
+    engine.registry().run_gc();
+    assert_eq!(engine.registry().get_commit_sequence(txn_id), None);
+    assert_eq!(
+        rows(executor.execute("SELECT SUM(g) FROM t").unwrap()),
+        vec![vec![Value::Integer(20)]]
+    );
+    assert_eq!(
+        rows(executor.execute("SELECT SUM(g) FROM outer_keys").unwrap()),
+        vec![vec![Value::Integer(30)]]
+    );
+    drop(lease);
+    engine.registry().run_gc();
+    // Retired outcome metadata becomes implicit only once no pre-undo root
+    // can refer to the aborted publication.
+    assert_eq!(engine.registry().get_commit_sequence(txn_id), Some(0));
+}

--- a/tests/truncate_epoch_atomicity_test.rs
+++ b/tests/truncate_epoch_atomicity_test.rs
@@ -1,0 +1,181 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "test-failpoints")]
+
+use std::sync::atomic::Ordering;
+#[cfg(not(feature = "test-filedb"))]
+use std::sync::Arc;
+use stoolap::core::IsolationLevel;
+use stoolap::storage::traits::Engine;
+use stoolap::{test_failpoints, Database};
+
+fn fixture() -> (tempfile::TempDir, String, Database) {
+    let dir = tempfile::tempdir().unwrap();
+    let dsn = format!(
+        "file://{}?sync_mode=full&checkpoint_interval=3600",
+        dir.path().display()
+    );
+    let db = Database::open(&dsn).unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, code TEXT UNIQUE)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 'a'), (2, 'b')", ())
+        .unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    db.execute("INSERT INTO t VALUES (3, 'c')", ()).unwrap();
+    (dir, dsn, db)
+}
+
+fn ids(db: &Database) -> Vec<i64> {
+    db.query("SELECT id FROM t ORDER BY id", ())
+        .unwrap()
+        .map(|row| row.unwrap().get(0).unwrap())
+        .collect()
+}
+
+#[test]
+fn wal_write_and_sync_failure_preserve_both_layers_and_reopen() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    for sync_failure in [false, true] {
+        let (_dir, dsn, db) = fixture();
+        let flag = if sync_failure {
+            &test_failpoints::WAL_SYNC_FAIL
+        } else {
+            &test_failpoints::WAL_WRITE_FAIL
+        };
+        flag.store(true, Ordering::Release);
+        let failed = db.execute("TRUNCATE TABLE t", ());
+        flag.store(false, Ordering::Release);
+        assert!(failed.is_err(), "TRUNCATE must report the WAL error");
+        assert_eq!(ids(&db), vec![1, 2, 3]);
+        for (code, expected) in [("a", 1i64), ("b", 2), ("c", 3)] {
+            assert_eq!(
+                db.query_one::<i64, _>("SELECT id FROM t WHERE code = ?", (code,))
+                    .unwrap(),
+                expected
+            );
+        }
+        // The existing WAL failure policy requires reopening for further writes.
+        let _ = db.close();
+        let db = Database::open(&dsn).unwrap();
+        assert_eq!(ids(&db), vec![1, 2, 3]);
+        assert_eq!(db.execute("TRUNCATE TABLE t", ()).unwrap(), 3);
+        db.execute("INSERT INTO t VALUES (1, 'a')", ()).unwrap();
+        db.close().unwrap();
+        let db = Database::open(&dsn).unwrap();
+        assert_eq!(
+            ids(&db),
+            vec![1],
+            "no duplicate TRUNCATE WAL record may erase later INSERT"
+        );
+        db.close().unwrap();
+    }
+}
+
+#[test]
+fn external_epoch_and_delayed_snapshot_block_before_any_table_capture() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let (_dir, _dsn, db) = fixture();
+    let epoch = db.engine().registry().capture_read_epoch();
+    assert!(db.execute("TRUNCATE TABLE t", ()).is_err());
+    assert_eq!(ids(&db), vec![1, 2, 3]);
+    drop(epoch);
+    let mut delayed = db
+        .engine()
+        .begin_transaction_with_level(IsolationLevel::SnapshotIsolation)
+        .unwrap();
+    assert!(db.execute("TRUNCATE TABLE t", ()).is_err());
+    delayed.rollback().unwrap();
+    assert_eq!(db.execute("TRUNCATE TABLE t", ()).unwrap(), 3);
+    assert!(ids(&db).is_empty());
+}
+
+#[test]
+#[cfg(not(feature = "test-filedb"))]
+fn direct_table_private_binding_is_exempt_but_external_strong_and_weak_views_are_not() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let db = Database::open(
+        "memory://direct_table_private_binding_is_exempt_but_external_strong_and_weak_views_are_not",
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, code TEXT UNIQUE)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')", ())
+        .unwrap();
+    let mut tx = db.engine().begin_transaction().unwrap();
+    let mut table = tx.get_table("t").unwrap();
+    let view = table.captured_hot_view().unwrap();
+    let weak = Arc::downgrade(&view);
+    assert!(table.truncate().is_err());
+    assert_eq!(table.row_count().unwrap(), 3);
+    drop(view);
+    assert!(
+        table.truncate().is_err(),
+        "a Weak owner can later upgrade the retained view"
+    );
+    drop(weak);
+    assert_eq!(table.truncate().unwrap(), 3);
+    assert_eq!(table.row_count().unwrap(), 0);
+    drop(table);
+    tx.rollback().unwrap();
+    assert!(
+        ids(&db).is_empty(),
+        "successful physical TRUNCATE remains nonrollbackable"
+    );
+}
+
+#[test]
+fn direct_truncate_checks_current_foreign_keys_after_its_private_epoch() {
+    let _guard = test_failpoints::FailpointGuard::new();
+    for nullable_replacement in [false, true] {
+        let (_dir, _dsn, db) = fixture();
+        db.execute(
+            "CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES t(id))",
+            (),
+        )
+        .unwrap();
+        if nullable_replacement {
+            db.execute("INSERT INTO child VALUES (1, 1)", ()).unwrap();
+            db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        }
+        let mut tx = db
+            .engine()
+            .begin_transaction_with_level(IsolationLevel::SnapshotIsolation)
+            .unwrap();
+        let mut table = tx.get_table("t").unwrap();
+        if nullable_replacement {
+            db.execute("UPDATE child SET parent_id = NULL WHERE id = 1", ())
+                .unwrap();
+            assert_eq!(
+                table.truncate().unwrap(),
+                3,
+                "current HOT NULL must suppress the older cold reference"
+            );
+        } else {
+            db.execute("INSERT INTO child VALUES (1, 1)", ()).unwrap();
+            let error = table.truncate().unwrap_err();
+            assert!(error.to_string().contains("foreign key"), "{error}");
+            assert_eq!(table.row_count().unwrap(), 3);
+        }
+        drop(table);
+        tx.rollback().unwrap();
+        assert_eq!(ids(&db).len(), if nullable_replacement { 0 } else { 3 });
+    }
+}


### PR DESCRIPTION
I bind SQL reads to a fixed hot/cold view and validate cached results against that view's provenance. The source diff spans several thousand lines because point reads, scans, aggregation, DML target selection, result lifetime and file retirement must agree on the same visibility cut; splitting those callers would leave mixed snapshots. Source totals include inline unit tests. This remains a draft with incomplete lifecycle validation.

Statements retain their read epoch, hot root, cold generation and private-write overlay. Visible hot values and tombstones decide authority before filtering. Results retain their reader lease until exhaustion, close or error. Cache entries retain their original visibility proof, and committed mutations invalidate that proof. Cold file leases preserve identity through replacement and retirement.

| Added module | Engine caller |
|---|---|
| mvcc/captured_scanner | SQL hot table scans and ordered scans |
| volume/captured_scanner | SQL cold point reads, scans and DML target lookup |
| volume/captured_aggregate | SQL filtered and grouped aggregates on a captured generation |

I traced all 27 remaining added public types to executor, DML, seal or retirement callers. I removed CapturedHotRowOwned and its cloning convenience API, replace_root, redundant visitor wrappers, the unused registry visibility helper and the snapshot-floor accessor made obsolete by BuildLease. Tests use the active borrowed and early-stop interfaces. This branch inherits the upstream bitmap dependency cleanup and removes all raw measurements.

Before this PR leaves draft, the final read-epoch binding cleanup will delete the legacy SegmentedTable::compute_filtered_aggregates and SegmentedTable::compute_grouped_aggregates bodies. Captured views remain the SQL path; unbound SegmentedTable handles will return Ok(None) for these optional pushdowns. The two direct error fixtures will bind epochs, including a fresh binding after registering another segment, and the obsolete comparison helpers will be removed with those bodies. The existing hot-only MVCCTable fallback is outside that step. The duplicate bodies are still present in this revision.

Read capture retains shared roots/generations and reader leases rather than copying every row or volume payload. Captured scans reuse typed views; per-statement structures and result rows still allocate. This cleanup does not establish zero engine allocations or a whole-engine memory bound.

The SQL cache regression fails against the exact cleaned parent runtime source (2a48586a; identical src/Cargo content to the current parent a6183d38 after its CI-only correction), in this checkout with the test unchanged: another executor commits row 3, but the reader returns only rows 1 and 2. It passes here for INSERT, UPDATE and DELETE. Strict all-target/all-feature Clippy passes; 2,373 targeted library/SQL tests pass (2 excluded), and the corrected test-filedb run passes all 123 applicable tests. The final memory-mode cache/TRUNCATE targets pass all 11 tests after the fixture correction; one run reported a lingering child-process handle. The default in-memory suite with test-failpoints passes: 5,608 tests, 3 excluded, one slow test, no leaked-process notices. The later change only restores the parent CI license check after vendor removal; that exact check and fresh strict Clippy pass locally, with runtime source unchanged.

The first file-backed run was 123 passed/1 failed: a memory-only fixture expected MVCCTable's optional exposed hot-view Arc under SegmentedTable. I restricted that fixture to its supported memory mode, used a unique DSN and kept all three real file-backed TRUNCATE/WAL/foreign-key tests enabled. Independent review verified that this is the required mode distinction, not an engine fix.

The exact-parent negative oracle covers cross-executor cache freshness. Other fixed-view, seal, DML and lifetime tests provide current-source or previously recorded intermediate regression coverage; they are not all exact-parent negative proofs.

Independent cleanup review confirmed lazy cold/aggregate binding, release of the previous decoded group before loading its replacement, and occupied transaction-slot updates without hash-table growth. Exhaustion and terminal poison checks retain explicit panic contracts; the cleanup does not claim to eliminate those failure modes.

The abort/publication exclusion correction is still unapplied. Full coherent-read lifecycle acceptance, the aggregate retirement step and fresh latency/allocation measurements remain incomplete. Historical alternating-run numbers are withdrawn, and previously recorded intermediate regressions are not described as exact-parent proofs. V5 sealing and hard admission are later activation work.

| Diff category | Added | Removed |
|---|---:|---:|
| Source | 13,744 | 1,714 |
| Tests | 3,413 | 10 |
| Docs | 1 | 1 |
| Other | 0 | 0 |
