### PR TITLE
Propagate exact row count failures to SQL

### DIFF
--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -5439,7 +5439,7 @@ impl Executor {
                         }
                     } else if agg.column == "*" {
                         // COUNT(*) - use row_count
-                        let count = table.row_count();
+                        let count = table.row_count()?;
                         result_values.push(Value::Integer(count as i64));
                     } else {
                         // COUNT(col) - need to count non-null values, can't pushdown easily
@@ -5822,7 +5822,7 @@ impl Executor {
                     "COUNT" => {
                         if agg.column == "*" {
                             // COUNT(*) - use row_count()
-                            Some(Value::Integer(table.row_count() as i64))
+                            Some(Value::Integer(table.row_count()? as i64))
                         } else {
                             // COUNT(col) - need scanner for NULL checking
                             // Could optimize with a dedicated count_non_null method
@@ -7170,7 +7170,7 @@ impl Executor {
         let tx = self.engine.begin_transaction()?;
         let table = tx.get_table(&cs.table_name)?;
 
-        let count = table.row_count();
+        let count = table.row_count()?;
 
         // Build result
         let mut result_values = CompactVec::with_capacity(1);
@@ -7388,7 +7388,10 @@ impl Executor {
         };
 
         // Get the count
-        let count = table.row_count();
+        let count = match table.row_count() {
+            Ok(count) => count,
+            Err(error) => return Some(Err(error)),
+        };
 
         // Cache the compiled state
         let compiled_cs = CompiledCountStar {

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -193,7 +193,7 @@ impl Executor {
         }
 
         // Use table's row_count method (O(1) instead of O(n))
-        let count = table.row_count();
+        let count = table.row_count()?;
 
         // Build result - wrap columns in CompactArc once for zero-copy sharing
         let col_name = alias.unwrap_or_else(|| "COUNT(*)".to_string());
@@ -1163,7 +1163,7 @@ impl Executor {
 
                 // Iterate through row_ids and collect non-excluded ones
                 // Row IDs are typically 1-based and sequential
-                let row_count = table.row_count();
+                let row_count = table.row_count()?;
                 for row_id in 1..=(row_count as i64) {
                     if !exclusion_set.contains(row_id) {
                         all_row_ids.push(row_id);

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -2176,12 +2176,13 @@ impl Executor {
         }
 
         // Try to get distinct values from the index
-        let distinct_values = table.get_partition_values(&column_name).or_else(|| {
-            // Fallback: dictionary-based extraction from cold volumes
-            let schema = table.schema();
-            let col_idx = *schema.column_index_map().get(&column_name)?;
-            table.compute_distinct_values(col_idx)
-        });
+        let distinct_values = match table.get_partition_values(&column_name) {
+            Some(values) => Some(values),
+            None => match table.schema().column_index_map().get(&column_name) {
+                Some(&col_idx) => table.compute_distinct_values(col_idx)?,
+                None => None,
+            },
+        };
 
         if let Some(distinct_values) = distinct_values {
             // Build output column name (use alias if present)

--- a/src/executor/statistics.rs
+++ b/src/executor/statistics.rs
@@ -155,7 +155,7 @@ impl Executor {
         let schema = table.schema().clone();
 
         // Get row count
-        let row_count = table.row_count();
+        let row_count = table.row_count()?;
 
         // Collect all rows for zone map building (zone maps need complete data)
         let mut all_rows = table.collect_all_rows(None)?;

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -3915,13 +3915,13 @@ impl Table for MVCCTable {
         None
     }
 
-    fn row_count(&self) -> usize {
+    fn row_count(&self) -> Result<usize> {
         // Try O(1) fast path first
         if let Some(count) = MVCCTable::fast_row_count(self) {
-            return count;
+            return Ok(count);
         }
         // Fall back to optimized single-pass counting
-        MVCCTable::row_count(self)
+        Ok(MVCCTable::row_count(self))
     }
 
     fn row_count_hint(&self) -> usize {

--- a/src/storage/traits/table.rs
+++ b/src/storage/traits/table.rs
@@ -870,8 +870,11 @@ pub trait Table: Send + Sync {
     ///
     /// # Returns
     /// The number of visible rows in the table
-    fn row_count(&self) -> usize {
-        0 // Default implementation - override in concrete tables
+    ///
+    /// # Errors
+    /// Returns a storage error if visible rows cannot be read.
+    fn row_count(&self) -> Result<usize> {
+        Ok(0) // Default implementation - override in concrete tables
     }
 
     /// Fast O(1) row count hint for optimizer decisions
@@ -879,7 +882,7 @@ pub trait Table: Send + Sync {
     /// Returns an upper bound estimate without expensive visibility checks.
     /// Use for cache eligibility and similar decisions where exact count isn't needed.
     fn row_count_hint(&self) -> usize {
-        self.row_count() // Default falls back to row_count
+        usize::MAX // Unknown cardinality, without loading table data
     }
 
     /// Fast O(1) exact row count for COUNT(*) queries
@@ -999,8 +1002,11 @@ pub trait Table: Send + Sync {
     ///
     /// # Returns
     /// Some(Vec<Value>) with distinct non-null values, or None if fast path unavailable
-    fn compute_distinct_values(&self, _col_idx: usize) -> Option<Vec<Value>> {
-        None
+    ///
+    /// # Errors
+    /// Returns a storage error if the required rows or columns cannot be read.
+    fn compute_distinct_values(&self, _col_idx: usize) -> Result<Option<Vec<Value>>> {
+        Ok(None)
     }
 
     /// Get the count of distinct non-null values from an indexed column.

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -2425,11 +2425,11 @@ impl Table for SegmentedTable {
     // Row count
     // =========================================================================
 
-    fn row_count(&self) -> usize {
+    fn row_count(&self) -> Result<usize> {
         // Snapshot isolation: deduped_row_count and the fast path subtract ALL
         // tombstones, but a snapshot may not see newer ones. Use full scan.
         if self.snapshot_seq.is_some() {
-            return self.collect_all_rows(None).map_or(0, |r| r.len());
+            return self.collect_all_rows(None).map(|rows| rows.len());
         }
         // During seal, rows temporarily exist in both hot and cold.
         // Use the same O(1) formula with overlap correction. The count
@@ -2440,7 +2440,7 @@ impl Table for SegmentedTable {
         let seg = self.segment_mgr.deduped_row_count();
         let pending = self.segment_mgr.pending_tombstone_count(self.txn_id());
         let overlap = self.segment_mgr.seal_overlap();
-        seg.saturating_sub(pending) + self.hot.row_count().saturating_sub(overlap)
+        Ok(seg.saturating_sub(pending) + self.hot.row_count()?.saturating_sub(overlap))
     }
 
     fn row_count_hint(&self) -> usize {
@@ -3356,19 +3356,19 @@ impl Table for SegmentedTable {
         Some(distinct.into_iter().collect())
     }
 
-    fn compute_distinct_values(&self, col_idx: usize) -> Option<Vec<Value>> {
+    fn compute_distinct_values(&self, col_idx: usize) -> Result<Option<Vec<Value>>> {
         // Bail for snapshot isolation — tombstone visibility is snapshot-dependent
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         // Bail during seal overlap — hot and cold may have duplicates
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
         let schema = self.hot.schema();
         if col_idx >= schema.columns.len() {
-            return None;
+            return Ok(None);
         }
         let col_name = &schema.columns[col_idx].name;
 
@@ -3378,19 +3378,19 @@ impl Table for SegmentedTable {
             for v in hot_values {
                 distinct.insert(v);
             }
-        } else if self.hot.row_count() > 0 {
+        } else if self.hot.row_count()? > 0 {
             // Hot has rows but no index on this column — cannot enumerate without full scan
-            return None;
+            return Ok(None);
         }
 
         if !self.segment_mgr.has_segments() {
-            return Some(distinct.into_iter().collect());
+            return Ok(Some(distinct.into_iter().collect()));
         }
 
         let no_tombstones = self.segment_mgr.is_tombstone_set_empty()
             && !self.segment_mgr.has_pending_tombstones(self.txn_id());
 
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = if no_tombstones {
             // Avoid cloning the Arc when we know the set is empty
             Arc::new(FxHashMap::default())
@@ -3474,7 +3474,7 @@ impl Table for SegmentedTable {
             }
         }
 
-        Some(distinct.into_iter().collect())
+        Ok(Some(distinct.into_iter().collect()))
     }
 
     fn collect_rows_grouped_by_partition(&self, column_name: &str) -> Option<Vec<(Value, RowVec)>> {
@@ -6400,8 +6400,8 @@ mod tests {
         ) -> Result<Box<dyn QueryResult>> {
             Err(crate::core::Error::internal("not implemented"))
         }
-        fn row_count(&self) -> usize {
-            self.rows.len()
+        fn row_count(&self) -> Result<usize> {
+            Ok(self.rows.len())
         }
         fn fast_row_count(&self) -> Option<usize> {
             Some(self.rows.len())
@@ -6469,7 +6469,7 @@ mod tests {
         );
         let table = SegmentedTable::hot_only(Box::new(hot));
 
-        assert_eq!(table.row_count(), 2);
+        assert_eq!(table.row_count().unwrap(), 2);
         assert_eq!(table.segment_count(), 0);
     }
 
@@ -6509,7 +6509,7 @@ mod tests {
 
         let table = SegmentedTable::new(Box::new(hot), mgr);
 
-        assert_eq!(table.row_count(), 5); // 3 segment + 2 hot
+        assert_eq!(table.row_count().unwrap(), 5); // 3 segment + 2 hot
         assert_eq!(table.fast_row_count(), Some(5));
     }
 
@@ -6651,7 +6651,7 @@ mod tests {
         let hot = MockHotTable::new(schema.clone(), vec![]);
 
         let mut table = SegmentedTable::hot_only(Box::new(hot));
-        assert_eq!(table.row_count(), 0);
+        assert_eq!(table.row_count().unwrap(), 0);
 
         table
             .insert(Row::from_values(vec![
@@ -6659,7 +6659,7 @@ mod tests {
                 Value::Float(10.0),
             ]))
             .unwrap();
-        assert_eq!(table.row_count(), 1);
+        assert_eq!(table.row_count().unwrap(), 1);
     }
 
     #[test]

--- a/tests/fallible_row_count_test.rs
+++ b/tests/fallible_row_count_test.rs
@@ -1,0 +1,181 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use stoolap::core::{DataType, Row, SchemaBuilder, Value};
+use stoolap::storage::mvcc::{MVCCTable, TransactionVersionStore, VersionStore};
+use stoolap::storage::traits::Table;
+use stoolap::storage::volume::io::{read_volume_from_disk, write_volume_to_disk};
+use stoolap::storage::volume::manifest::{SegmentManager, SegmentMeta};
+use stoolap::storage::volume::table::SegmentedTable;
+use stoolap::storage::volume::writer::VolumeBuilder;
+use stoolap::Database;
+
+fn cold_table(dir: &Path, snapshot: bool) -> (SegmentedTable, PathBuf) {
+    let schema = SchemaBuilder::new("t")
+        .column("id", DataType::Integer, false, true)
+        .column("v", DataType::Integer, false, false)
+        .build();
+    let mut builder = VolumeBuilder::new(&schema);
+    for id in [1, 2] {
+        builder.add_row(
+            id,
+            &Row::from_values(vec![Value::Integer(id), Value::Integer(id * 10)]),
+        );
+    }
+    let path = write_volume_to_disk(dir, "t", 1, &builder.finish()).unwrap();
+    let volume = Arc::new(read_volume_from_disk(&path).unwrap());
+    assert!(volume.is_warm());
+    volume.mark_accessed();
+    let manager = Arc::new(SegmentManager::new("t", Some(dir.to_path_buf())));
+    manager.register_segment(
+        1,
+        volume,
+        SegmentMeta {
+            segment_id: 1,
+            file_path: PathBuf::from("vol_0000000000000001.vol"),
+            row_count: 2,
+            min_row_id: 1,
+            max_row_id: 2,
+            creation_lsn: 0,
+            seal_seq: 0,
+            schema_version: 0,
+        },
+        Some(&schema),
+    );
+    manager.evict_idle_volumes(0);
+    manager.evict_idle_volumes(3);
+    assert!(manager.segments_raw()[&1].volume.is_cold());
+    let store = Arc::new(VersionStore::new(schema.table_name.clone(), schema));
+    let mut local = TransactionVersionStore::new(Arc::clone(&store), 1);
+    if snapshot {
+        local
+            .put(
+                3,
+                Row::from_values(vec![Value::Integer(3), Value::Integer(30)]),
+                false,
+            )
+            .unwrap();
+    }
+    let hot = Box::new(MVCCTable::new(1, store, local));
+    let table = if snapshot {
+        SegmentedTable::with_snapshot_seq(hot, manager, 1)
+    } else {
+        SegmentedTable::new(hot, manager)
+    };
+    (table, path)
+}
+
+#[test]
+fn snapshot_count_propagates_reload_failure_and_keeps_local_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let (table, path) = cold_table(dir.path(), true);
+    let bytes = std::fs::read(&path).unwrap();
+    std::fs::remove_file(&path).unwrap();
+    for _ in 0..2 {
+        let expected = table.collect_all_rows(None).map(|rows| rows.len());
+        assert!(expected
+            .as_ref()
+            .unwrap_err()
+            .to_string()
+            .contains("cold volume reload failed"));
+        assert_eq!(format!("{:?}", table.row_count()), format!("{expected:?}"));
+    }
+    std::fs::write(&path, bytes).unwrap();
+    assert_eq!(table.collect_all_rows(None).unwrap().len(), 3);
+}
+
+#[test]
+fn distinct_values_propagates_cold_reload_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let (table, path) = cold_table(dir.path(), false);
+    std::fs::remove_file(&path).unwrap();
+    let expected = table
+        .segment_manager()
+        .get_volumes_newest_first()
+        .map(|_| Some(Vec::<Value>::new()));
+    assert!(expected
+        .as_ref()
+        .unwrap_err()
+        .to_string()
+        .contains("cold volume reload failed"));
+    assert_eq!(
+        format!("{:?}", table.compute_distinct_values(1)),
+        format!("{expected:?}")
+    );
+}
+
+#[test]
+fn exact_counts_include_transaction_local_rows() {
+    let db = Database::open("memory://exact_counts_include_transaction_local_rows").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    tx.execute("INSERT INTO t VALUES (1, 10), (2, 20)", ())
+        .unwrap();
+    assert_eq!(
+        tx.query_one::<i64, _>("SELECT COUNT(*) FROM t", ())
+            .unwrap(),
+        2
+    );
+    tx.execute("DELETE FROM t WHERE id = 1", ()).unwrap();
+    assert_eq!(
+        tx.query_one::<i64, _>("SELECT COUNT(*) + 1 FROM t", ())
+            .unwrap(),
+        2
+    );
+    tx.rollback().unwrap();
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM t", ())
+            .unwrap(),
+        0
+    );
+}
+
+#[test]
+fn prepared_count_tracks_committed_changes() {
+    let db = Database::open("memory://prepared_count_tracks_committed_changes").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", ())
+        .unwrap();
+    let count = db.prepare("SELECT COUNT(*) FROM t").unwrap();
+    for id in 1..=3 {
+        assert_eq!(count.query_one::<i64, _>(()).unwrap(), id - 1);
+        db.execute("INSERT INTO t VALUES ($1)", (id,)).unwrap();
+        assert_eq!(count.query_one::<i64, _>(()).unwrap(), id);
+    }
+    db.execute("DELETE FROM t WHERE id = 2", ()).unwrap();
+    assert_eq!(count.query_one::<i64, _>(()).unwrap(), 2);
+}
+
+#[test]
+fn cold_distinct_preserves_local_unindexed_values() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open(&format!("file://{}", dir.path().display())).unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10), (2, 20)", ())
+        .unwrap();
+    db.execute("PRAGMA CHECKPOINT", ()).unwrap();
+    let mut tx = db.begin().unwrap();
+    tx.execute("INSERT INTO t VALUES (3, 30)", ()).unwrap();
+    let values: Vec<i64> = tx
+        .query("SELECT DISTINCT v FROM t ORDER BY v", ())
+        .unwrap()
+        .map(|row| row.unwrap().get(0).unwrap())
+        .collect();
+    assert_eq!(values, [10, 20, 30]);
+    tx.rollback().unwrap();
+}


### PR DESCRIPTION
I propagate storage errors from exact row counts, so a snapshot COUNT(*) cannot turn an unreadable cold volume into a count of zero. I carry the result through every exact-count caller, including compiled COUNT and ANALYZE. The DISTINCT fallback uses the same exact hot-row count to account for local inserts, so I make that fallback fallible and preserve its cold reload error too.

Custom Table implementations now return Result from row_count and compute_distinct_values. I keep both production row_count_hint implementations and the resident fast_row_count path unchanged. The default hint reports unknown cardinality conservatively without loading rows. I add no per-row or per-volume structure, successful-path allocation, or lock operation; the count algorithms and seal lock scope remain the same.

I measured allocations in release builds with DHAT, with no competing build or test job. All 112 runs, seven per build for each of eight workloads, match exactly in allocation count, allocated bytes, retained bytes and peak tracked heap. The hot write probes cover 1,000 prepared INSERT/UPDATE/point cycles in explicit and automatic transactions. The focused probes cover hot and sealed COUNT, transaction-local hot and snapshot COUNT, and cold DISTINCT with and without local rows. Focused allocation windows start after setup and warmup, with 1,000 queries for hot/sealed COUNT and cold DISTINCT, and 10 for the local-row cases. Hot COUNT retains 49,152 bytes and peaks at 73,912 bytes in both builds. Independent review verified the raw results. Latency acceptance remains open.

I added two failure guards using an evicted volume whose file is then removed. Both fail on the same checkout after reverting only the production change: the old code returns zero or None instead of the observed reload error. The tests compare Debug output so they compile against both the old usize/Option signatures and the new Result signatures. Three compatibility tests cover transaction-local rows, prepared counts after commits, and cold DISTINCT with unindexed local values. Independent source review and final re-review found no blockers for a draft.

Formatting, all-target/all-feature clippy with warnings denied, 46 focused tests and the same 46 file-backed tests pass. The full in-memory suite passes 5,337 tests with 3 skipped. Nextest reports one output-handle annotation in insert_select_test::test_insert_select_column_reorder; an isolated target recheck passes without the annotation. All CI checks pass, including Linux, macOS and Windows tests, coverage, feature checks, MSRV and release builds.

I keep this PR in draft because latency acceptance is unresolved. After competing work stopped, I completed a 28-run comparison and one 21-run reverse-order confirmation, using retained release binaries, seven runs per build, and one million explicit prepared INSERT/UPDATE/point cycles per run. Both host audits were clean and all row/result oracles passed. The p99 ranges below are nanoseconds, PR129 baseline versus this PR:

| Workload | First baseline | First candidate | Confirmation baseline | Confirmation candidate |
| --- | ---: | ---: | ---: | ---: |
| INSERT | 500-792 | 500-584 | 500-625 | 500-791 |
| UPDATE | 917-1834 | 1000-1542 | 1083-1584 | 1041-1875 |
| Point lookup | 834-1833 | 875-1125 | 958-1333 | 916-1833 |

The candidate's mean p99 moved down in the first comparison and up in the confirmation; both comparisons passed the effective CPU-rate screen. Overlap does not establish unchanged latency. The earlier PR129 versus PR128 gate is open too, and its confirmation failed the CPU-rate screen. Three diagnostic traces did not reproduce the high tails, so I cannot attribute them to scheduler interference. Instrumented trace timings are not acceptance evidence. I stopped additional reruns rather than continuing an inconclusive measurement loop. Remaining latency workloads are unmeasured; Stage 1 is not complete and Stage 2 has not started.

This is a small prerequisite within Stage 1. Whole-column decode errors, LazyColumns indexing removal, identity accessors, and the remaining optional aggregate error paths are still pending. A malformed whole-column payload can still panic through the existing infallible access path. I have not changed the format, residency policy, snapshot visibility rules, or memory admission. Backup and restore are outside this work.
