### PR TITLE
Return errors from whole-column decoding

### DIFF
--- a/src/storage/volume/format.rs
+++ b/src/storage/volume/format.rs
@@ -802,7 +802,7 @@ pub(crate) fn deserialize_column_block_into(
         }
         COL_BYTES => {
             read_nulls_into(data, &mut pos, row_count, nulls_out)?;
-            let offset_count = read_u64(data, &mut pos)? as usize;
+            let offset_count = read_u64(data, &mut pos)?;
             let bytes_data = bytes_data_out.ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidData, "missing bytes_data_out buffer")
             })?;
@@ -812,7 +812,7 @@ pub(crate) fn deserialize_column_block_into(
                     "missing bytes_offsets_out buffer",
                 )
             })?;
-            if offset_count != row_count {
+            if offset_count != row_count as u64 {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!(
@@ -821,9 +821,15 @@ pub(crate) fn deserialize_column_block_into(
                     ),
                 ));
             }
+            if row_count > data.len().saturating_sub(pos) / 16 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "truncated column block: bytes offsets",
+                ));
+            }
             let base = bytes_data.len() as u64;
-            bytes_offsets.reserve(offset_count);
-            for _ in 0..offset_count {
+            bytes_offsets.reserve(row_count);
+            for _ in 0..row_count {
                 let off = read_u64(data, &mut pos)?;
                 let len = read_u64(data, &mut pos)?;
                 let adjusted = off.checked_add(base).ok_or_else(|| {
@@ -831,18 +837,20 @@ pub(crate) fn deserialize_column_block_into(
                 })?;
                 bytes_offsets.push((adjusted, len));
             }
-            let data_len = read_u64(data, &mut pos)? as usize;
-            if pos + data_len > data.len() {
+            let data_len = read_u64(data, &mut pos)?;
+            if data_len > data.len().saturating_sub(pos) as u64 {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "truncated column block: bytes data",
                 ));
             }
-            bytes_data.extend_from_slice(&data[pos..pos + data_len]);
+            let end_pos = pos + data_len as usize;
+            bytes_data.extend_from_slice(&data[pos..end_pos]);
+            pos = end_pos;
             // Validate offsets against the data blob
             for (i, &(off, len)) in bytes_offsets
                 .iter()
-                .skip(bytes_offsets.len() - offset_count)
+                .skip(bytes_offsets.len() - row_count)
                 .enumerate()
             {
                 let end = off.checked_add(len).ok_or_else(|| {
@@ -851,7 +859,7 @@ pub(crate) fn deserialize_column_block_into(
                         format!("bytes offset overflow at row {}", i),
                     )
                 })?;
-                if (end as usize) > bytes_data.len() {
+                if end > bytes_data.len() as u64 {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!(
@@ -871,6 +879,12 @@ pub(crate) fn deserialize_column_block_into(
                 format!("unknown column type tag {}", col_type_tag),
             ));
         }
+    }
+    if pos != data.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "trailing bytes in column block",
+        ));
     }
     Ok(())
 }

