### PR TITLE
Return errors for malformed column groups

### DIFF
--- a/src/storage/volume/format.rs
+++ b/src/storage/volume/format.rs
@@ -885,7 +885,7 @@ pub(crate) fn deserialize_column_block(
     ext_type: DataType,
 ) -> io::Result<ColumnData> {
     let mut pos = 0;
-    match col_type_tag {
+    let column = match col_type_tag {
         COL_INT64 => {
             let nulls = read_nulls(data, &mut pos, row_count)?;
             let values = read_i64_bulk(data, &mut pos, row_count)?;
@@ -932,21 +932,33 @@ pub(crate) fn deserialize_column_block(
         }
         COL_BYTES => {
             let nulls = read_nulls(data, &mut pos, row_count)?;
-            let offset_count = read_u64(data, &mut pos)? as usize;
-            let mut offsets = Vec::with_capacity(offset_count);
-            for _ in 0..offset_count {
+            let offset_count = read_u64(data, &mut pos)?;
+            if offset_count != row_count as u64 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "bytes offset count does not match row count",
+                ));
+            }
+            if row_count > data.len().saturating_sub(pos) / 16 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "truncated column block: bytes offsets",
+                ));
+            }
+            let mut offsets = Vec::with_capacity(row_count);
+            for _ in 0..row_count {
                 let off = read_u64(data, &mut pos)?;
                 let len = read_u64(data, &mut pos)?;
                 offsets.push((off, len));
             }
-            let data_len = read_u64(data, &mut pos)? as usize;
-            if pos + data_len > data.len() {
+            let data_len = read_u64(data, &mut pos)?;
+            if data_len > data.len().saturating_sub(pos) as u64 {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "truncated column block: bytes data",
                 ));
             }
-            let blob = data[pos..pos + data_len].to_vec();
+            let end_pos = pos + data_len as usize;
             // Validate offsets to prevent panics on corrupted volumes
             for (i, &(off, len)) in offsets.iter().enumerate() {
                 if !nulls[i] {
@@ -956,20 +968,19 @@ pub(crate) fn deserialize_column_block(
                             format!("bytes offset overflow at row {}", i),
                         )
                     })?;
-                    if (end as usize) > blob.len() {
+                    if end > data_len {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
                             format!(
                                 "bytes offset {}+{} exceeds data length {} at row {}",
-                                off,
-                                len,
-                                blob.len(),
-                                i
+                                off, len, data_len, i
                             ),
                         ));
                     }
                 }
             }
+            let blob = data[pos..end_pos].to_vec();
+            pos = end_pos;
             Ok(ColumnData::Bytes {
                 data: blob,
                 offsets,
@@ -981,7 +992,14 @@ pub(crate) fn deserialize_column_block(
             io::ErrorKind::InvalidData,
             format!("unknown column type tag {}", col_type_tag),
         )),
+    }?;
+    if pos != data.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "trailing bytes in column block",
+        ));
     }
+    Ok(column)
 }
 
 /// Metadata parsed from a V4 volume file (everything except column data).

--- a/src/storage/volume/group_cache.rs
+++ b/src/storage/volume/group_cache.rs
@@ -35,7 +35,7 @@ pub const DEFAULT_BUDGET_BYTES: usize = 64 * 1024 * 1024;
 pub type GroupKey = (usize, u32, u32);
 
 struct Slot {
-    cell: OnceLock<Result<Arc<ColumnData>, String>>,
+    cell: OnceLock<std::io::Result<Arc<ColumnData>>>,
     /// The decoder charges the entry's bytes once
     charged: AtomicBool,
 }
@@ -116,9 +116,7 @@ impl DecodedGroupCache {
                 }
             }
         };
