### PR TITLE
Clear a valid dictionary column with one pass over its ids

### DIFF
--- a/src/storage/volume/writer.rs
+++ b/src/storage/volume/writer.rs
@@ -450,10 +450,18 @@ impl CompressedBlockStore {
                     )?;
                 }
                 let dictionary = dict.unwrap_or_else(|| Arc::from(Vec::<SmartString>::new()));
-                if all_ids
+                // One pass over the ids clears a valid column; the null-aware
+                // scan runs only when some id is out of range
+                let out_of_range = all_ids
                     .iter()
-                    .zip(&all_nulls)
-                    .any(|(&id, &is_null)| !is_null && id as usize >= dictionary.len())
+                    .copied()
+                    .max()
+                    .is_some_and(|max_id| max_id as usize >= dictionary.len());
+                if out_of_range
+                    && all_ids
+                        .iter()
+                        .zip(&all_nulls)
+                        .any(|(&id, &is_null)| !is_null && id as usize >= dictionary.len())
                 {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,


### PR DESCRIPTION
The dictionary id validation added by whole-column decoding walks the ids and the null flags together and branches per row. That is the cost behind the decoder slowdown reported in the parent pull request.

A valid column does not need the per-row scan: if the largest id is inside the dictionary, no row can be out of range, and one pass over the ids answers that. The null-aware scan stays, but it only runs when that check fails, so a malformed column still returns `dictionary id out of range`.

Measured with a probe that decodes an INTEGER column and a dictionary TEXT column of 65,553 rows in two compressed blocks, release with opt-level 3 and thin LTO, five runs per build in one session on an idle machine:

| build | p50 | p95 | p99 |
|---|---|---|---|
| parent branch | 312.5-313.3 us | 316.0-321.1 us | 322.4-329.2 us |
| with this change | 231.5-267.0 us | 270.6-288.8 us | 284.2-300.0 us |

For reference the same probe on the branch this stack started from measured 267-272 us at p50, so this brings whole-column decoding back to where it was.

The 29 group-access guards and the 19 row-count guards pass unchanged, including the malformed-dictionary case. Formatting and clippy with all targets, all features and warnings denied pass, and the in-memory suite passes.