--- a/src/storage/volume/writer.rs
+++ b/src/storage/volume/writer.rs
@@ -265,10 +265,36 @@ impl CompressedBlockStore {
 
     /// Decompress a single column from RAM. Concatenates all row-group blocks.
     /// Runs at ~4 GB/s (LZ4 from RAM), typically <1ms per column.
-    pub fn decompress_column(&self, col_idx: usize) -> ColumnData {
-        let col_blocks = &self.blocks[col_idx];
-        let type_tag = self.col_type_tags[col_idx];
-        let ext_type = DataType::from_u8(self.col_ext_types[col_idx]).unwrap_or(DataType::Null);
+    pub fn decompress_column(&self, col_idx: usize) -> std::io::Result<ColumnData> {
+        let col_blocks = self.blocks.get(col_idx).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "column index out of range",
+            )
+        })?;
+        let type_tag = *self.col_type_tags.get(col_idx).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "missing column type tag")
+        })?;
+        let ext_type = self
+            .col_ext_types
+            .get(col_idx)
+            .and_then(|&tag| DataType::from_u8(tag))
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "invalid extension type tag",
+                )
+            })?;
+        let num_groups = col_blocks.len();
+        if self.group_size == 0
+            || num_groups != self.row_count.div_ceil(self.group_size)
+            || self.decompressed_lens.get(col_idx).map(Vec::len) != Some(num_groups)
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid column block geometry",
+            ));
+        }
 
         // Find pre-built dictionary Arc for this column (Arc clone = ~5ns)
         let dict: Option<Arc<[SmartString]>> = if type_tag == COL_DICTIONARY {
@@ -280,53 +306,29 @@ impl CompressedBlockStore {
             None
         };
 
-        if col_blocks.len() == 1 {
-            let decomp_len = self.decompressed_lens[col_idx][0];
-            let group_rows = self.row_count.min(self.group_size);
-            if col_blocks[0].len() == decomp_len {
-                return deserialize_column_block(
-                    &col_blocks[0],
-                    type_tag,
-                    group_rows,
-                    dict,
-                    ext_type,
-                )
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "corrupt V4 block: col={}, raw, {} rows: {}",
-                        col_idx, group_rows, e
-                    )
-                });
-            }
-            let mut raw = vec![0u8; decomp_len];
-            lz4_flex::decompress_into(&col_blocks[0], &mut raw).unwrap_or_else(|e| {
-                panic!(
-                    "corrupt V4 block: col={}, {} bytes: {}",
-                    col_idx,
-                    col_blocks[0].len(),
-                    e
-                )
-            });
-            return deserialize_column_block(&raw, type_tag, group_rows, dict, ext_type)
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "corrupt V4 block: col={}, {} rows: {}",
-                        col_idx, group_rows, e
-                    )
-                });
+        if num_groups == 1 {
+            return self.decompress_block(
+                col_idx,
+                0,
+                &col_blocks[0],
+                type_tag,
+                num_groups,
+                dict,
+                ext_type,
+            );
         }
 
-        // Multiple groups — decompress each block directly into pre-allocated
-        // output buffers, avoiding one intermediate ColumnData per group.
-        // Reusable LZ4 scratch buffer — allocated once, reused across all groups.
-        let max_decomp = self.decompressed_lens[col_idx]
-            .iter()
-            .copied()
-            .max()
-            .unwrap_or(0);
-        let mut lz4_buf = Vec::with_capacity(max_decomp);
-        let num_groups = col_blocks.len();
-        match type_tag {
+        // Validate all group lengths before reserving the full-column buffers.
+        let mut max_decomp = 0;
+        for gi in 0..num_groups {
+            let (len, _) = self.block_layout(col_idx, gi, type_tag, num_groups)?;
+            max_decomp = max_decomp.max(len);
+        }
+        let mut lz4_buf = Vec::new();
+        lz4_buf
+            .try_reserve_exact(max_decomp)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::OutOfMemory, e))?;
+        Ok(match type_tag {
             super::format::COL_INT64 => {
                 let mut all_values = Vec::with_capacity(self.row_count);
                 let mut all_nulls = Vec::with_capacity(self.row_count);
@@ -345,8 +347,7 @@ impl CompressedBlockStore {
                         None,
                         None,
                         None,
-                    )
-                    .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}, group={gi}: {e}"));
+                    )?;
                 }
                 ColumnData::Int64 {
                     values: all_values,
@@ -371,8 +372,7 @@ impl CompressedBlockStore {
                         None,
                         None,
                         None,
-                    )
-                    .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}, group={gi}: {e}"));
+                    )?;
                 }
                 ColumnData::Float64 {
                     values: all_values,
@@ -397,8 +397,7 @@ impl CompressedBlockStore {
                         None,
                         None,
                         None,
-                    )
-                    .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}, group={gi}: {e}"));
+                    )?;
                 }
                 ColumnData::TimestampNanos {
                     values: all_values,
@@ -423,8 +422,7 @@ impl CompressedBlockStore {
                         Some(&mut all_values),
                         None,
                         None,
-                    )
-                    .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}, group={gi}: {e}"));
+                    )?;
                 }
                 ColumnData::Boolean {
                     values: all_values,
@@ -449,12 +447,22 @@ impl CompressedBlockStore {
                         None,
                         None,
                         None,
-                    )
-                    .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}, group={gi}: {e}"));
+                    )?;
+                }
+                let dictionary = dict.unwrap_or_else(|| Arc::from(Vec::<SmartString>::new()));
+                if all_ids
+                    .iter()
+                    .zip(&all_nulls)
+                    .any(|(&id, &is_null)| !is_null && id as usize >= dictionary.len())
+                {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "dictionary id out of range",
+                    ));
                 }
                 ColumnData::Dictionary {
                     ids: all_ids,
-                    dictionary: dict.unwrap_or_else(|| Arc::from(Vec::<SmartString>::new())),
+                    dictionary,
                     nulls: all_nulls,
                 }
             }
