### PR TITLE
Propagate failures from optional storage reads

### DIFF
--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -5430,7 +5430,7 @@ impl Executor {
                 "COUNT" => {
                     if agg.distinct {
                         // COUNT(DISTINCT col) - try to get count from index without cloning values
-                        if let Some(count) = table.get_partition_count(&agg.column_lower) {
+                        if let Some(count) = table.get_partition_count(&agg.column_lower)? {
                             // get_partition_count already excludes NULL values per SQL standard
                             result_values.push(Value::Integer(count as i64));
                         } else {
@@ -5487,7 +5487,7 @@ impl Executor {
                 "MIN" => {
                     let col_idx = col_index_map.get(&agg.column_lower).copied();
                     if let Some(idx) = col_idx {
-                        if let Some(min_val) = table.min_column(idx) {
+                        if let Some(min_val) = table.min_column(idx)? {
                             result_values
                                 .push(min_val.unwrap_or_else(|| {
                                     Value::null(crate::core::DataType::Integer)
@@ -5502,7 +5502,7 @@ impl Executor {
                 "MAX" => {
                     let col_idx = col_index_map.get(&agg.column_lower).copied();
                     if let Some(idx) = col_idx {
-                        if let Some(max_val) = table.max_column(idx) {
+                        if let Some(max_val) = table.max_column(idx)? {
                             result_values
                                 .push(max_val.unwrap_or_else(|| {
                                     Value::null(crate::core::DataType::Integer)
@@ -5699,7 +5699,7 @@ impl Executor {
 
         // --- Call storage-level filtered aggregation ---
 
-        let values = match table.compute_filtered_aggregates(&agg_ops, storage_expr.as_ref()) {
+        let values = match table.compute_filtered_aggregates(&agg_ops, storage_expr.as_ref())? {
             Some(v) => v,
             None => return Ok(None),
         };
@@ -5861,16 +5861,18 @@ impl Executor {
                             None
                         }
                     }
-                    "MIN" => col_idx.and_then(|idx| {
-                        table.min_column(idx).map(|min_opt| {
+                    "MIN" => match col_idx {
+                        Some(idx) => table.min_column(idx)?.map(|min_opt| {
                             min_opt.unwrap_or_else(|| Value::null(crate::core::DataType::Integer))
-                        })
-                    }),
-                    "MAX" => col_idx.and_then(|idx| {
-                        table.max_column(idx).map(|max_opt| {
+                        }),
+                        None => None,
+                    },
+                    "MAX" => match col_idx {
+                        Some(idx) => table.max_column(idx)?.map(|max_opt| {
                             max_opt.unwrap_or_else(|| Value::null(crate::core::DataType::Integer))
-                        })
-                    }),
+                        }),
+                        None => None,
+                    },
                     _ => None,
                 };
 
@@ -6550,7 +6552,7 @@ impl Executor {
         stmt: &SelectStatement,
         all_columns: &[String],
         classification: &QueryClassification,
-    ) -> Option<Box<dyn QueryResult>> {
+    ) -> Option<Result<Box<dyn QueryResult>>> {
         use crate::parser::ast::GroupByModifier;
         use crate::storage::mvcc::version_store::AggregateOp;
 
@@ -6824,7 +6826,10 @@ impl Executor {
         }
 
         // Call storage-level aggregation
-        let results = table.compute_grouped_aggregates(&group_by_indices, &aggregates)?;
+        let results = match table.compute_grouped_aggregates(&group_by_indices, &aggregates) {
+            Ok(results) => results?,
+            Err(error) => return Some(Err(error)),
+        };
 
         // Convert to rows
         let mut rows = RowVec::new();
@@ -6837,7 +6842,7 @@ impl Executor {
             ));
         }
 
-        Some(Box::new(ExecutorResult::new(result_columns, rows)))
+        Some(Ok(Box::new(ExecutorResult::new(result_columns, rows))))
     }
 
     /// Try fast COUNT(DISTINCT col) using compiled cache
@@ -6901,7 +6906,7 @@ impl Executor {
         let table = tx.get_table(&cd.table_name)?;
 
         let count = table
-            .get_partition_count(&cd.column_name)
+            .get_partition_count(&cd.column_name)?
             .ok_or_else(|| crate::core::Error::internal("Index no longer available for column"))?;
 
         // Build result
@@ -7076,15 +7081,14 @@ impl Executor {
             }
         };
 
-        // Check if column has an index (required for fast path). Reuse the
-        // value: a second call could return None (e.g. seal overlap or a
-        // cold-volume reload failure) and an unwrap would panic.
+        // Cache only an available count; storage failures must reach the caller.
         let count = match table.get_partition_count(&column_name) {
-            Some(c) => c,
-            None => {
+            Ok(Some(c)) => c,
+            Ok(None) => {
                 *compiled_guard = CompiledExecution::NotOptimizable(self.engine.schema_epoch());
                 return None;
             }
+            Err(error) => return Some(Err(error)),
         };
 
         // Cache the compiled state

--- a/src/executor/index_optimizer.rs
+++ b/src/executor/index_optimizer.rs
@@ -259,7 +259,7 @@ impl Executor {
 
         // Try to use index-ordered scan
         if let Some(rows) =
-            table.collect_rows_ordered_by_index(&column_name, ascending, limit, offset)
+            table.collect_rows_ordered_by_index(&column_name, ascending, limit, offset)?
         {
             // Project rows according to SELECT expressions
             let projected_rows = self.project_rows(&stmt.columns, rows, all_columns, ctx)?;

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -2176,7 +2176,7 @@ impl Executor {
         }
 
         // Try to get distinct values from the index
-        let distinct_values = match table.get_partition_values(&column_name) {
+        let distinct_values = match table.get_partition_values(&column_name)? {
             Some(values) => Some(values),
             None => match table.schema().column_index_map().get(&column_name) {
                 Some(&col_idx) => table.compute_distinct_values(col_idx)?,
@@ -2335,6 +2335,7 @@ impl Executor {
                 if let Some(result) =
                     self.try_storage_aggregation(table.as_ref(), stmt, &all_columns, classification)
                 {
+                    let result = result?;
                     let columns = CompactArc::new(result.columns().to_vec());
                     return Ok((result, columns, false, None));
                 }
@@ -3737,18 +3738,18 @@ impl Executor {
                                         &all_columns,
                                         &partition_col,
                                         limit_val,
-                                    );
-                                if let Ok(query_result) = result {
+                                    )?;
+                                if let Some(query_result) = result {
                                     let columns = CompactArc::new(query_result.columns().to_vec());
                                     return Ok((query_result, columns, false, None));
                                 }
-                                // Fall through to regular path if optimization fails
+                                // Fall through when the optimization is unavailable.
                             }
                         }
 
                         // Regular path: Fetch rows grouped by partition (no hash grouping needed)
                         if let Some(grouped_data) =
-                            table.collect_rows_grouped_by_partition(&partition_col)
+                            table.collect_rows_grouped_by_partition(&partition_col)?
                         {
                             // Flatten rows and build partition map
                             let mut all_rows = RowVec::new();
@@ -3826,7 +3827,7 @@ impl Executor {
                             ascending,
                             fetch_limit,
                             0,
-                        ) {
+                        )? {
                             (
                                 sorted_rows,
                                 Some(WindowPreSortedState {

--- a/src/executor/window.rs
+++ b/src/executor/window.rs
@@ -1130,14 +1130,12 @@ impl Executor {
         base_columns: &[String],
         partition_col: &str,
         limit: usize,
-    ) -> Result<Box<dyn QueryResult>> {
+    ) -> Result<Option<Box<dyn QueryResult>>> {
         // Parse window functions from SELECT list
         let mut window_functions = self.parse_window_functions(stmt, base_columns)?;
         self.fold_window_control_arguments(&mut window_functions, ctx)?;
         if window_functions.is_empty() {
-            return Err(Error::internal(
-                "No window functions found for lazy partition fetch",
-            ));
+            return Ok(None);
         }
 
         // Build column index map
@@ -1168,9 +1166,9 @@ impl Executor {
             select_items.iter().map(|i| i.output_name.clone()).collect();
 
         // Get partition values from the index (lazy iteration key!)
-        let partition_values = match table.get_partition_values(partition_col) {
+        let partition_values = match table.get_partition_values(partition_col)? {
             Some(values) => values,
-            None => return Err(Error::internal("Failed to get partition values from index")),
+            None => return Ok(None),
         };
 
         // Process partitions one at a time, stopping when we have enough rows
@@ -1341,7 +1339,10 @@ impl Executor {
             }
         }
 
-        Ok(Box::new(ExecutorResult::new(result_columns, result_rows)))
+        Ok(Some(Box::new(ExecutorResult::new(
+            result_columns,
+            result_rows,
+        ))))
     }
 
     /// Parse SELECT list to determine output order and sources

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -3939,14 +3939,14 @@ impl Table for MVCCTable {
         ascending: bool,
         limit: usize,
         offset: usize,
-    ) -> Option<RowVec> {
+    ) -> Result<Option<RowVec>> {
         // If transaction has local changes (inserts/updates/deletes), fall back to
         // the regular path which correctly merges local changes via collect_visible_rows.
         // This optimization only reads from the global version store and indexes.
         {
             let txn_versions = self.txn_versions.read().unwrap();
             if txn_versions.has_local_changes() {
-                return None;
+                return Ok(None);
             }
         }
 
@@ -3956,17 +3956,19 @@ impl Table for MVCCTable {
         if let Some(pk_idx) = self.cached_schema.pk_column_index() {
             let pk_col = &self.cached_schema.columns[pk_idx];
             if pk_col.name_lower == column_name.to_lowercase() {
-                return self.version_store.collect_rows_pk_ordered(
+                return Ok(self.version_store.collect_rows_pk_ordered(
                     self.txn_id,
                     ascending,
                     limit,
                     offset,
-                );
+                ));
             }
         }
 
         // Check if column has an index
-        let index = self.version_store.get_index_by_column(column_name)?;
+        let Some(index) = self.version_store.get_index_by_column(column_name) else {
+            return Ok(None);
+        };
 
         // Try using the efficient ordered iteration method (available in B-tree indexes)
         // We request more row IDs than needed to account for invisible rows
@@ -4000,7 +4002,7 @@ impl Table for MVCCTable {
 
                     // Check if we've reached the limit
                     if rows.len() >= limit {
-                        return Some(rows);
+                        return Ok(Some(rows));
                     }
                 }
             }
@@ -4008,7 +4010,7 @@ impl Table for MVCCTable {
             // If we got all needed rows, return them
             // If not, we may need to fetch more (rare case with many invisible rows)
             if !rows.is_empty() {
-                return Some(rows);
+                return Ok(Some(rows));
             }
         }
 
@@ -4018,7 +4020,7 @@ impl Table for MVCCTable {
         // If the index doesn't support get_all_values (returns empty), return None
         // to let the regular query execution path handle ORDER BY + LIMIT
         if all_values.is_empty() {
-            return None;
+            return Ok(None);
         }
 
         // Sort values using partial_cmp (Value implements PartialOrd)
@@ -4059,13 +4061,13 @@ impl Table for MVCCTable {
 
                     // Check if we've reached the limit
                     if rows.len() >= limit {
-                        return Some(rows);
+                        return Ok(Some(rows));
                     }
                 }
             }
         }
 
-        Some(rows)
+        Ok(Some(rows))
     }
 
     fn collect_rows_pk_keyset(
@@ -4097,22 +4099,27 @@ impl Table for MVCCTable {
         ))
     }
 
-    fn collect_rows_grouped_by_partition(&self, column_name: &str) -> Option<Vec<(Value, RowVec)>> {
+    fn collect_rows_grouped_by_partition(
+        &self,
+        column_name: &str,
+    ) -> Result<Option<Vec<(Value, RowVec)>>> {
         // If transaction has local changes, fall back to regular path
         {
             let txn_versions = self.txn_versions.read().unwrap();
             if txn_versions.has_local_changes() {
-                return None;
+                return Ok(None);
             }
         }
 
         // Check if column has an index
-        let index = self.version_store.get_index_by_column(column_name)?;
+        let Some(index) = self.version_store.get_index_by_column(column_name) else {
+            return Ok(None);
+        };
 
         // Get all unique values from the index (partition keys)
         let all_values = index.get_all_values();
         if all_values.is_empty() {
-            return Some(Vec::new());
+            return Ok(Some(Vec::new()));
         }
 
         // Collect rows grouped by partition value
@@ -4139,36 +4146,40 @@ impl Table for MVCCTable {
             }
         }
 
-        Some(result)
+        Ok(Some(result))
     }
 
-    fn get_partition_values(&self, column_name: &str) -> Option<Vec<Value>> {
+    fn get_partition_values(&self, column_name: &str) -> Result<Option<Vec<Value>>> {
         // Only use index-based distinct values if no uncommitted local changes
         // (local changes are in txn_versions, not reflected in the index)
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
-            return None;
+            return Ok(None);
         }
         drop(txn_versions);
 
         // Get index for the column
-        let index = self.version_store.get_index_by_column(column_name)?;
+        let Some(index) = self.version_store.get_index_by_column(column_name) else {
+            return Ok(None);
+        };
         // Return all distinct values from the index
-        Some(index.get_all_values())
+        Ok(Some(index.get_all_values()))
     }
 
-    fn get_partition_count(&self, column_name: &str) -> Option<usize> {
+    fn get_partition_count(&self, column_name: &str) -> Result<Option<usize>> {
         // Only use index-based count if no uncommitted local changes
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
-            return None;
+            return Ok(None);
         }
         drop(txn_versions);
 
         // Get index for the column
-        let index = self.version_store.get_index_by_column(column_name)?;
+        let Some(index) = self.version_store.get_index_by_column(column_name) else {
+            return Ok(None);
+        };
         // Return count of distinct non-null values without cloning
-        index.get_distinct_count_excluding_null()
+        Ok(index.get_distinct_count_excluding_null())
     }
 
     fn get_rows_for_partition_value(
@@ -4683,42 +4694,43 @@ impl Table for MVCCTable {
         Ok(Some(self.version_store.sum_column(self.txn_id, col_idx)))
     }
 
-    fn min_column(&self, col_idx: usize) -> Option<Option<Value>> {
+    fn min_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
         // Only use deferred aggregation if no uncommitted local changes
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
-            return None;
+            return Ok(None);
         }
         drop(txn_versions);
 
-        Some(self.version_store.min_column(self.txn_id, col_idx))
+        Ok(Some(self.version_store.min_column(self.txn_id, col_idx)))
     }
 
-    fn max_column(&self, col_idx: usize) -> Option<Option<Value>> {
+    fn max_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
         // Only use deferred aggregation if no uncommitted local changes
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
-            return None;
+            return Ok(None);
         }
         drop(txn_versions);
 
-        Some(self.version_store.max_column(self.txn_id, col_idx))
+        Ok(Some(self.version_store.max_column(self.txn_id, col_idx)))
     }
 
     fn compute_grouped_aggregates(
         &self,
         group_by_indices: &[usize],
         aggregates: &[(crate::storage::mvcc::version_store::AggregateOp, usize)],
-    ) -> Option<Vec<crate::storage::mvcc::version_store::GroupedAggregateResult>> {
+    ) -> Result<Option<Vec<crate::storage::mvcc::version_store::GroupedAggregateResult>>> {
         // Only use storage-level aggregation if no uncommitted local changes
         let txn_versions = self.txn_versions.read().unwrap();
         if txn_versions.has_local_changes() {
-            return None;
+            return Ok(None);
         }
         drop(txn_versions);
 
-        self.version_store
-            .compute_grouped_aggregates(self.txn_id, group_by_indices, aggregates)
+        Ok(self
+            .version_store
+            .compute_grouped_aggregates(self.txn_id, group_by_indices, aggregates))
     }
 }
 

--- a/src/storage/traits/table.rs
+++ b/src/storage/traits/table.rs
@@ -916,9 +916,9 @@ pub trait Table: Send + Sync {
         ascending: bool,
         limit: usize,
         offset: usize,
-    ) -> Option<RowVec> {
+    ) -> Result<Option<RowVec>> {
         let _ = (column_name, ascending, limit, offset);
-        None // Default implementation - override in concrete tables
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// The first `limit` rows after `offset` in the order of `column_name`,
@@ -974,9 +974,12 @@ pub trait Table: Send + Sync {
     /// # Returns
     /// Some(Vec<(Value, RowVec)>) where each tuple is (partition_value, rows_in_partition)
     /// Returns None if the column has no index
-    fn collect_rows_grouped_by_partition(&self, column_name: &str) -> Option<Vec<(Value, RowVec)>> {
+    fn collect_rows_grouped_by_partition(
+        &self,
+        column_name: &str,
+    ) -> Result<Option<Vec<(Value, RowVec)>>> {
         let _ = column_name;
-        None // Default implementation - override in concrete tables
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// Get distinct partition values from an indexed column.
@@ -987,9 +990,9 @@ pub trait Table: Send + Sync {
     ///
     /// # Returns
     /// Some(Vec<Value>) with distinct values, or None if column has no index
-    fn get_partition_values(&self, column_name: &str) -> Option<Vec<Value>> {
+    fn get_partition_values(&self, column_name: &str) -> Result<Option<Vec<Value>>> {
         let _ = column_name;
-        None // Default implementation - override in concrete tables
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// Compute distinct non-null values for a column by exploiting cold volume
@@ -1017,9 +1020,9 @@ pub trait Table: Send + Sync {
     ///
     /// # Returns
     /// Some(count) excluding NULL values, or None if column has no index
-    fn get_partition_count(&self, column_name: &str) -> Option<usize> {
+    fn get_partition_count(&self, column_name: &str) -> Result<Option<usize>> {
         let _ = column_name;
-        None // Default implementation - override in concrete tables
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// Get rows for a specific partition value.
@@ -1230,8 +1233,8 @@ pub trait Table: Send + Sync {
     ///
     /// # Arguments
     /// * `col_idx` - Column index to find minimum
-    fn min_column(&self, _col_idx: usize) -> Option<Option<Value>> {
-        None // Default implementation - override in concrete tables
+    fn min_column(&self, _col_idx: usize) -> Result<Option<Option<Value>>> {
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// Compute MAX of a column without materializing rows (deferred aggregation)
@@ -1241,8 +1244,8 @@ pub trait Table: Send + Sync {
     ///
     /// # Arguments
     /// * `col_idx` - Column index to find maximum
-    fn max_column(&self, _col_idx: usize) -> Option<Option<Value>> {
-        None // Default implementation - override in concrete tables
+    fn max_column(&self, _col_idx: usize) -> Result<Option<Option<Value>>> {
+        Ok(None) // Default implementation - override in concrete tables
     }
 
     /// Compute aggregates with a WHERE filter at the storage level.
@@ -1261,8 +1264,8 @@ pub trait Table: Send + Sync {
         &self,
         _aggregates: &[(AggregateOp, usize)],
         _where_expr: &dyn Expression,
-    ) -> Option<Vec<crate::core::Value>> {
-        None // Default: not supported
+    ) -> Result<Option<Vec<crate::core::Value>>> {
+        Ok(None) // Default: not supported
     }
 
     /// Compute grouped aggregates at the storage level.
@@ -1280,8 +1283,8 @@ pub trait Table: Send + Sync {
         &self,
         _group_by_indices: &[usize],
         _aggregates: &[(AggregateOp, usize)],
-    ) -> Option<Vec<GroupedAggregateResult>> {
-        None // Default: not supported
+    ) -> Result<Option<Vec<GroupedAggregateResult>>> {
+        Ok(None) // Default: not supported
     }
 }
 

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -2620,22 +2620,24 @@ impl Table for SegmentedTable {
         Ok(Some((total_sum, total_count)))
     }
 
-    fn min_column(&self, col_idx: usize) -> Option<Option<Value>> {
+    fn min_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
-        let hot_result = self.hot.min_column(col_idx);
+        let hot_result = self.hot.min_column(col_idx)?;
 
         if !self.segment_mgr.has_segments() {
-            return hot_result;
+            return Ok(hot_result);
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
-        let hot_min = hot_result?;
+        let Some(hot_min) = hot_result else {
+            return Ok(None);
+        };
 
         let schema = self.hot.schema();
         // Column resolution uses mapping (handles renames/drops) not col_name.
@@ -2688,7 +2690,7 @@ impl Table for SegmentedTable {
                     }
                 }
             }
-            return Some(overall_min);
+            return Ok(Some(overall_min));
         }
 
         // Zone-map fast path: when there are no tombstones/pending tombstones
@@ -2701,7 +2703,7 @@ impl Table for SegmentedTable {
             && !self.segment_mgr.has_pending_tombstones(self.txn_id());
 
         // Scan columnar data with dedup (typed direct access, no Value alloc)
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = if no_tombstones {
             None
         } else {
@@ -2921,25 +2923,27 @@ impl Table for SegmentedTable {
                 }
             }
         }
-        Some(overall_min)
+        Ok(Some(overall_min))
     }
 
-    fn max_column(&self, col_idx: usize) -> Option<Option<Value>> {
+    fn max_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
-        let hot_result = self.hot.max_column(col_idx);
+        let hot_result = self.hot.max_column(col_idx)?;
 
         if !self.segment_mgr.has_segments() {
-            return hot_result;
+            return Ok(hot_result);
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
-        let hot_max = hot_result?;
+        let Some(hot_max) = hot_result else {
+            return Ok(None);
+        };
 
         let schema = self.hot.schema();
         // Column resolution uses mapping (handles renames/drops) not col_name.
@@ -2993,14 +2997,14 @@ impl Table for SegmentedTable {
                     }
                 }
             }
-            return Some(overall_max);
+            return Ok(Some(overall_max));
         }
 
         // See min_column: same zone-map + typed scan strategy for MAX.
         let no_tombstones = self.segment_mgr.is_tombstone_set_empty()
             && !self.segment_mgr.has_pending_tombstones(self.txn_id());
 
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = if no_tombstones {
             None
         } else {
@@ -3215,16 +3219,16 @@ impl Table for SegmentedTable {
                 }
             }
         }
-        Some(overall_max)
+        Ok(Some(overall_max))
     }
 
     // =========================================================================
     // Partition and index-based pushdowns
     // =========================================================================
 
-    fn get_partition_count(&self, column_name: &str) -> Option<usize> {
+    fn get_partition_count(&self, column_name: &str) -> Result<Option<usize>> {
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         if !self.segment_mgr.has_segments() {
@@ -3233,22 +3237,26 @@ impl Table for SegmentedTable {
 
         // During seal, hot+cold overlap — can't reliably count
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
         let schema = self.hot.schema();
-        let col_idx = *schema.column_index_map().get(&column_name.to_lowercase())?;
+        let Some(&col_idx) = schema.column_index_map().get(&column_name.to_lowercase()) else {
+            return Ok(None);
+        };
 
         // Collect hot distinct values from index. If no index exists on this
         // column, bail — we can't enumerate hot values without a full scan.
         let mut distinct: ValueSet = ValueSet::default();
-        let hot_values = self.hot.get_partition_values(column_name)?;
+        let Some(hot_values) = self.hot.get_partition_values(column_name)? else {
+            return Ok(None);
+        };
         for v in hot_values {
             distinct.insert(v);
         }
 
         // Build skip set: hot row_ids + tombstones + pending tombstones
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -3289,33 +3297,37 @@ impl Table for SegmentedTable {
             }
         }
 
-        Some(distinct.len())
+        Ok(Some(distinct.len()))
     }
 
-    fn get_partition_values(&self, column_name: &str) -> Option<Vec<Value>> {
+    fn get_partition_values(&self, column_name: &str) -> Result<Option<Vec<Value>>> {
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         if let Some(result) = self.unsealed(|hot| hot.get_partition_values(column_name)) {
             return result;
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
         let schema = self.hot.schema();
-        let col_idx = *schema.column_index_map().get(&column_name.to_lowercase())?;
+        let Some(&col_idx) = schema.column_index_map().get(&column_name.to_lowercase()) else {
+            return Ok(None);
+        };
 
         // Bail if hot has no index on this column — can't enumerate hot values
         // without a full scan. Returning Some with only cold values would be wrong.
         let mut distinct: ValueSet = ValueSet::default();
-        let hot_values = self.hot.get_partition_values(column_name)?;
+        let Some(hot_values) = self.hot.get_partition_values(column_name)? else {
+            return Ok(None);
+        };
         for v in hot_values {
             distinct.insert(v);
         }
 
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -3355,7 +3367,7 @@ impl Table for SegmentedTable {
             }
         }
 
-        Some(distinct.into_iter().collect())
+        Ok(Some(distinct.into_iter().collect()))
     }
 
     fn compute_distinct_values(&self, col_idx: usize) -> Result<Option<Vec<Value>>> {
@@ -3376,7 +3388,7 @@ impl Table for SegmentedTable {
 
         // Collect hot distinct values via index (same requirement as get_partition_values)
         let mut distinct: ValueSet = ValueSet::default();
-        if let Some(hot_values) = self.hot.get_partition_values(col_name) {
+        if let Some(hot_values) = self.hot.get_partition_values(col_name)? {
             for v in hot_values {
                 distinct.insert(v);
             }
@@ -3479,9 +3491,12 @@ impl Table for SegmentedTable {
         Ok(Some(distinct.into_iter().collect()))
     }
 
-    fn collect_rows_grouped_by_partition(&self, column_name: &str) -> Option<Vec<(Value, RowVec)>> {
+    fn collect_rows_grouped_by_partition(
+        &self,
+        column_name: &str,
+    ) -> Result<Option<Vec<(Value, RowVec)>>> {
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         if !self.segment_mgr.has_segments() {
@@ -3489,22 +3504,24 @@ impl Table for SegmentedTable {
         }
 
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
         let schema = self.hot.schema();
-        let col_idx = *schema.column_index_map().get(&column_name.to_lowercase())?;
+        let Some(&col_idx) = schema.column_index_map().get(&column_name.to_lowercase()) else {
+            return Ok(None);
+        };
 
         // Start from hot grouped data
         let mut groups: ValueMap<RowVec> = ValueMap::default();
-        if let Some(hot_groups) = self.hot.collect_rows_grouped_by_partition(column_name) {
+        if let Some(hot_groups) = self.hot.collect_rows_grouped_by_partition(column_name)? {
             for (val, rows) in hot_groups {
                 groups.insert(val, rows);
             }
         }
 
         // Build hot_skip: hot row_ids + tombstones + pending tombstones
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -3554,7 +3571,7 @@ impl Table for SegmentedTable {
             }
         }
 
-        Some(groups.into_iter().collect())
+        Ok(Some(groups.into_iter().collect()))
     }
 
     fn get_rows_for_partition_value(
@@ -3675,7 +3692,7 @@ impl Table for SegmentedTable {
         ascending: bool,
         limit: usize,
         offset: usize,
-    ) -> Option<RowVec> {
+    ) -> Result<Option<RowVec>> {
         if let Some(result) = self.unsealed(|hot| {
             hot.collect_rows_ordered_by_index(column_name, ascending, limit, offset)
         }) {
@@ -3685,21 +3702,23 @@ impl Table for SegmentedTable {
         // Snapshot isolation: the merge path doesn't filter by snapshot_seq.
         // Fall back to the full scan + sort path which handles MVCC correctly.
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
 
         // Only optimize when ORDER BY column is the INTEGER PRIMARY KEY.
         // For PK, row_id order == value order, so we can merge sorted sources.
         let schema = self.hot.schema().clone();
-        let pk_idx = schema.pk_column_index()?;
+        let Some(pk_idx) = schema.pk_column_index() else {
+            return Ok(None);
+        };
         let pk_col = &schema.columns[pk_idx];
         if pk_col.name_lower != column_name.to_lowercase() {
-            return None;
+            return Ok(None);
         }
 
         let needed = limit.saturating_add(offset);
         if needed == 0 {
-            return Some(RowVec::new());
+            return Ok(Some(RowVec::new()));
         }
 
         // 1. Collect hot rows in PK order. Only materialize `needed` rows
@@ -3707,15 +3726,12 @@ impl Table for SegmentedTable {
         let hot_rows =
             match self
                 .hot
-                .collect_rows_ordered_by_index(column_name, ascending, needed, 0)
+                .collect_rows_ordered_by_index(column_name, ascending, needed, 0)?
             {
                 Some(rows) => rows,
                 None => {
                     // Local changes prevent ordered iteration — fall back to collect + sort.
-                    let mut rows = match self.hot.collect_all_rows(None) {
-                        Ok(r) => r,
-                        Err(_) => return None,
-                    };
+                    let mut rows = self.hot.collect_all_rows(None)?;
                     if ascending {
                         rows.sort_unstable_by_key(|&(id, _)| id);
                     } else {
@@ -3737,7 +3753,7 @@ impl Table for SegmentedTable {
 
         // 3. Get volumes (oldest first — segment_id ascending order).
         //    We need column data for materialization, so use ensure_columns path.
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         // volumes is oldest-first after the reverse inside get_volumes_newest_first.
 
         // 4. K-way merge using per-source cursors.
@@ -3881,7 +3897,7 @@ impl Table for SegmentedTable {
             }
         }
 
-        Some(result)
+        Ok(Some(result))
     }
 
     fn collect_rows_pk_keyset(
@@ -4621,27 +4637,27 @@ impl Table for SegmentedTable {
         &self,
         aggregates: &[(AggregateOp, usize)],
         where_expr: &dyn Expression,
-    ) -> Option<Vec<Value>> {
+    ) -> Result<Option<Vec<Value>>> {
         // Bail out: snapshot isolation requires tombstone filtering by snapshot_seq
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         // Bail out: during seal, hot+cold overlap makes aggregation unreliable
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
         // Bail out: no cold volumes — let the regular path handle hot-only data
         if !self.segment_mgr.has_segments() {
-            return None;
+            return Ok(None);
         }
         // Bail out: only conjunctive-simple filters can be evaluated on raw arrays
         if !where_expr.is_conjunctive_simple() {
-            return None;
+            return Ok(None);
         }
         let comparisons = where_expr.collect_comparisons();
         if comparisons.is_empty() {
-            return None;
+            return Ok(None);
         }
 
         let schema = self.hot.schema().clone();
@@ -4663,10 +4679,9 @@ impl Table for SegmentedTable {
 
         let mut preds: Vec<ResolvedPred> = Vec::with_capacity(comparisons.len());
         for (col_name, op, value) in &comparisons {
-            let col_idx = schema
-                .column_index_map()
-                .get(&col_name.to_lowercase())
-                .copied()?;
+            let Some(&col_idx) = schema.column_index_map().get(&col_name.to_lowercase()) else {
+                return Ok(None);
+            };
             let col_type = schema.columns[col_idx].data_type;
             let target = match (col_type, value) {
                 (DataType::Integer, Value::Integer(i)) => TypedTarget::Int64(*i),
@@ -4685,7 +4700,7 @@ impl Table for SegmentedTable {
                 (DataType::Text, Value::Text(s)) if *op == crate::core::Operator::Eq => {
                     TypedTarget::DictEq(crate::common::SmartString::from(s.as_str()))
                 }
-                _ => return None, // unsupported type combination
+                _ => return Ok(None), // unsupported type combination
             };
             preds.push(ResolvedPred {
                 schema_col_idx: col_idx,
@@ -4760,7 +4775,7 @@ impl Table for SegmentedTable {
         let mut accums = vec![Accum::default(); aggregates.len()];
 
         // --- Hot buffer rows -------------------------------------------------
-        let hot_rows = self.hot.collect_all_rows(Some(where_expr)).ok()?;
+        let hot_rows = self.hot.collect_all_rows(Some(where_expr))?;
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(hot_rows.len().max(1024), Default::default());
         for (row_id, row) in &hot_rows {
@@ -4864,7 +4879,7 @@ impl Table for SegmentedTable {
         self.hot.collect_hot_row_ids_into(&mut hot_skip);
 
         // --- Cold volumes (THE FAST PATH) ------------------------------------
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         self.segment_mgr
             .insert_pending_tombstones_into(self.txn_id(), &mut hot_skip);
@@ -5400,7 +5415,7 @@ impl Table for SegmentedTable {
             volumes.iter().filter_map(|v| process_volume(v)).collect();
 
         if bail.load(std::sync::atomic::Ordering::Relaxed) {
-            return None;
+            return Ok(None);
         }
 
         // Merge per-volume accumulators
@@ -5496,20 +5511,20 @@ impl Table for SegmentedTable {
             })
             .collect();
 
-        Some(results)
+        Ok(Some(results))
     }
 
     fn compute_grouped_aggregates(
         &self,
         group_by_indices: &[usize],
         aggregates: &[(AggregateOp, usize)],
-    ) -> Option<Vec<GroupedAggregateResult>> {
+    ) -> Result<Option<Vec<GroupedAggregateResult>>> {
         if self.snapshot_seq.is_some() {
-            return None;
+            return Ok(None);
         }
         // Multi-column GROUP BY: fall back to the full executor path.
         if group_by_indices.len() != 1 {
-            return None;
+            return Ok(None);
         }
         let _seal_guard = self.segment_mgr.acquire_seal_read();
         if !self.segment_mgr.has_segments() {
@@ -5520,7 +5535,7 @@ impl Table for SegmentedTable {
 
         // During seal, hot+cold overlap — can't reliably aggregate
         if self.segment_mgr.seal_overlap() > 0 {
-            return None;
+            return Ok(None);
         }
 
         let gb_idx = group_by_indices[0];
@@ -5784,7 +5799,7 @@ impl Table for SegmentedTable {
         let mut groups: ValueMap<(Vec<Value>, Vec<Accum>)> = ValueMap::default();
 
         // ---- Process hot rows (small, use Value-based path) ----
-        let hot_rows = self.hot.collect_all_rows(None).ok()?;
+        let hot_rows = self.hot.collect_all_rows(None)?;
         for (_, row) in &hot_rows {
             let key = row
                 .get(gb_idx)
@@ -5798,7 +5813,7 @@ impl Table for SegmentedTable {
         }
 
         // ---- Process cold volumes (columnar fast path) ----
-        let volumes = self.segment_mgr.get_volumes_newest_first().ok()?;
+        let volumes = self.segment_mgr.get_volumes_newest_first()?;
         let tombstones_arc = self.segment_mgr.tombstone_set_arc();
         let mut hot_skip: FxHashSet<i64> =
             FxHashSet::with_capacity_and_hasher(10_000, Default::default());
@@ -5810,7 +5825,7 @@ impl Table for SegmentedTable {
         let gb_data_type = if gb_idx < current_schema.columns.len() {
             current_schema.columns[gb_idx].data_type
         } else {
-            return None;
+            return Ok(None);
         };
 
         // Only support Dictionary (Text), Int64 (Integer), and TimestampNanos (Timestamp).
@@ -5818,7 +5833,7 @@ impl Table for SegmentedTable {
         let gb_is_dict = gb_data_type == DataType::Text;
         let gb_is_i64 = gb_data_type == DataType::Integer || gb_data_type == DataType::Timestamp;
         if !gb_is_dict && !gb_is_i64 {
-            return None;
+            return Ok(None);
         }
 
         // Resolved physical aggregate column for a volume.
@@ -6159,7 +6174,7 @@ impl Table for SegmentedTable {
                 let vol_group_maps: Vec<ValueMap<(Vec<Value>, Vec<Accum>)>> =
                     volumes.par_iter().filter_map(&process_volume).collect();
                 if bail.load(std::sync::atomic::Ordering::Relaxed) {
-                    return None;
+                    return Ok(None);
                 }
                 for vol_map in vol_group_maps {
                     for (key, (group_values, vol_accums)) in vol_map {
@@ -6175,7 +6190,7 @@ impl Table for SegmentedTable {
         } else {
             for v in volumes.iter() {
                 if bail.load(std::sync::atomic::Ordering::Relaxed) {
-                    return None;
+                    return Ok(None);
                 }
                 if let Some(vol_map) = process_volume(v) {
                     for (key, (group_values, vol_accums)) in vol_map {
@@ -6191,7 +6206,7 @@ impl Table for SegmentedTable {
         }
 
         if bail.load(std::sync::atomic::Ordering::Relaxed) {
-            return None;
+            return Ok(None);
         }
 
         // Convert to results
@@ -6204,7 +6219,7 @@ impl Table for SegmentedTable {
             })
             .collect();
 
-        Some(results)
+        Ok(Some(results))
     }
 }
 
@@ -6408,7 +6423,7 @@ mod tests {
         fn fast_row_count(&self) -> Option<usize> {
             Some(self.rows.len())
         }
-        fn max_column(&self, col_idx: usize) -> Option<Option<Value>> {
+        fn max_column(&self, col_idx: usize) -> Result<Option<Option<Value>>> {
             let mut max: Option<Value> = None;
             for (_, row) in &self.rows {
                 if let Some(val) = row.get(col_idx) {
@@ -6424,7 +6439,7 @@ mod tests {
                     }
                 }
             }
-            Some(max)
+            Ok(Some(max))
         }
         fn sum_column(&self, col_idx: usize) -> Result<Option<(f64, usize)>> {
             let mut sum = 0.0;
@@ -6571,7 +6586,7 @@ mod tests {
 
         let table = SegmentedTable::new(Box::new(hot), mgr);
 
-        let max = table.max_column(1);
+        let max = table.max_column(1).unwrap();
         assert_eq!(max, Some(Some(Value::Float(500.0))));
     }
 

--- a/tests/fallible_row_count_test.rs
+++ b/tests/fallible_row_count_test.rs
@@ -13,9 +13,15 @@
 // limitations under the License.
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
 
-use stoolap::core::{DataType, Row, SchemaBuilder, Value};
+use stoolap::core::{DataType, Result, Row, RowVec, SchemaBuilder, Value};
+use stoolap::executor::expression::clear_program_cache;
+use stoolap::functions::scalar::SleepFunction;
+use stoolap::functions::{global_registry, FunctionInfo, ScalarFunction};
+use stoolap::storage::expression::ComparisonExpr;
+use stoolap::storage::mvcc::version_store::{AggregateOp, GroupedAggregateResult};
 use stoolap::storage::mvcc::{MVCCTable, TransactionVersionStore, VersionStore};
 use stoolap::storage::traits::Table;
 use stoolap::storage::volume::io::{read_volume_from_disk, write_volume_to_disk};
@@ -25,6 +31,10 @@ use stoolap::storage::volume::writer::VolumeBuilder;
 use stoolap::Database;
 
 fn cold_table(dir: &Path, snapshot: bool) -> (SegmentedTable, PathBuf) {
+    cold_table_with_index(dir, snapshot, false)
+}
+
+fn cold_table_with_index(dir: &Path, snapshot: bool, indexed: bool) -> (SegmentedTable, PathBuf) {
     let schema = SchemaBuilder::new("t")
         .column("id", DataType::Integer, false, true)
         .column("v", DataType::Integer, false, false)
@@ -71,6 +81,9 @@ fn cold_table(dir: &Path, snapshot: bool) -> (SegmentedTable, PathBuf) {
             .unwrap();
     }
     let hot = Box::new(MVCCTable::new(1, store, local));
+    if indexed {
+        hot.create_btree_index("v", false, Some("idx_t_v")).unwrap();
+    }
     let table = if snapshot {
         SegmentedTable::with_snapshot_seq(hot, manager, 1)
     } else {
@@ -176,6 +189,230 @@ fn sum_propagates_cold_reload_failure() {
 #[test]
 fn avg_propagates_cold_reload_failure() {
     assert_sum_reload_failure(|table| format!("{:?}", table.avg_column(1)));
+}
+
+fn assert_optional_reload_failure(
+    read: impl Fn(&SegmentedTable) -> String,
+    expected_value: impl std::fmt::Debug,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let (table, path) = cold_table_with_index(dir.path(), false, true);
+    table.segment_manager().add_tombstones(&[1], 1);
+    let bytes = std::fs::read(&path).unwrap();
+    std::fs::remove_file(&path).unwrap();
+    for _ in 0..2 {
+        let expected = table
+            .segment_manager()
+            .get_volumes_newest_first()
+            .map(|_| ());
+        let error = expected.as_ref().unwrap_err();
+        assert!(error.to_string().contains("cold volume reload failed"));
+        assert_eq!(read(&table), format!("Err({error:?})"));
+    }
+    std::fs::write(&path, bytes).unwrap();
+    let restored = read(&table);
+    let expected = format!("Some({expected_value:?})");
+    assert!(
+        restored == expected || restored == format!("Ok({expected})"),
+        "{restored}"
+    );
+}
+
+#[test]
+fn min_propagates_cold_reload_failure() {
+    assert_optional_reload_failure(
+        |table| format!("{:?}", table.min_column(1)),
+        Some(Value::Integer(20)),
+    );
+}
+
+#[test]
+fn max_propagates_cold_reload_failure() {
+    assert_optional_reload_failure(
+        |table| format!("{:?}", table.max_column(1)),
+        Some(Value::Integer(20)),
+    );
+}
+
+#[test]
+fn partition_count_propagates_cold_reload_failure() {
+    assert_optional_reload_failure(|table| format!("{:?}", table.get_partition_count("v")), 1);
+}
+
+#[test]
+fn partition_values_propagate_cold_reload_failure() {
+    assert_optional_reload_failure(
+        |table| format!("{:?}", table.get_partition_values("v")),
+        vec![Value::Integer(20)],
+    );
+}
+
+fn surviving_rows() -> RowVec {
+    RowVec::from_vec(vec![(
+        2,
+        Row::from_values(vec![Value::Integer(2), Value::Integer(20)]),
+    )])
+}
+
+#[test]
+fn grouped_partition_rows_propagate_cold_reload_failure() {
+    assert_optional_reload_failure(
+        |table| format!("{:?}", table.collect_rows_grouped_by_partition("v")),
+        vec![(Value::Integer(20), surviving_rows())],
+    );
+}
+
+#[test]
+fn ordered_rows_propagate_cold_reload_failure() {
+    assert_optional_reload_failure(
+        |table| {
+            format!(
+                "{:?}",
+                table.collect_rows_ordered_by_index("id", true, 2, 0)
+            )
+        },
+        surviving_rows(),
+    );
+}
+
+#[test]
+fn filtered_aggregates_propagate_cold_reload_failure() {
+    assert_optional_reload_failure(
+        |table| {
+            format!(
+                "{:?}",
+                table.compute_filtered_aggregates(
+                    &[(AggregateOp::Sum, 1)],
+                    &ComparisonExpr::gte("v", Value::Integer(0)),
+                )
+            )
+        },
+        vec![Value::Integer(20)],
+    );
+}
+
+#[test]
+fn grouped_aggregates_propagate_cold_reload_failure() {
+    assert_optional_reload_failure(
+        |table| {
+            format!(
+                "{:?}",
+                table.compute_grouped_aggregates(&[1], &[(AggregateOp::Sum, 1)])
+            )
+        },
+        vec![GroupedAggregateResult {
+            group_values: vec![Value::Integer(20)],
+            aggregate_values: vec![Value::Integer(20)],
+        }],
+    );
+}
+
+static WINDOW_HOOK_LOCK: Mutex<()> = Mutex::new(());
+static WINDOW_HOOK_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Default)]
+struct InvalidFirstPattern;
+
+impl ScalarFunction for InvalidFirstPattern {
+    fn name(&self) -> &str {
+        "SLEEP"
+    }
+
+    fn info(&self) -> FunctionInfo {
+        SleepFunction.info()
+    }
+
+    fn evaluate(&self, _args: &[Value]) -> Result<Value> {
+        Ok(Value::Integer(
+            WINDOW_HOOK_CALLS.fetch_add(1, Ordering::SeqCst) as i64,
+        ))
+    }
+
+    fn clone_box(&self) -> Box<dyn ScalarFunction> {
+        Box::new(Self)
+    }
+}
+
+struct WindowHook {
+    _serial: MutexGuard<'static, ()>,
+}
+
+impl Drop for WindowHook {
+    fn drop(&mut self) {
+        global_registry().register_scalar::<SleepFunction>();
+        clear_program_cache();
+    }
+}
+
+#[test]
+fn lazy_window_propagates_first_error_without_retrying() {
+    let db =
+        Database::open("memory://lazy_window_propagates_first_error_without_retrying").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("CREATE INDEX idx_t_v ON t(v)", ()).unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10)", ()).unwrap();
+    let _hook = WindowHook {
+        _serial: WINDOW_HOOK_LOCK.lock().unwrap_or_else(|e| e.into_inner()),
+    };
+    WINDOW_HOOK_CALLS.store(0, Ordering::SeqCst);
+    global_registry().register_scalar::<InvalidFirstPattern>();
+    clear_program_cache();
+    let result = db.query_one::<bool, _>(
+        "SELECT 'x' REGEXP CASE WHEN SLEEP(v) = 0 THEN '[' ELSE 'x' END, \
+         ROW_NUMBER() OVER (PARTITION BY v) FROM t LIMIT 1",
+        (),
+    );
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Invalid regular expression"));
+    assert_eq!(WINDOW_HOOK_CALLS.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn optional_reads_preserve_fallbacks_with_local_changes() {
+    let db =
+        Database::open("memory://optional_reads_preserve_fallbacks_with_local_changes").unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ())
+        .unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10), (2, 20)", ())
+        .unwrap();
+    let count = db.prepare("SELECT COUNT(DISTINCT v) FROM t").unwrap();
+    for indexed in [false, true] {
+        if indexed {
+            db.execute("CREATE INDEX idx_t_v ON t(v)", ()).unwrap();
+        }
+        assert_eq!(count.query_one::<i64, _>(()).unwrap(), 2);
+        let mut tx = db.begin().unwrap();
+        tx.execute("INSERT INTO t VALUES (3, 30)", ()).unwrap();
+        for (query, expected) in [
+            ("SELECT MIN(v) FROM t", 10),
+            ("SELECT MAX(v) FROM t", 30),
+            ("SELECT COUNT(DISTINCT v) FROM t", 3),
+            ("SELECT SUM(v) FROM t WHERE v >= 20", 50),
+            (
+                "SELECT SUM(v) FROM t GROUP BY v ORDER BY v DESC LIMIT 1",
+                30,
+            ),
+            (
+                "SELECT ROW_NUMBER() OVER (PARTITION BY v) FROM t LIMIT 1",
+                1,
+            ),
+            (
+                "SELECT ROW_NUMBER() OVER (ORDER BY id DESC) FROM t ORDER BY id DESC LIMIT 1",
+                1,
+            ),
+        ] {
+            assert_eq!(
+                tx.query_one::<i64, _>(query, ()).unwrap(),
+                expected,
+                "{query}"
+            );
+        }
+        tx.rollback().unwrap();
+        assert_eq!(count.query_one::<i64, _>(()).unwrap(), 2);
+    }
 }
 
 #[test]


### PR DESCRIPTION
I now propagate storage errors through the remaining optional aggregate, partition and ordered-read APIs. A cold reload failure previously became an unavailable optimization and could trigger a fallback. The lazy window caller also swallowed evaluation errors; it now returns the first failure instead of retrying the query.

This is the next Stage 1 slice of #122, based on merged #131. I changed eight Table methods to return Result<Option<_>>, keeping Ok(None) for unavailable optimizations. This changes the public Table implementation signatures. Scan algorithms, resident-statistics shortcuts and transaction-local fallback behavior are unchanged.

Validation:

- Formatting and all-target/all-feature clippy with warnings denied passed.
- 107 focused tests passed normally and 107 passed with test-filedb.
- Reverting only the production diff made all nine new regression guards fail for the intended reasons; ten controls passed. The restored patch passed again.
- Independent source review, corrections to the test oracle, and final re-review found no remaining correctness blockers.
- All 14 CI checks passed, including the full Linux, macOS and Windows suites. I did not duplicate the full suite locally under the approved workflow.

Row-latency acceptance remains unresolved, so I am keeping this PR draft and do not recommend merging it yet. The original mixed-load median slowdown did not repeat in the bounded confirmation below, but unfavorable commit tails remain. I compared merged #131 (35e0d7a) with this commit (9d16878f) using a release profile with thin LTO, one codegen unit and opt-level 3. Each workload ran seven identical-binary controls, seven baseline runs and seven candidate runs in contiguous blocks. All 126 runs completed exact work with zero errors, stable AC power, low-power mode off, no observed concurrent builds and a clean sleep/display-event audit. I stopped after the declared schedule.

The ordinary hot-path ranges overlap and remain inconclusive. The mixed-64 results show a coherent slowdown despite overlap with one high baseline run. Neither result establishes a performance pass. Explicit-transaction INSERT and UPDATE p99 means increased 6.5% and 7.6%; mixed-16 INSERT increased 15.3%, while the two identical-baseline blocks differed 13.1% on that metric. Mixed-64 UPDATE and point-lookup p50 means increased 35.9% and 40.5%. Their ranges were 56.625..89.250 to 81.250..95.375 us for UPDATE and 18.791..32.917 to 28.292..34.125 us for point lookup. All seven candidate UPDATE and point-lookup p50 values exceed every identical-binary control value and six of seven baseline values. The final baseline run already shifted toward candidate timings, so this sequence cannot distinguish a code effect from a sustained environmental change. Row-latency acceptance has not passed.

| Workload | Operation | Base p99, us | Candidate p99, us | Mean change |
|---|---|---:|---:|---:|
| hot-explicit | insert | 0.458..0.500 | 0.417..0.542 | +6.5% |
| hot-explicit | update | 0.875..1.042 | 0.917..1.084 | +7.6% |
| hot-explicit | point | 0.750..1.000 | 0.750..0.916 | -0.1% |
| hot-auto | insert | 1.042..1.625 | 0.958..1.458 | +1.0% |
| hot-auto | update | 0.958..1.000 | 0.917..1.042 | +1.8% |
| hot-auto | point | 1.041..1.125 | 1.000..1.041 | -4.0% |
| mixed-16 | insert | 22.125..37.167 | 17.958..43.792 | +15.3% |
| mixed-16 | update | 176.875..257.709 | 167.917..221.958 | -13.7% |
| mixed-16 | point | 65.375..85.125 | 67.125..80.625 | -4.7% |
| mixed-64 | insert | 16.666..42.917 | 17.042..25.250 | -32.6% |
| mixed-64 | update | 161.208..220.583 | 184.500..211.208 | +4.4% |
| mixed-64 | point | 63.083..95.416 | 62.959..70.125 | -5.3% |

The hot workloads use one million prepared INSERT/UPDATE/point cycles per run. Mixed workloads use 2,000 transactions at 1,000 arrivals/second, with 2,000 analytic queries and ten ingest/checkpoint passes on cloned handles. The mixed analytic query is the existing filtered top-k control. Its working set fits within 16 MiB, so the 16/64 MiB settings do not test cache pressure. Throughput is approximately 1,000 transactions/second in both mixed builds at the fixed arrival rate, with no rejected work. This is not a capacity measurement.

I measured the changed read shapes separately over 1,023 rows, after warmup, for 2,000 executions of each query per run. Hot MAX has an unfavorable +39.2% p99 mean change; its identical-binary control range was 4.458..10.000 us, broader than either comparison range. These measurements do not establish an analytic speedup.

| Query | Hot base p99, us | Hot candidate p99, us | Sealed base p99, us | Sealed candidate p99, us |
|---|---:|---:|---:|---:|
| MIN(v) | 6.041..7.667 | 6.083..9.167 | 7.875..9.042 | 8.709..9.584 |
| MAX(v) | 4.375..5.041 | 4.833..7.917 | 4.334..5.458 | 4.416..5.167 |
| COUNT(DISTINCT v) | 0.792..0.875 | 0.708..0.875 | 11.083..14.334 | 11.083..12.958 |
| DISTINCT v | 3.209..5.750 | 3.375..5.458 | 14.833..16.292 | 15.250..16.417 |
| GROUP BY v, SUM(id) | 7.500..8.375 | 7.625..10.459 | 12.416..15.417 | 14.042..15.458 |
| Filtered SUM(id) | 5.375..7.375 | 5.250..7.667 | 8.291..11.208 | 10.750..11.500 |
| PK ordered LIMIT | 1.375..1.459 | 1.375..1.625 | 2.709..4.250 | 2.834..3.292 |
| Lazy partition window | 6.416..9.250 | 5.708..8.667 | 22.666..24.583 | 23.500..25.667 |
| Full partition window | 206.750..218.667 | 201.833..221.000 | 235.084..252.833 | 238.084..252.833 |

Allocation checks used seven runs per build and scope, 56 runs total. Hot explicit/autocommit and hot reads matched exactly. Sealed-read block and byte counts varied slightly within both builds; retained and peak bytes matched. The source adds no structures, retained per-row or per-volume bytes, allocation calls or locks. Return-value error checks change the call boundaries.

| Scope | Allocation blocks, base / candidate | Allocated bytes, base / candidate | Retained bytes, both | Peak bytes, both |
|---|---:|---:|---:|---:|
| hot-explicit | 819093 / 819093 | 44000944 / 44000944 | 2590635 | 3372663 |
| hot-auto | 709096 / 709096 | 44619072 / 44619072 | 2978198 | 3759894 |
| reads-hot | 80501 / 80501 | 13777870 / 13777870 | 1520 | 117230 |
| reads-sealed | 142546..142551 / 142546..142549 | 85959010..85959770 / 85959010..85959466 | 1520 | 217569 |

The hot allocation scope covers 10,000 cycles, with allocation deltas measured after warmup and retained/peak values including setup ownership. The read scope covers 50 executions of each of nine warmed queries and measures operation-created allocations only. These are separate scopes, not total engine footprint.

Whole-column decoding, the remaining identity-access migration, and later storage stages are still outstanding. The generic scalar-expression VM still converts scalar-function errors to NULL; this slice changes the window caller only. There is no format, residency, memory-enforcement, seal, WAL, backup or restore change. 

The bounded mixed-64 confirmation completed separately: seven candidate runs followed by seven baseline runs, using the same saved binaries, release profile, workload and guards. All 14 runs completed 2,000 transactions, 2,000 analytic queries and ten ingest/checkpoint passes with zero errors and a clean power-event audit. I did not pool these samples with the initial 126 runs. Percentages compare arithmetic means of seven per-run quantiles. Independent verification and final report re-review are complete.

The original UPDATE and point-lookup median slowdown did not repeat. Both builds now ran below the original control ranges, which weakens attribution to a stable source cost but does not identify the cause. Commit and transaction tails remain unfavorable: candidate runs 1 and 5 were near 7 ms, and run 6 exceeded this baseline maximum too. I retained every run. Row-latency acceptance remains unresolved, so this PR stays draft and is not recommended for merge. No further benchmark runs or rebuilds are scheduled.

| Confirmation metric | Base range, us | Candidate range, us | Base mean, us | Candidate mean, us | Mean change |
|---|---:|---:|---:|---:|---:|
| insert p50 | 3.042..3.667 | 2.916..3.667 | 3.286 | 3.173 | -3.45% |
| update p50 | 46.042..56.458 | 46.500..55.375 | 50.363 | 50.881 | +1.03% |
| point p50 | 15.833..20.125 | 15.292..19.250 | 17.488 | 17.149 | -1.94% |
| insert p99 | 28.583..36.542 | 27.833..40.208 | 33.804 | 33.387 | -1.23% |
| update p99 | 105.875..162.084 | 114.417..147.125 | 128.101 | 130.714 | +2.04% |
| point p99 | 44.458..62.417 | 48.666..59.709 | 53.678 | 53.464 | -0.40% |
| transaction p99 | 3976.792..4794.542 | 4012.958..7349.500 | 4332.262 | 5215.071 | +20.38% |
| commit p99 | 3915.792..4721.125 | 3880.209..7288.500 | 4262.816 | 5139.875 | +20.57% |

The changed optional-read APIs do not execute in this mixed probe. The analytic query uses the existing top-k scanner; explicit UPDATE and point reads use the unchanged mutation and scan paths. Shared function code generation can still affect a build. Checkpoints seal foreground tables, so this workload measures hot/cold interaction. These facts do not excuse the unfavorable tail measurements or prove equivalence.