-        let outcome = slot
-            .cell
-            .get_or_init(|| decode().map(Arc::new).map_err(|e| e.to_string()));
+        let outcome = slot.cell.get_or_init(|| decode().map(Arc::new));
         match outcome {
             Ok(column) => {
                 if !slot.charged.swap(true, Ordering::AcqRel) {
@@ -126,10 +124,18 @@ impl DecodedGroupCache {
                 }
                 Ok(Arc::clone(column))
             }
-            Err(message) => {
+            Err(error) => {
                 // A block that does not decode is not kept; the next reader tries again
-                self.lock().entries.remove(&key);
-                Err(std::io::Error::other(message.clone()))
+                let mut inner = self.lock();
+                if inner
+                    .entries
+                    .get(&key)
+                    .is_some_and(|entry| Arc::ptr_eq(&entry.slot, &slot))
+                {
+                    inner.entries.remove(&key);
+                }
+                drop(inner);
+                Err(std::io::Error::new(error.kind(), error.to_string()))
             }
         }
     }

--- a/src/storage/volume/scanner.rs
+++ b/src/storage/volume/scanner.rs
@@ -887,7 +887,7 @@ impl VolumeScanner {
         let mut columns: Vec<Option<Arc<super::column::ColumnData>>> = vec![None; col_count];
         if let Some(ref needed) = self.needed_cols {
             for (ci, &need) in needed.iter().enumerate() {
-                if need && ci < col_count && group_idx < store.num_groups(ci) {
+                if need && ci < col_count {
                     match store.group_column(ci, group_idx) {
                         Ok(col) => columns[ci] = Some(col),
                         Err(e) => {
@@ -899,13 +899,11 @@ impl VolumeScanner {
             }
         } else {
             for (ci, slot) in columns.iter_mut().enumerate() {
-                if group_idx < store.num_groups(ci) {
-                    match store.group_column(ci, group_idx) {
-                        Ok(col) => *slot = Some(col),
-                        Err(e) => {
-                            self.error = Some(Error::internal(format!("corrupt V4 block: {}", e)));
-                            return;
-                        }
+                match store.group_column(ci, group_idx) {
+                    Ok(col) => *slot = Some(col),
+                    Err(e) => {
+                        self.error = Some(Error::internal(format!("corrupt V4 block: {}", e)));
+                        return;
                     }
                 }
             }

--- a/src/storage/volume/writer.rs
+++ b/src/storage/volume/writer.rs
@@ -92,10 +92,18 @@ impl CompressedBlockStore {
         col_idx: usize,
         group_idx: usize,
     ) -> std::io::Result<Arc<ColumnData>> {
-        super::group_cache::DECODED_GROUPS
-            .get_or_decode((self.id, col_idx as u32, group_idx as u32), || {
-                self.decompress_single_group(col_idx, group_idx)
-            })
+        let key_col = u32::try_from(col_idx).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "column index out of range",
+            )
+        })?;
+        let key_group = u32::try_from(group_idx).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "group index out of range")
+        })?;
+        super::group_cache::DECODED_GROUPS.get_or_decode((self.id, key_col, key_group), || {
+            self.decompress_single_group(col_idx, group_idx)
+        })
     }
 
     /// Compress existing columns into per-group LZ4 blocks.
@@ -505,12 +513,44 @@ impl CompressedBlockStore {
         dict: Option<Arc<[SmartString]>>,
         ext_type: DataType,
     ) -> std::io::Result<ColumnData> {
-        let decomp_len = self.decompressed_lens[col_idx][gi];
-        let group_rows = self.group_row_count(gi, num_groups);
+        let decomp_len = *self
+            .decompressed_lens
+            .get(col_idx)
+            .and_then(|lens| lens.get(gi))
+            .ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "missing block length")
+            })?;
+        let group_rows = self.group_row_count(gi, num_groups)?;
+        let row_bytes = match type_tag {
+            super::format::COL_INT64
+            | super::format::COL_FLOAT64
+            | super::format::COL_TIMESTAMP => 9,
+            super::format::COL_BOOLEAN => 2,
+            COL_DICTIONARY => 5,
+            COL_BYTES => 0,
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "unknown column type tag",
+                ));
+            }
+        };
+        if (row_bytes != 0 && group_rows.checked_mul(row_bytes) != Some(decomp_len))
+            || decomp_len > isize::MAX as usize
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid column block length",
+            ));
+        }
         let raw_bytes = if block.len() == decomp_len {
             return deserialize_column_block(block, type_tag, group_rows, dict, ext_type);
         } else {
-            lz4_flex::decompress(block, decomp_len).map_err(|e| {
+            let mut raw = Vec::new();
+            raw.try_reserve_exact(decomp_len)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::OutOfMemory, e))?;
+            raw.resize(decomp_len, 0);
+            let decoded_len = lz4_flex::decompress_into(block, &mut raw).map_err(|e| {
                 std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
                     format!(
@@ -518,7 +558,14 @@ impl CompressedBlockStore {
                         col_idx, gi, num_groups, e
                     ),
                 )
-            })?
+            })?;
+            if decoded_len != decomp_len {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "LZ4 decoded length does not match block length",
+                ));
+            }
+            raw
         };
         deserialize_column_block(&raw_bytes, type_tag, group_rows, dict, ext_type)
     }