@@ -477,8 +485,7 @@ impl CompressedBlockStore {
                         None,
                         Some(&mut all_data),
                         Some(&mut all_offsets),
-                    )
-                    .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}, group={gi}: {e}"));
+                    )?;
                 }
                 ColumnData::Bytes {
                     data: all_data,
@@ -487,32 +494,22 @@ impl CompressedBlockStore {
                     nulls: all_nulls,
                 }
             }
-            _ => self
-                .decompress_block(
-                    col_idx,
-                    0,
-                    &col_blocks[0],
-                    type_tag,
-                    num_groups,
-                    dict,
-                    ext_type,
-                )
-                .unwrap_or_else(|e| panic!("corrupt V4 block: col={col_idx}: {e}")),
-        }
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "unknown column type tag",
+                ));
+            }
+        })
     }
 
-    /// Decompress and deserialize a single block with context in error messages.
-    #[allow(clippy::too_many_arguments)]
-    fn decompress_block(
+    fn block_layout(
         &self,
         col_idx: usize,
         gi: usize,
-        block: &[u8],
         type_tag: u8,
         num_groups: usize,
-        dict: Option<Arc<[SmartString]>>,
-        ext_type: DataType,
-    ) -> std::io::Result<ColumnData> {
+    ) -> std::io::Result<(usize, usize)> {
         let decomp_len = *self
             .decompressed_lens
             .get(col_idx)
@@ -543,6 +540,33 @@ impl CompressedBlockStore {
                 "invalid column block length",
             ));
         }
