### PR TITLE
Propagate whole-column read failures through storage

### DIFF
--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -724,10 +724,8 @@ impl MVCCEngine {
                     self.loading_from_disk.store(false, Ordering::Release);
 
                     // Force seal ALL hot rows into volumes
-                    if let Err(e) = self.checkpoint_cycle_inner(true) {
-                        eprintln!("Warning: snapshot-to-volume conversion failed: {}", e);
-                    }
-                    self.compact_after_checkpoint_forced();
+                    self.checkpoint_cycle_inner(true)?;
+                    self.compact_after_checkpoint_forced()?;
 
                     // Only remove snapshots/ if this is a real v0.3.7 migration
                     // (no ddl-*.bin). If DDL metadata exists, these are user-created
@@ -1443,13 +1441,18 @@ impl MVCCEngine {
     fn populate_hnsw_from_segments(&self) -> Result<()> {
         let stores = self.version_stores.read().unwrap();
         let mgrs = self.segment_managers.read().unwrap();
+        let tables: Vec<_> = stores
+            .iter()
+            .filter_map(|(name, store)| {
+                mgrs.get(name)
+                    .map(|mgr| (Arc::clone(store), Arc::clone(mgr)))
+            })
+            .collect();
+        drop(mgrs);
+        drop(stores);
 
-        for (table_name, store) in stores.iter() {
-            if let Some(mgr) = mgrs.get(table_name) {
-                if !mgr.has_segments() {
-                    continue;
-                }
-
+        for (store, mgr) in tables {
+            if mgr.has_segments() {
                 // Collect HNSW index info before iterating volumes
                 let indexes = store.get_all_indexes();
                 let hnsw_infos: Vec<(Vec<usize>, std::sync::Arc<dyn Index>)> = indexes
@@ -1495,7 +1498,23 @@ impl MVCCEngine {
 
                 for (_, cs) in volumes.iter() {
                     let vol = &cs.volume;
-                    for i in 0..vol.meta.row_count {
+                    let Some(start) = (0..vol.meta.row_count).find(|&i| {
+                        let row_id = vol.meta.row_ids[i];
+                        !tombstones.contains_key(&row_id) && !seen.contains(&row_id)
+                    }) else {
+                        continue;
+                    };
+                    let mut columns: smallvec::SmallVec<
+                        [Option<&crate::storage::volume::column::ColumnData>; 16],
+                    > = smallvec::smallvec![None; vol.columns.len()];
+                    for (col_indices, _) in &hnsw_infos {
+                        for &ci in col_indices {
+                            if ci < columns.len() {
+                                columns[ci] = Some(vol.columns.get(ci)?);
+                            }
+                        }
+                    }
+                    for i in start..vol.meta.row_count {
                         let row_id = vol.meta.row_ids[i];
                         if tombstones.contains_key(&row_id) || !seen.insert(row_id) {
                             continue;
@@ -1504,8 +1523,8 @@ impl MVCCEngine {
                             values_buf.clear();
                             let mut has_null = false;
                             for &ci in col_indices {
-                                let v = if ci < vol.columns.len() {
-                                    vol.columns[ci].get_value(i)
+                                let v = if let Some(Some(col)) = columns.get(ci) {
+                                    col.get_value(i)
                                 } else {
                                     crate::core::Value::Null(crate::core::DataType::Null)
                                 };
@@ -1536,7 +1555,8 @@ impl MVCCEngine {
                             if let Err(e) = index.add_batch_slice(&entry_refs) {
                                 eprintln!(
                                     "Warning: HNSW index population failed for {}: {}",
-                                    table_name, e
+                                    store.table_name(),
+                                    e
                                 );
                             }
                             batches[idx].clear();
@@ -1554,7 +1574,8 @@ impl MVCCEngine {
                         if let Err(e) = index.add_batch_slice(&entry_refs) {
                             eprintln!(
                                 "Warning: HNSW index population failed for {}: {}",
-                                table_name, e
+                                store.table_name(),
+                                e
                             );
                         }
                     }
@@ -2158,7 +2179,9 @@ impl MVCCEngine {
                             std::thread::sleep(std::time::Duration::from_millis(10));
                         }
                     }
-                    self.compact_after_checkpoint_forced();
+                    if let Err(e) = self.compact_after_checkpoint_forced() {
+                        eprintln!("Warning: final compaction during close failed: {}", e);
+                    }
                 }
             }
         } // checkpoint_on_close
@@ -4200,10 +4223,21 @@ impl MVCCEngine {
                             continue;
                         }
 
-                        let mut row = if mapping.is_identity {
+                        let row = if mapping.is_identity {
                             vol.get_row(i)
                         } else {
                             vol.get_row_mapped(i, &mapping)
+                        };
+                        let mut row = match row {
+                            Ok(row) => row,
+                            Err(e) => {
+                                eprintln!(
+                                    "Warning: Failed to read cold row {} for snapshot: {}",
+                                    row_id, e
+                                );
+                                write_error = true;
+                                break;
+                            }
                         };
 
                         if row.len() < schema_cols {
@@ -5046,10 +5080,11 @@ impl MVCCEngine {
                 message: format!("Restore data not persisted (crash may lose it): {}", e),
             }
         })?;
-        self.compact_after_checkpoint_forced();
+        let compaction_result = self.compact_after_checkpoint_forced();
 
         // Resume accepting transactions only after data is persisted
         self.registry.start_accepting_transactions();
+        compaction_result?;
 
         Ok(format!(
             "Restored {} tables ({} rows) from snapshot",
@@ -5075,8 +5110,7 @@ impl MVCCEngine {
         // trait users) get the full seal + compact behavior.
         // The background thread bypasses this by calling
         // checkpoint_cycle_inner + spawn_compaction directly.
-        self.compact_after_checkpoint_forced();
-        Ok(())
+        self.compact_after_checkpoint_forced()
     }
 
     /// Inner checkpoint implementation. When `force` is true, seals ALL hot rows
@@ -5101,9 +5135,7 @@ impl MVCCEngine {
         if force {
             self.force_seal_all.store(true, Ordering::Release);
         }
-        if let Err(e) = self.seal_hot_buffers() {
-            eprintln!("Warning: seal_hot_buffers failed: {}", e);
-        }
+        let mut seal_result = self.seal_hot_buffers();
         if force {
             self.force_seal_all.store(false, Ordering::Release);
         }
@@ -5118,12 +5150,10 @@ impl MVCCEngine {
                 .all(|store| store.committed_row_count() == 0)
         };
 
-        if !all_hot_empty && !force {
+        if seal_result.is_ok() && !all_hot_empty && !force {
             // Force-seal the stragglers (small tables below threshold)
             self.force_seal_all.store(true, Ordering::Release);
-            if let Err(e) = self.seal_hot_buffers() {
-                eprintln!("Warning: force-seal stragglers failed: {}", e);
-            }
+            seal_result = self.seal_hot_buffers();
             self.force_seal_all.store(false, Ordering::Release);
         }
 
@@ -5133,6 +5163,7 @@ impl MVCCEngine {
             let _admission = self.hot_limits.admission.0.lock().unwrap();
             self.hot_limits.admission.1.notify_all();
         }
+        seal_result?;
 
         // Step 3: Brief fence — block commits just long enough to check if all
         // hot buffers are empty and capture checkpoint_lsn. NO disk I/O inside
@@ -5232,11 +5263,9 @@ impl MVCCEngine {
     /// Run compaction synchronously under the compaction_running flag.
     /// The flag prevents concurrent compaction from background and forced
     /// callers. Clears the flag on exit (including panics via drop guard).
-    fn run_compaction_guarded(&self) {
+    fn run_compaction_guarded(&self) -> Result<()> {
         let _guard = AtomicBoolGuard(&self.compaction_running);
-        if let Err(e) = self.compact_volumes() {
-            eprintln!("Warning: compact_volumes failed: {}", e);
-        }
+        self.compact_volumes()
     }
 
     /// Evict idle volume data to save memory. Volumes not accessed since the
@@ -5270,7 +5299,9 @@ impl MVCCEngine {
         }
         let engine = Arc::clone(self);
         std::thread::spawn(move || {
-            engine.run_compaction_guarded();
+            if let Err(e) = engine.run_compaction_guarded() {
+                eprintln!("Warning: compact_volumes failed: {}", e);
+            }
             engine.evict_idle_volumes();
         });
     }
@@ -5278,7 +5309,7 @@ impl MVCCEngine {
     /// Run compaction synchronously, waiting for any in-flight background
     /// compaction to finish first. Used by PRAGMA CHECKPOINT, close_engine,
     /// restore, and v0.3.7 migration.
-    fn compact_after_checkpoint_forced(&self) {
+    fn compact_after_checkpoint_forced(&self) -> Result<()> {
         // Claim the compaction slot, waiting for any background compaction.
         // CAS loop: if background thread holds the flag, spin until it clears.
         // Once we claim it, no background thread can start a new compaction.
@@ -5289,7 +5320,7 @@ impl MVCCEngine {
         {
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
-        self.run_compaction_guarded();
+        self.run_compaction_guarded()
     }
 
     /// Re-record all DDL entries to WAL after checkpoint.
@@ -5527,19 +5558,29 @@ impl MVCCEngine {
                         .filter_map(|&i| {
                             let seg = &manifest.segments[i];
                             let vol = segs.get(&seg.segment_id)?;
-                            if vol.volume.is_cold() {
-                                // Load only this merge candidate from disk.
-                                let loaded = mgr.ensure_volume(seg.segment_id).ok()??;
-                                Some((seg.segment_id, loaded))
-                            } else {
-                                Some((seg.segment_id, Arc::clone(&vol.volume)))
-                            }
+                            Some((seg.segment_id, Arc::clone(&vol.volume)))
                         })
                         .collect();
                 drop(segs);
+                drop(manifest);
 
                 // Every manifest entry must have a loaded volume.
                 if vols.len() != old_ids.len() {
+                    continue;
+                }
+                let mut removed = false;
+                for (seg_id, vol) in &mut vols {
+                    if vol.is_cold() {
+                        match mgr.ensure_volume(*seg_id)? {
+                            Some(loaded) => *vol = loaded,
+                            None => {
+                                removed = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+                if removed {
                     continue;
                 }
                 // Sort by segment_id descending (newest first) for correct dedup.
@@ -5660,9 +5701,18 @@ impl MVCCEngine {
                 Arc<crate::storage::volume::writer::FrozenVolume>,
                 crate::storage::volume::manifest::SegmentMeta,
             )> = Vec::new();
-            let mut write_failed = false;
+            let mut prepare_error: Option<Error> = None;
+            let store = self
+                .version_stores
+                .read()
+                .map_err(|_| Error::internal("version stores lock poisoned"))?
+                .get(table_name)
+                .cloned();
+            let unique_columns = store
+                .map(|store| store.get_unique_non_pk_index_columns())
+                .unwrap_or_default();
 
-            for chunk in live_refs.chunks(chunk_size) {
+            'prepare: for chunk in live_refs.chunks(chunk_size) {
                 let mut builder = crate::storage::volume::writer::VolumeBuilder::with_capacity(
                     &schema,
                     chunk.len(),
@@ -5675,9 +5725,22 @@ impl MVCCEngine {
                     } else {
                         vol.get_row_mapped(row_idx, mapping)
                     };
+                    let row = match row {
+                        Ok(row) => row,
+                        Err(e) => {
+                            prepare_error = Some(e.into());
+                            break 'prepare;
+                        }
+                    };
                     builder.add_row(row_id, &row);
                 }
                 let mut compacted = builder.finish();
+                for (col_indices, _) in &unique_columns {
+                    if let Err(e) = compacted.prebuild_unique_index(col_indices) {
+                        prepare_error = Some(e.into());
+                        break 'prepare;
+                    }
+                }
 
                 let compact_vol_id = crate::storage::volume::io::next_volume_id();
                 match crate::storage::volume::io::write_volume_to_disk_opts(
@@ -5690,15 +5753,6 @@ impl MVCCEngine {
                     Ok((_path, store)) => {
                         // Retain compressed store for hot→warm eviction.
                         compacted.columns.attach_compressed_store(store);
-                        // Pre-build unique hash indices before registration.
-                        {
-                            let stores = self.version_stores.read().unwrap();
-                            if let Some(store) = stores.get(table_name) {
-                                for (col_indices, _) in store.get_unique_non_pk_index_columns() {
-                                    compacted.prebuild_unique_index(&col_indices);
-                                }
-                            }
-                        }
                         let min_id = chunk.first().map(|(id, _, _)| *id).unwrap_or(0);
                         let max_id = chunk.last().map(|(id, _, _)| *id).unwrap_or(0);
                         new_volumes.push((
@@ -5717,22 +5771,21 @@ impl MVCCEngine {
                         ));
                     }
                     Err(e) => {
-                        eprintln!(
-                            "Warning: Failed to write compacted volume for {}: {}",
-                            table_name, e
-                        );
-                        write_failed = true;
+                        prepare_error = Some(e);
                         break;
                     }
                 }
             }
 
-            if write_failed || new_volumes.is_empty() {
+            if prepare_error.is_some() || new_volumes.is_empty() {
                 // Clean up any volumes we did write before failure
                 let vol_table_dir = vol_dir.join(table_name);
                 for (vid, _, _) in &new_volumes {
                     let fname = format!("vol_{:016x}.vol", vid);
                     let _ = std::fs::remove_file(vol_table_dir.join(fname));
+                }
+                if let Some(error) = prepare_error {
+                    return Err(error);
                 }
                 continue;
             }
@@ -5966,113 +6019,103 @@ impl MVCCEngine {
                 .read()
                 .map(|c| c.persistence.volume_compression)
                 .unwrap_or(true);
-            match crate::storage::volume::seal::seal_and_persist_multi(
+            let sealed_volumes = crate::storage::volume::seal::seal_and_persist_multi(
                 &schema,
                 &all_rows,
                 &vol_dir,
                 &table_name,
                 compress,
                 target_volume_rows,
-            ) {
-                Ok(sealed_volumes) => {
-                    // Pre-build unique hash indices BEFORE registration so the
-                    // first INSERT after seal doesn't pay a ~60ms stall scanning
-                    // all rows. Safe: volumes are not yet visible to other threads.
-                    {
-                        let stores = self.version_stores.read().unwrap();
-                        if let Some(store) = stores.get(&table_name) {
-                            for (col_indices, _) in store.get_unique_non_pk_index_columns() {
-                                for (vol, _, _) in &sealed_volumes {
-                                    vol.prebuild_unique_index(&col_indices);
-                                }
-                            }
+            )?;
+            // Pre-build unique hash indices BEFORE registration so the
+            // first INSERT after seal doesn't pay a ~60ms stall scanning
+            // all rows. Safe: volumes are not yet visible to other threads.
+            for (col_indices, _) in store.get_unique_non_pk_index_columns() {
+                for (vol, _, _) in &sealed_volumes {
+                    if let Err(error) = vol.prebuild_unique_index(&col_indices) {
+                        for (_, path, _) in &sealed_volumes {
+                            let _ = std::fs::remove_file(path);
                         }
-                    }
-                    let mgr = self.get_or_create_segment_manager(&table_name);
-
-                    // Seal critical section under exclusive fence: register cold
-                    // segments + remove hot rows + remove hot index entries.
-                    // DML operations hold the shared fence, so they cannot race
-                    // between cold constraint checks and hot publication.
-                    {
-                        let _seal_guard = mgr.acquire_seal_write();
-
-                        mgr.set_seal_overlap(total_rows);
-
-                        // Stamp seal_seq to reflect what data the volume contains:
-                        // - With cutoff: volume has rows committed before cutoff, so use cutoff
-                        // - Without cutoff: all committed rows, use current sequence
-                        // Compaction skips volumes with seal_seq >= min_snap_begin_seq.
-                        let current_seal_seq = per_table_cutoff
-                            .map(|s| s as u64)
-                            .unwrap_or_else(|| self.registry.get_current_sequence() as u64);
-                        for (volume, _path, volume_id) in &sealed_volumes {
-                            self.register_volume_with_id_and_seal_seq(
-                                &table_name,
-                                Arc::clone(volume),
-                                *volume_id,
-                                current_seal_seq,
-                            );
-                        }
-
-                        let mut index_cleanups = Vec::new();
-                        let mut all_skipped_inner: Vec<i64> = Vec::new();
-                        let all_row_ids: Vec<i64> = all_rows.iter().map(|(id, _)| *id).collect();
-                        for batch in all_row_ids.chunks(REMOVE_BATCH_SIZE) {
-                            let (removed, cleanup, skipped) =
-                                store.remove_sealed_rows(batch, &extraction_snapshot);
-                            store.subtract_committed_row_count(removed);
-                            index_cleanups.push(cleanup);
-                            all_skipped_inner.extend(skipped);
-                        }
-
-                        if !all_skipped_inner.is_empty() {
-                            let seal_seq = self.registry.get_current_sequence() as u64;
-                            mgr.add_tombstones(&all_skipped_inner, seal_seq);
-                        }
-
-                        if let Some(&(max_id, _)) = all_rows.last() {
-                            let current = store.get_auto_increment_counter();
-                            if max_id > current {
-                                store.set_auto_increment_counter(max_id);
-                            }
-                        }
-
-                        mgr.clear_seal_overlap();
-
-                        for cleanup in index_cleanups {
-                            store.remove_sealed_index_entries(cleanup, &all_rows);
-                        }
-
-                        // Clear tombstones for sealed row_ids INSIDE the fence.
-                        {
-                            let skip_set: FxHashSet<i64> =
-                                all_skipped_inner.iter().copied().collect();
-                            let ts = mgr.tombstone_set_arc();
-                            if !ts.is_empty() {
-                                let mut sealed_ids: FxHashSet<i64> = FxHashSet::default();
-                                for (vol, _, _) in &sealed_volumes {
-                                    for &rid in &vol.meta.row_ids {
-                                        if ts.contains_key(&rid) && !skip_set.contains(&rid) {
-                                            sealed_ids.insert(rid);
-                                        }
-                                    }
-                                }
-                                if !sealed_ids.is_empty() {
-                                    mgr.remove_tombstones_for_rows(&sealed_ids);
-                                }
-                            }
-                        }
-
-                        // _seal_guard dropped here — DML unblocked
+                        return Err(error.into());
                     }
                 }
-                Err(e) => {
-                    eprintln!(
-                        "Warning: Failed to seal hot buffer for {}: {}",
-                        table_name, e
+            }
+            let mgr = self.get_or_create_segment_manager(&table_name);
+
+            // Seal critical section under exclusive fence: register cold
+            // segments + remove hot rows + remove hot index entries.
+            // DML operations hold the shared fence, so they cannot race
+            // between cold constraint checks and hot publication.
+            {
+                let _seal_guard = mgr.acquire_seal_write();
+
+                mgr.set_seal_overlap(total_rows);
+
+                // Stamp seal_seq to reflect what data the volume contains:
+                // - With cutoff: volume has rows committed before cutoff, so use cutoff
+                // - Without cutoff: all committed rows, use current sequence
+                // Compaction skips volumes with seal_seq >= min_snap_begin_seq.
+                let current_seal_seq = per_table_cutoff
+                    .map(|s| s as u64)
+                    .unwrap_or_else(|| self.registry.get_current_sequence() as u64);
+                for (volume, _path, volume_id) in &sealed_volumes {
+                    self.register_volume_with_id_and_seal_seq(
+                        &table_name,
+                        Arc::clone(volume),
+                        *volume_id,
+                        current_seal_seq,
                     );
                 }
+
+                let mut index_cleanups = Vec::new();
+                let mut all_skipped_inner: Vec<i64> = Vec::new();
+                let all_row_ids: Vec<i64> = all_rows.iter().map(|(id, _)| *id).collect();
+                for batch in all_row_ids.chunks(REMOVE_BATCH_SIZE) {
+                    let (removed, cleanup, skipped) =
+                        store.remove_sealed_rows(batch, &extraction_snapshot);
+                    store.subtract_committed_row_count(removed);
+                    index_cleanups.push(cleanup);
+                    all_skipped_inner.extend(skipped);
+                }
+
+                if !all_skipped_inner.is_empty() {
+                    let seal_seq = self.registry.get_current_sequence() as u64;
+                    mgr.add_tombstones(&all_skipped_inner, seal_seq);
+                }
+
+                if let Some(&(max_id, _)) = all_rows.last() {
+                    let current = store.get_auto_increment_counter();
+                    if max_id > current {
+                        store.set_auto_increment_counter(max_id);
+                    }
+                }
+
+                mgr.clear_seal_overlap();
+
+                for cleanup in index_cleanups {
+                    store.remove_sealed_index_entries(cleanup, &all_rows);
+                }
+
+                // Clear tombstones for sealed row_ids INSIDE the fence.
+                {
+                    let skip_set: FxHashSet<i64> = all_skipped_inner.iter().copied().collect();
+                    let ts = mgr.tombstone_set_arc();
+                    if !ts.is_empty() {
+                        let mut sealed_ids: FxHashSet<i64> = FxHashSet::default();
+                        for (vol, _, _) in &sealed_volumes {
+                            for &rid in &vol.meta.row_ids {
+                                if ts.contains_key(&rid) && !skip_set.contains(&rid) {
+                                    sealed_ids.insert(rid);
+                                }
+                            }
+                        }
+                        if !sealed_ids.is_empty() {
+                            mgr.remove_tombstones_for_rows(&sealed_ids);
+                        }
+                    }
+                }
+
+                // _seal_guard dropped here — DML unblocked
             }
         }
 
@@ -6266,8 +6309,7 @@ impl Engine for MVCCEngine {
 
     fn force_checkpoint_cycle(&self) -> Result<()> {
         MVCCEngine::checkpoint_cycle_inner(self, true)?;
-        self.compact_after_checkpoint_forced();
-        Ok(())
+        self.compact_after_checkpoint_forced()
     }
 
     fn create_snapshot(&self) -> Result<()> {

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -3627,6 +3627,7 @@ impl Table for MVCCTable {
             .cached_schema
             .pk_column_index()
             .map(|i| &self.cached_schema.columns[i].name_lower);
+        let mut unique = smallvec::SmallVec::<[Arc<dyn Index>; 4]>::new();
         let indexes = self.version_store.indexes_read();
         for idx in indexes.values() {
             if !idx.is_unique() {
@@ -3641,7 +3642,11 @@ impl Table for MVCCTable {
                     }
                 }
             }
-            f(idx.name(), names)?;
+            unique.push(Arc::clone(idx));
+        }
+        drop(indexes);
+        for idx in unique {
+            f(idx.name(), idx.column_names())?;
         }
         Ok(())
     }

--- a/src/storage/volume/format.rs
+++ b/src/storage/volume/format.rs
@@ -1051,7 +1051,7 @@ pub(crate) fn serialize_volume_metadata(vol: &FrozenVolume) -> io::Result<Vec<u8
     let mut shared_dict: Vec<SmartString> = Vec::new();
     let mut dict_counts: Vec<u32> = Vec::new();
     for i in 0..col_count {
-        if let ColumnData::Dictionary { dictionary, .. } = &vol.columns[i] {
+        if let ColumnData::Dictionary { dictionary, .. } = vol.columns.get(i)? {
             dict_counts.push(dictionary.len() as u32);
             shared_dict.extend(dictionary.iter().cloned());
         }
@@ -1060,7 +1060,7 @@ pub(crate) fn serialize_volume_metadata(vol: &FrozenVolume) -> io::Result<Vec<u8
     // Column directory: type(1) + flags(1) + extra(4) per column
     let mut dict_col_idx = 0usize;
     for i in 0..col_count {
-        let col = &vol.columns[i];
+        let col = vol.columns.get(i)?;
         let type_tag = match col {
             ColumnData::Int64 { .. } => COL_INT64,
             ColumnData::Float64 { .. } => COL_FLOAT64,

--- a/src/storage/volume/io.rs
+++ b/src/storage/volume/io.rs
@@ -145,7 +145,7 @@ fn serialize_v4_opts(
         &vol.meta.column_types,
         vol.meta.row_count,
         compress,
-    );
+    )?;
 
     // 3. Compute total size for pre-allocation
     let all_blocks = store.raw_blocks();
@@ -761,8 +761,8 @@ mod tests {
 
         let loaded = read_volume_from_disk(&path).unwrap();
         assert_eq!(loaded.meta.row_count, 2);
-        assert_eq!(loaded.columns[0].get_i64(0), 1);
-        assert_eq!(loaded.columns[1].get_str(1), "world");
+        assert_eq!(loaded.columns.get(0).unwrap().get_i64(0), 1);
+        assert_eq!(loaded.columns.get(1).unwrap().get_str(1), "world");
     }
 
     #[test]
@@ -928,11 +928,11 @@ mod tests {
         assert_eq!(loaded.meta.row_count, 3);
 
         // Access columns triggers decompression from RAM
-        assert_eq!(loaded.columns[0].get_i64(0), 1);
-        assert_eq!(loaded.columns[0].get_i64(2), 3);
-        assert_eq!(loaded.columns[1].get_str(0), "apple");
-        assert_eq!(loaded.columns[1].get_str(1), "banana");
-        assert_eq!(loaded.columns[2].get_f64(1), 0.75);
+        assert_eq!(loaded.columns.get(0).unwrap().get_i64(0), 1);
+        assert_eq!(loaded.columns.get(0).unwrap().get_i64(2), 3);
+        assert_eq!(loaded.columns.get(1).unwrap().get_str(0), "apple");
+        assert_eq!(loaded.columns.get(1).unwrap().get_str(1), "banana");
+        assert_eq!(loaded.columns.get(2).unwrap().get_f64(1), 0.75);
 
         // Zone maps survived
         assert_eq!(loaded.meta.zone_maps[0].min, Value::Integer(1));
@@ -976,11 +976,11 @@ mod tests {
         let loaded = read_volume_from_disk(&path).unwrap();
 
         assert_eq!(loaded.meta.row_count, 3);
-        assert!(!loaded.columns[1].is_null(0));
-        assert!(loaded.columns[1].is_null(1));
-        assert!(!loaded.columns[1].is_null(2));
-        assert_eq!(loaded.columns[1].get_f64(0), 10.0);
-        assert_eq!(loaded.columns[1].get_f64(2), 30.0);
+        assert!(!loaded.columns.get(1).unwrap().is_null(0));
+        assert!(loaded.columns.get(1).unwrap().is_null(1));
+        assert!(!loaded.columns.get(1).unwrap().is_null(2));
+        assert_eq!(loaded.columns.get(1).unwrap().get_f64(0), 10.0);
+        assert_eq!(loaded.columns.get(1).unwrap().get_f64(2), 30.0);
     }
 
     #[test]
@@ -1011,12 +1011,18 @@ mod tests {
         assert_eq!(loaded.meta.row_count, n);
 
         // Check first, middle, and last rows
-        assert_eq!(loaded.columns[0].get_i64(0), 0);
-        assert_eq!(loaded.columns[0].get_i64(n / 2), (n / 2) as i64);
-        assert_eq!(loaded.columns[0].get_i64(n - 1), (n - 1) as i64);
-        assert_eq!(loaded.columns[1].get_str(0), "even");
-        assert_eq!(loaded.columns[1].get_str(1), "odd");
-        assert_eq!(loaded.columns[1].get_str(n - 1), "odd");
+        assert_eq!(loaded.columns.get(0).unwrap().get_i64(0), 0);
+        assert_eq!(
+            loaded.columns.get(0).unwrap().get_i64(n / 2),
+            (n / 2) as i64
+        );
+        assert_eq!(
+            loaded.columns.get(0).unwrap().get_i64(n - 1),
+            (n - 1) as i64
+        );
+        assert_eq!(loaded.columns.get(1).unwrap().get_str(0), "even");
+        assert_eq!(loaded.columns.get(1).unwrap().get_str(1), "odd");
+        assert_eq!(loaded.columns.get(1).unwrap().get_str(n - 1), "odd");
 
         // Row groups present
         assert!(!loaded.meta.row_groups.is_empty());
@@ -1050,13 +1056,13 @@ mod tests {
 
         assert_eq!(loaded.meta.row_count, 2);
         // Timestamp nanosecond precision
-        if let Value::Timestamp(loaded_ts) = loaded.columns[0].get_value(0) {
+        if let Value::Timestamp(loaded_ts) = loaded.columns.get(0).unwrap().get_value(0) {
             assert_eq!(loaded_ts.timestamp_nanos_opt(), ts.timestamp_nanos_opt());
         } else {
             panic!("expected Timestamp");
         }
-        assert!(loaded.columns[1].get_bool(0));
-        assert!(!loaded.columns[1].get_bool(1));
+        assert!(loaded.columns.get(1).unwrap().get_bool(0));
+        assert!(!loaded.columns.get(1).unwrap().get_bool(1));
     }
 
     #[test]
@@ -1077,7 +1083,7 @@ mod tests {
         let path = write_volume_to_disk(dir.path(), "t", 1, &vol).unwrap();
         let loaded = read_volume_from_disk(&path).unwrap();
 
-        let row = loaded.get_row(0);
+        let row = loaded.get_row(0).unwrap();
         assert_eq!(row.get(0), Some(&Value::Integer(42)));
         assert_eq!(row.get(1), Some(&Value::text("test")));
     }

--- a/src/storage/volume/manifest.rs
+++ b/src/storage/volume/manifest.rs
@@ -987,12 +987,12 @@ impl SegmentManager {
                     };
                     if cold.volume.is_cold() {
                         if let Some(vol) = self.ensure_volume(*seg_id)? {
-                            return Ok(Some(vol.columns[pi].get_value(idx)));
+                            return Ok(Some(vol.columns.get(pi)?.get_value(idx)));
                         }
                         return Ok(None);
                     }
                     cold.volume.mark_accessed();
-                    return Ok(Some(cold.volume.columns[pi].get_value(idx)));
+                    return Ok(Some(cold.volume.columns.get(pi)?.get_value(idx)));
                 }
             }
         }
@@ -1055,10 +1055,11 @@ impl SegmentManager {
                 _ => None,
             };
             if let Some(target) = target {
+                let col = vol.columns.get(pi)?;
                 if vol.is_sorted(pi) {
-                    let start = vol.columns[pi].binary_search_ge(target);
+                    let start = col.binary_search_ge(target);
                     let mut i = start;
-                    while i < vol.meta.row_count && vol.columns[pi].get_i64(i) == target {
+                    while i < vol.meta.row_count && col.get_i64(i) == target {
                         let rid = vol.meta.row_ids[i];
                         if seen.insert(rid) && !ts.contains_key(&rid) {
                             if seg_ids.len() > 1 {
@@ -1081,10 +1082,7 @@ impl SegmentManager {
                         if !seen.insert(rid) {
                             continue;
                         }
-                        if !vol.columns[pi].is_null(i)
-                            && vol.columns[pi].get_i64(i) == target
-                            && !ts.contains_key(&rid)
-                        {
+                        if !col.is_null(i) && col.get_i64(i) == target && !ts.contains_key(&rid) {
                             if seg_ids.len() > 1 {
                                 if let Some(current_val) =
                                     self.get_authoritative_value(seg_ids, segs, rid, col_idx)?
@@ -1268,23 +1266,23 @@ impl SegmentManager {
                     } else {
                         false
                     }
-                });
+                })?;
             } else {
                 // Schema-evolved volume: some columns missing (default matches).
                 // Check only the columns that exist in the volume.
-                let present_cols: Vec<(usize, usize)> = vol_col_indices
+                let present_cols: Vec<_> = vol_col_indices
                     .iter()
                     .enumerate()
                     .filter(|(_, &vi)| vi != usize::MAX)
-                    .map(|(i, &vi)| (i, vi))
-                    .collect();
+                    .map(|(i, &vi)| vol.columns.get(vi).map(|col| (i, col)))
+                    .collect::<std::io::Result<_>>()?;
                 for i in 0..vol.meta.row_count {
                     let rid = vol.meta.row_ids[i];
                     if ts.contains_key(&rid) || !seen.insert(rid) {
                         continue;
                     }
-                    let matches = present_cols.iter().all(|&(val_idx, ci)| {
-                        let v = vol.columns[ci].get_value(i);
+                    let matches = present_cols.iter().all(|&(val_idx, col)| {
+                        let v = col.get_value(i);
                         !v.is_null() && v == *values[val_idx]
                     });
                     if matches {
@@ -1949,13 +1947,13 @@ impl SegmentManager {
                 if let Ok(idx) = cold.volume.meta.row_ids.binary_search(&row_id) {
                     if cold.volume.is_cold() {
                         if let Some(vol) = self.ensure_volume(*seg_id)? {
-                            return Ok(Some(vol.get_row(idx)));
+                            return Ok(Some(vol.get_row(idx)?));
                         }
                         // Segment removed by compaction — retry with fresh state.
                         return self.get_cold_row_retry(row_id);
                     }
                     cold.volume.mark_accessed();
-                    return Ok(Some(cold.volume.get_row(idx)));
+                    return Ok(Some(cold.volume.get_row(idx)?));
                 }
             }
         }
@@ -1989,7 +1987,7 @@ impl SegmentManager {
                         });
                     }
                     cold.volume.mark_accessed();
-                    return Ok(Some(cold.volume.get_row(idx)));
+                    return Ok(Some(cold.volume.get_row(idx)?));
                 }
             }
         }
@@ -2041,9 +2039,9 @@ impl SegmentManager {
                     };
                     let mapping = self.get_volume_mapping(*seg_id, schema);
                     if mapping.is_identity {
-                        return Ok(Some(vol.get_row(idx)));
+                        return Ok(Some(vol.get_row(idx)?));
                     }
-                    return Ok(Some(vol.get_row_mapped(idx, &mapping)));
+                    return Ok(Some(vol.get_row_mapped(idx, &mapping)?));
                 }
             }
         }
@@ -2083,9 +2081,9 @@ impl SegmentManager {
                     cold.volume.mark_accessed();
                     let mapping = self.get_volume_mapping(*seg_id, schema);
                     if mapping.is_identity {
-                        return Ok(Some(cold.volume.get_row(idx)));
+                        return Ok(Some(cold.volume.get_row(idx)?));
                     }
-                    return Ok(Some(cold.volume.get_row_mapped(idx, &mapping)));
+                    return Ok(Some(cold.volume.get_row_mapped(idx, &mapping)?));
                 }
             }
         }
@@ -3152,7 +3150,7 @@ mod tests {
         {
             let vols = mgr.get_volumes_newest_first().unwrap();
             let (_, cs) = &vols[0];
-            let row = cs.volume.get_row(0);
+            let row = cs.volume.get_row(0).unwrap();
             assert_eq!(row[0], Value::Integer(1));
         }
 
@@ -3208,7 +3206,7 @@ mod tests {
         {
             let vols = mgr.get_volumes_newest_first().unwrap();
             let (_, cs) = &vols[0];
-            let row = cs.volume.get_row(49);
+            let row = cs.volume.get_row(49).unwrap();
             assert_eq!(row[0], Value::Integer(50));
         }
 
@@ -3393,7 +3391,7 @@ mod tests {
         let vols = snap.volumes_newest_first();
         assert_eq!(vols.len(), 1, "snapshot must not lose its segment");
         assert_eq!(vols[0].0, 1);
-        assert_eq!(vols[0].1.volume.get_row(0)[0], Value::Integer(1));
+        assert_eq!(vols[0].1.volume.get_row(0).unwrap()[0], Value::Integer(1));
     }
     #[test]
     fn test_unique_lookup_uses_statement_snapshot_not_live_state() {

--- a/src/storage/volume/scanner.rs
+++ b/src/storage/volume/scanner.rs
@@ -195,46 +195,50 @@ impl VolumeScanner {
     }
 
     /// True when the row at `idx` lies past the stop key
-    fn past_stop_key(&self, idx: usize) -> bool {
+    fn past_stop_key(&self, idx: usize) -> Result<bool> {
         let Some((col_idx, target, ascending)) = self.stop_key else {
-            return false;
+            return Ok(false);
         };
-        let (col, local) = self.col_and_idx(col_idx, idx);
+        let (col, local) = self.col_and_idx(col_idx, idx)?;
         if col.is_null(local) {
-            return false;
+            return Ok(false);
         }
         let key = col.get_i64(local);
-        if ascending {
+        Ok(if ascending {
             key > target
         } else {
             key < target
-        }
+        })
     }
 
     /// The rows in `[lo, hi)` that pass every dictionary filter, in one pass
     /// over the raw ids of the group; None when a filter column is not a
     /// dictionary column here and the rows must be tested one by one
-    fn dictionary_candidates(&self, lo: usize, hi: usize) -> Option<Vec<usize>> {
+    fn dictionary_candidates(&self, lo: usize, hi: usize) -> Result<Option<Vec<usize>>> {
         let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = self
             .dict_filters
             .iter()
             .map(|&(col_idx, expected)| {
-                let (col, local_lo) = self.col_and_idx(col_idx, lo);
-                (col, local_lo, expected)
+                let (col, local_lo) = self.col_and_idx(col_idx, lo)?;
+                Ok((col, local_lo, expected))
             })
-            .collect();
+            .collect::<Result<_>>()?;
         let mut candidates = Vec::new();
-        super::column::ColumnData::dict_matching_offsets(&filters, hi - lo, &mut candidates)?;
+        if super::column::ColumnData::dict_matching_offsets(&filters, hi - lo, &mut candidates)
+            .is_none()
+        {
+            return Ok(None);
+        }
         for idx in &mut candidates {
             *idx += lo;
         }
-        Some(candidates)
+        Ok(Some(candidates))
     }
 
     /// The reverse walk: the newest row of the range first. Row groups are
     /// entered from their end; a pruned group is skipped whole; with
     /// dictionary filters the group's candidates are found in one pass.
-    fn next_reverse(&mut self) -> bool {
+    fn next_reverse(&mut self) -> Result<bool> {
         let use_group_cache = self.volume.columns.should_use_group_cache();
         while self.current_idx < self.end_idx {
             let idx = self.end_idx - 1;
@@ -252,13 +256,13 @@ impl VolumeScanner {
                     self.load_group_cache(group_idx);
                     if self.error.is_some() {
                         self.has_current = false;
-                        return false;
+                        return Ok(false);
                     }
                 }
             }
             if !self.dict_filters.is_empty() && self.candidates_group != Some(group_idx) {
                 let lo = group_start.max(self.current_idx);
-                match self.dictionary_candidates(lo, self.end_idx) {
+                match self.dictionary_candidates(lo, self.end_idx)? {
                     Some(candidates) => {
                         self.group_candidates = candidates;
                         self.candidates_group = Some(group_idx);
@@ -281,10 +285,10 @@ impl VolumeScanner {
             } else {
                 idx
             };
-            if self.past_stop_key(idx) {
+            if self.past_stop_key(idx)? {
                 self.end_idx = self.current_idx;
                 self.has_current = false;
-                return false;
+                return Ok(false);
             }
             self.end_idx = idx;
             if self.should_skip_row(idx) {
@@ -292,22 +296,22 @@ impl VolumeScanner {
             }
             if self.candidates_group != Some(group_idx)
                 && !self.dict_filters.is_empty()
-                && self.dict_filters_reject(idx)
+                && self.dict_filters_reject(idx)?
             {
                 continue;
             }
-            if !self.typed_predicates.is_empty() && !self.evaluate_typed_predicates(idx) {
+            if !self.typed_predicates.is_empty() && !self.evaluate_typed_predicates(idx)? {
                 continue;
             }
-            if !self.materialize_row(idx) {
+            if !self.materialize_row(idx)? {
                 continue;
             }
             self.current_rid = self.volume.meta.row_ids[idx];
             self.has_current = true;
-            return true;
+            return Ok(true);
         }
         self.has_current = false;
-        false
+        Ok(false)
     }
     /// Compute whether `project_cols` is an identity mapping over all volume columns.
     /// Extracted as a helper so both constructors share the same logic.
@@ -511,6 +515,17 @@ impl VolumeScanner {
     /// Set a predicate filter on this scanner.
     /// Automatically extracts dictionary-based fast filters for text equality predicates.
     pub fn set_filter(&mut self, filter: Box<dyn crate::storage::expression::Expression>) {
+        if let Err(error) = self.prepare_filter(filter) {
+            self.error = Some(error);
+            self.has_current = false;
+            self.current_idx = self.end_idx;
+        }
+    }
+
+    fn prepare_filter(
+        &mut self,
+        filter: Box<dyn crate::storage::expression::Expression>,
+    ) -> Result<()> {
         // Extract dictionary filters for fast pre-filtering.
         // Uses CompressedBlockStore's shared dict when available (no column decompression).
         let comparisons = filter.collect_comparisons();
@@ -532,14 +547,14 @@ impl VolumeScanner {
                     let dict_id = if let Some(st) = store {
                         st.dict_lookup(col_idx, s.as_str())
                     } else {
-                        self.volume.columns[col_idx].dict_lookup(s.as_str())
+                        self.volume.columns.get(col_idx)?.dict_lookup(s.as_str())
                     };
                     if let Some(id) = dict_id {
                         self.dict_filters.push((col_idx, id));
                     } else {
                         self.current_idx = self.end_idx;
                         self.filter = Some(filter);
-                        return;
+                        return Ok(());
                     }
                 }
             }
@@ -579,7 +594,7 @@ impl VolumeScanner {
                         self.error =
                             Some(Error::internal("corrupt V4 block during dictionary filter"));
                         self.filter = Some(filter);
-                        return;
+                        return Ok(());
                     }
                     let lo = gs.max(self.current_idx);
                     let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = self
@@ -621,17 +636,24 @@ impl VolumeScanner {
                 }
             } else {
                 let mut m = Vec::new();
+                let dict_columns =
+                    self.dict_filters
+                        .iter()
+                        .map(|&(ci, eid)| self.volume.columns.get(ci).map(|col| (col, eid)))
+                        .collect::<std::io::Result<
+                            smallvec::SmallVec<[(&super::column::ColumnData, u32); 4]>,
+                        >>()?;
                 // One row group at a time, so a filter that matches most rows
                 // stops at the selectivity cap instead of listing them all
                 let mut lo = self.current_idx;
                 let mut vectorized = true;
                 while lo < self.end_idx && m.len() <= selectivity_cap {
                     let hi = (lo + super::column::ROW_GROUP_SIZE).min(self.end_idx);
-                    let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = self
-                        .dict_filters
-                        .iter()
-                        .map(|&(ci, eid)| (&self.volume.columns[ci], lo, eid))
-                        .collect();
+                    let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> =
+                        dict_columns
+                            .iter()
+                            .map(|&(col, eid)| (col, lo, eid))
+                            .collect();
                     let first = m.len();
                     if super::column::ColumnData::dict_matching_offsets(&filters, hi - lo, &mut m)
                         .is_none()
@@ -648,10 +670,9 @@ impl VolumeScanner {
                 if !vectorized {
                     m.clear();
                     for i in self.current_idx..self.end_idx {
-                        let ok = self.dict_filters.iter().all(|&(ci, eid)| {
-                            !self.volume.columns[ci].is_null(i)
-                                && self.volume.columns[ci].get_dict_id(i) == eid
-                        });
+                        let ok = dict_columns
+                            .iter()
+                            .all(|&(col, eid)| !col.is_null(i) && col.get_dict_id(i) == eid);
                         if ok {
                             m.push(i);
                         }
@@ -788,15 +809,16 @@ impl VolumeScanner {
         }
 
         self.filter = Some(filter);
+        Ok(())
     }
 
     /// Evaluate typed pre-filter predicates directly on column data.
     /// Returns false only if the row definitely does not match (safe rejection).
     /// NULL columns conservatively pass through (the full filter handles NULL logic).
     #[inline]
-    fn evaluate_typed_predicates(&self, idx: usize) -> bool {
+    fn evaluate_typed_predicates(&self, idx: usize) -> Result<bool> {
         for pred in &self.typed_predicates {
-            let (col, local) = self.col_and_idx(pred.col_idx, idx);
+            let (col, local) = self.col_and_idx(pred.col_idx, idx)?;
             if col.is_null(local) {
                 // NULL: conservatively pass through (might match under SQL NULL semantics).
                 // The full filter will handle it correctly.
@@ -837,10 +859,10 @@ impl VolumeScanner {
                 }
             };
             if !matches {
-                return false;
+                return Ok(false);
             }
         }
-        true
+        Ok(true)
     }
 
     /// Set a precomputed column mapping for schema-evolved volumes.
@@ -859,13 +881,13 @@ impl VolumeScanner {
         &self,
         col_idx: usize,
         global_idx: usize,
-    ) -> (&super::column::ColumnData, usize) {
+    ) -> Result<(&super::column::ColumnData, usize)> {
         if let Some(ref cache) = self.group_cache {
             if let Some(pair) = cache.col_and_local(col_idx, global_idx) {
-                return pair;
+                return Ok(pair);
             }
         }
-        (&self.volume.columns[col_idx], global_idx)
+        Ok((self.volume.columns.get(col_idx)?, global_idx))
     }
 
     /// Load group cache for a new row group. Decompresses only the columns
@@ -954,21 +976,21 @@ impl VolumeScanner {
     /// does NOT match (should be skipped). Only called when dict_filters is
     /// non-empty.
     #[inline(always)]
-    fn dict_filters_reject(&self, idx: usize) -> bool {
+    fn dict_filters_reject(&self, idx: usize) -> Result<bool> {
         for &(col_idx, expected_id) in &self.dict_filters {
-            let (col, local) = self.col_and_idx(col_idx, idx);
+            let (col, local) = self.col_and_idx(col_idx, idx)?;
             if col.is_null(local) || col.get_dict_id(local) != expected_id {
-                return true;
+                return Ok(true);
             }
         }
-        false
+        Ok(false)
     }
 
     /// Materialize a row at `idx`, evaluate the filter (if any), and write
     /// the result into `self.current_row`. Returns false if the filter
     /// rejects the row.
     #[inline(always)]
-    fn materialize_row(&mut self, idx: usize) -> bool {
+    fn materialize_row(&mut self, idx: usize) -> Result<bool> {
         // Per-group cache path: only when no schema mapping is needed.
         // Schema-evolved volumes require column_mapping which remaps positions.
         if self.group_cache.is_some() && self.column_mapping.is_none() {
@@ -983,9 +1005,9 @@ impl VolumeScanner {
                 (Some(mask), None) => self.volume.get_row_needed(idx, mask),
                 (None, Some(mapping)) => self.volume.get_row_mapped(idx, mapping),
                 (None, None) => self.volume.get_row(idx),
-            };
+            }?;
             if !filter.evaluate_fast(&full_row) {
-                return false;
+                return Ok(false);
             }
             if self.is_full_projection {
                 self.current_row = full_row;
@@ -1004,51 +1026,49 @@ impl VolumeScanner {
             }
         } else if let Some(ref mapping) = self.column_mapping {
             if self.is_full_projection {
-                self.current_row = self.volume.get_row_mapped(idx, mapping);
+                self.current_row = self.volume.get_row_mapped(idx, mapping)?;
             } else {
                 self.current_row =
                     self.volume
-                        .get_row_mapped_projected(idx, mapping, &self.project_cols);
+                        .get_row_mapped_projected(idx, mapping, &self.project_cols)?;
             }
         } else if self.is_full_projection {
-            self.current_row = self.volume.get_row(idx);
+            self.current_row = self.volume.get_row(idx)?;
         } else {
-            self.current_row = self.volume.get_row_projected(idx, &self.project_cols);
+            self.current_row = self.volume.get_row_projected(idx, &self.project_cols)?;
         }
-        true
+        Ok(true)
     }
 
     /// Build a row from the per-group column cache (avoids full-column decompression).
-    fn materialize_row_from_cache(&mut self, idx: usize) -> bool {
+    fn materialize_row_from_cache(&mut self, idx: usize) -> Result<bool> {
         let col_count = self.volume.columns.len();
 
         // Build full-width row from cache
         let full_row = if let Some(ref needed) = self.needed_cols {
-            let values: Vec<Value> = (0..col_count)
-                .map(|ci| {
-                    if ci < needed.len() && needed[ci] {
-                        let (col, local) = self.col_and_idx(ci, idx);
-                        col.get_value(local)
-                    } else {
-                        Value::Null(self.volume.columns.data_type(ci))
-                    }
-                })
-                .collect();
+            let mut values = Vec::with_capacity(col_count);
+            for ci in 0..col_count {
+                values.push(if ci < needed.len() && needed[ci] {
+                    let (col, local) = self.col_and_idx(ci, idx)?;
+                    col.get_value(local)
+                } else {
+                    Value::Null(self.volume.columns.data_type(ci))
+                });
+            }
             Row::from_values(values)
         } else {
-            let values: Vec<Value> = (0..col_count)
-                .map(|ci| {
-                    let (col, local) = self.col_and_idx(ci, idx);
-                    col.get_value(local)
-                })
-                .collect();
+            let mut values = Vec::with_capacity(col_count);
+            for ci in 0..col_count {
+                let (col, local) = self.col_and_idx(ci, idx)?;
+                values.push(col.get_value(local));
+            }
             Row::from_values(values)
         };
 
         // Apply filter if present
         if let Some(ref filter) = self.filter {
             if !filter.evaluate_fast(&full_row) {
-                return false;
+                return Ok(false);
             }
         }
 
@@ -1068,15 +1088,15 @@ impl VolumeScanner {
                     .collect(),
             );
         }
-        true
+        Ok(true)
     }
 }
 
-impl Scanner for VolumeScanner {
-    fn next(&mut self) -> bool {
+impl VolumeScanner {
+    fn next_row(&mut self) -> Result<bool> {
         if self.error.is_some() {
             self.has_current = false;
-            return false;
+            return Ok(false);
         }
         if self.reverse {
             return self.next_reverse();
@@ -1094,7 +1114,7 @@ impl Scanner for VolumeScanner {
                     }
                     _ => {
                         self.has_current = false;
-                        return false;
+                        return Ok(false);
                     }
                 };
 
@@ -1110,21 +1130,21 @@ impl Scanner for VolumeScanner {
                         self.load_group_cache(gi);
                         if self.error.is_some() {
                             self.has_current = false;
-                            return false;
+                            return Ok(false);
                         }
                     }
                 }
 
-                if !self.typed_predicates.is_empty() && !self.evaluate_typed_predicates(idx) {
+                if !self.typed_predicates.is_empty() && !self.evaluate_typed_predicates(idx)? {
                     continue;
                 }
-                if !self.materialize_row(idx) {
+                if !self.materialize_row(idx)? {
                     continue;
                 }
 
                 self.current_rid = self.volume.meta.row_ids[idx];
                 self.has_current = true;
-                return true;
+                return Ok(true);
             }
         }
 
@@ -1150,15 +1170,15 @@ impl Scanner for VolumeScanner {
                     self.load_group_cache(group_idx);
                     if self.error.is_some() {
                         self.has_current = false;
-                        return false;
+                        return Ok(false);
                     }
                 }
             }
 
-            if self.stop_key.is_some() && self.past_stop_key(self.current_idx) {
+            if self.stop_key.is_some() && self.past_stop_key(self.current_idx)? {
                 self.current_idx = self.end_idx;
                 self.has_current = false;
-                return false;
+                return Ok(false);
             }
 
             if self.should_skip_row(self.current_idx) {
@@ -1168,15 +1188,15 @@ impl Scanner for VolumeScanner {
 
             let idx = self.current_idx;
 
-            if !self.dict_filters.is_empty() && self.dict_filters_reject(idx) {
+            if !self.dict_filters.is_empty() && self.dict_filters_reject(idx)? {
                 self.current_idx += 1;
                 continue;
             }
-            if !self.typed_predicates.is_empty() && !self.evaluate_typed_predicates(idx) {
+            if !self.typed_predicates.is_empty() && !self.evaluate_typed_predicates(idx)? {
                 self.current_idx += 1;
                 continue;
             }
-            if !self.materialize_row(idx) {
+            if !self.materialize_row(idx)? {
                 self.current_idx += 1;
                 continue;
             }
@@ -1184,11 +1204,24 @@ impl Scanner for VolumeScanner {
             self.current_rid = self.volume.meta.row_ids[idx];
             self.has_current = true;
             self.current_idx += 1;
-            return true;
+            return Ok(true);
         }
 
         self.has_current = false;
-        false
+        Ok(false)
+    }
+}
+
+impl Scanner for VolumeScanner {
+    fn next(&mut self) -> bool {
+        match self.next_row() {
+            Ok(has_row) => has_row,
+            Err(error) => {
+                self.error = Some(error);
+                self.has_current = false;
+                false
+            }
+        }
     }
 
     fn row(&self) -> &Row {

--- a/src/storage/volume/seal.rs
+++ b/src/storage/volume/seal.rs
@@ -165,8 +165,8 @@ mod tests {
 
         let volume = seal_rows(&schema, &rows);
         assert_eq!(volume.meta.row_count, 3);
-        assert_eq!(volume.columns[0].get_i64(0), 1);
-        assert_eq!(volume.columns[1].get_str(2), "carol");
+        assert_eq!(volume.columns.get(0).unwrap().get_i64(0), 1);
+        assert_eq!(volume.columns.get(1).unwrap().get_str(2), "carol");
         assert!(volume.is_sorted(0)); // id is sorted
     }
 
@@ -199,7 +199,7 @@ mod tests {
         // Read it back
         let loaded = io::read_volume_from_disk(&path).unwrap();
         assert_eq!(loaded.meta.row_count, 2);
-        assert_eq!(loaded.columns[0].get_i64(0), 1);
+        assert_eq!(loaded.columns.get(0).unwrap().get_i64(0), 1);
         assert_eq!(loaded.meta.stats.sum(1), 30.0);
     }
 }

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -308,7 +308,18 @@ impl SegmentedTable {
             // Use column mapping to translate schema indices to physical volume indices.
             // After DROP COLUMN + ADD COLUMN, schema positions may not match volume layout.
             let mapping = self.segment_mgr.get_volume_mapping(*seg_id, schema);
-            for i in 0..vol.meta.row_count {
+            let Some(start) = (0..vol.meta.row_count).find(|&i| {
+                cs.is_visible(i)
+                    && !self.is_row_tombstoned(&ts, vol.meta.row_ids[i])
+                    && !hot_skip.contains(&vol.meta.row_ids[i])
+            }) else {
+                continue;
+            };
+            let physical_columns = col_indices.iter().map(|&ci| match mapping.sources.get(ci) {
+                Some(super::writer::ColSource::Volume(phys)) => vol.columns.get(*phys).map(Some),
+                _ => Ok(None),
+            }).collect::<std::io::Result<smallvec::SmallVec<[Option<&super::column::ColumnData>; 4]>>>()?;
+            for i in start..vol.meta.row_count {
                 if !cs.is_visible(i) {
                     continue;
                 }
@@ -322,13 +333,13 @@ impl SegmentedTable {
                 }
                 let values: Vec<Value> = col_indices
                     .iter()
-                    .map(|&ci| {
+                    .zip(&physical_columns)
+                    .map(|(&ci, col)| {
                         use super::writer::ColSource;
-                        if ci < mapping.sources.len() {
-                            match &mapping.sources[ci] {
-                                ColSource::Volume(phys) => vol.columns[*phys].get_value(i),
-                                ColSource::Default(v) => v.clone(),
-                            }
+                        if let Some(col) = col {
+                            col.get_value(i)
+                        } else if let Some(ColSource::Default(v)) = mapping.sources.get(ci) {
+                            v.clone()
                         } else {
                             self.column_default(ci)
                         }
@@ -382,7 +393,16 @@ impl SegmentedTable {
             let vol = &cs.volume;
             // Use column mapping to translate schema indices to physical volume indices.
             let mapping = self.segment_mgr.get_volume_mapping(*seg_id, schema);
-            for i in 0..vol.meta.row_count {
+            let Some(start) = (0..vol.meta.row_count)
+                .find(|&i| cs.is_visible(i) && !self.is_row_tombstoned(&ts, vol.meta.row_ids[i]))
+            else {
+                continue;
+            };
+            let physical_columns = col_indices.iter().map(|&ci| match mapping.sources.get(ci) {
+                Some(super::writer::ColSource::Volume(phys)) => vol.columns.get(*phys).map(Some),
+                _ => Ok(None),
+            }).collect::<std::io::Result<smallvec::SmallVec<[Option<&super::column::ColumnData>; 4]>>>()?;
+            for i in start..vol.meta.row_count {
                 if !cs.is_visible(i) {
                     continue;
                 }
@@ -392,13 +412,13 @@ impl SegmentedTable {
                 }
                 let values: Vec<Value> = col_indices
                     .iter()
-                    .map(|&ci| {
+                    .zip(&physical_columns)
+                    .map(|(&ci, col)| {
                         use super::writer::ColSource;
-                        if ci < mapping.sources.len() {
-                            match &mapping.sources[ci] {
-                                ColSource::Volume(phys) => vol.columns[*phys].get_value(i),
-                                ColSource::Default(v) => v.clone(),
-                            }
+                        if let Some(col) = col {
+                            col.get_value(i)
+                        } else if let Some(ColSource::Default(v)) = mapping.sources.get(ci) {
+                            v.clone()
                         } else {
                             self.column_default(ci)
                         }
@@ -506,63 +526,77 @@ impl SegmentedTable {
         new_row: &Row,
         exclude_row_id: i64,
         snap: Option<&super::manifest::StatementSnapshot>,
+        unique_indexes: &mut Option<Vec<(String, Vec<String>)>>,
     ) -> Result<()> {
+        if unique_indexes.is_none() {
+            *unique_indexes = Some(self.cold_unique_indexes()?);
+        }
         let schema = self.hot.schema();
-        self.hot
-            .for_each_unique_non_pk_index(&mut |idx_name, col_names| {
-                let col_indices: Vec<usize> = col_names
-                    .iter()
-                    .filter_map(|name| schema.columns.iter().position(|c| c.name_lower == *name))
-                    .collect();
-                if col_indices.len() != col_names.len() {
-                    return Ok(());
-                }
-                let coerced: Vec<Value> = col_indices
-                    .iter()
-                    .filter_map(|&idx| {
-                        let val = new_row.get(idx)?;
-                        let target_type = schema.columns[idx].data_type;
-                        Some(val.coerce_to_type(target_type))
-                    })
-                    .collect();
-                if coerced.len() != col_indices.len() || coerced.iter().any(|v| v.is_null()) {
-                    return Ok(());
-                }
-                let values: Vec<&Value> = coerced.iter().collect();
+        for (idx_name, col_names) in unique_indexes.iter().flatten() {
+            let col_indices: smallvec::SmallVec<[usize; 4]> = col_names
+                .iter()
+                .filter_map(|name| schema.columns.iter().position(|c| c.name_lower == *name))
+                .collect();
+            if col_indices.len() != col_names.len() {
+                continue;
+            }
+            let coerced: smallvec::SmallVec<[Value; 4]> = col_indices
+                .iter()
+                .filter_map(|&idx| {
+                    let val = new_row.get(idx)?;
+                    let target_type = schema.columns[idx].data_type;
+                    Some(val.coerce_to_type(target_type))
+                })
+                .collect();
+            if coerced.len() != col_indices.len() || coerced.iter().any(|v| v.is_null()) {
+                continue;
+            }
+            let values: smallvec::SmallVec<[&Value; 4]> = coerced.iter().collect();
 
-                let found = match snap {
-                    Some(snap) => {
-                        self.find_segment_row_id_by_values_in_stmt(snap, &col_indices, &values)?
-                    }
-                    None => self.find_segment_row_id_by_values(&col_indices, &values)?,
-                };
-                if let Some(found_id) = found {
-                    if found_id != exclude_row_id {
-                        return Err(crate::core::Error::UniqueConstraint {
-                            index: idx_name.to_string(),
-                            column: col_names.join(", "),
-                            value: values
-                                .iter()
-                                .map(|v| format!("{}", v))
-                                .collect::<Vec<_>>()
-                                .join(", "),
-                            row_id: found_id,
-                        });
-                    }
+            let found = match snap {
+                Some(snap) => {
+                    self.find_segment_row_id_by_values_in_stmt(snap, &col_indices, &values)?
                 }
+                None => self.find_segment_row_id_by_values(&col_indices, &values)?,
+            };
+            if let Some(found_id) = found {
+                if found_id != exclude_row_id {
+                    return Err(crate::core::Error::UniqueConstraint {
+                        index: idx_name.to_string(),
+                        column: col_names.join(", "),
+                        value: values
+                            .iter()
+                            .map(|v| format!("{}", v))
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                        row_id: found_id,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn cold_unique_indexes(&self) -> Result<Vec<(String, Vec<String>)>> {
+        let mut indexes = Vec::new();
+        self.hot
+            .for_each_unique_non_pk_index(&mut |name, columns| {
+                indexes.push((name.to_owned(), columns.to_vec()));
                 Ok(())
-            })
+            })?;
+        Ok(indexes)
     }
 
     fn check_segment_constraints(&self, row: &Row) -> Result<()> {
         let snapshot = self.segment_mgr.cold_snapshot();
-        self.check_segment_constraints_with_snapshot(&snapshot, row)
+        self.check_segment_constraints_with_snapshot(&snapshot, row, None)
     }
 
     fn check_segment_constraints_with_snapshot(
         &self,
         snapshot: &super::manifest::ColdSnapshot,
         row: &Row,
+        unique_indexes: Option<&[(String, Vec<String>)]>,
     ) -> Result<()> {
         let schema = self.hot.schema();
 
@@ -587,53 +621,58 @@ impl SegmentedTable {
         }
 
         // 2. UNIQUE constraints: scan cold segments with pruning
-        if !self.hot.has_unique_non_pk_indexes() {
+        if unique_indexes.map_or_else(|| !self.hot.has_unique_non_pk_indexes(), |v| v.is_empty()) {
             return Ok(());
         }
-        self.hot
-            .for_each_unique_non_pk_index(&mut |idx_name, col_names| {
-                let col_indices: Vec<usize> = col_names
-                    .iter()
-                    .filter_map(|name| schema.columns.iter().position(|c| c.name_lower == *name))
-                    .collect();
-                if col_indices.len() != col_names.len() {
-                    return Ok(());
-                }
-                // Coerce values to schema column types before comparing with cold segments.
-                // Prepared statements may pass TEXT for TIMESTAMP columns — the row is
-                // coerced later in prepare_insert, but we need the correct types NOW for
-                // zone map / bloom / dict pruning and value comparison to work.
-                let coerced: Vec<Value> = col_indices
-                    .iter()
-                    .filter_map(|&idx| {
-                        let val = row.get(idx)?;
-                        let target_type = schema.columns[idx].data_type;
-                        Some(val.coerce_to_type(target_type))
-                    })
-                    .collect();
-                if coerced.len() != col_indices.len() || coerced.iter().any(|v| v.is_null()) {
-                    return Ok(());
-                }
-                let values: Vec<&Value> = coerced.iter().collect();
+        let mut check_unique = |idx_name: &str, col_names: &[String]| {
+            let col_indices: smallvec::SmallVec<[usize; 4]> = col_names
+                .iter()
+                .filter_map(|name| schema.columns.iter().position(|c| c.name_lower == *name))
+                .collect();
+            if col_indices.len() != col_names.len() {
+                return Ok(());
+            }
+            // Coerce values to schema column types before comparing with cold segments.
+            // Prepared statements may pass TEXT for TIMESTAMP columns — the row is
+            // coerced later in prepare_insert, but we need the correct types NOW for
+            // zone map / bloom / dict pruning and value comparison to work.
+            let coerced: smallvec::SmallVec<[Value; 4]> = col_indices
+                .iter()
+                .filter_map(|&idx| {
+                    let val = row.get(idx)?;
+                    let target_type = schema.columns[idx].data_type;
+                    Some(val.coerce_to_type(target_type))
+                })
+                .collect();
+            if coerced.len() != col_indices.len() || coerced.iter().any(|v| v.is_null()) {
+                return Ok(());
+            }
+            let values: smallvec::SmallVec<[&Value; 4]> = coerced.iter().collect();
 
-                if let Some(conflict_row_id) = self.find_segment_row_id_by_values_with_snapshot(
-                    snapshot,
-                    &col_indices,
-                    &values,
-                )? {
-                    return Err(crate::core::Error::UniqueConstraint {
-                        index: idx_name.to_string(),
-                        column: col_names.join(", "),
-                        value: values
-                            .iter()
-                            .map(|v| v.to_string())
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                        row_id: conflict_row_id,
-                    });
-                }
-                Ok(())
-            })
+            if let Some(conflict_row_id) =
+                self.find_segment_row_id_by_values_with_snapshot(snapshot, &col_indices, &values)?
+            {
+                return Err(crate::core::Error::UniqueConstraint {
+                    index: idx_name.to_string(),
+                    column: col_names.join(", "),
+                    value: values
+                        .iter()
+                        .map(|v| v.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    row_id: conflict_row_id,
+                });
+            }
+            Ok(())
+        };
+        if let Some(indexes) = unique_indexes {
+            for (name, columns) in indexes {
+                check_unique(name, columns)?;
+            }
+            Ok(())
+        } else {
+            self.hot.for_each_unique_non_pk_index(&mut check_unique)
+        }
     }
 
     /// Pre-compute bloom filter hashes for equality comparisons.
@@ -660,7 +699,7 @@ impl SegmentedTable {
         vol: &FrozenVolume,
         comparisons: &[(&str, crate::core::Operator, &Value)],
         bloom_hashes: &[Option<u64>],
-    ) -> (bool, usize, usize) {
+    ) -> Result<(bool, usize, usize)> {
         let mut start = 0usize;
         let mut end = vol.meta.row_count;
 
@@ -685,7 +724,7 @@ impl SegmentedTable {
                         _ => false,
                     };
                 if dominated {
-                    return (true, 0, 0);
+                    return Ok((true, 0, 0));
                 }
 
                 // Binary search on sorted columns.
@@ -718,7 +757,7 @@ impl SegmentedTable {
                                 let idx = if let Some(st) = store {
                                     st.binary_search_ge(col_idx, target, &vol.meta.row_groups)
                                 } else {
-                                    Some(vol.columns[col_idx].binary_search_ge(target))
+                                    Some(vol.columns.get(col_idx)?.binary_search_ge(target))
                                 };
                                 if let Some(idx) = idx {
                                     if idx > start {
@@ -730,7 +769,7 @@ impl SegmentedTable {
                                 let idx = if let Some(st) = store {
                                     st.binary_search_gt(col_idx, target, &vol.meta.row_groups)
                                 } else {
-                                    Some(vol.columns[col_idx].binary_search_gt(target))
+                                    Some(vol.columns.get(col_idx)?.binary_search_gt(target))
                                 };
                                 if let Some(idx) = idx {
                                     if idx > start {
@@ -742,7 +781,7 @@ impl SegmentedTable {
                                 let idx = if let Some(st) = store {
                                     st.binary_search_gt(col_idx, target, &vol.meta.row_groups)
                                 } else {
-                                    Some(vol.columns[col_idx].binary_search_gt(target))
+                                    Some(vol.columns.get(col_idx)?.binary_search_gt(target))
                                 };
                                 if let Some(idx) = idx {
                                     if idx < end {
@@ -754,7 +793,7 @@ impl SegmentedTable {
                                 let idx = if let Some(st) = store {
                                     st.binary_search_ge(col_idx, target, &vol.meta.row_groups)
                                 } else {
-                                    Some(vol.columns[col_idx].binary_search_ge(target))
+                                    Some(vol.columns.get(col_idx)?.binary_search_ge(target))
                                 };
                                 if let Some(idx) = idx {
                                     if idx < end {
@@ -769,7 +808,7 @@ impl SegmentedTable {
             }
         }
 
-        (start >= end, start, end)
+        Ok((start >= end, start, end))
     }
 
     /// Create lazy segment scanners for a read query, applying zone map pruning
@@ -812,7 +851,7 @@ impl SegmentedTable {
 
         for (seg_id, cs) in volumes.iter() {
             let vol = &cs.volume;
-            let (should_skip, start, end) = Self::prune_volume(vol, &comparisons, &bloom_hashes);
+            let (should_skip, start, end) = Self::prune_volume(vol, &comparisons, &bloom_hashes)?;
             if should_skip {
                 continue;
             }
@@ -824,7 +863,7 @@ impl SegmentedTable {
                     Some(v) => v,
                     None => continue,
                 };
-                let (_, s, e) = Self::prune_volume(&loaded, &comparisons, &bloom_hashes);
+                let (_, s, e) = Self::prune_volume(&loaded, &comparisons, &bloom_hashes)?;
                 (&loaded, s, e)
             } else {
                 (vol, start, end)
@@ -895,42 +934,34 @@ impl SegmentedTable {
         // Pre-filter volumes using zone-map metadata BEFORE parallel dispatch.
         // This avoids rayon scheduling overhead for volumes that would be pruned.
         let bloom_hashes = Self::precompute_bloom_hashes(&comparisons);
-        let pruned_volumes: Vec<&(u64, super::manifest::ColdSegment)> = if comparisons.is_empty() {
-            volumes.iter().collect()
-        } else {
-            volumes
-                .iter()
-                .filter(|(_, cs)| {
-                    let (skip, _, _) = Self::prune_volume(&cs.volume, &comparisons, &bloom_hashes);
-                    !skip
-                })
-                .collect()
-        };
+        let mut pruned_volumes = Vec::with_capacity(volumes.len());
+        for volume in volumes.iter() {
+            if comparisons.is_empty()
+                || !Self::prune_volume(&volume.1.volume, &comparisons, &bloom_hashes)?.0
+            {
+                pruned_volumes.push(volume);
+            }
+        }
         let hot_skip_ref = &hot_skip;
         let tombstones_ref = &tombstones_arc;
-        let reload_failed = std::sync::atomic::AtomicBool::new(false);
 
         // Per-volume row collection closure. Returns Some(vol_rows) or None if pruned.
         let process_volume =
-            |(seg_id, cs): &(u64, super::manifest::ColdSegment)| -> Option<RowVec> {
+            |(seg_id, cs): &(u64, super::manifest::ColdSegment)| -> Result<Option<RowVec>> {
                 let vol = &cs.volume;
                 let (should_skip, start, end) =
-                    Self::prune_volume(vol, &comparisons, &bloom_hashes);
+                    Self::prune_volume(vol, &comparisons, &bloom_hashes)?;
                 if should_skip {
-                    return None;
+                    return Ok(None);
                 }
                 // Load cold volume on demand after zone-map/bloom pruning.
                 let loaded;
                 let (vol, start, end) = if vol.is_cold() {
-                    loaded = match self.segment_mgr.ensure_volume(*seg_id) {
-                        Ok(Some(v)) => v,
-                        Ok(None) => return None,
-                        Err(_) => {
-                            reload_failed.store(true, std::sync::atomic::Ordering::Relaxed);
-                            return None;
-                        }
+                    loaded = match self.segment_mgr.ensure_volume(*seg_id)? {
+                        Some(v) => v,
+                        None => return Ok(None),
                     };
-                    let (_, s, e) = Self::prune_volume(&loaded, &comparisons, &bloom_hashes);
+                    let (_, s, e) = Self::prune_volume(&loaded, &comparisons, &bloom_hashes)?;
                     (&loaded, s, e)
                 } else {
                     vol.mark_accessed();
@@ -950,7 +981,7 @@ impl SegmentedTable {
                             let dict_id = if let Some(st) = store {
                                 st.dict_lookup(col_idx, s.as_str())
                             } else {
-                                vol.columns[col_idx].dict_lookup(s.as_str())
+                                vol.columns.get(col_idx)?.dict_lookup(s.as_str())
                             };
                             if let Some(id) = dict_id {
                                 dict_filters.push((col_idx, id));
@@ -963,7 +994,7 @@ impl SegmentedTable {
                 }
 
                 if start >= end {
-                    return None;
+                    return Ok(None);
                 }
 
                 let current_schema = self.hot.schema();
@@ -974,8 +1005,10 @@ impl SegmentedTable {
                 let mut candidates: Vec<usize> = Vec::new();
                 let filters: smallvec::SmallVec<[super::column::DictFilter<'_>; 4]> = dict_filters
                     .iter()
-                    .map(|&(col_idx, expected)| (&vol.columns[col_idx], start, expected))
-                    .collect();
+                    .map(|&(col_idx, expected)| {
+                        vol.columns.get(col_idx).map(|col| (col, start, expected))
+                    })
+                    .collect::<std::io::Result<_>>()?;
                 let prefiltered = !filters.is_empty()
                     && super::column::ColumnData::dict_matching_offsets(
                         &filters,
@@ -1014,10 +1047,8 @@ impl SegmentedTable {
 
                     if !prefiltered && !dict_filters.is_empty() {
                         let mut matches = true;
-                        for &(col_idx, expected_id) in &dict_filters {
-                            if vol.columns[col_idx].is_null(i)
-                                || vol.columns[col_idx].get_dict_id(i) != expected_id
-                            {
+                        for &(col, _, expected_id) in &filters {
+                            if col.is_null(i) || col.get_dict_id(i) != expected_id {
                                 matches = false;
                                 break;
                             }
@@ -1031,7 +1062,7 @@ impl SegmentedTable {
                         vol.get_row(i)
                     } else {
                         vol.get_row_mapped(i, &mapping)
-                    };
+                    }?;
                     if let Some(expr) = where_expr {
                         if !expr.evaluate_fast(&row) {
                             continue;
@@ -1039,7 +1070,7 @@ impl SegmentedTable {
                     }
                     vol_rows.push((row_id, row));
                 }
-                Some(vol_rows)
+                Ok(Some(vol_rows))
             };
 
         // Parallel or sequential volume processing.
@@ -1049,34 +1080,26 @@ impl SegmentedTable {
             .map(|(_, cs)| cs.volume.meta.row_count)
             .sum();
         #[cfg(feature = "parallel")]
-        let per_volume_rows: Vec<RowVec> =
+        let per_volume_rows: Vec<Option<RowVec>> =
             if pruned_volumes.len() >= 4 && _total_cold_rows >= 100_000 {
                 use rayon::prelude::*;
                 pruned_volumes
                     .par_iter()
-                    .filter_map(|v| process_volume(v))
-                    .collect()
+                    .map(|v| process_volume(v))
+                    .collect::<Result<_>>()?
             } else {
                 pruned_volumes
                     .iter()
-                    .filter_map(|v| process_volume(v))
-                    .collect()
+                    .map(|v| process_volume(v))
+                    .collect::<Result<_>>()?
             };
         #[cfg(not(feature = "parallel"))]
-        let per_volume_rows: Vec<RowVec> = pruned_volumes
+        let per_volume_rows: Vec<Option<RowVec>> = pruned_volumes
             .iter()
-            .filter_map(|v| process_volume(v))
-            .collect();
+            .map(|v| process_volume(v))
+            .collect::<Result<_>>()?;
 
-        if reload_failed.load(std::sync::atomic::Ordering::Relaxed) {
-            return Err(crate::core::Error::Internal {
-                message: format!(
-                    "table '{}': cold volume reload failed; refusing to serve partial data",
-                    self.segment_mgr.table_name()
-                ),
-            });
-        }
-        for vol_rows in per_volume_rows.into_iter().rev() {
+        for vol_rows in per_volume_rows.into_iter().rev().flatten() {
             for entry in vol_rows {
                 rows.push(entry);
             }
@@ -1233,14 +1256,14 @@ impl SegmentedTable {
         &self,
         vol: &FrozenVolume,
         cs: &super::manifest::ColdSegment,
-        pi: usize,
+        col: &super::column::ColumnData,
         overall_min: &mut Option<Value>,
         tombstones: &FxHashMap<i64, u64>,
         hot_skip: &FxHashSet<i64>,
         no_tombstones: bool,
     ) {
         for i in 0..vol.meta.row_count {
-            if vol.columns[pi].is_null(i) || !cs.is_visible(i) {
+            if col.is_null(i) || !cs.is_visible(i) {
                 continue;
             }
             let rid = vol.meta.row_ids[i];
@@ -1250,7 +1273,7 @@ impl SegmentedTable {
             if !no_tombstones && self.is_row_tombstoned(tombstones, rid) {
                 continue;
             }
-            let val = vol.columns[pi].get_value(i);
+            let val = col.get_value(i);
             match overall_min {
                 None => *overall_min = Some(val),
                 Some(ref current) => {
@@ -1268,14 +1291,14 @@ impl SegmentedTable {
         &self,
         vol: &FrozenVolume,
         cs: &super::manifest::ColdSegment,
-        pi: usize,
+        col: &super::column::ColumnData,
         overall_max: &mut Option<Value>,
         tombstones: &FxHashMap<i64, u64>,
         hot_skip: &FxHashSet<i64>,
         no_tombstones: bool,
     ) {
         for i in 0..vol.meta.row_count {
-            if vol.columns[pi].is_null(i) || !cs.is_visible(i) {
+            if col.is_null(i) || !cs.is_visible(i) {
                 continue;
             }
             let rid = vol.meta.row_ids[i];
@@ -1285,7 +1308,7 @@ impl SegmentedTable {
             if !no_tombstones && self.is_row_tombstoned(tombstones, rid) {
                 continue;
             }
-            let val = vol.columns[pi].get_value(i);
+            let val = col.get_value(i);
             match overall_max {
                 None => *overall_max = Some(val),
                 Some(ref current) => {
@@ -1388,8 +1411,17 @@ impl Table for SegmentedTable {
         if self.segment_mgr.has_segments() {
             // Snapshot once for the entire batch — eliminates 3 lock reads per row.
             let snapshot = self.segment_mgr.cold_snapshot();
+            let unique_indexes = if rows.len() > 1 && self.hot.has_unique_non_pk_indexes() {
+                Some(self.cold_unique_indexes()?)
+            } else {
+                None
+            };
             for row in &rows {
-                self.check_segment_constraints_with_snapshot(&snapshot, row)?;
+                self.check_segment_constraints_with_snapshot(
+                    &snapshot,
+                    row,
+                    unique_indexes.as_deref(),
+                )?;
             }
         }
         self.hot.insert_batch(rows)?;
@@ -1446,11 +1478,12 @@ impl Table for SegmentedTable {
             .unwrap_or_default();
         let bloom_hashes = Self::precompute_bloom_hashes(&comparisons);
 
+        let mut unique_indexes = None;
         for (seg_id, cs) in volumes.iter() {
             let vol = &cs.volume;
 
             // Prune volume by zone maps and bloom filters.
-            let (should_skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes);
+            let (should_skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes)?;
             if should_skip {
                 continue;
             }
@@ -1482,7 +1515,7 @@ impl Table for SegmentedTable {
                     vol.get_row(i)
                 } else {
                     vol.get_row_mapped(i, &mapping)
-                };
+                }?;
                 if let Some(expr) = where_expr {
                     if !expr.evaluate_fast(&row) {
                         continue;
@@ -1500,6 +1533,7 @@ impl Table for SegmentedTable {
                             &new_row,
                             row_id,
                             cold_snapshot.as_ref(),
+                            &mut unique_indexes,
                         )?;
                     }
 
@@ -1568,6 +1602,7 @@ impl Table for SegmentedTable {
             *const super::writer::FrozenVolume,
             super::writer::ColumnMapping,
         )> = None;
+        let mut unique_indexes = None;
         for &row_id in row_ids {
             let found = match &cold_snapshot {
                 Some(snap) => self.find_segment_row_in(snap, row_id),
@@ -1588,7 +1623,7 @@ impl Table for SegmentedTable {
                     vol.get_row(idx)
                 } else {
                     vol.get_row_mapped(idx, mapping)
-                };
+                }?;
                 let old_row = row.clone();
                 let (new_row, changed) = setter(row)?;
                 if changed {
@@ -1599,6 +1634,7 @@ impl Table for SegmentedTable {
                             &new_row,
                             row_id,
                             cold_snapshot.as_ref(),
+                            &mut unique_indexes,
                         )?;
                     }
                     let result = if has_int_pk {
@@ -1804,7 +1840,7 @@ impl Table for SegmentedTable {
             let vol = &cs.volume;
 
             // Prune volume by zone maps and bloom filters.
-            let (should_skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes);
+            let (should_skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes)?;
             if should_skip {
                 continue;
             }
@@ -1840,7 +1876,7 @@ impl Table for SegmentedTable {
                         (Some(mask), true) => {
                             for ci in 0..vol.columns.len() {
                                 if ci < mask.len() && mask[ci] {
-                                    reusable_row.push(vol.columns[ci].get_value(i));
+                                    reusable_row.push(vol.columns.get(ci)?.get_value(i));
                                 } else {
                                     reusable_row.push(Value::Null(vol.columns.data_type(ci)));
                                 }
@@ -1851,7 +1887,7 @@ impl Table for SegmentedTable {
                                 if ci < mask.len() && mask[ci] {
                                     match src {
                                         super::writer::ColSource::Volume(vi) => {
-                                            reusable_row.push(vol.columns[*vi].get_value(i));
+                                            reusable_row.push(vol.columns.get(*vi)?.get_value(i));
                                         }
                                         super::writer::ColSource::Default(val) => {
                                             reusable_row.push(val.clone());
@@ -1872,14 +1908,14 @@ impl Table for SegmentedTable {
                         }
                         (None, true) => {
                             for ci in 0..vol.columns.len() {
-                                reusable_row.push(vol.columns[ci].get_value(i));
+                                reusable_row.push(vol.columns.get(ci)?.get_value(i));
                             }
                         }
                         (None, false) => {
                             for src in &mapping.sources {
                                 match src {
                                     super::writer::ColSource::Volume(vi) => {
-                                        reusable_row.push(vol.columns[*vi].get_value(i));
+                                        reusable_row.push(vol.columns.get(*vi)?.get_value(i));
                                     }
                                     super::writer::ColSource::Default(val) => {
                                         reusable_row.push(val.clone());
@@ -2038,7 +2074,7 @@ impl Table for SegmentedTable {
                     vol.get_row(idx)
                 } else {
                     vol.get_row_mapped(idx, mapping)
-                };
+                }?;
                 result.push((row_id, row));
             } else {
                 hot_ids.push(row_id);
@@ -2095,7 +2131,7 @@ impl Table for SegmentedTable {
                     vol.get_row(idx)
                 } else {
                     vol.get_row_mapped(idx, mapping)
-                };
+                }?;
                 if filter.evaluate_fast(&row) {
                     buffer.push((row_id, row));
                 }
@@ -2173,7 +2209,7 @@ impl Table for SegmentedTable {
         'done: for (nf_idx, (seg_id, cs)) in volumes.iter().enumerate().rev() {
             let vol = &cs.volume;
             if !comparisons.is_empty() {
-                let (skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes);
+                let (skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes)?;
                 if skip {
                     continue;
                 }
@@ -2203,7 +2239,7 @@ impl Table for SegmentedTable {
                     vol.get_row(i)
                 } else {
                     vol.get_row_mapped(i, &mapping)
-                };
+                }?;
                 if let Some(expr) = where_expr {
                     if !expr.evaluate_fast(&row) {
                         continue;
@@ -2286,7 +2322,7 @@ impl Table for SegmentedTable {
             let vol = &cs.volume;
             // Zone-map pruning: skip entire volume if no rows can match.
             let pruned = if !comparisons.is_empty() {
-                let (skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes);
+                let (skip, _, _) = Self::prune_volume(vol, &comparisons, &bloom_hashes)?;
                 skip
             } else {
                 false
@@ -2326,7 +2362,7 @@ impl Table for SegmentedTable {
                         vol.get_row(i)
                     } else {
                         vol.get_row_mapped(i, &mapping)
-                    };
+                    }?;
                     if let Some(expr) = where_expr {
                         if !expr.evaluate_fast(&row) {
                             continue;
@@ -2347,7 +2383,7 @@ impl Table for SegmentedTable {
                             vol.get_row(i)
                         } else {
                             vol.get_row_mapped(i, &mapping)
-                        };
+                        }?;
                         result.push((row_id, row));
                     }
                 }
@@ -2575,6 +2611,13 @@ impl Table for SegmentedTable {
 
         for (seg_id, cs) in volumes.iter() {
             let vol = &cs.volume;
+            let Some(start) = (0..vol.meta.row_count).find(|&i| {
+                cs.is_visible(i)
+                    && !self.is_row_tombstoned(&tombstones_arc, vol.meta.row_ids[i])
+                    && !hot_skip.contains(&vol.meta.row_ids[i])
+            }) else {
+                continue;
+            };
             let mapping = self.segment_mgr.get_volume_mapping(*seg_id, schema);
             let phys = if col_idx < mapping.sources.len() {
                 match &mapping.sources[col_idx] {
@@ -2584,7 +2627,8 @@ impl Table for SegmentedTable {
             } else {
                 None
             };
-            for i in 0..vol.meta.row_count {
+            let column = phys.map(|pi| vol.columns.get(pi)).transpose()?;
+            for i in start..vol.meta.row_count {
                 if !cs.is_visible(i) {
                     continue;
                 }
@@ -2592,11 +2636,11 @@ impl Table for SegmentedTable {
                 if self.is_row_tombstoned(&tombstones_arc, rid) || hot_skip.contains(&rid) {
                     continue;
                 }
-                if let Some(pi) = phys {
-                    if vol.columns[pi].is_null(i) {
+                if let Some(col) = column {
+                    if col.is_null(i) {
                         continue;
                     }
-                    match &vol.columns[pi] {
+                    match col {
                         crate::storage::volume::column::ColumnData::Int64 { values, .. } => {
                             total_sum += values[i] as f64;
                             total_count += 1;
@@ -2754,7 +2798,8 @@ impl Table for SegmentedTable {
 
             // Typed direct scan: compare on primitive types to avoid Value alloc
             if let Some(pi) = phys {
-                match &vol.columns[pi] {
+                let col = vol.columns.get(pi)?;
+                match col {
                     crate::storage::volume::column::ColumnData::Int64 { values, nulls } => {
                         let mut best_i64 = match &overall_min {
                             Some(Value::Integer(v)) => Some(*v),
@@ -2764,7 +2809,7 @@ impl Table for SegmentedTable {
                                 self.min_column_scan_generic(
                                     vol,
                                     cs,
-                                    pi,
+                                    col,
                                     &mut overall_min,
                                     tombstones_ref,
                                     &hot_skip,
@@ -2801,7 +2846,7 @@ impl Table for SegmentedTable {
                                 self.min_column_scan_generic(
                                     vol,
                                     cs,
-                                    pi,
+                                    col,
                                     &mut overall_min,
                                     tombstones_ref,
                                     &hot_skip,
@@ -2847,7 +2892,7 @@ impl Table for SegmentedTable {
                                 self.min_column_scan_generic(
                                     vol,
                                     cs,
-                                    pi,
+                                    col,
                                     &mut overall_min,
                                     tombstones_ref,
                                     &hot_skip,
@@ -2887,7 +2932,7 @@ impl Table for SegmentedTable {
                         self.min_column_scan_generic(
                             vol,
                             cs,
-                            pi,
+                            col,
                             &mut overall_min,
                             tombstones_ref,
                             &hot_skip,
@@ -3053,7 +3098,8 @@ impl Table for SegmentedTable {
 
             // Typed direct scan: compare on primitive types to avoid Value alloc
             if let Some(pi) = phys {
-                match &vol.columns[pi] {
+                let col = vol.columns.get(pi)?;
+                match col {
                     crate::storage::volume::column::ColumnData::Int64 { values, nulls } => {
                         let mut best_i64 = match &overall_max {
                             Some(Value::Integer(v)) => Some(*v),
@@ -3062,7 +3108,7 @@ impl Table for SegmentedTable {
                                 self.max_column_scan_generic(
                                     vol,
                                     cs,
-                                    pi,
+                                    col,
                                     &mut overall_max,
                                     tombstones_ref,
                                     &hot_skip,
@@ -3099,7 +3145,7 @@ impl Table for SegmentedTable {
                                 self.max_column_scan_generic(
                                     vol,
                                     cs,
-                                    pi,
+                                    col,
                                     &mut overall_max,
                                     tombstones_ref,
                                     &hot_skip,
@@ -3145,7 +3191,7 @@ impl Table for SegmentedTable {
                                 self.max_column_scan_generic(
                                     vol,
                                     cs,
-                                    pi,
+                                    col,
                                     &mut overall_max,
                                     tombstones_ref,
                                     &hot_skip,
@@ -3185,7 +3231,7 @@ impl Table for SegmentedTable {
                         self.max_column_scan_generic(
                             vol,
                             cs,
-                            pi,
+                            col,
                             &mut overall_max,
                             tombstones_ref,
                             &hot_skip,
@@ -3270,6 +3316,13 @@ impl Table for SegmentedTable {
         let has_non_null_default = !default_val.is_null();
         for (seg_id, cs) in volumes.iter() {
             let vol = &cs.volume;
+            let Some(start) = (0..vol.meta.row_count).find(|&i| {
+                cs.is_visible(i)
+                    && !self.is_row_tombstoned(&tombstones_arc, vol.meta.row_ids[i])
+                    && !hot_skip.contains(&vol.meta.row_ids[i])
+            }) else {
+                continue;
+            };
             let mapping = self.segment_mgr.get_volume_mapping(*seg_id, schema);
             let phys = if col_idx < mapping.sources.len() {
                 match &mapping.sources[col_idx] {
@@ -3279,7 +3332,8 @@ impl Table for SegmentedTable {
             } else {
                 None
             };
-            for i in 0..vol.meta.row_count {
+            let column = phys.map(|pi| vol.columns.get(pi)).transpose()?;
+            for i in start..vol.meta.row_count {
                 if !cs.is_visible(i) {
                     continue;
                 }
@@ -3287,9 +3341,9 @@ impl Table for SegmentedTable {
                 if self.is_row_tombstoned(&tombstones_arc, rid) || hot_skip.contains(&rid) {
                     continue;
                 }
-                if let Some(pi) = phys {
-                    if !vol.columns[pi].is_null(i) {
-                        distinct.insert(vol.columns[pi].get_value(i));
+                if let Some(col) = column {
+                    if !col.is_null(i) {
+                        distinct.insert(col.get_value(i));
                     }
                 } else if has_non_null_default {
                     distinct.insert(default_val.clone());
@@ -3340,6 +3394,13 @@ impl Table for SegmentedTable {
         let has_non_null_default = !default_val.is_null();
         for (seg_id, cs) in volumes.iter() {
             let vol = &cs.volume;
+            let Some(start) = (0..vol.meta.row_count).find(|&i| {
+                cs.is_visible(i)
+                    && !self.is_row_tombstoned(&tombstones_arc, vol.meta.row_ids[i])
+                    && !hot_skip.contains(&vol.meta.row_ids[i])
+            }) else {
+                continue;
+            };
             let mapping = self.segment_mgr.get_volume_mapping(*seg_id, schema);
             let phys = if col_idx < mapping.sources.len() {
                 match &mapping.sources[col_idx] {
@@ -3349,7 +3410,8 @@ impl Table for SegmentedTable {
             } else {
                 None
             };
-            for i in 0..vol.meta.row_count {
+            let column = phys.map(|pi| vol.columns.get(pi)).transpose()?;
+            for i in start..vol.meta.row_count {
                 if !cs.is_visible(i) {
                     continue;
                 }
@@ -3357,9 +3419,9 @@ impl Table for SegmentedTable {
                 if self.is_row_tombstoned(&tombstones_arc, rid) || hot_skip.contains(&rid) {
                     continue;
                 }
-                if let Some(pi) = phys {
-                    if !vol.columns[pi].is_null(i) {
-                        distinct.insert(vol.columns[pi].get_value(i));
+                if let Some(col) = column {
+                    if !col.is_null(i) {
+                        distinct.insert(col.get_value(i));
                     }
                 } else if has_non_null_default {
                     distinct.insert(default_val.clone());
@@ -3441,7 +3503,7 @@ impl Table for SegmentedTable {
                 let can_use_dict = no_tombstones && cs.visible.is_none() && hot_skip.is_empty();
 
                 if can_use_dict {
-                    if let Some(dict_arc) = vol.get_column_dictionary(pi) {
+                    if let Some(dict_arc) = vol.get_column_dictionary(pi)? {
                         for entry in dict_arc.iter() {
                             distinct.insert(Value::text(entry.as_str()));
                         }
@@ -3452,7 +3514,16 @@ impl Table for SegmentedTable {
                 }
 
                 // Fallback: row-by-row scan on this volume's column
-                for i in 0..vol.meta.row_count {
+                let Some(start) = (0..vol.meta.row_count).find(|&i| {
+                    cs.is_visible(i)
+                        && !hot_skip.contains(&vol.meta.row_ids[i])
+                        && (no_tombstones
+                            || !self.is_row_tombstoned(&tombstones_arc, vol.meta.row_ids[i]))
+                }) else {
+                    continue;
+                };
+                let col = vol.columns.get(pi)?;
+                for i in start..vol.meta.row_count {
                     if !cs.is_visible(i) {
                         continue;
                     }
@@ -3463,8 +3534,8 @@ impl Table for SegmentedTable {
                     if !no_tombstones && self.is_row_tombstoned(&tombstones_arc, rid) {
                         continue;
                     }
-                    if !vol.columns[pi].is_null(i) {
-                        distinct.insert(vol.columns[pi].get_value(i));
+                    if !col.is_null(i) {
+                        distinct.insert(col.get_value(i));
                     }
                 }
             } else if has_non_null_default {
@@ -3534,6 +3605,13 @@ impl Table for SegmentedTable {
         for (_seg_id, cs) in volumes.iter() {
             let vol = &cs.volume;
             let mapping = &cs.mapping;
+            let Some(start) = (0..vol.meta.row_count).find(|&i| {
+                cs.is_visible(i)
+                    && !self.is_row_tombstoned(&tombstones_arc, vol.meta.row_ids[i])
+                    && !hot_skip.contains(&vol.meta.row_ids[i])
+            }) else {
+                continue;
+            };
             // Resolve partition column through mapping (handles DROP COLUMN ordinal shifts)
             let phys_col = if col_idx < mapping.sources.len() {
                 match &mapping.sources[col_idx] {
@@ -3544,7 +3622,8 @@ impl Table for SegmentedTable {
                 None
             };
 
-            for i in 0..vol.meta.row_count {
+            let column = phys_col.map(|pc| vol.columns.get(pc)).transpose()?;
+            for i in start..vol.meta.row_count {
                 if !cs.is_visible(i) {
                     continue;
                 }
@@ -3552,11 +3631,11 @@ impl Table for SegmentedTable {
                 if self.is_row_tombstoned(&tombstones_arc, rid) || hot_skip.contains(&rid) {
                     continue;
                 }
-                let val = if let Some(pc) = phys_col {
-                    if vol.columns[pc].is_null(i) {
+                let val = if let Some(col) = column {
+                    if col.is_null(i) {
                         continue;
                     }
-                    vol.columns[pc].get_value(i)
+                    col.get_value(i)
                 } else if has_non_null_default {
                     default_val.clone()
                 } else {
@@ -3566,7 +3645,7 @@ impl Table for SegmentedTable {
                     vol.get_row(i)
                 } else {
                     vol.get_row_mapped(i, mapping)
-                };
+                }?;
                 groups.entry(val).or_default().push((rid, row));
             }
         }
@@ -3641,6 +3720,13 @@ impl Table for SegmentedTable {
                     continue;
                 }
             }
+            let Some(start) = (0..vol.meta.row_count).find(|&i| {
+                cs.is_visible(i)
+                    && !self.is_row_tombstoned(&tombstones_arc, vol.meta.row_ids[i])
+                    && !hot_skip.contains(&vol.meta.row_ids[i])
+            }) else {
+                continue;
+            };
             // Load cold volume on demand after pruning.
             let loaded;
             let vol: &Arc<FrozenVolume> = if vol.is_cold() {
@@ -3654,7 +3740,8 @@ impl Table for SegmentedTable {
                 vol
             };
 
-            for i in 0..vol.meta.row_count {
+            let column = phys_col.map(|pc| vol.columns.get(pc)).transpose()?;
+            for i in start..vol.meta.row_count {
                 if !cs.is_visible(i) {
                     continue;
                 }
@@ -3662,11 +3749,11 @@ impl Table for SegmentedTable {
                 if self.is_row_tombstoned(&tombstones_arc, rid) || hot_skip.contains(&rid) {
                     continue;
                 }
-                let matches = if let Some(pc) = phys_col {
-                    if vol.columns[pc].is_null(i) {
+                let matches = if let Some(col) = column {
+                    if col.is_null(i) {
                         false
                     } else {
-                        &vol.columns[pc].get_value(i) == partition_value
+                        &col.get_value(i) == partition_value
                     }
                 } else {
                     // Missing column → all rows have default, already checked match above
@@ -3677,7 +3764,7 @@ impl Table for SegmentedTable {
                         vol.get_row(i)
                     } else {
                         vol.get_row_mapped(i, mapping)
-                    };
+                    }?;
                     result.push((rid, row));
                 }
             }
@@ -3887,7 +3974,7 @@ impl Table for SegmentedTable {
                     vs.volume.get_row(idx)
                 } else {
                     vs.volume.get_row_mapped(idx, &vs.mapping)
-                };
+                }?;
 
                 if skipped < offset {
                     skipped += 1;
@@ -4085,7 +4172,7 @@ impl Table for SegmentedTable {
             }
             let (seg_id, cs) = &volumes[i];
             let (should_skip, mut narrow_start, mut narrow_end) =
-                Self::prune_volume(&cs.volume, &comparisons, &bloom_hashes);
+                Self::prune_volume(&cs.volume, &comparisons, &bloom_hashes)?;
             if should_skip {
                 continue;
             }
@@ -4098,7 +4185,7 @@ impl Table for SegmentedTable {
                 // Only a loaded volume can narrow the range through the sorted
                 // columns' binary search; a warm one already did above
                 (_, narrow_start, narrow_end) =
-                    Self::prune_volume(&loaded, &comparisons, &bloom_hashes);
+                    Self::prune_volume(&loaded, &comparisons, &bloom_hashes)?;
                 &loaded
             } else {
                 &cs.volume
@@ -4580,9 +4667,9 @@ impl Table for SegmentedTable {
                                     DataType::Integer | DataType::Timestamp
                                 )
                                 && pi < vol.columns.len()
-                                && !vol.columns[pi].is_null(i)
+                                && !vol.columns.get(pi)?.is_null(i)
                             {
-                                let pk_val = vol.columns[pi].get_i64(i);
+                                let pk_val = vol.columns.get(pi)?.get_i64(i);
                                 if hot_pks.contains(&pk_val) {
                                     continue;
                                 }
@@ -4593,7 +4680,7 @@ impl Table for SegmentedTable {
                         vol.get_row(i)
                     } else {
                         vol.get_row_mapped(i, &mapping)
-                    };
+                    }?;
                     if let Some(e) = expr {
                         if !e.evaluate_fast(&row) {
                             continue;
@@ -4925,7 +5012,7 @@ impl Table for SegmentedTable {
         fn accumulate_row(
             accums: &mut [Accum],
             phys_aggs: &[PhysAgg],
-            columns: &super::writer::LazyColumns,
+            columns: &[Option<&super::column::ColumnData>],
             i: usize,
         ) {
             for (agg_idx, pa) in phys_aggs.iter().enumerate() {
@@ -4933,8 +5020,8 @@ impl Table for SegmentedTable {
                 match pa.op {
                     AggregateOp::CountStar => acc.count += 1,
                     AggregateOp::Count => {
-                        if let Some(pc) = pa.phys_col {
-                            if !columns[pc].is_null(i) {
+                        if let Some(col) = columns[agg_idx] {
+                            if !col.is_null(i) {
                                 acc.count += 1;
                             }
                         } else if let Some(ref def) = pa.default_val {
@@ -4944,8 +5031,7 @@ impl Table for SegmentedTable {
                         }
                     }
                     AggregateOp::Sum | AggregateOp::Avg => {
-                        if let Some(pc) = pa.phys_col {
-                            let col = &columns[pc];
+                        if let Some(col) = columns[agg_idx] {
                             if !col.is_null(i) {
                                 match col.data_type() {
                                     DataType::Integer | DataType::Timestamp => {
@@ -4987,8 +5073,7 @@ impl Table for SegmentedTable {
                         }
                     }
                     AggregateOp::Min => {
-                        if let Some(pc) = pa.phys_col {
-                            let col = &columns[pc];
+                        if let Some(col) = columns[agg_idx] {
                             if !col.is_null(i) {
                                 match col.data_type() {
                                     DataType::Integer | DataType::Timestamp => {
@@ -5033,8 +5118,7 @@ impl Table for SegmentedTable {
                         }
                     }
                     AggregateOp::Max => {
-                        if let Some(pc) = pa.phys_col {
-                            let col = &columns[pc];
+                        if let Some(col) = columns[agg_idx] {
                             if !col.is_null(i) {
                                 match col.data_type() {
                                     DataType::Integer | DataType::Timestamp => {
@@ -5099,23 +5183,16 @@ impl Table for SegmentedTable {
             })
             .collect();
         let bloom_hashes = Self::precompute_bloom_hashes(&comparisons_for_prune);
-        let volumes: Vec<&(u64, super::manifest::ColdSegment)> = if comparisons_for_prune.is_empty()
-        {
-            volumes.iter().collect()
-        } else {
-            volumes
-                .iter()
-                .filter(|(_, cs)| {
-                    // Only pre-prune identity-mapped volumes (no schema evolution)
-                    if !cs.mapping.is_identity {
-                        return true; // keep — pruned inside closure with mapping
-                    }
-                    let (skip, _, _) =
-                        Self::prune_volume(&cs.volume, &comparisons_for_prune, &bloom_hashes);
-                    !skip
-                })
-                .collect()
-        };
+        let mut pruned_volumes = Vec::with_capacity(volumes.len());
+        for volume in volumes.iter() {
+            if comparisons_for_prune.is_empty()
+                || !volume.1.mapping.is_identity
+                || !Self::prune_volume(&volume.1.volume, &comparisons_for_prune, &bloom_hashes)?.0
+            {
+                pruned_volumes.push(volume);
+            }
+        }
+        let volumes = pruned_volumes;
 
         // --- Per-volume accumulation closure -----------------------------------
         // Extracted so both sequential and parallel paths share one implementation.
@@ -5127,9 +5204,9 @@ impl Table for SegmentedTable {
         let tombstones_ref = &tombstones_arc;
 
         let process_volume =
-            |(seg_id, cs): &(u64, super::manifest::ColdSegment)| -> Option<Vec<Accum>> {
+            |(seg_id, cs): &(u64, super::manifest::ColdSegment)| -> Result<Option<Vec<Accum>>> {
                 if bail.load(std::sync::atomic::Ordering::Relaxed) {
-                    return None;
+                    return Ok(None);
                 }
                 let vol = &cs.volume;
                 let mapping = self.segment_mgr.get_volume_mapping(*seg_id, &schema);
@@ -5141,12 +5218,12 @@ impl Table for SegmentedTable {
                 for pred in &preds {
                     if pred.schema_col_idx >= mapping.sources.len() {
                         bail.store(true, std::sync::atomic::Ordering::Relaxed);
-                        return None;
+                        return Ok(None);
                     }
                     match &mapping.sources[pred.schema_col_idx] {
                         super::writer::ColSource::Volume(phys_idx) => {
                             let dict_id = if let TypedTarget::DictEq(ref s) = pred.target {
-                                match vol.get_column_dictionary(*phys_idx) {
+                                match vol.get_column_dictionary(*phys_idx)? {
                                     Some(dict) => {
                                         match dict
                                             .iter()
@@ -5161,7 +5238,7 @@ impl Table for SegmentedTable {
                                     }
                                     None => {
                                         bail.store(true, std::sync::atomic::Ordering::Relaxed);
-                                        return None;
+                                        return Ok(None);
                                     }
                                 }
                             } else {
@@ -5207,7 +5284,7 @@ impl Table for SegmentedTable {
                     }
                 }
                 if skip_volume {
-                    return None;
+                    return Ok(None);
                 }
 
                 // Zone-map pruning
@@ -5226,7 +5303,7 @@ impl Table for SegmentedTable {
                             _ => true,
                         };
                         if !can_match {
-                            return None;
+                            return Ok(None);
                         }
                     }
                 }
@@ -5277,7 +5354,7 @@ impl Table for SegmentedTable {
                     }
                     if *col_idx >= mapping.sources.len() {
                         bail.store(true, std::sync::atomic::Ordering::Relaxed);
-                        return None;
+                        return Ok(None);
                     }
                     match &mapping.sources[*col_idx] {
                         super::writer::ColSource::Volume(phys_idx) => {
@@ -5299,6 +5376,8 @@ impl Table for SegmentedTable {
 
                 // Inner loop: per-volume accumulators
                 let mut vol_accums = vec![Accum::default(); agg_count];
+                let mut agg_columns =
+                    smallvec::SmallVec::<[Option<&super::column::ColumnData>; 4]>::new();
                 let mut group_candidates: Vec<usize> = Vec::new();
                 let row_count = vol.meta.row_count;
                 let rg_size = super::column::ROW_GROUP_SIZE;
@@ -5319,13 +5398,13 @@ impl Table for SegmentedTable {
                             .iter()
                             .filter(|pp| matches!(pp.target, TypedTarget::DictEq(_)))
                             .map(|pp| {
-                                (
-                                    &vol.columns[pp.phys_col],
+                                Ok((
+                                    vol.columns.get(pp.phys_col)?,
                                     g_start,
                                     pp.dict_id.unwrap_or(u32::MAX),
-                                )
+                                ))
                             })
-                            .collect();
+                            .collect::<std::io::Result<_>>()?;
                     group_candidates.clear();
                     let prefiltered = !dict_preds.is_empty()
                         && super::column::ColumnData::dict_matching_offsets(
@@ -5365,7 +5444,7 @@ impl Table for SegmentedTable {
                             if prefiltered && matches!(pp.target, TypedTarget::DictEq(_)) {
                                 continue;
                             }
-                            let col = &vol.columns[pp.phys_col];
+                            let col = vol.columns.get(pp.phys_col)?;
                             if col.is_null(i) {
                                 all_pass = false;
                                 break;
@@ -5390,36 +5469,48 @@ impl Table for SegmentedTable {
                             continue;
                         }
 
-                        accumulate_row(&mut vol_accums, &phys_aggs, &vol.columns, i);
+                        if agg_columns.is_empty() {
+                            for pa in &phys_aggs {
+                                agg_columns
+                                    .push(pa.phys_col.map(|pc| vol.columns.get(pc)).transpose()?);
+                            }
+                        }
+                        accumulate_row(&mut vol_accums, &phys_aggs, &agg_columns, i);
                     }
                 }
 
-                Some(vol_accums)
+                Ok(Some(vol_accums))
             };
 
         // Parallel or sequential volume processing.
         // Only use rayon when total cold rows justify the scheduling overhead.
         let _total_cold_rows: usize = volumes.iter().map(|(_, cs)| cs.volume.meta.row_count).sum();
         #[cfg(feature = "parallel")]
-        let volume_accums: Vec<Vec<Accum>> = if volumes.len() >= 4 && _total_cold_rows >= 100_000 {
-            use rayon::prelude::*;
-            volumes
-                .par_iter()
-                .filter_map(|v| process_volume(v))
-                .collect()
-        } else {
-            volumes.iter().filter_map(|v| process_volume(v)).collect()
-        };
+        let volume_accums: Vec<Option<Vec<Accum>>> =
+            if volumes.len() >= 4 && _total_cold_rows >= 100_000 {
+                use rayon::prelude::*;
+                volumes
+                    .par_iter()
+                    .map(|v| process_volume(v))
+                    .collect::<Result<_>>()?
+            } else {
+                volumes
+                    .iter()
+                    .map(|v| process_volume(v))
+                    .collect::<Result<_>>()?
+            };
         #[cfg(not(feature = "parallel"))]
-        let volume_accums: Vec<Vec<Accum>> =
-            volumes.iter().filter_map(|v| process_volume(v)).collect();
+        let volume_accums: Vec<Option<Vec<Accum>>> = volumes
+            .iter()
+            .map(|v| process_volume(v))
+            .collect::<Result<_>>()?;
 
         if bail.load(std::sync::atomic::Ordering::Relaxed) {
             return Ok(None);
         }
 
         // Merge per-volume accumulators
-        for vol_acc in &volume_accums {
+        for vol_acc in volume_accums.iter().flatten() {
             for (i, acc) in vol_acc.iter().enumerate() {
                 merge_accum(&mut accums[i], acc);
             }
@@ -5837,27 +5928,22 @@ impl Table for SegmentedTable {
         }
 
         // Resolved physical aggregate column for a volume.
-        struct PhysAgg {
-            phys_col: Option<usize>, // None for CountStar or ColSource::Default
+        struct PhysAgg<'a> {
+            phys_col: Option<&'a super::column::ColumnData>, // None for CountStar or ColSource::Default
             op: AggregateOp,
             default_val: Option<Value>, // For ColSource::Default
         }
 
         // Inline accumulation from raw columnar data for a single row.
         #[inline(always)]
-        fn accumulate_columnar(
-            accums: &mut [Accum],
-            phys_aggs: &[PhysAgg],
-            vol_columns: &super::writer::LazyColumns,
-            i: usize,
-        ) {
+        fn accumulate_columnar(accums: &mut [Accum], phys_aggs: &[PhysAgg<'_>], i: usize) {
             for (agg_idx, pa) in phys_aggs.iter().enumerate() {
                 let acc = &mut accums[agg_idx];
                 match pa.op {
                     AggregateOp::CountStar => acc.count += 1,
                     AggregateOp::Count => {
-                        if let Some(phys_col) = pa.phys_col {
-                            if !vol_columns[phys_col].is_null(i) {
+                        if let Some(col) = pa.phys_col {
+                            if !col.is_null(i) {
                                 acc.count += 1;
                             }
                         } else if let Some(ref def) = pa.default_val {
@@ -5867,8 +5953,7 @@ impl Table for SegmentedTable {
                         }
                     }
                     AggregateOp::Sum | AggregateOp::Avg => {
-                        if let Some(phys_col) = pa.phys_col {
-                            let col = &vol_columns[phys_col];
+                        if let Some(col) = pa.phys_col {
                             if !col.is_null(i) {
                                 match col.data_type() {
                                     DataType::Integer | DataType::Timestamp => {
@@ -5910,8 +5995,7 @@ impl Table for SegmentedTable {
                         }
                     }
                     AggregateOp::Min => {
-                        if let Some(phys_col) = pa.phys_col {
-                            let col = &vol_columns[phys_col];
+                        if let Some(col) = pa.phys_col {
                             if !col.is_null(i) {
                                 match col.data_type() {
                                     DataType::Integer | DataType::Timestamp => {
@@ -5966,8 +6050,7 @@ impl Table for SegmentedTable {
                         }
                     }
                     AggregateOp::Max => {
-                        if let Some(phys_col) = pa.phys_col {
-                            let col = &vol_columns[phys_col];
+                        if let Some(col) = pa.phys_col {
                             if !col.is_null(i) {
                                 match col.data_type() {
                                     DataType::Integer | DataType::Timestamp => {
@@ -6032,132 +6115,212 @@ impl Table for SegmentedTable {
         let hot_skip_ref = &hot_skip;
         let tombstones_ref = &tombstones_arc;
 
-        let process_volume = |(seg_id, cs): &(u64, super::manifest::ColdSegment)|
-             -> Option<ValueMap<(Vec<Value>, Vec<Accum>)>> {
-            if bail.load(std::sync::atomic::Ordering::Relaxed) { return None; }
-            let vol = &cs.volume;
-            let mapping = self.segment_mgr.get_volume_mapping(*seg_id, current_schema);
-
-            if gb_idx >= mapping.sources.len() {
-                bail.store(true, std::sync::atomic::Ordering::Relaxed);
-                return None;
-            }
-
-            let mut phys_aggs: Vec<PhysAgg> = Vec::with_capacity(agg_count);
-            for (op, col_idx) in aggregates {
-                if matches!(op, AggregateOp::CountStar) {
-                    phys_aggs.push(PhysAgg { phys_col: None, op: *op, default_val: None });
-                    continue;
+        type VolumeGroups = ValueMap<(Vec<Value>, Vec<Accum>)>;
+        let process_volume =
+            |(seg_id, cs): &(u64, super::manifest::ColdSegment)| -> Result<Option<VolumeGroups>> {
+                if bail.load(std::sync::atomic::Ordering::Relaxed) {
+                    return Ok(None);
                 }
-                if *col_idx >= mapping.sources.len() {
+                let vol = &cs.volume;
+                let mapping = self.segment_mgr.get_volume_mapping(*seg_id, current_schema);
+
+                if gb_idx >= mapping.sources.len() {
                     bail.store(true, std::sync::atomic::Ordering::Relaxed);
-                    return None;
+                    return Ok(None);
                 }
-                match &mapping.sources[*col_idx] {
-                    super::writer::ColSource::Volume(phys_idx) => {
-                        phys_aggs.push(PhysAgg { phys_col: Some(*phys_idx), op: *op, default_val: None });
+
+                let Some(start) = (0..vol.meta.row_count).find(|&i| {
+                    cs.is_visible(i)
+                        && !self.is_row_tombstoned(tombstones_ref, vol.meta.row_ids[i])
+                        && !hot_skip_ref.contains(&vol.meta.row_ids[i])
+                }) else {
+                    return Ok(None);
+                };
+
+                let mut phys_aggs: Vec<PhysAgg> = Vec::with_capacity(agg_count);
+                for (op, col_idx) in aggregates {
+                    if matches!(op, AggregateOp::CountStar) {
+                        phys_aggs.push(PhysAgg {
+                            phys_col: None,
+                            op: *op,
+                            default_val: None,
+                        });
+                        continue;
                     }
-                    super::writer::ColSource::Default(val) => {
-                        phys_aggs.push(PhysAgg { phys_col: None, op: *op, default_val: Some(val.clone()) });
+                    if *col_idx >= mapping.sources.len() {
+                        bail.store(true, std::sync::atomic::Ordering::Relaxed);
+                        return Ok(None);
+                    }
+                    match &mapping.sources[*col_idx] {
+                        super::writer::ColSource::Volume(phys_idx) => {
+                            phys_aggs.push(PhysAgg {
+                                phys_col: Some(vol.columns.get(*phys_idx)?),
+                                op: *op,
+                                default_val: None,
+                            });
+                        }
+                        super::writer::ColSource::Default(val) => {
+                            phys_aggs.push(PhysAgg {
+                                phys_col: None,
+                                op: *op,
+                                default_val: Some(val.clone()),
+                            });
+                        }
                     }
                 }
-            }
 
-            let mut local_groups: ValueMap<(Vec<Value>, Vec<Accum>)> = ValueMap::default();
+                let mut local_groups: ValueMap<(Vec<Value>, Vec<Accum>)> = ValueMap::default();
 
-            match &mapping.sources[gb_idx] {
-                super::writer::ColSource::Volume(gb_phys_idx) => {
-                    let gb_phys = *gb_phys_idx;
-                    let gb_col = &vol.columns[gb_phys];
+                match &mapping.sources[gb_idx] {
+                    super::writer::ColSource::Volume(gb_phys_idx) => {
+                        let gb_phys = *gb_phys_idx;
+                        let gb_col = vol.columns.get(gb_phys)?;
 
-                    if gb_is_dict {
-                        if let super::column::ColumnData::Dictionary { ids: dict_ids, dictionary, nulls: gb_nulls } = gb_col {
-                            let dict_len = dictionary.len();
-                            let num_local = dict_len + 1;
-                            let mut la: Vec<Vec<Accum>> = (0..num_local).map(|_| vec![Accum::default(); agg_count]).collect();
-                            let mut lc = vec![0u32; num_local];
+                        if gb_is_dict {
+                            if let super::column::ColumnData::Dictionary {
+                                ids: dict_ids,
+                                dictionary,
+                                nulls: gb_nulls,
+                            } = gb_col
+                            {
+                                let dict_len = dictionary.len();
+                                let num_local = dict_len + 1;
+                                let mut la: Vec<Vec<Accum>> = (0..num_local)
+                                    .map(|_| vec![Accum::default(); agg_count])
+                                    .collect();
+                                let mut lc = vec![0u32; num_local];
 
-                            for i in 0..vol.meta.row_count {
-                                if !cs.is_visible(i) { continue; }
-                                let rid = vol.meta.row_ids[i];
-                                if self.is_row_tombstoned(tombstones_ref, rid) || hot_skip_ref.contains(&rid) { continue; }
-                                let g = if gb_nulls[i] { dict_len } else { dict_ids[i] as usize };
-                                lc[g] += 1;
-                                accumulate_columnar(&mut la[g], &phys_aggs, &vol.columns, i);
-                            }
+                                for i in start..vol.meta.row_count {
+                                    if !cs.is_visible(i) {
+                                        continue;
+                                    }
+                                    let rid = vol.meta.row_ids[i];
+                                    if self.is_row_tombstoned(tombstones_ref, rid)
+                                        || hot_skip_ref.contains(&rid)
+                                    {
+                                        continue;
+                                    }
+                                    let g = if gb_nulls[i] {
+                                        dict_len
+                                    } else {
+                                        dict_ids[i] as usize
+                                    };
+                                    lc[g] += 1;
+                                    accumulate_columnar(&mut la[g], &phys_aggs, i);
+                                }
 
-                            for gid in 0..num_local {
-                                if lc[gid] == 0 { continue; }
-                                let key = if gid == dict_len { Value::Null(DataType::Text) } else { Value::Text(dictionary[gid].clone()) };
-                                let entry = local_groups.entry(key.clone()).or_insert_with(|| (vec![key], vec![Accum::default(); agg_count]));
-                                for (ai, la_acc) in la[gid].iter().enumerate() { merge_accum(&mut entry.1[ai], la_acc); }
+                                for gid in 0..num_local {
+                                    if lc[gid] == 0 {
+                                        continue;
+                                    }
+                                    let key = if gid == dict_len {
+                                        Value::Null(DataType::Text)
+                                    } else {
+                                        Value::Text(dictionary[gid].clone())
+                                    };
+                                    let entry =
+                                        local_groups.entry(key.clone()).or_insert_with(|| {
+                                            (vec![key], vec![Accum::default(); agg_count])
+                                        });
+                                    for (ai, la_acc) in la[gid].iter().enumerate() {
+                                        merge_accum(&mut entry.1[ai], la_acc);
+                                    }
+                                }
+                            } else {
+                                bail.store(true, std::sync::atomic::Ordering::Relaxed);
+                                return Ok(None);
                             }
                         } else {
-                            bail.store(true, std::sync::atomic::Ordering::Relaxed);
-                            return None;
-                        }
-                    } else {
-                        let mut key_to_group: FxHashMap<i64, usize> = FxHashMap::default();
-                        let mut la: Vec<Vec<Accum>> = Vec::new();
-                        let mut null_acc: Vec<Accum> = vec![Accum::default(); agg_count];
-                        let mut null_cnt: u32 = 0;
+                            let mut key_to_group: FxHashMap<i64, usize> = FxHashMap::default();
+                            let mut la: Vec<Vec<Accum>> = Vec::new();
+                            let mut null_acc: Vec<Accum> = vec![Accum::default(); agg_count];
+                            let mut null_cnt: u32 = 0;
 
-                        for i in 0..vol.meta.row_count {
-                            if !cs.is_visible(i) { continue; }
-                            let rid = vol.meta.row_ids[i];
-                            if self.is_row_tombstoned(tombstones_ref, rid) || hot_skip_ref.contains(&rid) { continue; }
-                            if gb_col.is_null(i) {
-                                null_cnt += 1;
-                                accumulate_columnar(&mut null_acc, &phys_aggs, &vol.columns, i);
-                            } else {
-                                let raw_key = gb_col.get_i64(i);
-                                let next_id = la.len();
-                                let gid = *key_to_group.entry(raw_key).or_insert_with(|| { la.push(vec![Accum::default(); agg_count]); next_id });
-                                accumulate_columnar(&mut la[gid], &phys_aggs, &vol.columns, i);
+                            for i in start..vol.meta.row_count {
+                                if !cs.is_visible(i) {
+                                    continue;
+                                }
+                                let rid = vol.meta.row_ids[i];
+                                if self.is_row_tombstoned(tombstones_ref, rid)
+                                    || hot_skip_ref.contains(&rid)
+                                {
+                                    continue;
+                                }
+                                if gb_col.is_null(i) {
+                                    null_cnt += 1;
+                                    accumulate_columnar(&mut null_acc, &phys_aggs, i);
+                                } else {
+                                    let raw_key = gb_col.get_i64(i);
+                                    let next_id = la.len();
+                                    let gid = *key_to_group.entry(raw_key).or_insert_with(|| {
+                                        la.push(vec![Accum::default(); agg_count]);
+                                        next_id
+                                    });
+                                    accumulate_columnar(&mut la[gid], &phys_aggs, i);
+                                }
+                            }
+
+                            if null_cnt > 0 {
+                                let nk = Value::Null(gb_data_type);
+                                let entry = local_groups.entry(nk.clone()).or_insert_with(|| {
+                                    (vec![nk], vec![Accum::default(); agg_count])
+                                });
+                                for (ai, a) in null_acc.iter().enumerate() {
+                                    merge_accum(&mut entry.1[ai], a);
+                                }
+                            }
+                            for (raw_key, gid) in &key_to_group {
+                                let key = if gb_data_type == DataType::Timestamp {
+                                    let secs = raw_key.div_euclid(1_000_000_000);
+                                    let sub = raw_key.rem_euclid(1_000_000_000) as u32;
+                                    match chrono::TimeZone::timestamp_opt(&chrono::Utc, secs, sub) {
+                                        chrono::LocalResult::Single(dt) => Value::Timestamp(dt),
+                                        _ => Value::Null(DataType::Timestamp),
+                                    }
+                                } else {
+                                    Value::Integer(*raw_key)
+                                };
+                                let entry = local_groups.entry(key.clone()).or_insert_with(|| {
+                                    (vec![key], vec![Accum::default(); agg_count])
+                                });
+                                for (ai, a) in la[*gid].iter().enumerate() {
+                                    merge_accum(&mut entry.1[ai], a);
+                                }
                             }
                         }
-
-                        if null_cnt > 0 {
-                            let nk = Value::Null(gb_data_type);
-                            let entry = local_groups.entry(nk.clone()).or_insert_with(|| (vec![nk], vec![Accum::default(); agg_count]));
-                            for (ai, a) in null_acc.iter().enumerate() { merge_accum(&mut entry.1[ai], a); }
+                    }
+                    super::writer::ColSource::Default(default_val) => {
+                        let mut la = vec![Accum::default(); agg_count];
+                        let mut visible = 0usize;
+                        for i in start..vol.meta.row_count {
+                            if !cs.is_visible(i) {
+                                continue;
+                            }
+                            let rid = vol.meta.row_ids[i];
+                            if self.is_row_tombstoned(tombstones_ref, rid)
+                                || hot_skip_ref.contains(&rid)
+                            {
+                                continue;
+                            }
+                            visible += 1;
+                            accumulate_columnar(&mut la, &phys_aggs, i);
                         }
-                        for (raw_key, gid) in &key_to_group {
-                            let key = if gb_data_type == DataType::Timestamp {
-                                let secs = raw_key.div_euclid(1_000_000_000);
-                                let sub = raw_key.rem_euclid(1_000_000_000) as u32;
-                                match chrono::TimeZone::timestamp_opt(&chrono::Utc, secs, sub) {
-                                    chrono::LocalResult::Single(dt) => Value::Timestamp(dt),
-                                    _ => Value::Null(DataType::Timestamp),
+                        if visible > 0 {
+                            let key = default_val.clone();
+                            local_groups
+                                .entry(key.clone())
+                                .or_insert_with(|| (vec![key], vec![Accum::default(); agg_count]));
+                            if let Some(entry) = local_groups.get_mut(default_val) {
+                                for (ai, a) in la.iter().enumerate() {
+                                    merge_accum(&mut entry.1[ai], a);
                                 }
-                            } else { Value::Integer(*raw_key) };
-                            let entry = local_groups.entry(key.clone()).or_insert_with(|| (vec![key], vec![Accum::default(); agg_count]));
-                            for (ai, a) in la[*gid].iter().enumerate() { merge_accum(&mut entry.1[ai], a); }
+                            }
                         }
                     }
                 }
-                super::writer::ColSource::Default(default_val) => {
-                    let mut la = vec![Accum::default(); agg_count];
-                    let mut visible = 0usize;
-                    for i in 0..vol.meta.row_count {
-                        if !cs.is_visible(i) { continue; }
-                        let rid = vol.meta.row_ids[i];
-                        if self.is_row_tombstoned(tombstones_ref, rid) || hot_skip_ref.contains(&rid) { continue; }
-                        visible += 1;
-                        accumulate_columnar(&mut la, &phys_aggs, &vol.columns, i);
-                    }
-                    if visible > 0 {
-                        let key = default_val.clone();
-                        local_groups.entry(key.clone()).or_insert_with(|| (vec![key], vec![Accum::default(); agg_count]));
-                        if let Some(entry) = local_groups.get_mut(default_val) {
-                            for (ai, a) in la.iter().enumerate() { merge_accum(&mut entry.1[ai], a); }
-                        }
-                    }
-                }
-            }
 
-            Some(local_groups)
-        };
+                Ok(Some(local_groups))
+            };
 
         // Sequential: merge each volume's groups immediately (O(1) extra maps).
         // Parallel: collect per-volume maps then merge (O(volumes) extra maps).
@@ -6171,12 +6334,14 @@ impl Table for SegmentedTable {
             #[cfg(feature = "parallel")]
             {
                 use rayon::prelude::*;
-                let vol_group_maps: Vec<ValueMap<(Vec<Value>, Vec<Accum>)>> =
-                    volumes.par_iter().filter_map(&process_volume).collect();
+                let vol_group_maps: Vec<Option<VolumeGroups>> = volumes
+                    .par_iter()
+                    .map(&process_volume)
+                    .collect::<Result<_>>()?;
                 if bail.load(std::sync::atomic::Ordering::Relaxed) {
                     return Ok(None);
                 }
-                for vol_map in vol_group_maps {
+                for vol_map in vol_group_maps.into_iter().flatten() {
                     for (key, (group_values, vol_accums)) in vol_map {
                         let entry = groups
                             .entry(key)
@@ -6192,7 +6357,7 @@ impl Table for SegmentedTable {
                 if bail.load(std::sync::atomic::Ordering::Relaxed) {
                     return Ok(None);
                 }
-                if let Some(vol_map) = process_volume(v) {
+                if let Some(vol_map) = process_volume(v)? {
                     for (key, (group_values, vol_accums)) in vol_map {
                         let entry = groups
                             .entry(key)

--- a/src/storage/volume/writer.rs
+++ b/src/storage/volume/writer.rs
@@ -112,7 +112,7 @@ impl CompressedBlockStore {
         columns: &LazyColumns,
         col_data_types: &[DataType],
         row_count: usize,
-    ) -> Self {
+    ) -> std::io::Result<Self> {
         Self::compress_columns_opts(columns, col_data_types, row_count, true)
     }
 
@@ -124,7 +124,7 @@ impl CompressedBlockStore {
         col_data_types: &[DataType],
         row_count: usize,
         compress: bool,
-    ) -> Self {
+    ) -> std::io::Result<Self> {
         let group_size = ROW_GROUP_SIZE;
         let col_count = columns.len();
         let num_groups = if row_count == 0 {
@@ -141,7 +141,7 @@ impl CompressedBlockStore {
         let mut col_ext_types = Vec::with_capacity(col_count);
 
         for col_idx in 0..col_count {
-            let col = &columns[col_idx];
+            let col = columns.get(col_idx)?;
             let type_tag = match col {
                 ColumnData::Int64 { .. } => super::format::COL_INT64,
                 ColumnData::Float64 { .. } => super::format::COL_FLOAT64,
@@ -191,8 +191,8 @@ impl CompressedBlockStore {
             use rayon::prelude::*;
             let results: Vec<(Vec<Vec<u8>>, Vec<usize>)> = (0..col_count)
                 .into_par_iter()
-                .map(|col_idx| compress_blocks(&columns[col_idx]))
-                .collect();
+                .map(|col_idx| columns.get(col_idx).map(compress_blocks))
+                .collect::<std::io::Result<_>>()?;
             let mut all_blocks = Vec::with_capacity(col_count);
             let mut all_decomp_lens = Vec::with_capacity(col_count);
             for (blocks, lens) in results {
@@ -207,7 +207,7 @@ impl CompressedBlockStore {
             let mut all_blocks = Vec::with_capacity(col_count);
             let mut all_decomp_lens = Vec::with_capacity(col_count);
             for col_idx in 0..col_count {
-                let (blocks, lens) = compress_blocks(&columns[col_idx]);
+                let (blocks, lens) = compress_blocks(columns.get(col_idx)?);
                 all_blocks.push(blocks);
                 all_decomp_lens.push(lens);
             }
@@ -218,7 +218,7 @@ impl CompressedBlockStore {
             .iter()
             .map(|(ci, start, end)| (*ci, Arc::from(&shared_dict[*start..*end])))
             .collect();
-        Self {
+        Ok(Self {
             blocks: all_blocks,
             decompressed_lens: all_decomp_lens,
             col_type_tags,
@@ -228,7 +228,7 @@ impl CompressedBlockStore {
             group_size,
             row_count,
             id: next_store_id(),
-        }
+        })
     }
 
     /// Build a CompressedBlockStore from pre-compressed blocks (V4 file read).
@@ -889,14 +889,14 @@ impl CompressedBlockStore {
 }
 
 // =============================================================================
-// LazyColumns: per-column OnceLock with transparent Index<usize> access
+// LazyColumns: cached, fallible whole-column access
 // =============================================================================
 
 /// Column storage that decompresses from CompressedBlockStore on first access.
 /// After OnceLock init, subsequent access is a pointer dereference (free).
 pub struct LazyColumns {
     /// Per-column OnceLock slots. Empty until first access.
-    slots: Vec<OnceLock<ColumnData>>,
+    slots: Vec<OnceLock<std::io::Result<ColumnData>>>,
     /// Compressed backing store. None for eagerly-loaded columns.
     /// Wrapped in Arc so warm-tier volumes can share the store cheaply.
     compressed_store: Option<Arc<CompressedBlockStore>>,
@@ -912,11 +912,11 @@ impl LazyColumns {
     /// Create from pre-loaded columns (VolumeBuilder::finish(), V4 eager load).
     /// All OnceLock slots are pre-initialized. No compressed store.
     pub fn eager(columns: Vec<ColumnData>, col_data_types: Vec<DataType>) -> Self {
-        let slots: Vec<OnceLock<ColumnData>> = columns
+        let slots = columns
             .into_iter()
             .map(|col| {
                 let cell = OnceLock::new();
-                let _ = cell.set(col);
+                let _ = cell.set(Ok(col));
                 cell
             })
             .collect();
@@ -958,8 +958,7 @@ impl LazyColumns {
     }
 
     /// Create columns with only data types (for cold-tier volumes).
-    /// No columns, no compressed store. Column access will panic;
-    /// the volume must be reloaded from disk before scanning.
+    /// The volume must be reloaded from disk before column access.
     pub fn metadata_only(col_data_types: Vec<DataType>) -> Self {
         let col_count = col_data_types.len();
         Self {
@@ -1028,7 +1027,7 @@ impl LazyColumns {
         }
         // Loaded (decompressed) columns
         for slot in &self.slots {
-            if let Some(col) = slot.get() {
+            if let Some(Ok(col)) = slot.get() {
                 size += col.memory_size();
             }
         }
@@ -1052,19 +1051,32 @@ impl LazyColumns {
     /// Return the dictionary for a dictionary-encoded column without
     /// decompressing column data. Checks loaded OnceLock slots first,
     /// then falls back to the CompressedBlockStore's pre-built dictionary.
-    /// Returns None for non-dictionary columns or cold-tier volumes.
-    pub fn get_column_dictionary(&self, col_idx: usize) -> Option<Arc<[SmartString]>> {
+    /// Returns None for non-dictionary columns and propagates cached failures.
+    pub fn get_column_dictionary(
+        &self,
+        col_idx: usize,
+    ) -> std::io::Result<Option<Arc<[SmartString]>>> {
+        let slot = self.slots.get(col_idx).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "column index out of range",
+            )
+        })?;
         // Fast path: column already loaded in OnceLock
-        if let Some(col) = self.slots.get(col_idx).and_then(|s| s.get()) {
+        if let Some(col) = slot.get() {
+            let col = col
+                .as_ref()
+                .map_err(|e| std::io::Error::new(e.kind(), e.to_string()))?;
             if let ColumnData::Dictionary { dictionary, .. } = col {
-                return Some(Arc::clone(dictionary));
+                return Ok(Some(Arc::clone(dictionary)));
             }
-            return None;
+            return Ok(None);
         }
         // Slow path: extract from compressed store without decompressing
-        self.compressed_store
-            .as_ref()
-            .and_then(|store| store.get_column_dictionary(col_idx).cloned())
+        let store = self.compressed_store.as_ref().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "column data is not loaded")
+        })?;
+        Ok(store.get_column_dictionary(col_idx).cloned())
     }
 
     /// Access the compressed store (for V4 write).
@@ -1077,57 +1089,53 @@ impl LazyColumns {
         self.compressed_store.as_ref()
     }
 
-    /// Take ownership of all loaded columns, consuming the LazyColumns.
-    /// Used by compress_and_release to avoid cloning.
-    pub fn take_columns(self) -> Vec<ColumnData> {
+    /// Decode and take ownership of every column, consuming the LazyColumns.
+    pub fn take_columns(self) -> std::io::Result<Vec<ColumnData>> {
+        for idx in 0..self.len() {
+            self.get(idx)?;
+        }
         let mut result = Vec::with_capacity(self.slots.len());
         for slot in self.slots {
             if let Some(col) = slot.into_inner() {
-                result.push(col);
+                result.push(col?);
             }
         }
-        result
+        Ok(result)
     }
-}
 
-impl std::ops::Index<usize> for LazyColumns {
-    type Output = ColumnData;
-
+    /// Borrow a column, caching both successful decodes and failures.
     #[inline]
-    fn index(&self, idx: usize) -> &ColumnData {
+    pub fn get(&self, idx: usize) -> std::io::Result<&ColumnData> {
+        let slot = self.slots.get(idx).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "column index out of range",
+            )
+        })?;
         // Fast path: already initialized
-        if let Some(col) = self.slots[idx].get() {
-            return col;
+        if let Some(Ok(col)) = slot.get() {
+            return Ok(col);
         }
-        // Slow path: decompress on first access via get_or_init (runs closure
-        // exactly once per slot, even under concurrent access).
+        self.load_column(idx)
+    }
+
+    #[cold]
+    fn load_column(&self, idx: usize) -> std::io::Result<&ColumnData> {
         let col = self.slots[idx].get_or_init(|| {
-            self.compressed_store
-                .as_ref()
-                .map(|store| {
-                    store
-                        .decompress_column(idx)
-                        .unwrap_or_else(|e| panic!("corrupt V4 column: col={idx}: {e}"))
-                })
-                .unwrap_or_else(|| {
-                    panic!(
-                        "BUG: column {} accessed on cold volume (no compressed store). \
-                         A caller is missing is_cold() check before column access. \
-                         Run with RUST_BACKTRACE=1 to find the caller.",
-                        idx
-                    )
-                })
+            let store = self.compressed_store.as_ref().ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "column data is not loaded")
+            })?;
+            store.decompress_column(idx)
         });
-        // Check if all slots are now populated. This is O(C) where C = column
-        // count, but only runs on the slow path (first access per column).
-        // Avoids the loaded_count race where concurrent threads double-increment.
+        // Promote only after every column has decoded successfully.
         if !self.is_eager.load(std::sync::atomic::Ordering::Relaxed)
-            && self.slots.iter().all(|s| s.get().is_some())
+            && self.slots.iter().all(|s| matches!(s.get(), Some(Ok(_))))
         {
             self.is_eager
                 .store(true, std::sync::atomic::Ordering::Relaxed);
         }
-        col
+        col.as_ref()
+            .map_err(|e| std::io::Error::new(e.kind(), e.to_string()))
     }
 }
 
@@ -1138,11 +1146,11 @@ pub struct LazyColumnsIter<'a> {
 }
 
 impl<'a> Iterator for LazyColumnsIter<'a> {
-    type Item = &'a ColumnData;
+    type Item = std::io::Result<&'a ColumnData>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.idx < self.columns.len() {
-            let col = &self.columns[self.idx];
+            let col = self.columns.get(self.idx);
             self.idx += 1;
             Some(col)
         } else {
@@ -1159,7 +1167,7 @@ impl<'a> Iterator for LazyColumnsIter<'a> {
 impl ExactSizeIterator for LazyColumnsIter<'_> {}
 
 impl<'a> IntoIterator for &'a LazyColumns {
-    type Item = &'a ColumnData;
+    type Item = std::io::Result<&'a ColumnData>;
     type IntoIter = LazyColumnsIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -1237,12 +1245,10 @@ pub struct FrozenVolume {
     pub meta: Arc<VolumeMeta>,
     /// Per-volume unique index: lazily built, never invalidated (volume is immutable).
     /// Key: sorted column indices for a UNIQUE constraint.
-    /// Value: sorted Vec of (hash, row_idx) pairs -- binary search for lookup.
-    /// Uses 12 bytes per entry vs ~80 bytes for FxHashMap<u64, Vec<u32>>, and
-    /// zero tiny heap allocations (single contiguous allocation).
+    /// Value: shared sorted (hash, row_idx) pairs, 16 bytes per entry.
     #[allow(clippy::type_complexity)]
     pub unique_indices:
-        Arc<parking_lot::RwLock<rustc_hash::FxHashMap<Vec<usize>, Vec<(u64, u32)>>>>,
+        Arc<parking_lot::RwLock<rustc_hash::FxHashMap<Vec<usize>, Arc<Vec<(u64, u32)>>>>>,
     /// Access epoch counter. Bumped per scan for eviction tracking.
     pub last_access_epoch: std::sync::atomic::AtomicU64,
 }
@@ -1801,16 +1807,15 @@ pub fn compute_column_mapping_with_drops(
 impl FrozenVolume {
     /// Get a row using a precomputed column mapping.
     /// Materializes all schema columns through the mapping.
-    pub fn get_row_mapped(&self, idx: usize, mapping: &ColumnMapping) -> Row {
-        let values: Vec<Value> = mapping
-            .sources
-            .iter()
-            .map(|src| match src {
-                ColSource::Volume(vol_idx) => self.columns[*vol_idx].get_value(idx),
+    pub fn get_row_mapped(&self, idx: usize, mapping: &ColumnMapping) -> std::io::Result<Row> {
+        let mut values = Vec::with_capacity(mapping.sources.len());
+        for src in &mapping.sources {
+            values.push(match src {
+                ColSource::Volume(vol_idx) => self.columns.get(*vol_idx)?.get_value(idx),
                 ColSource::Default(val) => val.clone(),
-            })
-            .collect();
-        Row::from_values(values)
+            });
+        }
+        Ok(Row::from_values(values))
     }
 
     /// Get specific columns of a row using a precomputed column mapping.
@@ -1820,15 +1825,15 @@ impl FrozenVolume {
         idx: usize,
         mapping: &ColumnMapping,
         col_indices: &[usize],
-    ) -> Row {
-        let values: Vec<Value> = col_indices
-            .iter()
-            .map(|&ci| match &mapping.sources[ci] {
-                ColSource::Volume(vol_idx) => self.columns[*vol_idx].get_value(idx),
+    ) -> std::io::Result<Row> {
+        let mut values = Vec::with_capacity(col_indices.len());
+        for &ci in col_indices {
+            values.push(match &mapping.sources[ci] {
+                ColSource::Volume(vol_idx) => self.columns.get(*vol_idx)?.get_value(idx),
                 ColSource::Default(val) => val.clone(),
-            })
-            .collect();
-        Row::from_values(values)
+            });
+        }
+        Ok(Row::from_values(values))
     }
 
     /// Get a row materializing only columns marked true in the mask.
@@ -1836,17 +1841,16 @@ impl FrozenVolume {
     /// The row has full schema width so filter column indices work.
     /// Uses LazyColumns::data_type() for unneeded columns to avoid decompression.
     #[inline]
-    pub fn get_row_needed(&self, idx: usize, needed: &[bool]) -> Row {
-        let values: Vec<Value> = (0..self.columns.len())
-            .map(|ci| {
-                if ci < needed.len() && needed[ci] {
-                    self.columns[ci].get_value(idx)
-                } else {
-                    Value::Null(self.columns.data_type(ci))
-                }
-            })
-            .collect();
-        Row::from_values(values)
+    pub fn get_row_needed(&self, idx: usize, needed: &[bool]) -> std::io::Result<Row> {
+        let mut values = Vec::with_capacity(self.columns.len());
+        for ci in 0..self.columns.len() {
+            values.push(if ci < needed.len() && needed[ci] {
+                self.columns.get(ci)?.get_value(idx)
+            } else {
+                Value::Null(self.columns.data_type(ci))
+            });
+        }
+        Ok(Row::from_values(values))
     }
 
     /// Get a row using a mapping, materializing only needed columns.
@@ -1858,41 +1862,40 @@ impl FrozenVolume {
         idx: usize,
         mapping: &ColumnMapping,
         needed: &[bool],
-    ) -> Row {
-        let values: Vec<Value> = mapping
-            .sources
-            .iter()
-            .enumerate()
-            .map(|(ci, src)| {
-                if ci < needed.len() && needed[ci] {
-                    match src {
-                        ColSource::Volume(vol_idx) => self.columns[*vol_idx].get_value(idx),
-                        ColSource::Default(val) => val.clone(),
-                    }
-                } else {
-                    match src {
-                        ColSource::Volume(vol_idx) => Value::Null(self.columns.data_type(*vol_idx)),
-                        ColSource::Default(val) => Value::Null(val.data_type()),
-                    }
+    ) -> std::io::Result<Row> {
+        let mut values = Vec::with_capacity(mapping.sources.len());
+        for (ci, src) in mapping.sources.iter().enumerate() {
+            values.push(if ci < needed.len() && needed[ci] {
+                match src {
+                    ColSource::Volume(vol_idx) => self.columns.get(*vol_idx)?.get_value(idx),
+                    ColSource::Default(val) => val.clone(),
                 }
-            })
-            .collect();
-        Row::from_values(values)
+            } else {
+                match src {
+                    ColSource::Volume(vol_idx) => Value::Null(self.columns.data_type(*vol_idx)),
+                    ColSource::Default(val) => Value::Null(val.data_type()),
+                }
+            });
+        }
+        Ok(Row::from_values(values))
     }
 
     /// Get a row as a Vec of Values (for executor compatibility).
-    pub fn get_row(&self, idx: usize) -> Row {
-        let values: Vec<Value> = self.columns.iter().map(|col| col.get_value(idx)).collect();
-        Row::from_values(values)
+    pub fn get_row(&self, idx: usize) -> std::io::Result<Row> {
+        let mut values = Vec::with_capacity(self.columns.len());
+        for col in &self.columns {
+            values.push(col?.get_value(idx));
+        }
+        Ok(Row::from_values(values))
     }
 
     /// Get specific columns of a row (projection pushdown).
-    pub fn get_row_projected(&self, idx: usize, col_indices: &[usize]) -> Row {
-        let values: Vec<Value> = col_indices
-            .iter()
-            .map(|&col| self.columns[col].get_value(idx))
-            .collect();
-        Row::from_values(values)
+    pub fn get_row_projected(&self, idx: usize, col_indices: &[usize]) -> std::io::Result<Row> {
+        let mut values = Vec::with_capacity(col_indices.len());
+        for &col in col_indices {
+            values.push(self.columns.get(col)?.get_value(idx));
+        }
+        Ok(Row::from_values(values))
     }
 
     /// Check if a column is sorted (enables binary search).
@@ -1914,12 +1917,8 @@ impl FrozenVolume {
         col_indices: &[usize],
         values: &[&Value],
         mut f: impl FnMut(u32) -> bool, // return true to stop early
-    ) {
+    ) -> std::io::Result<()> {
         use std::hash::{Hash, Hasher};
-
-        if col_indices.iter().any(|&idx| idx >= self.columns.len()) {
-            return;
-        }
 
         // Compute hash of query values
         let mut hasher = ahash::AHasher::default();
@@ -1928,89 +1927,73 @@ impl FrozenVolume {
         }
         let hash = hasher.finish();
 
-        // Fast path: check if index is already built
-        {
+        let cached = {
             let indices = self.unique_indices.read();
-            if let Some(sorted_idx) = indices.get(col_indices) {
-                // Binary search for the hash, then scan all entries with same hash
-                let pos = sorted_idx.partition_point(|&(h, _)| h < hash);
-                for &(h, row_idx) in &sorted_idx[pos..] {
-                    if h != hash {
-                        break;
-                    }
-                    let matches = col_indices.iter().zip(values.iter()).all(|(&ci, &val)| {
-                        let vol_val = self.columns[ci].get_value(row_idx as usize);
-                        !vol_val.is_null() && vol_val == *val
-                    });
-                    if matches && f(row_idx) {
-                        return;
-                    }
+            if let Some(entries) = indices.get(col_indices) {
+                let pos = entries.partition_point(|&(h, _)| h < hash);
+                if entries.get(pos).is_none_or(|&(h, _)| h != hash) {
+                    return Ok(());
                 }
-                return;
+                Some((Arc::clone(entries), pos))
+            } else {
+                None
             }
-        }
-
-        // Build sorted index for this column set (first use)
-        let mut entries: Vec<(u64, u32)> = Vec::with_capacity(self.meta.row_count);
-        for row_idx in 0..self.meta.row_count {
-            let mut row_hasher = ahash::AHasher::default();
-            let mut has_null = false;
-            for &ci in col_indices {
-                if self.columns[ci].is_null(row_idx) {
-                    has_null = true;
-                    break;
-                }
-                self.columns[ci].get_value(row_idx).hash(&mut row_hasher);
+        };
+        let (entries, pos) = match cached {
+            Some(cached) => cached,
+            None => {
+                let entries = self.unique_index(col_indices)?;
+                let pos = entries.partition_point(|&(h, _)| h < hash);
+                (entries, pos)
             }
-            if has_null {
-                continue;
-            }
-            entries.push((row_hasher.finish(), row_idx as u32));
-        }
-        entries.sort_unstable_by_key(|&(h, _)| h);
-
-        // Look up before storing
-        let pos = entries.partition_point(|&(h, _)| h < hash);
+        };
         for &(h, row_idx) in &entries[pos..] {
             if h != hash {
                 break;
             }
-            let matches = col_indices.iter().zip(values.iter()).all(|(&ci, &val)| {
-                let vol_val = self.columns[ci].get_value(row_idx as usize);
-                !vol_val.is_null() && vol_val == *val
-            });
+            let mut matches = true;
+            for (&ci, &val) in col_indices.iter().zip(values) {
+                let vol_val = self.columns.get(ci)?.get_value(row_idx as usize);
+                if vol_val.is_null() || vol_val != *val {
+                    matches = false;
+                    break;
+                }
+            }
             if matches && f(row_idx) {
                 break;
             }
         }
 
-        // Store the built index
-        self.unique_indices
-            .write()
-            .insert(col_indices.to_vec(), entries);
+        Ok(())
     }
 
     /// Pre-build the unique sorted index for a set of column indices.
     /// Called during seal/compaction so the first INSERT after seal doesn't
     /// pay a ~60ms stall scanning all rows to build the index.
-    pub fn prebuild_unique_index(&self, col_indices: &[usize]) {
+    pub fn prebuild_unique_index(&self, col_indices: &[usize]) -> std::io::Result<()> {
+        self.unique_index(col_indices).map(|_| ())
+    }
+
+    fn unique_index(&self, col_indices: &[usize]) -> std::io::Result<Arc<Vec<(u64, u32)>>> {
         use std::hash::{Hash, Hasher};
-        if col_indices.iter().any(|&idx| idx >= self.columns.len()) {
-            return;
+        let cached = self.unique_indices.read().get(col_indices).cloned();
+        if let Some(entries) = cached {
+            return Ok(entries);
         }
-        if self.unique_indices.read().contains_key(col_indices) {
-            return;
-        }
+        let columns = col_indices
+            .iter()
+            .map(|&ci| self.columns.get(ci))
+            .collect::<std::io::Result<smallvec::SmallVec<[&ColumnData; 4]>>>()?;
         let mut entries: Vec<(u64, u32)> = Vec::with_capacity(self.meta.row_count);
         for row_idx in 0..self.meta.row_count {
             let mut row_hasher = ahash::AHasher::default();
             let mut has_null = false;
-            for &ci in col_indices {
-                if self.columns[ci].is_null(row_idx) {
+            for &col in &columns {
+                if col.is_null(row_idx) {
                     has_null = true;
                     break;
                 }
-                self.columns[ci].get_value(row_idx).hash(&mut row_hasher);
+                col.get_value(row_idx).hash(&mut row_hasher);
             }
             if has_null {
                 continue;
@@ -2018,9 +2001,14 @@ impl FrozenVolume {
             entries.push((row_hasher.finish(), row_idx as u32));
         }
         entries.sort_unstable_by_key(|&(h, _)| h);
-        self.unique_indices
+        let entries = Arc::new(entries);
+        let key = col_indices.to_vec();
+        let replaced = self
+            .unique_indices
             .write()
-            .insert(col_indices.to_vec(), entries);
+            .insert(key, Arc::clone(&entries));
+        drop(replaced);
+        Ok(entries)
     }
 
     /// Find the column index by name. O(1) via precomputed hashmap.
@@ -2050,8 +2038,11 @@ impl FrozenVolume {
     /// Return the dictionary for a dictionary-encoded column.
     /// Avoids decompressing the full column — extracts from the shared
     /// dictionary stored in the compressed block store or OnceLock slot.
-    /// Returns None for non-dictionary columns or cold-tier volumes.
-    pub fn get_column_dictionary(&self, col_idx: usize) -> Option<Arc<[SmartString]>> {
+    /// Returns None for non-dictionary columns and propagates cached failures.
+    pub fn get_column_dictionary(
+        &self,
+        col_idx: usize,
+    ) -> std::io::Result<Option<Arc<[SmartString]>>> {
         self.columns.get_column_dictionary(col_idx)
     }
 
@@ -2172,18 +2163,18 @@ mod tests {
         assert_eq!(volume.meta.stats.count_star(), 3);
 
         // Check typed access
-        assert_eq!(volume.columns[0].get_i64(0), 1);
-        assert_eq!(volume.columns[0].get_i64(2), 3);
-        assert_eq!(volume.columns[3].get_f64(1), 101.5);
+        assert_eq!(volume.columns.get(0).unwrap().get_i64(0), 1);
+        assert_eq!(volume.columns.get(0).unwrap().get_i64(2), 3);
+        assert_eq!(volume.columns.get(3).unwrap().get_f64(1), 101.5);
 
         // Check dictionary encoding
-        assert_eq!(volume.columns[2].get_str(0), "binance");
-        assert_eq!(volume.columns[2].get_str(1), "coinbase");
-        assert_eq!(volume.columns[2].get_str(2), "binance");
+        assert_eq!(volume.columns.get(2).unwrap().get_str(0), "binance");
+        assert_eq!(volume.columns.get(2).unwrap().get_str(1), "coinbase");
+        assert_eq!(volume.columns.get(2).unwrap().get_str(2), "binance");
         // binance appears twice but uses same dict ID
         assert_eq!(
-            volume.columns[2].get_dict_id(0),
-            volume.columns[2].get_dict_id(2)
+            volume.columns.get(2).unwrap().get_dict_id(0),
+            volume.columns.get(2).unwrap().get_dict_id(2)
         );
 
         // Check zone maps
@@ -2200,7 +2191,7 @@ mod tests {
         assert!(volume.is_sorted(1)); // time is sorted
 
         // Check row reconstruction
-        let row = volume.get_row(0);
+        let row = volume.get_row(0).unwrap();
         assert_eq!(row.get(0), Some(&Value::Integer(1)));
         assert_eq!(row.get(2), Some(&Value::text("binance")));
     }
@@ -2221,11 +2212,11 @@ mod tests {
         );
 
         let volume = builder.finish();
-        assert!(volume.columns[1].is_null(0));
-        assert!(volume.columns[3].is_null(0));
-        assert!(!volume.columns[0].is_null(0));
+        assert!(volume.columns.get(1).unwrap().is_null(0));
+        assert!(volume.columns.get(3).unwrap().is_null(0));
+        assert!(!volume.columns.get(0).unwrap().is_null(0));
 
-        let row = volume.get_row(0);
+        let row = volume.get_row(0).unwrap();
         assert_eq!(row.get(0), Some(&Value::Integer(1)));
         assert!(row.get(1).unwrap().is_null());
     }
@@ -2252,7 +2243,11 @@ mod tests {
             ts.timestamp_nanos_opt()
                 .unwrap_or(ts.timestamp() * 1_000_000_000)
         };
-        let idx = volume.columns[0].binary_search_ge(target_nanos);
+        let idx = volume
+            .columns
+            .get(0)
+            .unwrap()
+            .binary_search_ge(target_nanos);
         assert_eq!(idx, 50);
     }
 
@@ -2274,7 +2269,7 @@ mod tests {
         let volume = builder.finish();
 
         // Project only id and price (columns 0 and 3)
-        let row = volume.get_row_projected(0, &[0, 3]);
+        let row = volume.get_row_projected(0, &[0, 3]).unwrap();
         assert_eq!(row.len(), 2);
         assert_eq!(row.get(0), Some(&Value::Integer(1)));
         assert_eq!(row.get(1), Some(&Value::Float(100.0)));

--- a/tests/decoded_group_cache_test.rs
+++ b/tests/decoded_group_cache_test.rs
@@ -358,7 +358,8 @@ mod invariants {
         };
         assert!(column.memory_size() < 2 * 1024 * 1024);
         let columns = LazyColumns::eager(vec![column], vec![DataType::Text]);
-        let store = CompressedBlockStore::compress_columns(&columns, &[DataType::Text], rows);
+        let store =
+            CompressedBlockStore::compress_columns(&columns, &[DataType::Text], rows).unwrap();
         DECODED_GROUPS.set_budget_bytes(2 * 1024 * 1024);
         let first = store.group_column(0, 0).unwrap();
         let _second = store.group_column(0, 1).unwrap();

--- a/tests/fallible_group_access_test.rs
+++ b/tests/fallible_group_access_test.rs
@@ -53,10 +53,66 @@ impl ColumnErrorKind for ColumnData {
     }
 }
 
-impl ColumnErrorKind for std::io::Result<ColumnData> {
+impl ColumnErrorKind for &ColumnData {
+    fn error_kind(self) -> Option<ErrorKind> {
+        None
+    }
+}
+
+impl<T> ColumnErrorKind for std::io::Result<T> {
     fn error_kind(self) -> Option<ErrorKind> {
         self.err().map(|error| error.kind())
     }
+}
+
+impl ColumnErrorKind for stoolap::core::Row {
+    fn error_kind(self) -> Option<ErrorKind> {
+        None
+    }
+}
+
+impl ColumnErrorKind for () {
+    fn error_kind(self) -> Option<ErrorKind> {
+        None
+    }
+}
+
+impl<T> ColumnErrorKind for Vec<T> {
+    fn error_kind(self) -> Option<ErrorKind> {
+        None
+    }
+}
+
+impl<T> ColumnErrorKind for Option<T> {
+    fn error_kind(self) -> Option<ErrorKind> {
+        None
+    }
+}
+
+// Keep the guards executable when only production changes are reverted.
+#[allow(dead_code)]
+trait BaselineUnwrap: Sized {
+    fn unwrap(self) -> Self {
+        self
+    }
+}
+impl<T> BaselineUnwrap for T {}
+
+#[allow(dead_code)]
+trait BaselineColumnAccess {
+    fn get(&self, index: usize) -> std::io::Result<&ColumnData>;
+}
+
+impl BaselineColumnAccess for LazyColumns {
+    fn get(&self, index: usize) -> std::io::Result<&ColumnData> {
+        Ok(self.iter().nth(index).unwrap().unwrap())
+    }
+}
+
+fn assert_io_failure<T: ColumnErrorKind>(read: impl FnOnce() -> T, kind: ErrorKind) {
+    let outcome = catch_unwind(AssertUnwindSafe(|| read().error_kind()));
+    assert!(outcome.is_ok(), "column failure panicked");
+    assert_eq!(outcome.unwrap(), Some(kind));
 }
 
 fn assert_column_error(store: &CompressedBlockStore, col: usize, kind: ErrorKind) {
@@ -221,10 +277,10 @@ fn empty_whole_column_preserves_its_type() {
         }],
         types.clone(),
     );
-    let store = CompressedBlockStore::compress_columns(&columns, &types, 0);
+    let store = CompressedBlockStore::compress_columns(&columns, &types, 0).unwrap();
     let decoded = LazyColumns::deferred(store, types);
     assert!(
-        matches!(&decoded[0], ColumnData::Int64 { values, nulls } if values.is_empty() && nulls.is_empty())
+        matches!(decoded.get(0).unwrap(), ColumnData::Int64 { values, nulls } if values.is_empty() && nulls.is_empty())
     );
 }
 
@@ -443,12 +499,16 @@ fn valid_group_round_trip_preserves_all_column_types_and_nulls() {
         types.clone(),
     );
     for compress in [false, true] {
-        let store = CompressedBlockStore::compress_columns_opts(&columns, &types, 2, compress);
+        let store =
+            CompressedBlockStore::compress_columns_opts(&columns, &types, 2, compress).unwrap();
         for ci in 0..types.len() {
             let group = store.group_column(ci, 0).unwrap();
             assert_eq!(group.len(), 2);
             for row in 0..2 {
-                assert_eq!(group.get_value(row), columns[ci].get_value(row));
+                assert_eq!(
+                    group.get_value(row),
+                    columns.get(ci).unwrap().get_value(row)
+                );
             }
         }
         let two_groups = CompressedBlockStore::from_raw_blocks(
@@ -473,9 +533,12 @@ fn valid_group_round_trip_preserves_all_column_types_and_nulls() {
         for (store, rows) in [(store, 2), (two_groups, 4)] {
             let decoded = LazyColumns::deferred(store, types.clone());
             for ci in 0..types.len() {
-                assert_eq!(decoded[ci].len(), rows);
+                assert_eq!(decoded.get(ci).unwrap().len(), rows);
                 for row in 0..rows {
-                    assert_eq!(decoded[ci].get_value(row), columns[ci].get_value(row % 2));
+                    assert_eq!(
+                        decoded.get(ci).unwrap().get_value(row),
+                        columns.get(ci).unwrap().get_value(row % 2)
+                    );
                 }
             }
         }
@@ -498,7 +561,8 @@ fn valid_final_partial_group_preserves_rows() {
             &[DataType::Integer],
             rows,
             compress,
-        );
+        )
+        .unwrap();
         assert_eq!(store.group_column(0, 0).unwrap().len(), ROW_GROUP_SIZE);
         let last = store.group_column(0, 1).unwrap();
         assert_eq!(last.len(), 3);
@@ -506,9 +570,9 @@ fn valid_final_partial_group_preserves_rows() {
             assert_eq!(last.get_i64(i), (ROW_GROUP_SIZE + i) as i64);
         }
         let decoded = LazyColumns::deferred(store, vec![DataType::Integer]);
-        assert_eq!(decoded[0].len(), rows);
+        assert_eq!(decoded.get(0).unwrap().len(), rows);
         for i in [0, ROW_GROUP_SIZE - 1, ROW_GROUP_SIZE, rows - 1] {
-            assert_eq!(decoded[0].get_i64(i), i as i64);
+            assert_eq!(decoded.get(0).unwrap().get_i64(i), i as i64);
         }
     }
 }
@@ -553,6 +617,593 @@ fn two_column_volume() -> stoolap::storage::volume::writer::FrozenVolume {
         );
     }
     builder.finish()
+}
+
+fn malformed_columns() -> LazyColumns {
+    let mut valid = vec![0, 0];
+    valid.extend_from_slice(&1i64.to_le_bytes());
+    valid.extend_from_slice(&2i64.to_le_bytes());
+    LazyColumns::deferred(
+        CompressedBlockStore::from_raw_blocks(
+            vec![vec![valid], vec![vec![0; 19]]],
+            vec![vec![18], vec![19]],
+            vec![1; 2],
+            vec![DataType::Integer; 2],
+            vec![0; 2],
+            Vec::new(),
+            Vec::new(),
+            ROW_GROUP_SIZE,
+            2,
+        ),
+        vec![DataType::Integer; 2],
+    )
+}
+
+#[test]
+fn lazy_columns_cache_failure_and_never_promote_it_to_eager() {
+    let mut columns = malformed_columns();
+    assert_eq!(columns.get(0).unwrap().get_i64(1), 2);
+    assert_io_failure(|| columns.get(1), ErrorKind::InvalidData);
+    let good = two_column_volume();
+    columns.attach_compressed_store(
+        CompressedBlockStore::compress_columns(&good.columns, &[DataType::Integer; 2], 2).unwrap(),
+    );
+    assert_io_failure(|| columns.get(1), ErrorKind::InvalidData);
+    assert_io_failure(|| columns.get_column_dictionary(1), ErrorKind::InvalidData);
+    assert!(!columns.is_eager());
+}
+
+#[test]
+fn lazy_column_iterator_yields_errors_and_reaches_the_end() {
+    let columns = malformed_columns();
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        columns
+            .iter()
+            .map(|col| col.error_kind())
+            .collect::<Vec<_>>()
+    }));
+    assert!(outcome.is_ok(), "column iterator panicked");
+    assert_eq!(outcome.unwrap(), vec![None, Some(ErrorKind::InvalidData)]);
+}
+
+#[test]
+fn take_columns_rejects_a_partial_decode() {
+    let columns = malformed_columns();
+    assert_eq!(columns.get(0).unwrap().get_i64(0), 1);
+    assert_io_failure(|| columns.take_columns(), ErrorKind::InvalidData);
+}
+
+#[test]
+fn metadata_only_columns_return_errors() {
+    let columns = LazyColumns::metadata_only(vec![DataType::Integer]);
+    assert_io_failure(|| columns.get(0), ErrorKind::InvalidData);
+    assert_io_failure(|| columns.get_column_dictionary(0), ErrorKind::InvalidData);
+    assert_io_failure(|| columns.take_columns(), ErrorKind::InvalidData);
+}
+
+#[test]
+fn take_columns_decodes_every_uninitialized_column() {
+    let volume = two_column_volume();
+    let store = CompressedBlockStore::compress_columns(&volume.columns, &[DataType::Integer; 2], 2)
+        .unwrap();
+    let columns = LazyColumns::deferred(store, vec![DataType::Integer; 2]);
+    let decoded = columns.take_columns().unwrap();
+    assert_eq!(decoded.len(), 2);
+    assert_eq!(decoded[1].get_i64(1), 2);
+}
+
+#[test]
+fn lazy_column_access_rejects_invalid_indices() {
+    let columns = two_column_volume().columns;
+    assert_io_failure(|| columns.get(2), ErrorKind::InvalidInput);
+    assert_io_failure(|| columns.get_column_dictionary(2), ErrorKind::InvalidInput);
+}
+
+fn assert_row_materializer_failure(which: usize) {
+    use stoolap::storage::volume::writer::{ColSource, ColumnMapping};
+    let mut volume = two_column_volume();
+    volume.columns = malformed_columns();
+    let mapping = ColumnMapping {
+        sources: vec![ColSource::Volume(0), ColSource::Volume(1)],
+        is_identity: true,
+    };
+    assert_io_failure(
+        || match which {
+            0 => volume.get_row(0),
+            1 => volume.get_row_projected(0, &[1]),
+            2 => volume.get_row_needed(0, &[false, true]),
+            3 => volume.get_row_mapped(0, &mapping),
+            4 => volume.get_row_mapped_projected(0, &mapping, &[1]),
+            5 => volume.get_row_mapped_needed(0, &mapping, &[false, true]),
+            _ => unreachable!(),
+        },
+        ErrorKind::InvalidData,
+    );
+}
+
+#[test]
+fn full_row_propagates_column_failure() {
+    assert_row_materializer_failure(0);
+}
+
+#[test]
+fn projected_row_propagates_column_failure() {
+    assert_row_materializer_failure(1);
+}
+
+#[test]
+fn needed_row_propagates_column_failure() {
+    assert_row_materializer_failure(2);
+}
+
+#[test]
+fn mapped_row_propagates_column_failure() {
+    assert_row_materializer_failure(3);
+}
+
+#[test]
+fn mapped_projection_propagates_column_failure() {
+    assert_row_materializer_failure(4);
+}
+
+#[test]
+fn mapped_needed_row_propagates_column_failure() {
+    assert_row_materializer_failure(5);
+}
+
+#[test]
+fn projections_leave_unrequested_corrupt_columns_untouched() {
+    use stoolap::core::Value;
+    use stoolap::storage::volume::writer::{ColSource, ColumnMapping};
+    let mut volume = two_column_volume();
+    volume.columns = malformed_columns();
+    let mapping = ColumnMapping {
+        sources: vec![ColSource::Volume(0), ColSource::Default(Value::Integer(9))],
+        is_identity: false,
+    };
+    for row in [
+        volume.get_row_projected(0, &[0]).unwrap(),
+        volume.get_row_needed(0, &[true, false]).unwrap(),
+        volume.get_row_mapped(0, &mapping).unwrap(),
+        volume.get_row_mapped_projected(0, &mapping, &[0]).unwrap(),
+        volume
+            .get_row_mapped_needed(0, &mapping, &[true, false])
+            .unwrap(),
+    ] {
+        assert_eq!(row.get(0), Some(&Value::Integer(1)));
+    }
+    assert!(!volume.columns.is_eager());
+}
+
+#[test]
+fn unique_lookup_releases_its_guard_before_callbacks() {
+    use stoolap::core::Value;
+    let volume = two_column_volume();
+    for _ in 0..2 {
+        let mut hits = 0;
+        volume
+            .unique_lookup_all(&[1], &[&Value::Integer(1)], |_| {
+                assert!(volume.unique_indices.try_write().is_some());
+                hits += 1;
+                false
+            })
+            .unwrap();
+        assert_eq!(hits, 1);
+    }
+}
+
+#[test]
+fn cached_unique_miss_skips_columns_but_matching_hash_propagates_failure() {
+    use stoolap::core::Value;
+    let mut volume = two_column_volume();
+    volume.prebuild_unique_index(&[1]).unwrap();
+    volume.columns = malformed_columns();
+    volume
+        .unique_lookup_all(&[1], &[&Value::Integer(99)], |_| {
+            panic!("missing hash invoked callback");
+        })
+        .unwrap();
+    assert_io_failure(
+        || {
+            volume.unique_lookup_all(&[1], &[&Value::Integer(1)], |_| {
+                panic!("failed column invoked callback");
+            })
+        },
+        ErrorKind::InvalidData,
+    );
+}
+
+#[test]
+fn scanner_whole_column_failures_are_sticky_in_both_directions() {
+    use std::sync::Arc;
+    use stoolap::core::Value;
+    use stoolap::storage::expression::ComparisonExpr;
+    use stoolap::storage::traits::Scanner;
+    use stoolap::storage::volume::scanner::VolumeScanner;
+    for ascending in [true, false] {
+        for mode in 0..3 {
+            let mut volume = two_column_volume();
+            volume.columns = LazyColumns::metadata_only(vec![DataType::Integer; 2]);
+            let mut scanner = VolumeScanner::new(Arc::new(volume), vec![1], None);
+            scanner.set_ordered_walk(ascending);
+            if mode == 1 {
+                scanner.set_stop_key(1, &Value::Integer(1), ascending);
+            }
+            let outcome = catch_unwind(AssertUnwindSafe(|| {
+                if mode == 2 {
+                    scanner.set_filter(Box::new(ComparisonExpr::gte("b", Value::Integer(1))));
+                }
+                scanner.next()
+            }));
+            assert!(outcome.is_ok(), "whole-column scanner panicked");
+            assert!(!outcome.unwrap());
+            let error = scanner
+                .err()
+                .expect("failure became end of scan")
+                .to_string();
+            assert!(!scanner.next());
+            assert_eq!(scanner.err().unwrap().to_string(), error);
+        }
+    }
+}
+
+fn malformed_warm_table() -> stoolap::storage::volume::table::SegmentedTable {
+    use std::sync::Arc;
+    use stoolap::core::SchemaBuilder;
+    use stoolap::storage::mvcc::{MVCCTable, TransactionVersionStore, VersionStore};
+    use stoolap::storage::traits::Table;
+    use stoolap::storage::volume::manifest::{SegmentManager, SegmentMeta};
+    use stoolap::storage::volume::table::SegmentedTable;
+    let schema = SchemaBuilder::new("group_access")
+        .column("a", DataType::Integer, false, true)
+        .column("b", DataType::Integer, false, false)
+        .build();
+    let mut volume = two_column_volume();
+    volume.columns = malformed_columns();
+    let manager = Arc::new(SegmentManager::new("group_access", None));
+    manager.register_segment(
+        1,
+        Arc::new(volume),
+        SegmentMeta {
+            segment_id: 1,
+            file_path: Default::default(),
+            row_count: 2,
+            min_row_id: 1,
+            max_row_id: 2,
+            creation_lsn: 0,
+            seal_seq: 0,
+            schema_version: 0,
+        },
+        Some(&schema),
+    );
+    let store = Arc::new(VersionStore::new(schema.table_name.clone(), schema));
+    let local = TransactionVersionStore::new(Arc::clone(&store), 1);
+    let hot = Box::new(MVCCTable::new(1, store, local));
+    hot.create_btree_index("b", false, Some("idx_b")).unwrap();
+    SegmentedTable::new(hot, manager)
+}
+
+fn assert_warm_read_failure(
+    read: impl FnOnce(&stoolap::storage::volume::table::SegmentedTable) -> stoolap::core::Result<()>,
+) {
+    let table = malformed_warm_table();
+    table.segment_manager().add_tombstones(&[1], 1);
+    let outcome = catch_unwind(AssertUnwindSafe(|| read(&table)));
+    assert!(outcome.is_ok(), "warm-column read panicked");
+    assert!(
+        outcome.unwrap().is_err(),
+        "corruption became a successful result"
+    );
+}
+
+#[test]
+fn warm_collection_propagates_column_failure() {
+    use stoolap::storage::traits::Table;
+    assert_warm_read_failure(|table| table.collect_all_rows(None).map(drop));
+}
+
+#[test]
+fn warm_sum_propagates_column_failure() {
+    use stoolap::storage::traits::Table;
+    assert_warm_read_failure(|table| table.sum_column(1).map(drop));
+}
+
+#[test]
+fn warm_partitions_propagate_column_failure() {
+    use stoolap::storage::traits::Table;
+    assert_warm_read_failure(|table| table.get_partition_values("b").map(drop));
+}
+
+#[test]
+fn warm_distinct_propagates_column_failure() {
+    use stoolap::storage::traits::Table;
+    assert_warm_read_failure(|table| table.compute_distinct_values(1).map(drop));
+}
+
+#[test]
+fn warm_filtered_aggregation_propagates_column_failure() {
+    use stoolap::core::Value;
+    use stoolap::storage::expression::ComparisonExpr;
+    use stoolap::storage::mvcc::version_store::AggregateOp;
+    use stoolap::storage::traits::Table;
+    assert_warm_read_failure(|table| {
+        table
+            .compute_filtered_aggregates(
+                &[(AggregateOp::Sum, 1)],
+                &ComparisonExpr::gte("a", Value::Integer(0)),
+            )
+            .map(drop)
+    });
+}
+
+#[test]
+fn warm_grouped_aggregation_propagates_column_failure() {
+    use stoolap::storage::mvcc::version_store::AggregateOp;
+    use stoolap::storage::traits::Table;
+    assert_warm_read_failure(|table| {
+        table
+            .compute_grouped_aggregates(&[0], &[(AggregateOp::Sum, 1)])
+            .map(drop)
+    });
+}
+
+#[test]
+fn fully_hidden_warm_columns_are_not_decoded() {
+    use stoolap::core::Value;
+    use stoolap::storage::mvcc::version_store::AggregateOp;
+    use stoolap::storage::traits::Table;
+    let table = malformed_warm_table();
+    table.segment_manager().add_tombstones(&[1, 2], 1);
+    assert_eq!(table.sum_column(1).unwrap(), Some((0.0, 0)));
+    assert_eq!(table.get_partition_count("b").unwrap(), Some(0));
+    assert!(table.get_partition_values("b").unwrap().unwrap().is_empty());
+    assert!(table
+        .compute_distinct_values(1)
+        .unwrap()
+        .unwrap()
+        .is_empty());
+    assert!(table
+        .collect_rows_grouped_by_partition("b")
+        .unwrap()
+        .unwrap()
+        .is_empty());
+    assert!(table
+        .get_rows_for_partition_value("b", &Value::Integer(1))
+        .unwrap()
+        .unwrap()
+        .is_empty());
+    assert!(table
+        .compute_grouped_aggregates(&[0], &[(AggregateOp::Sum, 1)])
+        .unwrap()
+        .unwrap()
+        .is_empty());
+    table.drop_index("idx_b").unwrap();
+    table
+        .create_btree_index("b", true, Some("unique_b"))
+        .unwrap();
+}
+
+fn maintenance_config(path: &std::path::Path) -> stoolap::storage::config::Config {
+    let mut config = stoolap::storage::config::Config::with_path(path.to_str().unwrap());
+    config.cleanup.enabled = false;
+    config.persistence.checkpoint_on_close = false;
+    config.persistence.checkpoint_interval = 3600;
+    config.persistence.target_volume_rows = 32_768;
+    config
+}
+
+fn volume_files(path: &std::path::Path) -> std::collections::BTreeSet<std::path::PathBuf> {
+    std::fs::read_dir(path)
+        .into_iter()
+        .flatten()
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "vol"))
+        .collect()
+}
+
+#[test]
+fn late_compaction_failure_removes_output_and_preserves_original_volumes() {
+    use std::sync::Arc;
+    use stoolap::core::{Row, SchemaBuilder, Value};
+    use stoolap::storage::mvcc::MVCCEngine;
+    use stoolap::storage::traits::Engine;
+    use stoolap::storage::volume::io::{read_volume_from_disk, write_volume_to_disk};
+    use stoolap::storage::volume::manifest::{SegmentManager, SegmentMeta, TableManifest};
+    use stoolap::storage::volume::writer::VolumeBuilder;
+    let dir = tempfile::tempdir().unwrap();
+    let schema = SchemaBuilder::new("group_access")
+        .column("a", DataType::Integer, false, true)
+        .column("b", DataType::Integer, false, false)
+        .build();
+    let engine = MVCCEngine::new(maintenance_config(dir.path()));
+    engine.open_engine().unwrap();
+    engine.create_table(schema.clone()).unwrap();
+    engine.close_engine().unwrap();
+    drop(engine);
+    let volume_dir = dir.path().join("volumes");
+    let table_dir = volume_dir.join("group_access");
+    let manager = SegmentManager::new("group_access", Some(volume_dir.clone()));
+    let mut good_last_file = Vec::new();
+    let mut last_path = std::path::PathBuf::new();
+    for (volume_id, start, end) in [(1, 1, 65_536), (2, 65_537, 65_537)] {
+        let mut builder = VolumeBuilder::new(&schema);
+        for row_id in start..=end {
+            builder.add_row(row_id, &Row::from_values(vec![Value::Integer(row_id); 2]));
+        }
+        let volume = builder.finish();
+        let path = write_volume_to_disk(&volume_dir, "group_access", volume_id, &volume).unwrap();
+        if volume_id == 2 {
+            good_last_file = std::fs::read(&path).unwrap();
+            let meta_len = u32::from_le_bytes(good_last_file[16..20].try_into().unwrap()) as usize;
+            let mut bytes = good_last_file[..20 + meta_len].to_vec();
+            for size in [9u64, 10] {
+                bytes.extend_from_slice(&size.to_le_bytes());
+                bytes.extend_from_slice(&size.to_le_bytes());
+            }
+            bytes.extend_from_slice(&[0; 19]);
+            bytes.extend_from_slice(&crc32fast::hash(&bytes).to_le_bytes());
+            std::fs::write(&path, bytes).unwrap();
+            last_path = path.clone();
+        }
+        manager.register_segment(
+            volume_id,
+            Arc::new(read_volume_from_disk(&path).unwrap()),
+            SegmentMeta {
+                segment_id: volume_id,
+                file_path: path.file_name().unwrap().into(),
+                row_count: volume.meta.row_count,
+                min_row_id: start,
+                max_row_id: end,
+                creation_lsn: 0,
+                seal_seq: 0,
+                schema_version: 0,
+            },
+            Some(&schema),
+        );
+    }
+    manager.persist().unwrap();
+    let original_files = volume_files(&table_dir);
+    let manifest_path = table_dir.join("manifest.bin");
+    let engine = MVCCEngine::new(maintenance_config(dir.path()));
+    engine.open_engine().unwrap();
+    for _ in 0..2 {
+        let outcome = catch_unwind(AssertUnwindSafe(|| engine.force_checkpoint_cycle()));
+        assert!(outcome.is_ok(), "compaction panicked after writing a chunk");
+        assert!(
+            matches!(outcome.unwrap(), Err(stoolap::core::Error::Io { message })
+            if message == "invalid column block length")
+        );
+        assert_eq!(
+            engine
+                .volume_stats()
+                .into_iter()
+                .map(|entry| (entry.1, entry.3))
+                .collect::<std::collections::BTreeSet<_>>(),
+            [(1, 65_536), (2, 1)].into()
+        );
+        assert_eq!(volume_files(&table_dir), original_files);
+        let manifest = TableManifest::read_from_disk(&manifest_path).unwrap();
+        assert_eq!(
+            manifest
+                .segments
+                .iter()
+                .map(|seg| seg.segment_id)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+    }
+    engine.close_engine().unwrap();
+    drop(engine);
+    std::fs::write(&last_path, good_last_file).unwrap();
+    let engine = MVCCEngine::new(maintenance_config(dir.path()));
+    engine.open_engine().unwrap();
+    engine.force_checkpoint_cycle().unwrap();
+    let mut tx = engine.begin_transaction().unwrap();
+    assert_eq!(
+        tx.get_table("group_access").unwrap().row_count().unwrap(),
+        65_537
+    );
+    tx.rollback().unwrap();
+    engine.close_engine().unwrap();
+}
+
+fn hot_maintenance_engine(path: &std::path::Path) -> stoolap::storage::mvcc::MVCCEngine {
+    use stoolap::core::{Row, SchemaBuilder, Value};
+    use stoolap::storage::mvcc::MVCCEngine;
+    use stoolap::storage::traits::Engine;
+    let engine = MVCCEngine::new(maintenance_config(path));
+    engine.open_engine().unwrap();
+    engine
+        .create_table(
+            SchemaBuilder::new("group_access")
+                .column("a", DataType::Integer, false, true)
+                .column("b", DataType::Integer, false, false)
+                .build(),
+        )
+        .unwrap();
+    let mut tx = engine.begin_transaction().unwrap();
+    tx.get_table("group_access")
+        .unwrap()
+        .insert_batch(vec![
+            Row::from_values(vec![Value::Integer(1); 2]),
+            Row::from_values(vec![Value::Integer(2); 2]),
+        ])
+        .unwrap();
+    tx.commit().unwrap();
+    engine
+}
+
+#[test]
+fn seal_prebuild_schema_mismatch_removes_output_and_keeps_hot_rows() {
+    use std::sync::Arc;
+    use stoolap::common::CompactArc;
+    use stoolap::core::SchemaBuilder;
+    use stoolap::storage::index::HashIndex;
+    use stoolap::storage::traits::Engine;
+    let dir = tempfile::tempdir().unwrap();
+    let engine = hot_maintenance_engine(dir.path());
+    let store = engine.get_version_store("group_access").unwrap();
+    let original_schema = store.schema();
+    *store.schema_mut() = CompactArc::new(
+        SchemaBuilder::new("group_access")
+            .column("a", DataType::Integer, false, true)
+            .column("b", DataType::Integer, false, false)
+            .column("extra", DataType::Integer, false, false)
+            .build(),
+    );
+    store.add_index(
+        "extra_unique".into(),
+        Arc::new(HashIndex::new(
+            "extra_unique".into(),
+            "group_access".into(),
+            vec!["extra".into()],
+            vec![2],
+            vec![DataType::Integer],
+            true,
+            0,
+        )),
+    );
+    let outcome = catch_unwind(AssertUnwindSafe(|| engine.force_checkpoint_cycle()));
+    assert!(outcome.is_ok(), "seal prebuild panicked on schema mismatch");
+    assert!(
+        matches!(outcome.unwrap(), Err(stoolap::core::Error::Io { message })
+        if message == "column index out of range")
+    );
+    assert!(engine.volume_stats().is_empty());
+    assert_eq!(store.committed_row_count(), 2);
+    let table_dir = dir.path().join("volumes/group_access");
+    assert!(volume_files(&table_dir).is_empty());
+    store.remove_index("extra_unique");
+    *store.schema_mut() = original_schema;
+    engine.force_checkpoint_cycle().unwrap();
+    assert_eq!(store.committed_row_count(), 0);
+    assert_eq!(volume_files(&table_dir).len(), 1);
+    engine.close_engine().unwrap();
+}
+
+#[test]
+fn seal_write_failure_is_reported_and_can_be_retried() {
+    use stoolap::storage::traits::Engine;
+    let dir = tempfile::tempdir().unwrap();
+    let engine = hot_maintenance_engine(dir.path());
+    let table_dir = dir.path().join("volumes/group_access");
+    std::fs::create_dir_all(table_dir.parent().unwrap()).unwrap();
+    std::fs::write(&table_dir, b"blocked directory").unwrap();
+    assert!(
+        engine.force_checkpoint_cycle().is_err(),
+        "seal write failure was swallowed"
+    );
+    assert_eq!(
+        engine
+            .get_version_store("group_access")
+            .unwrap()
+            .committed_row_count(),
+        2
+    );
+    std::fs::remove_file(&table_dir).unwrap();
+    engine.force_checkpoint_cycle().unwrap();
+    assert_eq!(volume_files(&table_dir).len(), 1);
+    engine.close_engine().unwrap();
 }
 
 #[test]

--- a/tests/fallible_row_count_test.rs
+++ b/tests/fallible_row_count_test.rs
@@ -99,12 +99,16 @@ fn snapshot_count_propagates_reload_failure_and_keeps_local_rows() {
     let bytes = std::fs::read(&path).unwrap();
     std::fs::remove_file(&path).unwrap();
     for _ in 0..2 {
-        let expected = table.collect_all_rows(None).map(|rows| rows.len());
+        let expected = table.segment_manager().ensure_volume(1).map(|_| 0usize);
         assert!(expected
             .as_ref()
             .unwrap_err()
             .to_string()
-            .contains("cold volume reload failed"));
+            .contains("failed to reload cold volume seg=1"));
+        assert_eq!(
+            format!("{:?}", table.collect_all_rows(None).map(|rows| rows.len())),
+            format!("{expected:?}")
+        );
         assert_eq!(format!("{:?}", table.row_count()), format!("{expected:?}"));
     }
     std::fs::write(&path, bytes).unwrap();


### PR DESCRIPTION
I propagate whole-column read failures through storage so corrupt or unavailable columns return errors instead of panicking, disappearing from results, or letting CHECKPOINT report success. This is the next Stage 1 prerequisite of #122, based on merged #133 and #134. The larger diff removes the temporary LazyColumns Index adapter and migrates its callers together: row constructors, scanners, aggregates, serialization, unique constraints and maintenance. Splitting those callers would retain the panic adapter.

I cache successful columns and decode errors in the existing OnceLock slots. Iteration reports every outcome, taking columns requires complete decoding, and a failed slot never promotes a volume to eager. Scanners keep their first error and stop. Projection and metadata pruning avoid unneeded payloads. Failed seal preparation preserves hot rows. A failed later compaction chunk removes unpublished output and preserves original volumes. Explicit CHECKPOINT exposes seal and compaction errors, including the original reload context.

I retain exact row-buffer capacity and inline resident column checks, keeping initialization/error handling on the slow path. Index and engine-map read guards are released before decoding or callbacks. Cached unique misses return before pinning the immutable index array; matching hashes pin it before releasing the guard. Multi-row INSERT batches and cold UPDATE statements capture unique definitions once, while single-row INSERT uses the existing borrowed callback. Short constraint temporaries use inline buffers.

Validation:

- Formatting and all-target/all-feature clippy with warnings denied pass.
- The initial nine focused targets pass in normal and file-backed modes, 167 tests each. After the final performance refinements, all 130 tests in the six affected targets pass again in both modes.
- Reverting only production on the same checkout makes all 24 new failure guards fail, with 29 existing tests and two valid-data controls passing. The separate strengthened reload-context assertion fails specifically on the old generic error. Restored guards pass.
- Coverage includes cached failures, six row constructors, iterator/take completeness, projection pruning, scanner termination, warm aggregate errors, callback lock release, hidden data, late compaction cleanup and failed seal retry. Maintenance assertions check exact I/O errors, unchanged publication, file cleanup and successful retry.
- Independent source review, fixes and re-review are complete. Independent measurement review keeps the performance gate open. Linux, macOS and Windows full tests pass. Coverage failed one pre-existing global-cache pointer-identity test (2,036 passed, one failed); independent review verified the cross-test clear race. A coverage-only retry is running; its result remains pending. I run the full suite in CI rather than duplicating it locally.

On this 64-bit build, Value remains 16 bytes, ColumnData 80 bytes and both old/new column slots 88 bytes. There is no added retained per-row structure. Unique entries remain 16 bytes each. Each built unique index gains one 40-byte Arc allocation, while its map value shrinks from 24 to 8 bytes per bucket. A matching-hash lookup adds an Arc pin/drop; misses do not. Cold constraint metadata ownership scales with statements/batches. Error-message reconstruction allocates only on failure. Existing volume-size estimates still omit unique-index ownership, so this delivers neither complete accounting nor enforcement.

The first measurements exposed additional metadata allocations and latency for single-row cold INSERT, plus a non-inlined resident accessor. I fixed both before acceptance. The revised comparison uses base 29f7b551 and this candidate, release opt-level 3, thin LTO, one codegen unit. Seven same-binary controls, seven baseline runs and seven candidate runs use contiguous cohorts; allocation runs are separate. Scopes are hot SQL INSERT/UPDATE/PK and a 1,024-row PK scan; row widths 1/8/32; cached unique hit/miss widths 1/6; cold INSERT batches 1/16 with six unique indexes; and 256-row cold UPDATE with six unique indexes. Hot loops use 500,000 cycles; row/unique loops use 100,000 samples of 64 accesses. Their quantiles describe batch averages, not individual-access tails. The revised run completed, but the hot-path latency gate remains open, so this remains a draft. Autocommit UPDATE p50 was 0.667 to 0.709 us on the baseline and 0.709 to 0.792 us on the candidate; p99 was 0.917 to 1.000 us versus 1.167 to 1.875 us. An unchanged-baseline postcontrol completed four runs before the harness stopped for a concurrent Cargo build. Baseline throughput moved from 395.5 to 416.5 thousand cycles/s to 377.6 to 388.3 thousand, demonstrating drift but not explaining the entire candidate loss. The incomplete control cannot clear the gate. I do not call the current result a pass.

I recorded AC power and thermal state and checked for Cargo/rustc/clippy at process boundaries. Ordinary desktop activity and the inherited environment remained. This runner did not apply the earlier fixed rests, allocator sanitization or sleep/display audit. A subsequent process snapshot showed active desktop/UI processes; this does not establish the cause of the timing differences.

The completed hot SQL results are below. Each cell gives the seven-run range in microseconds.

| Mode / operation | Base p50 | Candidate p50 | Base p95 | Candidate p95 | Base p99 | Candidate p99 |
|---|---|---|---|---|---|---|
| auto / insert | 0.709 to 0.791 | 0.750 to 0.834 | 0.834 to 0.917 | 0.916 to 1.041 | 1.083 to 1.625 | 1.250 to 2.250 |
| auto / update | 0.667 to 0.709 | 0.709 to 0.792 | 0.834 to 0.875 | 1.000 to 1.166 | 0.917 to 1.000 | 1.167 to 1.875 |
| auto / point | 0.875 to 0.917 | 0.958 to 1.042 | 1.000 to 1.125 | 1.083 to 1.208 | 1.084 to 1.250 | 1.166 to 2.000 |
| explicit / insert | 0.375 to 0.417 | 0.417 to 0.458 | 0.458 to 0.500 | 0.500 to 0.500 | 0.500 to 0.583 | 0.542 to 0.625 |
| explicit / update | 0.750 to 0.792 | 0.833 to 0.875 | 0.834 to 0.917 | 0.958 to 1.000 | 1.000 to 1.042 | 1.083 to 1.166 |
| explicit / point | 0.750 to 0.750 | 0.750 to 0.833 | 0.792 to 0.834 | 0.834 to 0.917 | 0.875 to 0.958 | 0.917 to 1.000 |

Allocation runs confirm identical hot-cycle allocated blocks/bytes and retained/process-peak bytes. Cold single-row INSERT falls from 27.15 to 10.15 allocations per batch and 1,472.6 to 976.6 allocated bytes; the 16-row batch falls from 417.45 to 150.45 allocations. The 256-row cold UPDATE falls from 7,701 to 7,714 allocations to 3,114 to 3,127. These are seven process runs per build; UPDATE ranges cover three operation records per process. Retained/process-peak figures include setup, not per-ledger accounting. After accounting for the eight-byte executable-name length difference, the first cold UPDATE operation has 564 additional peak bytes, consistent with bounded statement metadata, with no retained per-row growth; this is an inference without allocation-stack attribution. Cached unique hits were slower in these measurements: width-one p50 is 13.02 to 13.67 ns on the baseline versus 16.27 to 18.22 ns on the candidate; width-six is 35.81 to 37.77 ns versus 40.38 to 42.97 ns. These helper measurements do not substitute for SQL latency acceptance.

Resident identity accessors, remaining counter closures, constructor validation and later storage stages remain outstanding. File format, residency policy and publication protocol stay as before. Existing seal/compaction still materialize rows and remain unbounded. Backup and restore receive only necessary caller/error-cleanup adaptations. Disk first-touch, mixed ingest/analytics/compaction and future per-ledger/fence metrics are not established by these micro-probes; historical mixed-workload uncertainty remains open.