@@ -545,7 +592,7 @@ impl CompressedBlockStore {
         bytes_offsets_out: Option<&mut Vec<(u64, u64)>>,
     ) -> std::io::Result<()> {
         let decomp_len = self.decompressed_lens[col_idx][gi];
-        let group_rows = self.group_row_count(gi, num_groups);
+        let group_rows = self.group_row_count(gi, num_groups)?;
         if block.len() == decomp_len {
             return deserialize_column_block_into(
                 block,
@@ -594,9 +641,29 @@ impl CompressedBlockStore {
         col_idx: usize,
         group_idx: usize,
     ) -> std::io::Result<ColumnData> {
-        let num_groups = self.blocks[col_idx].len();
-        let type_tag = self.col_type_tags[col_idx];
-        let ext_type = DataType::from_u8(self.col_ext_types[col_idx]).unwrap_or(DataType::Null);
+        let col_blocks = self.blocks.get(col_idx).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "column index out of range",
+            )
+        })?;
+        let block = col_blocks.get(group_idx).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "group index out of range")
+        })?;
+        let num_groups = col_blocks.len();
+        let type_tag = *self.col_type_tags.get(col_idx).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "missing column type tag")
+        })?;
+        let ext_type = self
+            .col_ext_types
+            .get(col_idx)
+            .and_then(|&tag| DataType::from_u8(tag))
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "invalid extension type tag",
+                )
+            })?;
         let dict: Option<Arc<[SmartString]>> = if type_tag == COL_DICTIONARY {
             self.col_dicts
                 .iter()
@@ -606,13 +673,7 @@ impl CompressedBlockStore {
             None
         };
         self.decompress_block(
-            col_idx,
-            group_idx,
-            &self.blocks[col_idx][group_idx],
-            type_tag,
-            num_groups,
-            dict,
-            ext_type,
+            col_idx, group_idx, block, type_tag, num_groups, dict, ext_type,
         )
     }
 
@@ -715,12 +776,17 @@ impl CompressedBlockStore {
     }
 
     /// Number of rows in a specific group.
-    fn group_row_count(&self, group_idx: usize, num_groups: usize) -> usize {
-        if group_idx == num_groups - 1 {
-            self.row_count - group_idx * self.group_size
-        } else {
-            self.group_size
+    fn group_row_count(&self, group_idx: usize, num_groups: usize) -> std::io::Result<usize> {
+        if self.group_size == 0
+            || num_groups != self.row_count.div_ceil(self.group_size)
+            || group_idx >= num_groups
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid row group geometry",
+            ));
         }
+        Ok((self.row_count - group_idx * self.group_size).min(self.group_size))
     }
 
     /// Number of columns.

--- a/tests/decoded_group_cache_test.rs
+++ b/tests/decoded_group_cache_test.rs
@@ -210,6 +210,60 @@ mod invariants {
     }
 
     #[test]