+        if type_tag == COL_BYTES
+            && group_rows
+                .checked_mul(17)
+                .and_then(|len| len.checked_add(16))
+                .is_none_or(|len| len > decomp_len)
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid bytes block length",
+            ));
+        }
+        Ok((decomp_len, group_rows))
+    }
+
+    /// Decompress and deserialize a single block with context in error messages.
+    #[allow(clippy::too_many_arguments)]
+    fn decompress_block(
+        &self,
+        col_idx: usize,
+        gi: usize,
+        block: &[u8],
+        type_tag: u8,
+        num_groups: usize,
+        dict: Option<Arc<[SmartString]>>,
+        ext_type: DataType,
+    ) -> std::io::Result<ColumnData> {
+        let (decomp_len, group_rows) = self.block_layout(col_idx, gi, type_tag, num_groups)?;
         let raw_bytes = if block.len() == decomp_len {
             return deserialize_column_block(block, type_tag, group_rows, dict, ext_type);
         } else {
@@ -591,8 +615,7 @@ impl CompressedBlockStore {
         bytes_data_out: Option<&mut Vec<u8>>,
         bytes_offsets_out: Option<&mut Vec<(u64, u64)>>,
     ) -> std::io::Result<()> {
-        let decomp_len = self.decompressed_lens[col_idx][gi];
-        let group_rows = self.group_row_count(gi, num_groups)?;
+        let (decomp_len, group_rows) = self.block_layout(col_idx, gi, type_tag, num_groups)?;
         if block.len() == decomp_len {
             return deserialize_column_block_into(
                 block,
@@ -611,15 +634,22 @@ impl CompressedBlockStore {
         if lz4_buf.len() < decomp_len {
             lz4_buf.resize(decomp_len, 0);
         }
-        lz4_flex::decompress_into(block, &mut lz4_buf[..decomp_len]).map_err(|e| {
-            std::io::Error::new(
+        let decoded_len =
+            lz4_flex::decompress_into(block, &mut lz4_buf[..decomp_len]).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "corrupt V4 block: col={}, group={}/{}: {}",
+                        col_idx, gi, num_groups, e
+                    ),
+                )
+            })?;
+        if decoded_len != decomp_len {
+            return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                format!(
-                    "corrupt V4 block: col={}, group={}/{}: {}",
-                    col_idx, gi, num_groups, e
-                ),
-            )
-        })?;
+                "LZ4 decoded length does not match block length",
+            ));
+        }
         deserialize_column_block_into(
             &lz4_buf[..decomp_len],
             type_tag,
@@ -1066,7 +1096,11 @@ impl std::ops::Index<usize> for LazyColumns {
         let col = self.slots[idx].get_or_init(|| {
             self.compressed_store
                 .as_ref()
-                .map(|store| store.decompress_column(idx))
+                .map(|store| {
+                    store
+                        .decompress_column(idx)
+                        .unwrap_or_else(|e| panic!("corrupt V4 column: col={idx}: {e}"))
+                })
                 .unwrap_or_else(|| {
                     panic!(
                         "BUG: column {} accessed on cold volume (no compressed store). \

--- a/tests/fallible_group_access_test.rs
+++ b/tests/fallible_group_access_test.rs
@@ -43,6 +43,191 @@ fn bytes_block(offset_count: u64) -> Vec<u8> {
     raw
 }
 
+trait ColumnErrorKind {
+    fn error_kind(self) -> Option<ErrorKind>;
+}
+
+impl ColumnErrorKind for ColumnData {
+    fn error_kind(self) -> Option<ErrorKind> {
+        None
+    }
+}
+
+impl ColumnErrorKind for std::io::Result<ColumnData> {
+    fn error_kind(self) -> Option<ErrorKind> {
+        self.err().map(|error| error.kind())
+    }
+}
+
+fn assert_column_error(store: &CompressedBlockStore, col: usize, kind: ErrorKind) {
+    for _ in 0..2 {
+        let outcome = catch_unwind(AssertUnwindSafe(|| {
+            store.decompress_column(col).error_kind()
+        }));
+        assert!(outcome.is_ok(), "whole-column decode panicked");
+        assert_eq!(outcome.unwrap(), Some(kind));
+    }
+}
+
+fn two_group_store(
+    first: Vec<u8>,
+    second: Vec<u8>,
+    lengths: Vec<usize>,
+    data_type: DataType,
+) -> CompressedBlockStore {
+    let dictionary = data_type == DataType::Text;
+    CompressedBlockStore::from_raw_blocks(
+        vec![vec![first, second]],
+        vec![lengths],
+        vec![match data_type {
+            DataType::Text => 5,
+            DataType::Json => 6,
+            _ => 1,
+        }],
+        vec![data_type],
+        vec![data_type as u8],
+        if dictionary {
+            vec!["value".into()]
+        } else {
+            Vec::new()
+        },
+        if dictionary {
+            vec![(0, 0, 1)]
+        } else {
+            Vec::new()
+        },
+        2,
+        4,
+    )
+}
+
+#[test]
+fn whole_column_rejects_incorrect_lz4_output_length() {
+    let store = store(lz4_flex::compress(&[0; 17]), 18, DataType::Integer);
+    assert_column_error(&store, 0, ErrorKind::InvalidData);
+}
+
+#[test]
+fn whole_column_rejects_late_short_lz4_output() {
+    let store = two_group_store(
+        lz4_flex::compress(&[0; 18]),
+        lz4_flex::compress(&[0; 17]),
+        vec![18, 18],
+        DataType::Integer,
+    );
+    assert_column_error(&store, 0, ErrorKind::InvalidData);
+}
+
+#[test]
+fn whole_column_rejects_late_trailing_payload() {
+    for data_type in [DataType::Integer, DataType::Json] {
+        let raw = if data_type == DataType::Json {
+            bytes_block(2)
+        } else {
+            vec![0; 18]
+        };
+        let mut trailing = raw.clone();
+        trailing.push(0);
+        for compressed in [false, true] {
+            let store = two_group_store(
+                raw.clone(),
+                if compressed {
+                    lz4_flex::compress(&trailing)
+                } else {
+                    trailing.clone()
+                },
+                vec![raw.len(), trailing.len()],
+                data_type,
+            );
+            assert_column_error(&store, 0, ErrorKind::InvalidData);
+        }
+    }
+}
+
+#[test]
+fn whole_column_rejects_late_invalid_bytes_offsets() {
+    for count in [1, 3, u64::MAX] {
+        let raw = bytes_block(2);
+        let bad = bytes_block(count);
+        let lengths = vec![raw.len(), bad.len()];
+        let store = two_group_store(raw, bad, lengths, DataType::Json);
+        assert_column_error(&store, 0, ErrorKind::InvalidData);
+    }
+}
+
+#[test]
+fn whole_column_rejects_late_overflowing_blob_length() {
+    let raw = bytes_block(2);
+    let mut bad = raw.clone();
+    let len_offset = bad.len() - 8;
+    bad[len_offset..].copy_from_slice(&u64::MAX.to_le_bytes());
+    let lengths = vec![raw.len(), bad.len()];
+    let store = two_group_store(raw, bad, lengths, DataType::Json);
+    assert_column_error(&store, 0, ErrorKind::InvalidData);
+}
+
+#[test]
+fn whole_column_rejects_late_invalid_dictionary_ids() {
+    let raw = vec![0; 10];
+    let mut bad = raw.clone();
+    bad[2..6].copy_from_slice(&1u32.to_le_bytes());
+    let store = two_group_store(raw, bad, vec![10, 10], DataType::Text);
+    assert_column_error(&store, 0, ErrorKind::InvalidData);
+}
+
+#[test]
+fn whole_column_rejects_missing_group_lengths() {
+    let store = two_group_store(vec![0; 18], vec![0; 18], vec![18], DataType::Integer);
+    assert_column_error(&store, 0, ErrorKind::InvalidData);
+}
+
+#[test]
+fn whole_column_rejects_inconsistent_row_geometry() {
+    let store = CompressedBlockStore::from_raw_blocks(
+        vec![vec![vec![0; 18]]],
+        vec![vec![18]],
+        vec![1],
+        vec![DataType::Integer],
+        vec![0],
+        Vec::new(),
+        Vec::new(),
+        1,
+        2,
+    );
+    assert_column_error(&store, 0, ErrorKind::InvalidData);
+}
+
+#[test]
+fn whole_column_rejects_unrepresentable_decoded_length() {
+    let store = store(vec![0xff], usize::MAX, DataType::Json);
+    assert_column_error(&store, 0, ErrorKind::InvalidData);
+}
+
+#[test]
+fn whole_column_rejects_out_of_range_indices() {
+    let store = store(vec![0; 18], 18, DataType::Integer);
+    for col in [1, usize::MAX] {
+        assert_column_error(&store, col, ErrorKind::InvalidInput);
+    }
+}
+
+#[test]
+fn empty_whole_column_preserves_its_type() {
+    let types = vec![DataType::Integer];
+    let columns = LazyColumns::eager(
+        vec![ColumnData::Int64 {
+            values: Vec::new(),
+            nulls: Vec::new(),
+        }],
+        types.clone(),
+    );
+    let store = CompressedBlockStore::compress_columns(&columns, &types, 0);
+    let decoded = LazyColumns::deferred(store, types);
+    assert!(
+        matches!(&decoded[0], ColumnData::Int64 { values, nulls } if values.is_empty() && nulls.is_empty())
+    );
+}
+
 fn assert_invalid_block(raw: Vec<u8>, data_type: DataType) {
     let store = store(raw.clone(), raw.len(), data_type);
     for _ in 0..2 {
@@ -266,6 +451,34 @@ fn valid_group_round_trip_preserves_all_column_types_and_nulls() {
                 assert_eq!(group.get_value(row), columns[ci].get_value(row));
             }
         }
+        let two_groups = CompressedBlockStore::from_raw_blocks(
+            store
+                .raw_blocks()
+                .iter()
+                .map(|blocks| vec![blocks[0].clone(); 2])
+                .collect(),
+            store
+                .decompressed_lens()
+                .iter()
+                .map(|lengths| vec![lengths[0]; 2])
+                .collect(),
+            store.col_type_tags().to_vec(),
+            types.clone(),
+            store.col_ext_types().to_vec(),
+            vec!["value".into()],
+            vec![(4, 0, 1)],
+            2,
+            4,
+        );
+        for (store, rows) in [(store, 2), (two_groups, 4)] {
+            let decoded = LazyColumns::deferred(store, types.clone());
+            for ci in 0..types.len() {
+                assert_eq!(decoded[ci].len(), rows);
+                for row in 0..rows {
+                    assert_eq!(decoded[ci].get_value(row), columns[ci].get_value(row % 2));
+                }
+            }
+        }
     }
 }
 
@@ -291,6 +504,11 @@ fn valid_final_partial_group_preserves_rows() {
         assert_eq!(last.len(), 3);
         for i in 0..3 {
             assert_eq!(last.get_i64(i), (ROW_GROUP_SIZE + i) as i64);
+        }
+        let decoded = LazyColumns::deferred(store, vec![DataType::Integer]);
+        assert_eq!(decoded[0].len(), rows);
+        for i in [0, ROW_GROUP_SIZE - 1, ROW_GROUP_SIZE, rows - 1] {
+            assert_eq!(decoded[0].get_i64(i), i as i64);
         }
     }
 }


### PR DESCRIPTION
I make the public whole-column decoder return io::Result and reject malformed blocks before returning decoded columns. A short LZ4 result could previously leave zero-filled or reused scratch bytes in the output. Later groups could also accept trailing bytes or invalid dictionary IDs. Single-group decoding now uses the existing strict decoder, and multi-group decoding keeps its typed output buffers and reusable LZ4 scratch space.

This Stage 1 prerequisite of #122 follows merged #132 and targets main. I rebased it as 1f03e2c9 without changing any tracked file; its source tree is identical to the reviewed and measured 394334e5. The public CompressedBlockStore::decompress_column signature changes. The existing LazyColumns Index adapter still panics on a decode error, so SQL and row-materializer error propagation is not delivered here. I will remove that adapter in the immediately following Stage 1 PR that introduces fallible LazyColumns access and migrates every caller. There is one decoder implementation, with this temporary adapter at its boundary.

Validation:

- Formatting and all-target/all-feature clippy with warnings denied passed.
- 69 focused tests passed normally and 69 passed with test-filedb. The restored regression target passed all 29 tests.
- Reverting only the production change made all ten new error guards fail: four exposed silently accepted corruption and six exposed panics. All 19 controls passed.
- Valid-data checks cover all six column representations, NULL payloads, raw and compressed blocks, multiple groups, byte-offset rebasing, an empty column and a partial final group.
- Independent source review and final source/guard re-review found no blockers.
- All 14 checks passed on the current 1f03e2c9, including the 13 GitHub Actions checks and codecov/patch. The original 394334e5 also passed all 13 GitHub Actions checks, including coverage and the full Linux, macOS and Windows suites. I reused the local checks after verifying identical source trees.

No structure or retained per-row/per-volume bytes are added. Whole-column decoding adds O(groups) layout validation and an O(rows) dictionary-ID validation pass. It keeps the existing typed buffers and scratch allocation, with no per-group ColumnData, per-row heap object or new cache lock. Resident column access is unchanged in the source.

The bounded whole-column comparison found a decoder slowdown. I compared #132 (9d16878f) with the original candidate (394334e5, source-identical to 1f03e2c9) in an optimized release profile, opt-level 3, thin LTO and one codegen unit. The same probe ran seven identical-binary controls, seven baseline runs and seven candidate runs in contiguous blocks. Each run decoded and dropped three whole columns, INTEGER, dictionary TEXT and Bytes, 1,000 times. Each column held 65,553 rows in two compressed blocks. The machine stayed on battery power at 70%, low-power mode was off, no concurrent builds were observed, and the sleep/display audit was clean. This is a separate study from #132.

| Metric per three-column batch | Control range, us | Base range, us | Candidate range, us | Mean change |
|---|---:|---:|---:|---:|
| p50 | 630.500..662.917 | 651.833..660.959 | 673.208..680.750 | +3.02% |
| p95 | 692.083..772.750 | 698.833..718.042 | 722.167..786.625 | +4.20% |
| p99 | 734.791..1150.916 | 742.625..766.959 | 760.042..1166.708 | +10.47% |

Every candidate p50 exceeded both baseline/control maxima. Mean total elapsed time increased 3.64%. Percentages compare arithmetic means of seven per-run quantiles; samples are not pooled. Dictionary-ID validation is a plausible cost, but I did not isolate its contribution experimentally. I do not call the decoder unchanged.

Follow-up #134 optimizes the dictionary-ID validation with a maximum-ID check and retains the null-aware scan when an ID is out of range. Its separate INTEGER plus dictionary TEXT probe reports p50 of 312.5..313.3 us on this parent and 231.5..267.0 us with the optimization, compared with 267..272 us at the start of the stack. Those are five runs per build of a two-column workload. I have not repeated the three-column comparison above against #134; that table remains the result for this PR's original candidate. All 14 checks on #134 passed.

Seven incremental allocation runs per build, 100 batches each, matched exactly: 1,100 allocation blocks, 511,235,100 allocated bytes, zero retained bytes and a 3,014,961-byte peak. These scopes exclude setup and compressed-store ownership. Allocation runs stayed at 69% battery, with the same guards and a clean audit. Independent measurement verification and report re-review are complete.

This measures combined compressed whole-column decoding and destruction after warmup. It does not measure individual types, raw or single-group timing, NULL-heavy timing, cache hits, disk I/O or SQL row latency. I have not established SQL row-latency acceptance for this PR, so I am keeping it draft. The earlier #132 row-latency findings remain recorded. No row-latency pass is claimed. I stopped after the declared 21 timing and 14 allocation runs.

Constructor metadata validation, cached whole-column errors, identity accessors and later storage stages remain outstanding. Existing typed Vec allocation failures can still abort the process; this is not a hard memory bound. There is no file-format, residency, seal protocol, WAL, backup or restore change.
