### PR TITLE
Propagate storage errors from SUM and AVG

### DIFF
--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -5449,7 +5449,7 @@ impl Executor {
                 "SUM" => {
                     let col_idx = col_index_map.get(&agg.column_lower).copied();
                     if let Some(idx) = col_idx {
-                        if let Some((sum, count)) = table.sum_column(idx) {
+                        if let Some((sum, count)) = table.sum_column(idx)? {
                             if count == 0 {
                                 result_values.push(Value::null(crate::core::DataType::Float));
                             } else {
@@ -5471,7 +5471,7 @@ impl Executor {
                 "AVG" => {
                     let col_idx = col_index_map.get(&agg.column_lower).copied();
                     if let Some(idx) = col_idx {
-                        if let Some((sum, count)) = table.avg_column(idx) {
+                        if let Some((sum, count)) = table.avg_column(idx)? {
                             if count == 0 {
                                 result_values.push(Value::null(crate::core::DataType::Float));
                             } else {
@@ -5831,7 +5831,7 @@ impl Executor {
                     }
                     "SUM" => {
                         if let Some(idx) = col_idx {
-                            if let Some((sum, count)) = table.sum_column(idx) {
+                            if let Some((sum, count)) = table.sum_column(idx)? {
                                 if count == 0 {
                                     Some(Value::null(crate::core::DataType::Float))
                                 } else if sum.fract() == 0.0 && sum.abs() < i64::MAX as f64 {
@@ -5848,7 +5848,7 @@ impl Executor {
                     }
                     "AVG" => {
                         if let Some(idx) = col_idx {
-                            if let Some((sum, count)) = table.avg_column(idx) {
+                            if let Some((sum, count)) = table.avg_column(idx)? {
                                 if count == 0 {
                                     Some(Value::null(crate::core::DataType::Float))
                                 } else {

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -4671,16 +4671,16 @@ impl Table for MVCCTable {
             .get_segments_to_scan(column, operator, value)
     }
 
-    fn sum_column(&self, col_idx: usize) -> Option<(f64, usize)> {
+    fn sum_column(&self, col_idx: usize) -> Result<Option<(f64, usize)>> {
         // Only use deferred aggregation if no uncommitted local changes
         // (local changes are in txn_versions, not the main version_store)
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
-            return None;
+            return Ok(None);
         }
         drop(txn_versions);
 
-        Some(self.version_store.sum_column(self.txn_id, col_idx))
+        Ok(Some(self.version_store.sum_column(self.txn_id, col_idx)))
     }
 
     fn min_column(&self, col_idx: usize) -> Option<Option<Value>> {

--- a/src/storage/traits/table.rs
+++ b/src/storage/traits/table.rs
@@ -1207,8 +1207,8 @@ pub trait Table: Send + Sync {
     ///
     /// # Arguments
     /// * `col_idx` - Column index to sum
-    fn sum_column(&self, _col_idx: usize) -> Option<(f64, usize)> {
-        None // Default implementation - override in concrete tables
+    fn sum_column(&self, _col_idx: usize) -> Result<Option<(f64, usize)>> {
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// Compute AVG of a column without materializing rows (deferred aggregation)
@@ -1218,7 +1218,7 @@ pub trait Table: Send + Sync {
     ///
     /// # Arguments
     /// * `col_idx` - Column index to average
-    fn avg_column(&self, _col_idx: usize) -> Option<(f64, usize)> {
+    fn avg_column(&self, _col_idx: usize) -> Result<Option<(f64, usize)>> {
         // Default: use sum_column if available
         self.sum_column(_col_idx)
     }

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -2472,25 +2472,27 @@ impl Table for SegmentedTable {
     // Aggregation pushdown
     // =========================================================================
 
-    fn sum_column(&self, col_idx: usize) -> Option<(f64, usize)> {
+    fn sum_column(&self, col_idx: usize) -> Result<Option<(f64, usize)>> {
         // Snapshot isolation: cold aggregation uses tombstones without snapshot
         // filtering. Bail so the executor falls back to full scan.
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
-        let hot_result = self.hot.sum_column(col_idx);
+        let hot_result = self.hot.sum_column(col_idx)?;
 
         if !self.segment_mgr.has_segments() {
-            return hot_result;
+            return Ok(hot_result);
         }
 
         // During seal, hot+cold overlap — can't reliably sum
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
-        let (hot_sum, hot_count) = hot_result?;
+        let Some((hot_sum, hot_count)) = hot_result else {
+            return Ok(None);
+        };
 
         // Pre-compute default contribution for schema-evolved volumes
         // that are missing this column (added via ALTER TABLE ADD COLUMN).
@@ -2556,11 +2558,11 @@ impl Table for SegmentedTable {
                 }
             }
             let total_sum = hot_sum + cold_sum_int as f64 + cold_sum_float;
-            return Some((total_sum, total_count));
+            return Ok(Some((total_sum, total_count)));
         }
 
         // Tombstones exist: scan columnar data with dedup (avoids full Row materialization)
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -2615,7 +2617,7 @@ impl Table for SegmentedTable {
                 }
             }
         }
-        Some((total_sum, total_count))
+        Ok(Some((total_sum, total_count)))
     }
 
     fn min_column(&self, col_idx: usize) -> Option<Option<Value>> {
@@ -6424,7 +6426,7 @@ mod tests {
             }
             Some(max)
         }
-        fn sum_column(&self, col_idx: usize) -> Option<(f64, usize)> {
+        fn sum_column(&self, col_idx: usize) -> Result<Option<(f64, usize)>> {
             let mut sum = 0.0;
             let mut count = 0;
             for (_, row) in &self.rows {
@@ -6440,7 +6442,7 @@ mod tests {
                     _ => {}
                 }
             }
-            Some((sum, count))
+            Ok(Some((sum, count)))
         }
     }
 
@@ -6599,7 +6601,7 @@ mod tests {
 
         let table = SegmentedTable::new(Box::new(hot), mgr);
 
-        let (sum, count) = table.sum_column(1).unwrap();
+        let (sum, count) = table.sum_column(1).unwrap().unwrap();
         assert_eq!(sum, 530.0);
         assert_eq!(count, 3);
     }

--- a/tests/fallible_row_count_test.rs
+++ b/tests/fallible_row_count_test.rs
@@ -145,6 +145,82 @@ fn exact_counts_include_transaction_local_rows() {
     );
 }
 
+fn assert_sum_reload_failure(aggregate: impl Fn(&SegmentedTable) -> String) {
+    let dir = tempfile::tempdir().unwrap();
+    let (table, path) = cold_table(dir.path(), false);
+    table.segment_manager().add_tombstones(&[1], 1);
+    let bytes = std::fs::read(&path).unwrap();
+    std::fs::remove_file(&path).unwrap();
+    for _ in 0..2 {
+        let expected = table
+            .segment_manager()
+            .get_volumes_newest_first()
+            .map(|_| Some((0.0, 0_usize)));
+        assert!(expected
+            .as_ref()
+            .unwrap_err()
+            .to_string()
+            .contains("cold volume reload failed"));
+        assert_eq!(aggregate(&table), format!("{expected:?}"));
+    }
+    std::fs::write(&path, bytes).unwrap();
+    let restored = aggregate(&table);
+    assert!(restored == "Some((20.0, 1))" || restored == "Ok(Some((20.0, 1)))");
+}
+
+#[test]
+fn sum_propagates_cold_reload_failure() {
+    assert_sum_reload_failure(|table| format!("{:?}", table.sum_column(1)));
+}
+
+#[test]
+fn avg_propagates_cold_reload_failure() {
+    assert_sum_reload_failure(|table| format!("{:?}", table.avg_column(1)));
+}
+
+#[test]
+fn sum_and_avg_use_resident_stats_without_reloading() {
+    let dir = tempfile::tempdir().unwrap();
+    let (table, path) = cold_table(dir.path(), false);
+    std::fs::remove_file(&path).unwrap();
+    for result in [
+        format!("{:?}", table.sum_column(1)),
+        format!("{:?}", table.avg_column(1)),
+    ] {
+        assert!(result == "Some((30.0, 2))" || result == "Ok(Some((30.0, 2)))");
+    }
+    assert!(table.segment_manager().segments_raw()[&1].volume.is_cold());
+}
+
+#[test]
+fn sum_and_avg_preserve_local_rows_and_wrapped_expressions() {
+    let db =
+        Database::open("memory://sum_and_avg_preserve_local_rows_and_wrapped_expressions").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10), (2, 20)", ())
+        .unwrap();
+    let mut tx = db.begin().unwrap();
+    tx.execute("INSERT INTO t VALUES (3, 30)", ()).unwrap();
+    for (query, expected) in [
+        ("SELECT SUM(v) FROM t", 60.0),
+        ("SELECT AVG(v) FROM t", 20.0),
+        ("SELECT SUM(v) + 1 FROM t", 61.0),
+        ("SELECT AVG(v) * 2 FROM t", 40.0),
+    ] {
+        assert_eq!(tx.query_one::<f64, _>(query, ()).unwrap(), expected);
+    }
+    tx.rollback().unwrap();
+    for (query, expected) in [
+        ("SELECT SUM(v) FROM t", 30.0),
+        ("SELECT AVG(v) FROM t", 15.0),
+        ("SELECT SUM(v) + 1 FROM t", 31.0),
+        ("SELECT AVG(v) * 2 FROM t", 30.0),
+    ] {
+        assert_eq!(db.query_one::<f64, _>(query, ()).unwrap(), expected);
+    }
+}
+
 #[test]
 fn prepared_count_tracks_committed_changes() {
     let db = Database::open("memory://prepared_count_tracks_committed_changes").unwrap();


### PR DESCRIPTION
I propagate cold-volume reload errors from SUM and AVG instead of treating an unreadable volume as an unavailable optimization. Both aggregate execution paths now return the storage error. I preserve the resident-statistics fast path, snapshot and transaction-local fallbacks, arithmetic, and existing lock scope.

This is stacked on #130 and remains a draft. Table implementers must update sum_column and avg_column to return Result<Option<(f64, usize)>>. I add no per-row or per-volume structure, successful-path allocation, or lock operation. This slice does not change INSERT, UPDATE or point lookup algorithms. I have not measured latency or allocations for this slice, and the unresolved latency gates for #129 and #130 remain open. I am not claiming performance acceptance or completion of Stage 1.

I reuse the existing cold-volume fixture for two reload-error guards and controls for metadata-only reads, transaction-local rows, and wrapped aggregate expressions. On the same checkout, reverting only the four source files makes both guards fail with None instead of the reload error; all seven other tests pass. Restoring the source passes 90 focused tests and the same 90 file-backed tests. Formatting and all-target/all-feature clippy with warnings denied pass. Independent source review and final guard re-review found no blockers. The full in-memory suite passes 5,341 tests with 3 skipped and one nextest output-handle annotation in upsert_cold_dupe_test::test_upsert_cold_composite_unique_no_dupes.

The isolated three-test target passes without the output-handle annotation.

Whole-column decoding can still panic through the existing infallible access path. MIN/MAX, partition/ordered access, filtered/grouped aggregates and identity accessors remain for the rest of Stage 1. I have not changed the file format, residency policy, visibility rules or memory admission. Backup and restore are outside this work.