+    fn failed_decode_preserves_error_kind_and_can_retry() {
+        let _serial = serial();
+        DECODED_GROUPS.set_budget_bytes(1024);
+        let error = DECODED_GROUPS
+            .get_or_decode((700, 0, 0), || {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "invalid group payload",
+                ))
+            })
+            .err()
+            .unwrap();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(error.to_string(), "invalid group payload");
+        let stats = DECODED_GROUPS.stats();
+        assert_eq!((stats.bytes, stats.entries), (0, 0));
+        let column = DECODED_GROUPS
+            .get_or_decode((700, 0, 0), || Ok(ints(2)))
+            .unwrap();
+        assert_eq!(column.len(), 2);
+        DECODED_GROUPS.remove_store(700);
+    }
+
+    #[test]
+    fn failed_decode_does_not_remove_a_replacement_entry() {
+        let _serial = serial();
+        DECODED_GROUPS.set_budget_bytes(1024);
+        let mut replacement = None;
+        let result = DECODED_GROUPS.get_or_decode((800, 0, 0), || {
+            DECODED_GROUPS.remove_store(800);
+            replacement = Some(
+                DECODED_GROUPS
+                    .get_or_decode((800, 0, 0), || Ok(ints(2)))
+                    .unwrap(),
+            );
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "obsolete decode failed",
+            ))
+        });
+        assert!(result.is_err());
+        let replacement = replacement.unwrap();
+        let stats = DECODED_GROUPS.stats();
+        assert_eq!((stats.bytes, stats.entries), (replacement.cache_size(), 1));
+        let cached = DECODED_GROUPS
+            .get_or_decode((800, 0, 0), || panic!("replacement was evicted"))
+            .unwrap();
+        assert!(Arc::ptr_eq(&cached, &replacement));
+        DECODED_GROUPS.remove_store(800);
+        let stats = DECODED_GROUPS.stats();
+        assert_eq!((stats.bytes, stats.entries), (0, 0));
+    }
+
+    #[test]
     fn an_entry_evicted_while_decoding_leaves_no_phantom_bytes() {
         let _serial = serial();
         DECODED_GROUPS.set_budget_bytes(18);

--- a/tests/fallible_group_access_test.rs
+++ b/tests/fallible_group_access_test.rs
@@ -1,0 +1,396 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::ErrorKind;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use stoolap::core::DataType;
+use stoolap::storage::volume::column::{ColumnData, ROW_GROUP_SIZE};
+use stoolap::storage::volume::writer::{CompressedBlockStore, LazyColumns};
+
+fn store(block: Vec<u8>, decoded_len: usize, data_type: DataType) -> CompressedBlockStore {
+    CompressedBlockStore::from_raw_blocks(
+        vec![vec![block]],
+        vec![vec![decoded_len]],
+        vec![if data_type == DataType::Json { 6 } else { 1 }],
+        vec![data_type],
+        vec![data_type as u8],
+        Vec::new(),
+        Vec::new(),
+        ROW_GROUP_SIZE,
+        2,
+    )
+}
+
+fn bytes_block(offset_count: u64) -> Vec<u8> {
+    let mut raw = vec![0, 0];
+    raw.extend_from_slice(&offset_count.to_le_bytes());
+    for _ in 0..offset_count.min(3) {
+        raw.extend_from_slice(&0u64.to_le_bytes());
+        raw.extend_from_slice(&0u64.to_le_bytes());
+    }
+    raw.extend_from_slice(&0u64.to_le_bytes());
+    raw
+}
+
+fn assert_invalid_block(raw: Vec<u8>, data_type: DataType) {
+    let store = store(raw.clone(), raw.len(), data_type);
+    for _ in 0..2 {
+        let outcome = catch_unwind(AssertUnwindSafe(|| store.group_column(0, 0)));
+        assert!(outcome.is_ok(), "group access panicked");
+        let error = outcome.unwrap().err().expect("invalid block was accepted");
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+    }
+}
+
+#[test]
+fn bytes_group_rejects_missing_offsets() {
+    assert_invalid_block(bytes_block(1), DataType::Json);
+}
+
+#[test]
+fn bytes_group_rejects_extra_offsets() {
+    assert_invalid_block(bytes_block(3), DataType::Json);
+}
+
+#[test]
+fn bytes_group_rejects_oversized_offset_count_before_allocation() {
+    assert_invalid_block(bytes_block(u64::MAX), DataType::Json);
+}
+
+#[test]
+fn bytes_group_rejects_overflowing_blob_length() {
+    let mut raw = bytes_block(2);
+    let len_offset = raw.len() - 8;
+    raw[len_offset..].copy_from_slice(&u64::MAX.to_le_bytes());
+    assert_invalid_block(raw, DataType::Json);
+}
+
+#[test]
+fn bytes_group_rejects_trailing_payload() {
+    let mut raw = bytes_block(2);
+    raw.push(0);
+    assert_invalid_block(raw, DataType::Json);
+}
+
+#[test]
+fn integer_group_rejects_trailing_payload() {
+    assert_invalid_block(vec![0; 19], DataType::Integer);
+}
+
+#[test]
+fn group_rejects_incorrect_decoded_length() {
+    let raw = vec![0; 18];
+    let store = store(lz4_flex::compress(&raw), raw.len() + 1, DataType::Integer);
+    let outcome = catch_unwind(AssertUnwindSafe(|| store.group_column(0, 0)));
+    assert!(outcome.is_ok(), "group access panicked");
+    let error = outcome
+        .unwrap()
+        .err()
+        .expect("wrong decoded length accepted");
+    assert_eq!(error.kind(), ErrorKind::InvalidData);
+}
+
+#[test]
+fn bytes_group_rejects_incorrect_lz4_output_length() {
+    let raw = bytes_block(2);
+    let store = store(lz4_flex::compress(&raw), raw.len() + 1, DataType::Json);
+    let error = store.group_column(0, 0).err().unwrap();
+    assert_eq!(error.kind(), ErrorKind::InvalidData);
+    assert!(error.to_string().contains("LZ4 decoded length"));
+}
+
+#[test]
+fn group_rejects_unrepresentable_decoded_length() {
+    for data_type in [DataType::Integer, DataType::Json] {
+        let store = store(vec![0xff], usize::MAX, data_type);
+        let outcome = catch_unwind(AssertUnwindSafe(|| store.group_column(0, 0)));
+        assert!(outcome.is_ok(), "invalid decoded length panicked");
+        assert_eq!(
+            outcome.unwrap().err().unwrap().kind(),
+            ErrorKind::InvalidData
+        );
+    }
+}
+
+#[test]
+fn group_rejects_missing_metadata() {
+    for missing in 0..3 {
+        let store = CompressedBlockStore::from_raw_blocks(
+            vec![vec![vec![0; 18]]],
+            if missing == 0 {
+                Vec::new()
+            } else {
+                vec![vec![18]]
+            },
+            if missing == 1 { Vec::new() } else { vec![1] },
+            vec![DataType::Integer],
+            if missing == 2 { Vec::new() } else { vec![0] },
+            Vec::new(),
+            Vec::new(),
+            ROW_GROUP_SIZE,
+            2,
+        );
+        let outcome = catch_unwind(AssertUnwindSafe(|| store.group_column(0, 0)));
+        assert!(outcome.is_ok(), "missing metadata {missing} panicked");
+        assert_eq!(
+            outcome.unwrap().err().unwrap().kind(),
+            ErrorKind::InvalidData
+        );
+    }
+}
+
+#[test]
+fn group_rejects_inconsistent_row_geometry() {
+    for (group_size, rows) in [(0, 2), (ROW_GROUP_SIZE, 0), (1, 2)] {
+        let store = CompressedBlockStore::from_raw_blocks(
+            vec![vec![vec![0; 18]]],
+            vec![vec![18]],
+            vec![1],
+            vec![DataType::Integer],
+            vec![0],
+            Vec::new(),
+            Vec::new(),
+            group_size,
+            rows,
+        );
+        let outcome = catch_unwind(AssertUnwindSafe(|| store.group_column(0, 0)));
+        assert!(outcome.is_ok(), "invalid geometry panicked");
+        assert_eq!(
+            outcome.unwrap().err().unwrap().kind(),
+            ErrorKind::InvalidData
+        );
+    }
+}
+
+#[test]
+fn group_access_rejects_out_of_range_indices() {
+    let store = store(vec![0; 18], 18, DataType::Integer);
+    let cached = store.group_column(0, 0).unwrap();
+    assert_eq!(cached.len(), 2);
+    for (col, group) in [(1, 0), (0, 1), (usize::MAX, 0), (0, usize::MAX)] {
+        let outcome = catch_unwind(AssertUnwindSafe(|| store.group_column(col, group)));
+        assert!(
+            outcome.is_ok(),
+            "group access panicked for ({col}, {group})"
+        );
+        let error = outcome.unwrap().err().expect("invalid index accepted");
+        assert_eq!(error.kind(), ErrorKind::InvalidInput);
+        let outcome = catch_unwind(AssertUnwindSafe(|| {
+            store.decompress_single_group(col, group)
+        }));
+        assert!(
+            outcome.is_ok(),
+            "direct decode panicked for ({col}, {group})"
+        );
+        assert_eq!(
+            outcome.unwrap().err().unwrap().kind(),
+            ErrorKind::InvalidInput
+        );
+    }
+}
+
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn group_cache_key_does_not_alias_large_indices() {
+    let store = store(vec![0; 18], 18, DataType::Integer);
+    let _cached = store.group_column(0, 0).unwrap();
+    for (col, group) in [(1usize << 32, 0), (0, 1usize << 32)] {
+        let outcome = catch_unwind(AssertUnwindSafe(|| store.group_column(col, group)));
+        assert!(outcome.is_ok(), "large index panicked");
+        assert_eq!(
+            outcome.unwrap().err().unwrap().kind(),
+            ErrorKind::InvalidInput
+        );
+    }
+}
+
+#[test]
+fn valid_group_round_trip_preserves_all_column_types_and_nulls() {
+    let types = vec![
+        DataType::Integer,
+        DataType::Float,
+        DataType::Timestamp,
+        DataType::Boolean,
+        DataType::Text,
+        DataType::Json,
+    ];
+    let columns = LazyColumns::eager(
+        vec![
+            ColumnData::Int64 {
+                values: vec![-7, 0],
+                nulls: vec![false, true],
+            },
+            ColumnData::Float64 {
+                values: vec![1.5, 0.0],
+                nulls: vec![false, true],
+            },
+            ColumnData::TimestampNanos {
+                values: vec![100, 0],
+                nulls: vec![false, true],
+            },
+            ColumnData::Boolean {
+                values: vec![true, false],
+                nulls: vec![false, true],
+            },
+            ColumnData::Dictionary {
+                ids: vec![0, u32::MAX],
+                dictionary: vec!["value".into()].into(),
+                nulls: vec![false, true],
+            },
+            ColumnData::Bytes {
+                data: vec![b'{', b'}'],
+                offsets: vec![(0, 2), (2, 0)],
+                ext_type: DataType::Json,
+                nulls: vec![false, true],
+            },
+        ],
+        types.clone(),
+    );
+    for compress in [false, true] {
+        let store = CompressedBlockStore::compress_columns_opts(&columns, &types, 2, compress);
+        for ci in 0..types.len() {
+            let group = store.group_column(ci, 0).unwrap();
+            assert_eq!(group.len(), 2);
+            for row in 0..2 {
+                assert_eq!(group.get_value(row), columns[ci].get_value(row));
+            }
+        }
+    }
+}
+
+#[test]
+fn valid_final_partial_group_preserves_rows() {
+    let rows = ROW_GROUP_SIZE + 3;
+    let columns = LazyColumns::eager(
+        vec![ColumnData::Int64 {
+            values: (0..rows as i64).collect(),
+            nulls: vec![false; rows],
+        }],
+        vec![DataType::Integer],
+    );
+    for compress in [false, true] {
+        let store = CompressedBlockStore::compress_columns_opts(
+            &columns,
+            &[DataType::Integer],
+            rows,
+            compress,
+        );
+        assert_eq!(store.group_column(0, 0).unwrap().len(), ROW_GROUP_SIZE);
+        let last = store.group_column(0, 1).unwrap();
+        assert_eq!(last.len(), 3);
+        for i in 0..3 {
+            assert_eq!(last.get_i64(i), (ROW_GROUP_SIZE + i) as i64);
+        }
+    }
+}
+
+#[test]
+fn all_null_dictionary_group_does_not_require_a_dictionary_range() {
+    use stoolap::core::Value;
+    let mut raw = vec![1, 1];
+    raw.extend_from_slice(&[0xff; 8]);
+    let store = CompressedBlockStore::from_raw_blocks(
+        vec![vec![raw]],
+        vec![vec![10]],
+        vec![5],
+        vec![DataType::Text],
+        vec![0],
+        Vec::new(),
+        Vec::new(),
+        ROW_GROUP_SIZE,
+        2,
+    );
+    let group = store.group_column(0, 0).unwrap();
+    assert_eq!(group.len(), 2);
+    assert_eq!(group.get_value(0), Value::Null(DataType::Text));
+    assert_eq!(group.get_value(1), Value::Null(DataType::Text));
+}
+
+fn two_column_volume() -> stoolap::storage::volume::writer::FrozenVolume {
+    use stoolap::core::{Row, Schema, SchemaColumn, Value};
+    use stoolap::storage::volume::writer::VolumeBuilder;
+    let schema = Schema::new(
+        "group_access",
+        vec![
+            SchemaColumn::new(0, "a", DataType::Integer, false, false),
+            SchemaColumn::new(1, "b", DataType::Integer, false, false),
+        ],
+    );
+    let mut builder = VolumeBuilder::new(&schema);
+    for id in [1, 2] {
+        builder.add_row(
+            id,
+            &Row::from_values(vec![Value::Integer(id), Value::Integer(id)]),
+        );
+    }
+    builder.finish()
+}
+
+#[test]
+fn scanner_reports_a_missing_group_for_full_and_partial_projections() {
+    use std::sync::Arc;
+    use stoolap::storage::traits::Scanner;
+    use stoolap::storage::volume::scanner::VolumeScanner;
+    for projection in [vec![], vec![1]] {
+        let mut volume = two_column_volume();
+        let store = CompressedBlockStore::from_raw_blocks(
+            vec![vec![vec![0; 18]], vec![]],
+            vec![vec![18], vec![]],
+            vec![1, 1],
+            vec![DataType::Integer; 2],
+            vec![0; 2],
+            Vec::new(),
+            Vec::new(),
+            ROW_GROUP_SIZE,
+            2,
+        );
+        volume.columns = LazyColumns::deferred(store, vec![DataType::Integer; 2]);
+        let mut scanner = VolumeScanner::new(Arc::new(volume), projection, None);
+        let outcome = catch_unwind(AssertUnwindSafe(|| scanner.next()));
+        assert!(outcome.is_ok(), "scanner panicked on missing group");
+        assert!(!outcome.unwrap());
+        assert!(
+            scanner.err().is_some(),
+            "missing group became an empty result"
+        );
+    }
+}
+
+#[test]
+fn scanner_reports_structural_payload_corruption_after_reopen() {
+    use std::sync::Arc;
+    use stoolap::storage::traits::Scanner;
+    use stoolap::storage::volume::io::{read_volume_from_disk, write_volume_to_disk};
+    use stoolap::storage::volume::scanner::VolumeScanner;
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_volume_to_disk(dir.path(), "group_access", 1, &two_column_volume()).unwrap();
+    let original = std::fs::read(&path).unwrap();
+    let meta_len = u32::from_le_bytes(original[16..20].try_into().unwrap()) as usize;
+    let index_offset = 20 + meta_len;
+    let mut bytes = original[..index_offset].to_vec();
+    for size in [18u64, 19] {
+        bytes.extend_from_slice(&size.to_le_bytes());
+        bytes.extend_from_slice(&size.to_le_bytes());
+    }
+    bytes.extend_from_slice(&[0; 37]);
+    bytes.extend_from_slice(&crc32fast::hash(&bytes).to_le_bytes());
+    std::fs::write(&path, bytes).unwrap();
+    let volume = Arc::new(read_volume_from_disk(&path).unwrap());
+    let mut scanner = VolumeScanner::new(volume, vec![1], None);
+    assert!(!scanner.next(), "malformed block yielded a row");
+    assert!(
+        scanner.err().is_some(),
+        "malformed block became an empty result"
+    );
+}


### PR DESCRIPTION
I validate group indices, row geometry, decoded lengths and bytes-column offsets before returning decoded column groups. Malformed payloads now return errors instead of panicking or yielding invalid columns. I preserve cached error kinds and remove a failed cache slot only if it still belongs to that decode, so a successful replacement stays cached with correct byte accounting. Scanners report missing requested groups through their existing error path.

I added 17 regression guards covering malformed payloads, missing metadata/groups, oversized and aliased indices, exact LZ4 lengths, reopen with a valid file checksum, and cache retry/eviction behavior. All 17 fail after reverting only the production change on the same checkout. Valid raw/compressed columns, final partial groups and all-null dictionaries have compatibility checks. Independent source review and re-review found no blockers.

Formatting, all-target/all-feature clippy with warnings denied, 65 focused tests and the same 65 with test-filedb pass. The full in-memory suite passes 5,332 tests with 3 skipped. Nextest reports one output-handle annotation in a file-backed cache test; an isolated recheck of that target passes all 10 tests without the annotation. All GitHub CI checks pass. This PR has been merged. Independent allocation review passes; latency acceptance remains open because concurrent builds and tests invalidated the first timing control. I will close that gate before starting the next storage change.

I add no per-row or per-volume structure. A cache slot stores its original I/O error instead of a string; successful decoding still uses one LZ4 buffer and typed output arrays. Group checks run per decoded group, with cache-key width checks before lookup. Across seven allocation runs per build and workload, hot explicit/auto transactions have identical allocation counts, requested bytes, retained bytes and peak bytes. Direct reads over 65,553 rows in three typed columns have these unchanged results for 100 batches:

| Read path | Allocations | Requested bytes | Incremental peak bytes |
| --- | ---: | ---: | ---: |
| Raw groups | 2,000 | 229,493,100 | 1,376,352 |
| LZ4 groups | 2,600 | 458,931,800 | 2,752,528 |
| Whole columns | 1,100 | 511,235,100 | 3,014,961 |
| Warm group cache | 0 | 0 | 0 |

These are optimized release builds, with allocation instrumentation run separately from timing. The incremental read scope starts after setup and warmup; setup-inclusive lifetime peaks are reported separately and vary before the measured reads. Six warmed cache slots retain 48 fewer bytes in the candidate. All 140 allocation runs pass their exact workload checks. These figures describe requested heap memory, not resident memory or an enforced budget.

This is the group-access prerequisite within Stage 1. Full whole-column and identity error propagation, raw-constructor/dictionary-directory validation, and removal of infallible LazyColumns indexing belong to the next Stage 1 PR. The shared deserializer and row-count helper affect whole-column decoding too, and valid multi-group whole-column reads are included in validation. The remaining infallible whole-column entry points will be removed in that next PR. I have not changed the file format, residency, snapshot rules or budget enforcement. Variable-width scratch remains unbudgeted; representationally impossible lengths and reported allocation failures return errors, but this is not an engine memory guarantee. Backup and restore are outside this work.
