### PR TITLE
Restore transaction state after failed DML statements

### DIFF
--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -41,6 +41,39 @@ use super::utils::dummy_token_clone;
 use super::Executor;
 use std::sync::RwLock;
 
+struct StatementRollback<'a> {
+    engine: &'a crate::storage::mvcc::MVCCEngine,
+    checkpoint: Option<(i64, i64)>,
+}
+
+impl<'a> StatementRollback<'a> {
+    fn new(
+        engine: &'a crate::storage::mvcc::MVCCEngine,
+        active: Option<&super::ActiveTransaction>,
+    ) -> Self {
+        Self {
+            engine,
+            checkpoint: active
+                .map(|tx| (tx.transaction.id(), crate::storage::mvcc::last_timestamp())),
+        }
+    }
+
+    fn finish<T>(mut self, result: Result<T>) -> Result<T> {
+        if result.is_ok() {
+            self.checkpoint = None;
+        }
+        result
+    }
+}
+
+impl Drop for StatementRollback<'_> {
+    fn drop(&mut self) {
+        if let Some((txn_id, timestamp)) = self.checkpoint {
+            self.engine.rollback_dml_after(txn_id, timestamp);
+        }
+    }
+}
+
 /// Check whether a constraint violation matches the ON CONFLICT target columns.
 /// Returns true if the conflict should be handled (DO UPDATE / DO NOTHING).
 /// Returns false if the violation is on a different constraint, meaning the
@@ -464,6 +497,8 @@ impl Executor {
             }
             None => ctx,
         };
