### PR TITLE
Run CI for stacked storage pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'storage/**' ]
 
 # Cancel previous runs when new commits are pushed
 concurrency:


### PR DESCRIPTION
I enable the existing CI workflow for pull requests targeting `storage/**` branches so each unmerged storage prerequisite can be checked against its predecessor. This PR is stacked on #124. The first storage PR still targets `main`.

I validated the workflow with actionlint 1.7.12 and ran `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings`. The pre-push in-memory suite passed 5,300 tests, with 3 skipped. Independent review and final re-review found no issues. GitHub started all 13 expected jobs for this stacked PR in run 34393783099; their final outcomes are pending.

I changed only the pull request base-branch filter. Push triggers, CI jobs and database code retain their current behavior. There are no added per-row or per-volume costs. No Rust test target was touched, and I did not rerun file-backed tests or performance probes for this workflow-only change.
