### PR TITLE
Roll back autocommit writes when RETURNING fails

### DIFF
--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -25,7 +25,7 @@ use crate::common::SmartString;
 use crate::core::{DataType, Error, Result, Row, RowVec, Schema, Value, ValueMap};
 use crate::parser::ast::*;
 use crate::storage::expression::{ComparisonExpr, Expression as StorageExpr};
-use crate::storage::traits::{Engine, QueryResult, Table};
+use crate::storage::traits::{Engine, QueryResult, Table, Transaction};
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
@@ -36,7 +36,7 @@ use super::context::{
 use super::expression::CompiledEvaluator;
 use super::pushdown;
 use super::query_cache::{CompiledExecution, CompiledInsert};
-use super::result::ExecResult;
+use super::result::{ExecResult, ExecutorResult};
 use super::utils::dummy_token_clone;
 use super::Executor;
 use std::sync::RwLock;
@@ -910,6 +910,17 @@ impl Executor {
                 invalidate_in_subquery_cache_for_table(table_name);
             }
 
+            let mut returning_result = if let Some(column_names) = &schema_column_names_arc {
+                Some(self.build_returning_result(
+                    &stmt.returning,
+                    returning_rows,
+                    column_names,
+                    ctx,
+                )?)
+            } else {
+                None
+            };
+
             // Commit if this is a standalone (auto-commit) transaction
             if should_auto_commit {
                 if let Some(mut tx) = standalone_tx {
@@ -922,6 +933,7 @@ impl Executor {
                             if stmt.on_duplicate && ctx.query_depth == 0 {
                                 // Commit-time PK/unique violation during upsert:
                                 // a concurrent plain INSERT committed first. Retry once.
+                                drop(returning_result);
                                 drop(_upsert_guard);
                                 let retry_ctx = ctx.with_incremented_query_depth();
                                 return self.execute_insert(stmt, &retry_ctx);
@@ -929,7 +941,11 @@ impl Executor {
                             if stmt.do_nothing {
                                 // DO NOTHING: returning 0 rows is the correct semantic
                                 rows_affected = 0;
-                                returning_rows.clear();
+                                if let Some(result) = &mut returning_result {
+                                    *result = Box::new(ExecutorResult::with_columns(
+                                        result.columns().to_vec(),
+                                    ));
+                                }
                             } else {
                                 return Err(e);
                             }
@@ -939,14 +955,8 @@ impl Executor {
                 }
             }
 
-            // Handle RETURNING clause for INSERT...SELECT
-            if has_returning {
-                return statement_rollback.finish(self.build_returning_result(
-                    &stmt.returning,
-                    returning_rows,
-                    schema_column_names_arc.as_ref().unwrap(),
-                    ctx,
-                ));
+            if let Some(result) = returning_result {
+                return statement_rollback.finish(Ok(result));
             }
 
             return statement_rollback
@@ -1267,6 +1277,12 @@ impl Executor {
             invalidate_in_subquery_cache_for_table(table_name);
         }
 
+        let mut returning_result = if let Some(column_names) = &schema_column_names_arc {
+            Some(self.build_returning_result(&stmt.returning, returning_rows, column_names, ctx)?)
+        } else {
+            None
+        };
+
         // Commit if this is a standalone (auto-commit) transaction
         if should_auto_commit {
             if let Some(mut tx) = standalone_tx {
@@ -1277,6 +1293,7 @@ impl Executor {
                             && e.is_pk_or_unique_violation() =>
                     {
                         if stmt.on_duplicate && ctx.query_depth == 0 {
+                            drop(returning_result);
                             drop(_upsert_guard);
                             let retry_ctx = ctx.with_incremented_query_depth();
                             return self.execute_insert(stmt, &retry_ctx);
@@ -1284,7 +1301,11 @@ impl Executor {
                         if stmt.do_nothing {
                             // DO NOTHING: returning 0 rows is the correct semantic
                             rows_affected = 0;
-                            returning_rows.clear();
+                            if let Some(result) = &mut returning_result {
+                                *result = Box::new(ExecutorResult::with_columns(
+                                    result.columns().to_vec(),
+                                ));
+                            }
                         } else {
                             return Err(e);
                         }
@@ -1294,14 +1315,8 @@ impl Executor {
             }
         }
 
-        // Handle RETURNING clause
-        if has_returning {
-            return statement_rollback.finish(self.build_returning_result(
-                &stmt.returning,
-                returning_rows,
-                schema_column_names_arc.as_ref().unwrap(),
-                ctx,
-            ));
+        if let Some(result) = returning_result {
+            return statement_rollback.finish(Ok(result));
         }
 
         statement_rollback.finish(Ok(Box::new(ExecResult::with_rows_affected(rows_affected))))
@@ -1707,21 +1722,21 @@ impl Executor {
             invalidate_in_subquery_cache_for_table(table_name);
         }
 
+        if let Some(column_names) = &schema_column_names_arc {
+            return statement_rollback.finish(self.finish_returning(
+                &stmt.returning,
+                returning_rows,
+                column_names,
+                ctx,
+                standalone_tx,
+            ));
+        }
+
         // Commit if this is a standalone (auto-commit) transaction
         if should_auto_commit {
             if let Some(mut tx) = standalone_tx {
                 tx.commit()?;
             }
-        }
-
-        // Handle RETURNING clause
-        if has_returning {
-            return statement_rollback.finish(self.build_returning_result(
-                &stmt.returning,
-                returning_rows,
-                schema_column_names_arc.as_ref().unwrap(),
-                ctx,
-            ));
         }
 
         statement_rollback.finish(Ok(Box::new(ExecResult::with_rows_affected(rows_affected))))
@@ -2691,23 +2706,22 @@ impl Executor {
             invalidate_in_subquery_cache_for_table(table_name);
         }
 
+        if has_returning {
+            return statement_rollback.finish(self.finish_returning(
+                &stmt.returning,
+                returning_rows.into_inner(),
+                &column_names,
+                ctx,
+                standalone_tx,
+            ));
+        }
+
         // Commit if this is a standalone (auto-commit) transaction
         if should_auto_commit {
             // Commit the transaction - it will commit all tables via commit_all_tables()
             if let Some(mut tx) = standalone_tx {
                 tx.commit()?;
             }
-        }
-
-        // Handle RETURNING clause
-        if has_returning {
-            let rows = returning_rows.into_inner();
-            return statement_rollback.finish(self.build_returning_result(
-                &stmt.returning,
-                rows,
-                &column_names,
-                ctx,
-            ));
         }
 
         statement_rollback.finish(Ok(Box::new(ExecResult::with_rows_affected(
@@ -3199,22 +3213,22 @@ impl Executor {
             invalidate_in_subquery_cache_for_table(table_name);
         }
 
+        if has_returning {
+            return statement_rollback.finish(self.finish_returning(
+                &stmt.returning,
+                returning_rows,
+                &column_names_owned,
+                ctx,
+                standalone_tx,
+            ));
+        }
+
         // Commit if this is a standalone (auto-commit) transaction
         if should_auto_commit {
             // Commit the transaction - it will commit all tables via commit_all_tables()
             if let Some(mut tx) = standalone_tx {
                 tx.commit()?;
             }
-        }
-
-        // Handle RETURNING clause
-        if has_returning {
-            return statement_rollback.finish(self.build_returning_result(
-                &stmt.returning,
-                returning_rows,
-                &column_names_owned,
-                ctx,
-            ));
         }
 
         statement_rollback.finish(Ok(Box::new(ExecResult::with_rows_affected(
@@ -3829,6 +3843,22 @@ impl Executor {
         }
     }
 
+    #[inline(never)]
+    fn finish_returning(
+        &self,
+        returning: &[Expression],
+        source_rows: Vec<Row>,
+        column_names: &[String],
+        ctx: &ExecutionContext,
+        standalone_tx: Option<Box<dyn Transaction>>,
+    ) -> Result<Box<dyn QueryResult>> {
+        let result = self.build_returning_result(returning, source_rows, column_names, ctx)?;
+        if let Some(mut tx) = standalone_tx {
+            tx.commit()?;
+        }
+        Ok(result)
+    }
+
     /// Build a result from RETURNING clause expressions
     ///
     /// Evaluates the RETURNING expressions for each affected row and returns
@@ -3840,11 +3870,8 @@ impl Executor {
         column_names: &[String],
         ctx: &ExecutionContext,
     ) -> Result<Box<dyn QueryResult>> {
-        use super::result::ExecutorResult;
         use crate::parser::{Identifier, Position, Token, TokenType};
 
-        // Expand Star expressions to all columns
-        let mut expanded_exprs: Vec<Expression> = Vec::new();
         let mut result_columns: Vec<String> = Vec::new();
 
         for (i, expr) in returning.iter().enumerate() {
@@ -3853,20 +3880,10 @@ impl Executor {
                     // Expand * to all columns
                     for col_name in column_names {
                         result_columns.push(col_name.clone());
-                        let token = Token::new(
-                            TokenType::Identifier,
-                            col_name.clone(),
-                            Position::new(0, 0, 0),
-                        );
-                        expanded_exprs.push(Expression::Identifier(Identifier::new(
-                            token,
-                            col_name.clone(),
-                        )));
                     }
                 }
                 _ => {
                     result_columns.push(Self::get_returning_column_name(expr, i));
-                    expanded_exprs.push(expr.clone());
                 }
             }
         }
@@ -3879,10 +3896,24 @@ impl Executor {
         use super::expression::{compile_expression, ExecuteContext, ExprVM, SharedProgram};
 
         // Pre-compile all RETURNING expressions
-        let compiled_exprs: Vec<SharedProgram> = expanded_exprs
-            .iter()
-            .map(|expr| compile_expression(expr, column_names))
-            .collect::<Result<Vec<_>>>()?;
+        let mut compiled_exprs: Vec<SharedProgram> = Vec::with_capacity(result_columns.len());
+        for expr in returning {
+            match expr {
+                Expression::Star(_) => {
+                    for col_name in column_names {
+                        let token = Token::new(
+                            TokenType::Identifier,
+                            col_name.clone(),
+                            Position::new(0, 0, 0),
+                        );
+                        let column =
+                            Expression::Identifier(Identifier::new(token, col_name.clone()));
+                        compiled_exprs.push(compile_expression(&column, column_names)?);
+                    }
+                }
+                _ => compiled_exprs.push(compile_expression(expr, column_names)?),
+            }
+        }
 
         // Create VM for execution (reused for all rows)
         let mut vm = ExprVM::new();

--- a/tests/returning_atomicity_test.rs
+++ b/tests/returning_atomicity_test.rs
@@ -1,0 +1,283 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Mutex, MutexGuard};
+
+use stoolap::api::Transaction;
+use stoolap::core::{Result, Value};
+use stoolap::functions::scalar::SleepFunction;
+use stoolap::functions::{global_registry, FunctionInfo, ScalarFunction};
+use stoolap::Database;
+
+fn setup(name: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10), (2, 20)", ())
+        .unwrap();
+    db
+}
+
+fn values(db: &Database) -> Vec<(i64, i64)> {
+    db.query("SELECT id, v FROM t ORDER BY id", ())
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (row.get(0).unwrap(), row.get(1).unwrap())
+        })
+        .collect()
+}
+
+fn check_rollback(db: &Database, sql: &str) {
+    let error = db.query(sql, ()).err().unwrap();
+    assert!(
+        error.to_string().contains("Invalid regular expression"),
+        "{error}"
+    );
+    assert_eq!(values(db), [(1, 10), (2, 20)], "{sql}");
+    let other = db.clone();
+    assert_eq!(other.execute("UPDATE t SET v = v + 1", ()).unwrap(), 2);
+    assert_eq!(values(db), [(1, 11), (2, 21)]);
+}
+
+#[test]
+fn autocommit_insert_returning_error_rolls_back() {
+    let db = setup("autocommit_insert_returning_error_rolls_back");
+    check_rollback(&db, "INSERT INTO t VALUES (3, 30), (4, 40) RETURNING 'x' REGEXP CASE WHEN id = 4 THEN '[' ELSE 'x' END");
+}
+
+#[test]
+fn autocommit_insert_select_returning_error_rolls_back() {
+    let db = setup("autocommit_insert_select_returning_error_rolls_back");
+    check_rollback(&db, "INSERT INTO t SELECT id + 2, v FROM t ORDER BY id RETURNING 'x' REGEXP CASE WHEN id = 4 THEN '[' ELSE 'x' END");
+}
+
+#[test]
+fn autocommit_upsert_returning_error_rolls_back() {
+    let db = setup("autocommit_upsert_returning_error_rolls_back");
+    check_rollback(&db, "INSERT INTO t VALUES (1, 30), (2, 40) ON CONFLICT (id) DO UPDATE SET v = EXCLUDED.v RETURNING 'x' REGEXP CASE WHEN id = 2 THEN '[' ELSE 'x' END");
+}
+
+#[test]
+fn autocommit_upsert_select_returning_error_rolls_back() {
+    let db = setup("autocommit_upsert_select_returning_error_rolls_back");
+    check_rollback(&db, "INSERT INTO t SELECT id, v + 20 FROM t ORDER BY id ON CONFLICT (id) DO UPDATE SET v = EXCLUDED.v RETURNING 'x' REGEXP CASE WHEN id = 2 THEN '[' ELSE 'x' END");
+}
+
+#[test]
+fn autocommit_update_returning_error_rolls_back() {
+    let db = setup("autocommit_update_returning_error_rolls_back");
+    check_rollback(
+        &db,
+        "UPDATE t SET v = v + 20 RETURNING 'x' REGEXP CASE WHEN id = 2 THEN '[' ELSE 'x' END",
+    );
+}
+
+#[test]
+fn autocommit_delete_returning_error_rolls_back() {
+    let db = setup("autocommit_delete_returning_error_rolls_back");
+    check_rollback(
+        &db,
+        "DELETE FROM t RETURNING 'x' REGEXP CASE WHEN id = 2 THEN '[' ELSE 'x' END",
+    );
+}
+
+#[test]
+fn prepared_returning_error_leaves_autocommit_reusable() {
+    let db = setup("prepared_returning_error_leaves_autocommit_reusable");
+    let insert = db
+        .prepare("INSERT INTO t VALUES ($1, $2) RETURNING id, v, 'x' REGEXP $3")
+        .unwrap();
+    for id in [3, 4] {
+        let error = insert.query((id, id * 10, "[")).err().unwrap();
+        assert!(
+            error.to_string().contains("Invalid regular expression"),
+            "{error}"
+        );
+        assert_eq!(values(&db), [(1, 10), (2, 20)]);
+    }
+    for id in [3, 4] {
+        let mut rows = insert.query((id, id * 10, "x")).unwrap();
+        let row = rows.next().unwrap().unwrap();
+        assert_eq!(row.get::<i64>(0).unwrap(), id);
+        assert_eq!(row.get::<i64>(1).unwrap(), id * 10);
+        assert!(row.get::<bool>(2).unwrap());
+        assert!(rows.next().is_none());
+    }
+    assert_eq!(values(&db), [(1, 10), (2, 20), (3, 30), (4, 40)]);
+}
+
+#[test]
+fn failed_cold_delete_returning_restores_cascade_after_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+    let dsn = format!("file://{}/returning", dir.path().display());
+    {
+        let db = Database::open(&dsn).unwrap();
+        db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+            .unwrap();
+        db.execute("CREATE TABLE children (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES t(id) ON DELETE CASCADE)", ()).unwrap();
+        db.execute("INSERT INTO t VALUES (1, 10), (2, 20)", ())
+            .unwrap();
+        db.execute("INSERT INTO children VALUES (1, 1), (2, 2)", ())
+            .unwrap();
+        db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+        check_rollback(
+            &db,
+            "DELETE FROM t RETURNING 'x' REGEXP CASE WHEN id = 2 THEN '[' ELSE 'x' END",
+        );
+        assert_eq!(
+            db.query_one::<i64, _>("SELECT COUNT(*) FROM children", ())
+                .unwrap(),
+            2
+        );
+    }
+    let db = Database::open(&dsn).unwrap();
+    assert_eq!(values(&db), [(1, 11), (2, 21)]);
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT SUM(parent_id) FROM children", ())
+            .unwrap(),
+        3
+    );
+}
+
+static HOOK_LOCK: Mutex<()> = Mutex::new(());
+static HOOK_STATE: Mutex<(Option<Transaction>, usize)> = Mutex::new((None, 0));
+
+#[derive(Default)]
+struct CommitDuringReturning;
+
+impl ScalarFunction for CommitDuringReturning {
+    fn name(&self) -> &str {
+        "SLEEP"
+    }
+
+    fn info(&self) -> FunctionInfo {
+        SleepFunction.info()
+    }
+
+    fn evaluate(&self, args: &[Value]) -> Result<Value> {
+        let transaction = {
+            let mut state = HOOK_STATE.lock().unwrap();
+            state.1 += 1;
+            state.0.take()
+        };
+        if let Some(mut transaction) = transaction {
+            transaction.commit().unwrap();
+        }
+        Ok(args[0].clone())
+    }
+
+    fn clone_box(&self) -> Box<dyn ScalarFunction> {
+        Box::new(Self)
+    }
+}
+
+struct ReturningHook {
+    _serial: MutexGuard<'static, ()>,
+}
+
+impl ReturningHook {
+    fn new(transaction: Transaction) -> Self {
+        let serial = HOOK_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        *HOOK_STATE.lock().unwrap() = (Some(transaction), 0);
+        global_registry().register_scalar::<CommitDuringReturning>();
+        Self { _serial: serial }
+    }
+
+    fn calls(&self) -> usize {
+        HOOK_STATE.lock().unwrap().1
+    }
+}
+
+impl Drop for ReturningHook {
+    fn drop(&mut self) {
+        global_registry().register_scalar::<SleepFunction>();
+        let transaction = HOOK_STATE.lock().unwrap().0.take();
+        drop(transaction);
+    }
+}
+
+fn check_commit_conflict(name: &str, source: &str, upsert: bool) {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, u INTEGER UNIQUE, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    let mut competing = db.begin().unwrap();
+    competing
+        .execute("INSERT INTO t VALUES (1, 7, 50)", ())
+        .unwrap();
+    let hook = ReturningHook::new(competing);
+    let action = if upsert {
+        "DO UPDATE SET v = 20"
+    } else {
+        "DO NOTHING"
+    };
+    let mut rows = db
+        .query(
+            &format!("INSERT INTO t {source} ON CONFLICT (u) {action} RETURNING id, v, SLEEP(v)"),
+            (),
+        )
+        .unwrap();
+    assert_eq!(rows.columns(), ["id", "v", "SLEEP(v)"]);
+    if upsert {
+        let row = rows.next().unwrap().unwrap();
+        assert_eq!(row.get::<i64>(0).unwrap(), 1);
+        assert_eq!(row.get::<i64>(1).unwrap(), 20);
+        assert_eq!(row.get::<i64>(2).unwrap(), 20);
+        assert_eq!(hook.calls(), 2);
+        assert_eq!(values(&db), [(1, 20)]);
+    } else {
+        assert_eq!(hook.calls(), 1);
+        assert_eq!(values(&db), [(1, 50)]);
+    }
+    assert!(rows.next().is_none());
+}
+
+#[test]
+fn do_nothing_discards_prepared_returning_after_commit_conflict() {
+    check_commit_conflict(
+        "do_nothing_discards_prepared_returning_after_commit_conflict",
+        "VALUES (2, 7, 10)",
+        false,
+    );
+}
+
+#[test]
+fn select_do_nothing_discards_prepared_returning_after_commit_conflict() {
+    check_commit_conflict(
+        "select_do_nothing_discards_prepared_returning_after_commit_conflict",
+        "SELECT 2, 7, 10",
+        false,
+    );
+}
+
+#[test]
+fn upsert_retry_replaces_prepared_returning_after_commit_conflict() {
+    check_commit_conflict(
+        "upsert_retry_replaces_prepared_returning_after_commit_conflict",
+        "VALUES (2, 7, 10)",
+        true,
+    );
+}
+
+#[test]
+fn select_upsert_retry_replaces_prepared_returning_after_commit_conflict() {
+    check_commit_conflict(
+        "select_upsert_retry_replaces_prepared_returning_after_commit_conflict",
+        "SELECT 2, 7, 10",
+        true,
+    );
+}


### PR DESCRIPTION
I evaluate RETURNING before committing an autocommit write, so an expression error rolls back the write and its cascades. INSERT VALUES, INSERT SELECT, compiled INSERT, UPDATE and DELETE prepare owned output before commit and expose it only after success. A commit-time DO NOTHING conflict discards its rows while keeping column metadata; an upsert retry discards the first result before retrying.

I compile RETURNING expressions from the existing AST instead of copying an expansion vector. The three simple exits share a result-and-commit helper. I added no persistent per-row or per-volume structure, and ordinary single-row writes add no allocations.

I added 12 regression tests for runtime expression failures, prepared-statement reuse, a sealed-row cascade with reopen, and commit-time DO NOTHING/upsert collisions. All 12 failed when I reverted only the original production fix on the same checkout. The final revision passes formatting, all-target/all-feature clippy with warnings denied, 113 focused in-memory tests, and the same 113 with test-filedb. The full in-memory suite passes 5,312 tests with 3 skipped. Nextest reports one output-handle leak annotation in hot_index_top_k_test; an isolated rerun of that target passes all 11 tests without the annotation. All GitHub CI checks pass on this final revision, including MSRV, Linux/macOS/Windows tests, feature tests, coverage and release builds.

I measured requested heap allocations with an external DHAT probe on an Apple M5 and rustc 1.98, in release mode with opt-level 3, thin LTO, one codegen unit and panic abort. Seven runs per shape gave identical totals. These counts include result validation and consumer copies, rather than engine ledger totals or process RSS.

| Shape | Baseline allocations / bytes | Final allocations / bytes |
|---|---:|---:|
| 1,000 hot explicit cycles | 82,013 / 4,376,000 | unchanged |
| 1,000 hot autocommit cycles | 71,014 / 4,467,304 | unchanged |
| 1,000 plain INSERT/UPDATE/point/DELETE cycles | 88,011 / 5,838,616 | unchanged |
| 1,000 cycles returning one integer | 152,011 / 10,594,616 | 149,011 / 8,890,616 |
| 100 wide RETURNING batches | 1,739,660 / 534,213,520 | 1,739,260 / 534,103,920 |

Each wide batch updates 1,024 rows and returns 2,048 bytes of text per row, with WAL enabled after checkpoint and warmup. I re-measured the final revision seven times at each 16 and 64 MiB group-cache setting. Retained heap stays at 2,011,788 bytes; peak heap rises from 4,202,958 to 4,365,339 bytes, an additional 162,381 bytes (3.863%), because owned output must coexist with pending transaction state until commit. This grows with result cardinality, not a fixed allowance. Single-row allocation measurements are retained from the preceding revision; restoring the original multi-row sort does not execute on those paths.

I investigated executable-dependent allocator placement and CPU-rate drift before accepting the original hot-path measurements. A controlled comparison used seven signing identities per build and three one-million-cycle runs per identity and transaction mode. Only signing identifier bytes changed between copies; code and layout stayed identical. All 84 runs had zero errors and passed the predeclared CPU-rate screen. Mean identity-median throughput changed -0.46% for explicit transactions and +0.90% for autocommit. An explicit-only reversed confirmation gave -0.46%. Default point-tail variation remained; same-code profiles and a verified allocator intervention supported the independent review's acceptance. The intervention was diagnostic, not a default-performance pass. [Apple documents executable-dependent allocation policy here.](https://github.com/apple-oss-distributions/libmalloc/blob/main/doc/xzone_malloc.md)

The broader timing matrix ran on the preceding revision: narrow plain/RETURNING, wide RETURNING at both cache settings, PK-ordered scan, and idle/mixed file workloads. Seven unchanged-baseline controls preceded seven baseline and seven candidate identities per condition. All 189 retained runs had zero errors. Earlier comparisons affected by sleep or a display transition were excluded and repeated with wake guards. A 42-run reversed plain-write confirmation closed its initial UPDATE-tail concern. The wider matrix was not rebuilt after the one-line sort restoration described below.

The preceding revision failed the 16 MiB mixed row-latency gate even when build order was reversed. I removed its optional unstable-sort optimization and retained the original stable sort. The reduced revision then passed independent review of the targeted mixed workload: 131,072 initially sealed rows, 10,000 foreground transactions at 1,000/s, 10,000 analytic queries, and 50 ingestion/checkpoint operations. Twenty-one fresh runs comprise seven unchanged-baseline controls, seven baseline identities and seven final identities, with exact completed work, zero errors and no sleep/display events. No builds, tests or profiles ran concurrently.

| Final mixed workload | Baseline p99 range | Final p99 range | Mean change |
|---|---:|---:|---:|
| INSERT | 4.208 to 5.042 us | 3.292 to 4.750 us | -5.86% |
| UPDATE | 46.500 to 54.500 us | 41.750 to 50.959 us | -8.18% |
| Point read | 17.417 to 18.583 us | 16.667 to 19.084 us | -2.34% |

Mean INSERT p50 is effectively unchanged, UPDATE p50 changes -0.86%, and point p50 +1.88% with isolated higher centers. Review accepted the combined service, arrival-delay and completed-work evidence. The rebuild changes executable identity/layout too, so I do not claim a proven scheduling mechanism for the sort change. In this same trial, first application cold touch is 7.50% slower and the pre-load warm-query median 10.66% slower; analytics during mixed load changes +0.81% at p50 and -1.45% at p99. These are separate query conditions, and I do not claim an analytic speedup.

I have not changed cold-access fallibility, complete multi-table/WAL-marker commit undo, the file format, residency or memory admission. No per-ledger or seal-fence instrumentation is added here. RETURNING expression errors can precede a competing DO NOTHING commit-time collision. Whole-column accesses still escape the group-cache budget; the file probes record zero group-cache hits/misses, so neither cache setting demonstrates pressure enforcement. Backup and restore are outside this work.