+
+        let statement_rollback = StatementRollback::new(&self.engine, active_tx.as_ref());
 
         let (mut table, should_auto_commit, standalone_tx) =
             if let Some(ref mut tx_state) = *active_tx {
@@ -906,15 +941,16 @@ impl Executor {
 
             // Handle RETURNING clause for INSERT...SELECT
             if has_returning {
-                return self.build_returning_result(
+                return statement_rollback.finish(self.build_returning_result(
                     &stmt.returning,
                     returning_rows,
                     schema_column_names_arc.as_ref().unwrap(),
                     ctx,
-                );
+                ));
             }
 
-            return Ok(Box::new(ExecResult::with_rows_affected(rows_affected)));
+            return statement_rollback
+                .finish(Ok(Box::new(ExecResult::with_rows_affected(rows_affected))));
         }
 
         // Process each row of values - use fast path for normal INSERT, slow path for conflict handling
@@ -1260,15 +1296,15 @@ impl Executor {
 
         // Handle RETURNING clause
         if has_returning {
-            return self.build_returning_result(
+            return statement_rollback.finish(self.build_returning_result(
                 &stmt.returning,
                 returning_rows,
                 schema_column_names_arc.as_ref().unwrap(),
                 ctx,
-            );
+            ));
         }
 
-        Ok(Box::new(ExecResult::with_rows_affected(rows_affected)))
+        statement_rollback.finish(Ok(Box::new(ExecResult::with_rows_affected(rows_affected))))
     }
 
     /// Execute an INSERT statement with compiled cache support
@@ -1290,6 +1326,7 @@ impl Executor {
 
         // Check if there's an active explicit transaction
         let mut active_tx = self.active_transaction.lock().unwrap();
+        let statement_rollback = StatementRollback::new(&self.engine, active_tx.as_ref());
 
         let (mut table, should_auto_commit, standalone_tx) =
             if let Some(ref mut tx_state) = *active_tx {
@@ -1679,15 +1716,15 @@ impl Executor {
 
         // Handle RETURNING clause
         if has_returning {
-            return self.build_returning_result(
+            return statement_rollback.finish(self.build_returning_result(
                 &stmt.returning,
                 returning_rows,
                 schema_column_names_arc.as_ref().unwrap(),
                 ctx,
-            );
+            ));
         }
 
-        Ok(Box::new(ExecResult::with_rows_affected(rows_affected)))
+        statement_rollback.finish(Ok(Box::new(ExecResult::with_rows_affected(rows_affected))))
     }
 
     /// Execute an UPDATE statement
@@ -1742,6 +1779,7 @@ impl Executor {
 
         // Check if there's an active explicit transaction
         let mut active_tx = self.active_transaction.lock().unwrap();
+        let statement_rollback = StatementRollback::new(&self.engine, active_tx.as_ref());
 
         let (mut table, should_auto_commit, standalone_tx) =
             if let Some(ref mut tx_state) = *active_tx {
@@ -2664,12 +2702,17 @@ impl Executor {
         // Handle RETURNING clause
         if has_returning {
             let rows = returning_rows.into_inner();
-            return self.build_returning_result(&stmt.returning, rows, &column_names, ctx);
+            return statement_rollback.finish(self.build_returning_result(
+                &stmt.returning,
+                rows,
+                &column_names,
+                ctx,
+            ));
         }
 
-        Ok(Box::new(ExecResult::with_rows_affected(
+        statement_rollback.finish(Ok(Box::new(ExecResult::with_rows_affected(
             rows_affected as i64,
-        )))
+        ))))
     }
 
     /// Try to extract a constant value from a SET expression for FK pre-validation.
@@ -2727,6 +2770,7 @@ impl Executor {
 
         // Check if there's an active explicit transaction
         let mut active_tx = self.active_transaction.lock().unwrap();
+        let statement_rollback = StatementRollback::new(&self.engine, active_tx.as_ref());
 
         let (mut table, should_auto_commit, standalone_tx) =
             if let Some(ref mut tx_state) = *active_tx {
@@ -3165,17 +3209,17 @@ impl Executor {
 
         // Handle RETURNING clause
         if has_returning {
-            return self.build_returning_result(
+            return statement_rollback.finish(self.build_returning_result(
                 &stmt.returning,
                 returning_rows,
                 &column_names_owned,
                 ctx,
-            );
+            ));
         }
 
-        Ok(Box::new(ExecResult::with_rows_affected(
+        statement_rollback.finish(Ok(Box::new(ExecResult::with_rows_affected(
             rows_affected as i64,
-        )))
+        ))))
     }
 
     /// Execute a TRUNCATE statement

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -9492,23 +9492,6 @@ impl Executor {
         // Check if this is a ROLLBACK TO SAVEPOINT
         if let Some(ref savepoint_name) = stmt.savepoint_name {
             if let Some(ref mut tx_state) = *active_tx {
-                // Get the savepoint timestamp first
-                let timestamp = tx_state
-                    .transaction
-                    .get_savepoint_timestamp(&savepoint_name.value)
-                    .ok_or_else(|| {
-                        Error::invalid_argument(format!(
-                            "savepoint '{}' does not exist",
-                            savepoint_name.value
-                        ))
-                    })?;
-
-                // Rollback each table's local changes that occurred after the savepoint
-                for table in tx_state.tables.values() {
-                    table.rollback_to_timestamp(timestamp);
-                }
-
-                // Rollback to savepoint in the transaction (removes the savepoint and any after it)
                 tx_state
                     .transaction
                     .rollback_to_savepoint(&savepoint_name.value)?;

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -3855,6 +3855,11 @@ impl MVCCEngine {
         Arc::new(EngineOperations::new(self))
     }
 
+    /// Undo one failed statement without changing its transaction or savepoints.
+    pub(crate) fn rollback_dml_after(&self, txn_id: i64, timestamp: i64) {
+        EngineOperations::new(self).rollback_dml_after(txn_id, timestamp);
+    }
+
     // --- View Management Methods ---
 
     /// Create a new view
@@ -7429,39 +7434,6 @@ impl TransactionEngineOperations for EngineOperations {
         Ok(())
     }
 
-    fn get_tables_with_pending_changes(&self, txn_id: i64) -> Result<Vec<Box<dyn Table>>> {
-        let mut tables = Vec::new();
-
-        // O(1) lookup for this transaction's tables (hot changes)
-        let cache = self.txn_version_stores().read().unwrap();
-
-        if let Some(txn_tables) = cache.get(txn_id) {
-            for (table_name, txn_store) in txn_tables.iter() {
-                let has_hot = {
-                    let store = txn_store.read().unwrap();
-                    store.has_local_changes()
-                };
-
-                if has_hot {
-                    let stores = self.version_stores().read().unwrap();
-                    if let Some(version_store) = stores.get(table_name.as_str()).cloned() {
-                        drop(stores);
-
-                        let table = MVCCTable::new_with_shared_store(
-                            txn_id,
-                            Arc::clone(&version_store),
-                            Arc::clone(txn_store),
-                        );
-
-                        tables.push(Box::new(table) as Box<dyn Table>);
-                    }
-                }
-            }
-        }
-
-        Ok(tables)
-    }
-
     fn has_pending_dml_changes(&self, txn_id: i64) -> bool {
         // Check hot-side DML changes
         let cache = self.txn_version_stores().read().unwrap();
@@ -7784,9 +7756,7 @@ impl TransactionEngineOperations for EngineOperations {
         }
     }
 
-    fn rollback_tombstones_after(&self, txn_id: i64, timestamp: i64) {
-        // Same lock order as rollback_all_tables: the txn cache is released
-        // before the segment managers are read.
+    fn rollback_dml_after(&self, txn_id: i64, timestamp: i64) {
         let cache = self.txn_version_stores().read().unwrap();
         let touched: smallvec::SmallVec<
             [(
@@ -7804,17 +7774,24 @@ impl TransactionEngineOperations for EngineOperations {
             .unwrap_or_default();
         drop(cache);
 
-        if touched.is_empty() {
-            return;
-        }
-        let mgrs = self.segment_managers.read().unwrap();
         for (name, txn_store) in &touched {
-            if let Some(mgr) = mgrs.get(name.as_str()) {
-                let discarded = mgr.rollback_pending_tombstones_after(txn_id, timestamp);
-                if !discarded.is_empty() {
-                    txn_store.write().unwrap().release_claims(&discarded);
-                }
-            }
+            let mgr = self
+                .segment_managers
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .get(name.as_str())
+                .cloned();
+            let mut pending = if let Some(mgr) = mgr {
+                mgr.rollback_pending_tombstones_after(txn_id, timestamp);
+                mgr.get_pending_tombstones(txn_id)
+            } else {
+                Vec::new()
+            };
+            pending.sort_unstable();
+            txn_store
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .rollback_to_timestamp_with_pending(timestamp, &pending);
         }
     }
 

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -70,6 +70,7 @@ pub use snapshot::{DiskVersionStore, SnapshotReader, SnapshotWriter};
 pub use streaming_result::{AggregationScanner, StreamingResult, VisibleRowInfo};
 pub use table::MVCCTable;
 pub use timestamp::get_fast_timestamp;
+pub(crate) use timestamp::last_timestamp;
 pub use transaction::{
     MvccTransaction, SealFenceGuard, TransactionEngineOperations, TransactionState,
 };

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -3197,11 +3197,11 @@ impl Table for MVCCTable {
         self.txn_versions.write().unwrap().rollback();
     }
 
-    fn rollback_to_timestamp(&self, timestamp: i64) {
+    fn rollback_to_timestamp_with_pending(&self, timestamp: i64, pending: &[i64]) {
         self.txn_versions
             .write()
             .unwrap()
-            .rollback_to_timestamp(timestamp);
+            .rollback_to_timestamp_with_pending(timestamp, pending);
     }
 
     fn has_local_changes(&self) -> bool {

--- a/src/storage/mvcc/timestamp.rs
+++ b/src/storage/mvcc/timestamp.rs
@@ -25,6 +25,11 @@ use crate::common::time_compat::{SystemTime, UNIX_EPOCH};
 /// Global state for timestamp generation - tracks last issued timestamp
 static LAST_TIMESTAMP: AtomicI64 = AtomicI64::new(0);
 
+/// Latest issued timestamp for a serialized statement boundary.
+pub(crate) fn last_timestamp() -> i64 {
+    LAST_TIMESTAMP.load(Ordering::Acquire)
+}
+
 /// Returns a monotonically increasing timestamp suitable for transaction
 /// ordering and version tracking.
 ///

--- a/src/storage/mvcc/transaction.rs
+++ b/src/storage/mvcc/transaction.rs
@@ -115,9 +115,6 @@ pub trait TransactionEngineOperations: Send + Sync {
     /// Record rollback in WAL
     fn record_rollback(&self, txn_id: i64) -> Result<()>;
 
-    /// Get all tables with pending changes for a transaction
-    fn get_tables_with_pending_changes(&self, txn_id: i64) -> Result<Vec<Box<dyn Table>>>;
-
     /// Check if transaction has any pending DML changes (without allocating)
     fn has_pending_dml_changes(&self, txn_id: i64) -> bool;
 
@@ -156,9 +153,8 @@ pub trait TransactionEngineOperations: Send + Sync {
         let _ = hold;
     }
 
-    /// Discard the cold-row tombstones the transaction made after a timestamp
-    /// (savepoint rollback). Engines without cold storage have none.
-    fn rollback_tombstones_after(&self, _txn_id: i64, _timestamp: i64) {}
+    /// Discard later DML across all touched tables, including cold claims.
+    fn rollback_dml_after(&self, txn_id: i64, timestamp: i64);
 
     /// Defer table cleanup to background thread (avoids synchronous deallocation)
     /// Default implementation drops synchronously
@@ -375,14 +371,8 @@ impl MvccTransaction {
         let position = self.savepoint_position(name)?;
         let sp_state = self.savepoints[position].1;
 
-        // Rollback DML changes via engine operations (not self.tables which is empty)
         if let Some(ops) = &self.engine_operations {
-            if let Ok(tables) = ops.get_tables_with_pending_changes(self.id) {
-                for table in &tables {
-                    table.rollback_to_timestamp(sp_state.timestamp);
-                }
-            }
-            ops.rollback_tombstones_after(self.id, sp_state.timestamp);
+            ops.rollback_dml_after(self.id, sp_state.timestamp);
         }
 
         // Rollback DDL: undo CREATE TABLEs after savepoint

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -7641,36 +7641,41 @@ impl TransactionVersionStore {
         self.release_all_claims();
     }
 
-    /// Rollback to a specific timestamp (for savepoint support)
-    ///
-    /// Discards all local changes that were made after the given timestamp.
-    /// For rows with version history, keeps versions at or before the timestamp.
-    /// Row claims are released only if all versions for that row are discarded.
+    /// Discard later local versions and release claims with no surviving write.
     pub fn rollback_to_timestamp(&mut self, timestamp: i64) {
-        let Some(local_versions) = self.local_versions.as_mut() else {
+        self.rollback_to_timestamp_with_pending(timestamp, &[]);
+    }
+
+    /// Retain claims for surviving cold tombstones as well as local versions.
+    /// `pending` contains sorted row IDs after the cold rollback.
+    pub(crate) fn rollback_to_timestamp_with_pending(&mut self, timestamp: i64, pending: &[i64]) {
+        debug_assert!(pending.windows(2).all(|pair| pair[0] < pair[1]));
+        if let Some(local_versions) = self.local_versions.as_mut() {
+            local_versions.retain(|_, versions| {
+                versions.retain(|v| v.create_time <= timestamp);
+                !versions.is_empty()
+            });
+        }
+        let Some(write_set) = self.write_set.as_mut() else {
             return;
         };
-
-        let mut rows_to_remove_completely: Vec<i64> = Vec::new();
-
-        // For each row, remove versions with create_time > timestamp
-        for (row_id, versions) in local_versions.iter_mut() {
-            // Keep only versions at or before the timestamp
-            versions.retain(|v| v.create_time <= timestamp);
-
-            // If all versions are removed, mark for complete removal
-            if versions.is_empty() {
-                rows_to_remove_completely.push(row_id);
-            }
+        let mut released: Vec<i64> = write_set
+            .keys()
+            .filter(|&row_id| {
+                !self
+                    .local_versions
+                    .as_ref()
+                    .is_some_and(|versions| versions.contains_key(row_id))
+                    && pending.binary_search(&row_id).is_err()
+            })
+            .collect();
+        for &row_id in &released {
+            write_set.remove(row_id);
         }
-
-        // Remove rows with no remaining versions and release their claims
-        for row_id in &rows_to_remove_completely {
-            local_versions.remove(*row_id);
-            self.parent_store.release_row_claim(*row_id, self.txn_id);
-            if let Some(write_set) = self.write_set.as_mut() {
-                write_set.remove(*row_id);
-            }
+        if !released.is_empty() {
+            released.sort_unstable();
+            self.parent_store
+                .release_row_claims_batch(&released, self.txn_id);
         }
     }
 
@@ -7689,30 +7694,6 @@ impl TransactionVersionStore {
                 read_version: None,
                 read_version_seq: 0,
             });
-        }
-    }
-
-    /// Release the claims on rows this transaction no longer changes (savepoint
-    /// rollback of cold-row tombstones). A row that still has a local version
-    /// keeps its claim.
-    pub fn release_claims(&mut self, row_ids: &[i64]) {
-        let Some(write_set) = self.write_set.as_mut() else {
-            return;
-        };
-        let mut released: Vec<i64> = Vec::with_capacity(row_ids.len());
-        for &row_id in row_ids {
-            let has_local_version = self
-                .local_versions
-                .as_ref()
-                .is_some_and(|versions| versions.contains_key(row_id));
-            if !has_local_version && write_set.remove(row_id).is_some() {
-                released.push(row_id);
-            }
-        }
-        if !released.is_empty() {
-            released.sort_unstable();
-            self.parent_store
-                .release_row_claims_batch(&released, self.txn_id);
         }
     }
 

--- a/src/storage/traits/table.rs
+++ b/src/storage/traits/table.rs
@@ -592,7 +592,12 @@ pub trait Table: Send + Sync {
     ///
     /// # Arguments
     /// * `timestamp` - The timestamp to roll back to (in nanoseconds since epoch)
-    fn rollback_to_timestamp(&self, timestamp: i64);
+    fn rollback_to_timestamp(&self, timestamp: i64) {
+        self.rollback_to_timestamp_with_pending(timestamp, &[]);
+    }
+
+    /// Roll back local versions while retaining sorted pending cold-row claims.
+    fn rollback_to_timestamp_with_pending(&self, timestamp: i64, pending: &[i64]);
 
     /// Returns true if this table has uncommitted local changes
     ///

--- a/src/storage/volume/manifest.rs
+++ b/src/storage/volume/manifest.rs
@@ -1799,7 +1799,8 @@ impl SegmentManager {
             .write()
             .entry(txn_id)
             .or_default()
-            .insert(row_id, get_fast_timestamp());
+            .entry(row_id)
+            .or_insert_with(get_fast_timestamp);
     }
 
     /// Get pending tombstone row_ids for a transaction (for WAL recording).

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -3925,8 +3925,16 @@ impl Table for SegmentedTable {
         self.segment_mgr.clear_txn_seal_generation(txn_id);
     }
 
-    fn rollback_to_timestamp(&self, timestamp: i64) {
-        self.hot.rollback_to_timestamp(timestamp);
+    fn rollback_to_timestamp_with_pending(&self, timestamp: i64, retained: &[i64]) {
+        let txn_id = self.txn_id();
+        self.segment_mgr
+            .rollback_pending_tombstones_after(txn_id, timestamp);
+        let mut pending = self.segment_mgr.get_pending_tombstones(txn_id);
+        pending.extend_from_slice(retained);
+        pending.sort_unstable();
+        pending.dedup();
+        self.hot
+            .rollback_to_timestamp_with_pending(timestamp, &pending);
     }
 
     fn has_local_changes(&self) -> bool {
@@ -6350,7 +6358,7 @@ mod tests {
             Ok(())
         }
         fn rollback(&mut self) {}
-        fn rollback_to_timestamp(&self, _: i64) {}
+        fn rollback_to_timestamp_with_pending(&self, _: i64, _: &[i64]) {}
         fn has_local_changes(&self) -> bool {
             false
         }

--- a/tests/statement_atomicity_test.rs
+++ b/tests/statement_atomicity_test.rs
@@ -1,0 +1,247 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use stoolap::core::{DataType, Row, SchemaBuilder, Value};
+use stoolap::storage::mvcc::{
+    get_fast_timestamp, MVCCTable, TransactionVersionStore, VersionStore,
+};
+use stoolap::storage::traits::Table;
+use stoolap::storage::volume::manifest::SegmentManager;
+use stoolap::storage::volume::table::SegmentedTable;
+use stoolap::Database;
+
+fn values(db: &Database) -> Vec<i64> {
+    db.query("SELECT v FROM t ORDER BY id", ())
+        .unwrap()
+        .map(|r| r.unwrap().get::<i64>(0).unwrap())
+        .collect()
+}
+
+#[test]
+fn failed_insert_preserves_prior_statement_and_savepoint() {
+    let db =
+        Database::open("memory://failed_insert_preserves_prior_statement_and_savepoint").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER CHECK (v > 0))",
+        (),
+    )
+    .unwrap();
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10)", ()).unwrap();
+    db.execute("SAVEPOINT saved", ()).unwrap();
+    assert!(db
+        .execute("INSERT INTO t VALUES (2, 20), (3, -1)", ())
+        .is_err());
+    assert_eq!(values(&db), [10]);
+    db.execute("INSERT INTO t VALUES (4, 40)", ()).unwrap();
+    db.execute("ROLLBACK TO saved", ()).unwrap();
+    assert_eq!(values(&db), [10]);
+    db.execute("COMMIT", ()).unwrap();
+    assert_eq!(values(&db), [10]);
+}
+
+#[test]
+fn failed_prepared_insert_preserves_transaction_overlay() {
+    let db =
+        Database::open("memory://failed_prepared_insert_preserves_transaction_overlay").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER CHECK (v > 0))",
+        (),
+    )
+    .unwrap();
+    let insert = db
+        .prepare("INSERT INTO t VALUES ($1, $2), ($3, $4)")
+        .unwrap();
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10)", ()).unwrap();
+    for first_id in [2, 4] {
+        assert!(insert.execute((first_id, 20, first_id + 1, -1)).is_err());
+        assert_eq!(values(&db), [10]);
+    }
+    db.execute("COMMIT", ()).unwrap();
+    assert_eq!(values(&db), [10]);
+}
+
+#[test]
+fn failed_insert_select_rolls_back_destination_writes() {
+    let db = Database::open("memory://failed_insert_select_rolls_back_destination_writes").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER CHECK (v > 0))",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE source (id INTEGER PRIMARY KEY, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO source VALUES (2, 20), (3, -1)", ())
+        .unwrap();
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10)", ()).unwrap();
+    assert!(db
+        .execute("INSERT INTO t SELECT * FROM source ORDER BY id", ())
+        .is_err());
+    assert_eq!(values(&db), [10]);
+    db.execute("COMMIT", ()).unwrap();
+    assert_eq!(values(&db), [10]);
+}
+
+#[test]
+fn failed_cold_update_releases_claim_without_a_local_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open(&format!("file://{}/claims", dir.path().display())).unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER UNIQUE)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10), (2, 20)", ())
+        .unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    db.execute("BEGIN", ()).unwrap();
+    assert!(db.execute("UPDATE t SET v = 20 WHERE id = 1", ()).is_err());
+    let other = db.clone();
+    assert_eq!(
+        other
+            .execute("UPDATE t SET v = 11 WHERE id = 1", ())
+            .unwrap(),
+        1
+    );
+    db.execute("COMMIT", ()).unwrap();
+    assert_eq!(values(&db), [11, 20]);
+}
+
+#[test]
+fn repeated_pending_tombstone_keeps_its_original_boundary() {
+    let manager = SegmentManager::new(
+        "repeated_pending_tombstone_keeps_its_original_boundary",
+        None,
+    );
+    manager.add_pending_tombstone(1, 1);
+    let boundary = get_fast_timestamp();
+    manager.add_pending_tombstone(1, 1);
+    manager.add_pending_tombstone(1, 2);
+    manager.rollback_pending_tombstones_after(1, boundary);
+    assert!(manager.is_pending_tombstone(1, 1));
+    assert!(!manager.is_pending_tombstone(1, 2));
+}
+
+#[test]
+fn table_rollback_keeps_the_claim_for_an_earlier_cold_delete() {
+    let schema = SchemaBuilder::new("table_rollback_keeps_the_claim_for_an_earlier_cold_delete")
+        .column("id", DataType::Integer, false, true)
+        .build();
+    let store = Arc::new(VersionStore::new(schema.table_name.clone(), schema));
+    let mut local = TransactionVersionStore::new(Arc::clone(&store), 1);
+    let manager = Arc::new(SegmentManager::new("retained_claim", None));
+    store.try_claim_row(1, 1).unwrap();
+    local.track_external_claim(1);
+    manager.add_pending_tombstone(1, 1);
+    let boundary = get_fast_timestamp();
+    local
+        .put(1, Row::from_values(vec![Value::Integer(1)]), false)
+        .unwrap();
+    let hot = MVCCTable::new(1, Arc::clone(&store), local);
+    let table = SegmentedTable::new(Box::new(hot), Arc::clone(&manager));
+    table.rollback_to_timestamp(boundary);
+    assert!(manager.is_pending_tombstone(1, 1));
+    assert!(store.try_claim_row(1, 2).is_err());
+    table.rollback_to_timestamp(0);
+    assert!(!manager.is_pending_tombstone(1, 1));
+    store.try_claim_row(1, 2).unwrap();
+}
+
+#[test]
+fn returning_error_undoes_each_dml_path_in_transaction_api() {
+    let db =
+        Database::open("memory://returning_error_undoes_each_dml_path_in_transaction_api").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    tx.execute("INSERT INTO t VALUES (1, 10)", ()).unwrap();
+    for sql in [
+        "INSERT INTO t VALUES (2, 20) RETURNING REGEXP_LIKE('x', '[')",
+        "INSERT INTO t SELECT 2, 20 RETURNING REGEXP_LIKE('x', '[')",
+        "INSERT INTO t VALUES (1, 20) ON CONFLICT (id) DO UPDATE SET v = 20 RETURNING REGEXP_LIKE('x', '[')",
+        "UPDATE t SET v = 20 WHERE id = 1 RETURNING REGEXP_LIKE('x', '[')",
+        "DELETE FROM t WHERE id = 1 RETURNING REGEXP_LIKE('x', '[')",
+    ] {
+        assert!(tx.execute(sql, ()).is_err(), "{sql}");
+        assert_eq!(tx.query_one::<i64, _>("SELECT COUNT(*) FROM t", ()).unwrap(), 1, "{sql}");
+        assert_eq!(tx.query_one::<i64, _>("SELECT v FROM t WHERE id = 1", ()).unwrap(), 10, "{sql}");
+    }
+    tx.commit().unwrap();
+    assert_eq!(values(&db), [10]);
+}
+
+#[test]
+fn failed_cascade_restores_every_touched_table() {
+    let db = Database::open("memory://failed_cascade_restores_every_touched_table").unwrap();
+    db.execute("CREATE TABLE parents (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    db.execute("CREATE TABLE children (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parents(id) ON DELETE CASCADE, v INTEGER)", ()).unwrap();
+    db.execute("INSERT INTO parents VALUES (1), (2)", ())
+        .unwrap();
+    db.execute("INSERT INTO children VALUES (1, 1, 10), (2, 2, 20)", ())
+        .unwrap();
+    let other = db.clone();
+    let mut blocker = other.begin().unwrap();
+    blocker
+        .execute("UPDATE children SET v = 21 WHERE id = 2", ())
+        .unwrap();
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("INSERT INTO parents VALUES (3)", ()).unwrap();
+    assert!(db
+        .execute("DELETE FROM parents WHERE id IN (1, 2)", ())
+        .is_err());
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM parents", ())
+            .unwrap(),
+        3
+    );
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM children", ())
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        other
+            .execute("UPDATE children SET v = 11 WHERE id = 1", ())
+            .unwrap(),
+        1
+    );
+    blocker.rollback().unwrap();
+    db.execute("COMMIT", ()).unwrap();
+}
+
+#[test]
+fn prepared_returning_error_undoes_its_insert() {
+    let db = Database::open("memory://prepared_returning_error_undoes_its_insert").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    let insert = db
+        .prepare("INSERT INTO t VALUES ($1, $2) RETURNING REGEXP_LIKE('x', $3)")
+        .unwrap();
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10)", ()).unwrap();
+    for id in [2, 3] {
+        assert!(insert.execute((id, 20, "[")).is_err());
+        assert_eq!(values(&db), [10]);
+    }
+    db.execute("COMMIT", ()).unwrap();
+    assert_eq!(values(&db), [10]);
+}


### PR DESCRIPTION
I made failed DML statements inside an explicit transaction restore the state from before that statement. For example, if the second row of a multi-row INSERT fails a CHECK constraint, neither row from that INSERT remains pending, and earlier successful statements can still commit.

I capture an anonymous boundary from the issued MVCC timestamp while holding the existing transaction mutex. INSERT, prepared INSERT, UPDATE and DELETE keep that boundary active through RETURNING evaluation. On failure I undo changes in every touched engine table, including cascade tables, and release claims only when neither an earlier local version nor an earlier pending cold tombstone still needs them. A repeated pending tombstone keeps its first timestamp. Named savepoints use the same cleanup.

This is the first small prerequisite PR for Stage 1 of #122. The next stacked prerequisites move autocommit RETURNING evaluation before commit and make group, identity and cold access fallible over the current format. I will leave this PR unmerged.

Cost: one atomic load per successful explicit DML statement, no new success-path allocation or mutex, and no new per-row or per-volume storage. Failed-statement cleanup traverses transaction histories and allocates temporary row-ID buffers. It does not yet provide the prepaid undo required for memory admission in K8.

I validated the change with:

- Nine regression tests fail on the same checkout with only the production patch reverted, then pass with it restored.
- 89 touched tests pass in memory and with test-filedb; the default profile skips the existing wall-clock test.
- Formatting and all-target, all-feature clippy with warnings denied pass.
- Independent source review, fixes and re-review found no remaining correctness blockers.
- The full in-memory suite passed 5,300 tests, with three default-profile skips and one leaky annotation. The annotated INSERT SELECT restart target then passed both tests in isolation without the annotation.
- Seven allocation runs per transaction mode have exactly the same allocation counts, allocated bytes, retained bytes and peak bytes as the baseline. The longer hot DML and repeated PK-ordered scan probes show no measurable regression.

I compared main (`9cf15ea4`) with this patch on an Apple M5 using release opt-level 3, thin LTO, one codegen unit and default features, with no builds or unrelated heavy jobs during measurements. Each build ran in contiguous blocks of at least seven processes. Longer hot runs used 500,000 INSERT/UPDATE/point cycles per process. The file probe used 131,072 sealed rows across 174 keys, 10,000 explicit transactions at 1,000/s, and both idle and mixed workloads at 16/64 MiB GROUP_CACHE_MB. Mixed runs performed exactly 10,000 analytics and 50 ingest/checkpoint batches on separate handles at fixed arrival times, including existing compaction policy. Foreground throughput stayed at 1,000.048-1,000.068 transactions/s with zero errors or dropped work.

I recorded the following per-process quantile ranges in microseconds, shown as p50 / p95 / p99. Hot ranges use seven runs per build; file baseline ranges combine the two seven-run control blocks.

| Shape | Operation | Baseline ranges | Candidate ranges |
|---|---|---|---|
| Hot explicit | insert | 0.375-0.416 / 0.458-0.459 / 0.459-0.500 | 0.375-0.417 / 0.458-0.459 / 0.459-0.500 |
| Hot explicit | update | 0.750-0.791 / 0.834-0.875 / 0.958-1.042 | 0.750-0.791 / 0.834-0.875 / 0.959-1.042 |
| Hot explicit | point | 0.709-0.750 / 0.792-0.834 / 0.875-0.958 | 0.709-0.750 / 0.750-0.833 / 0.833-0.917 |
| Hot auto | insert | 0.709-0.750 / 0.875-0.875 / 1.041-1.125 | 0.750-0.750 / 0.834-0.875 / 1.000-1.084 |
| Hot auto | update | 0.667-0.708 / 0.834-0.875 / 0.917-0.959 | 0.667-0.708 / 0.833-0.875 / 0.917-0.959 |
| Hot auto | point | 0.875-0.917 / 1.000-1.042 / 1.125-1.166 | 0.875-0.917 / 1.000-1.042 / 1.084-1.167 |
| File 16-idle | insert | 5.708-6.084 / 7.542-8.292 / 9.417-11.458 | 5.875-6.125 / 7.834-8.125 / 9.625-10.500 |
| File 16-idle | update | 30.416-30.917 / 43.625-49.666 / 54.834-65.625 | 30.375-30.583 / 45.083-47.791 / 58.334-61.500 |
| File 16-idle | point | 8.750-8.958 / 11.000-11.667 / 12.958-15.584 | 8.750-8.958 / 11.250-11.542 / 13.792-15.167 |
| File 16-mixed | insert | 1.750-1.916 / 2.500-2.750 / 4.709-6.584 | 1.750-1.917 / 2.542-2.875 / 3.667-6.041 |
| File 16-mixed | update | 37.834-42.792 / 51.625-63.542 / 63.458-145.583 | 36.084-39.583 / 48.792-54.083 / 56.958-64.792 |
| File 16-mixed | point | 10.541-12.541 / 14.417-17.917 / 17.625-20.083 | 10.458-11.750 / 13.959-16.583 / 17.000-18.709 |
| File 64-idle | insert | 5.791-6.125 / 7.666-8.625 / 9.417-11.334 | 5.917-6.125 / 7.917-8.292 / 9.542-11.042 |
| File 64-idle | update | 30.459-31.458 / 42.875-52.417 / 54.000-68.375 | 30.042-30.708 / 44.125-48.041 / 57.459-62.667 |
| File 64-idle | point | 8.708-8.917 / 10.959-12.208 / 13.167-14.875 | 8.584-8.833 / 10.917-11.416 / 13.333-14.917 |
| File 64-mixed | insert | 1.709-1.875 / 2.417-2.709 / 4.209-6.375 | 1.791-2.000 / 2.375-2.916 / 4.500-5.208 |
| File 64-mixed | update | 39.459-42.542 / 53.125-62.375 / 70.916-145.625 | 36.791-39.791 / 46.208-56.917 / 52.250-71.458 |
| File 64-mixed | point | 11.125-12.208 / 15.292-18.125 / 18.250-20.542 | 10.417-11.333 / 14.041-16.750 / 17.041-18.875 |

I also measured full transaction latency, scheduling delay and peak process RSS for the fixed workload:

| Shape | Transaction baseline p50 / p95 / p99 | Transaction candidate p50 / p95 / p99 | RSS baseline / candidate, MiB |
|---|---|---|---|
| 16-idle | 81.625-83.084 / 105.375-112.208 / 124.542-142.084 | 81.792-82.417 / 107.000-110.375 / 130.833-136.042 | 121.172-124.562 / 119.438-123.062 |
| 16-mixed | 63.875-73.709 / 2562.750-3029.750 / 4394.875-6322.750 | 60.792-67.375 / 2493.500-2791.000 / 4169.333-5996.208 | 181.141-186.500 / 180.188-184.156 |
| 64-idle | 81.834-83.667 / 103.917-118.666 / 123.542-146.541 | 81.125-82.792 / 105.541-110.791 / 126.250-141.125 | 121.484-124.969 / 119.453-123.625 |
| 64-mixed | 65.917-73.166 / 2492.459-2807.042 / 5073.250-6079.792 | 62.167-66.167 / 2592.500-2854.917 / 4320.500-6048.125 | 180.422-185.344 / 179.375-185.312 |

Mixed foreground scheduling-delay p99 ranges were 8.382-14.818 ms in the controls and 8.327-8.567 ms in the candidate. I kept these delays separate from operation service time.

For 1,000 complete hot cycles, all seven instrumented runs per mode had identical baseline and candidate totals:

| Mode | Allocation count | Allocated bytes | Retained bytes | Peak heap bytes |
|---|---:|---:|---:|---:|
| Explicit | 82,013 | 4,376,000 | 1,022,363 | 1,024,200 |
| Autocommit | 71,014 | 4,467,304 | 1,115,014 | 1,116,415 |

Counts and allocated bytes cover the measured batch; retained/peak bytes include setup, warmup and probe buffers. I measured timing with the allocator profiler disabled. The separate 1,024-row ordered-scan probe warmed 1,000 scans and measured 10,000 scans per process. Its p50/p95/p99 ranges were 17.375-17.834 / 17.791-23.000 / 19.167-30.208 us across the control blocks and 17.208-17.709 / 17.750-22.792 / 20.541-26.500 us in the candidate.

An earlier completion-paced probe showed a roughly 5% mixed point-read median increase. I replaced that confounded comparison with fixed work and measured two same-binary control blocks. Their mixed point medians differed by about 1.9%; the controlled candidate medians were lower than both controls at both budgets. Independent re-review found no remaining repeatable row-latency regression for the measured shapes.

I still observed an isolated 64 MiB idle INSERT median increase of about 2.1%, to 6.041 us from about 5.916 us. Its per-run p50/p95/p99 values remain within the control ranges, and it did not repeat in the independent earlier long idle comparison or continuous hot probe. Mixed analytic service medians rose to 659.500/658.416 us versus control medians of 634.334-641.542 us, with equal work counts and generally lower analytic scheduling delay. I am not claiming a columnar speedup.

I have not changed the file format, cold-column decoding, residency, snapshot fallback, or WAL coverage. Whole-column reads still bypass GROUP_CACHE_MB, so these settings are not engine-wide limits. I did not measure per-ledger allocations, block I/O/copy counts or seal-fence distributions, or run the full stress profile and future-format tests. The existing autocommit RETURNING-after-commit ordering is unchanged here and is the next Stage 1 prerequisite. This PR addresses explicit-transaction rollback before those later storage changes.
