### PR TITLE
Propagate sorted-boundary read failures

### DIFF
--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -750,12 +750,9 @@ impl SegmentedTable {
                             None
                         };
                         match op {
-                            // A search that hits a block it cannot decode
-                            // leaves the range as it is: the scan then reaches
-                            // the block and reports the error
                             crate::core::Operator::Gte => {
                                 let idx = if let Some(st) = store {
-                                    st.binary_search_ge(col_idx, target, &vol.meta.row_groups)
+                                    st.binary_search_ge(col_idx, target, &vol.meta.row_groups)?
                                 } else {
                                     Some(vol.columns.get(col_idx)?.binary_search_ge(target))
                                 };
@@ -767,7 +764,7 @@ impl SegmentedTable {
                             }
                             crate::core::Operator::Gt => {
                                 let idx = if let Some(st) = store {
-                                    st.binary_search_gt(col_idx, target, &vol.meta.row_groups)
+                                    st.binary_search_gt(col_idx, target, &vol.meta.row_groups)?
                                 } else {
                                     Some(vol.columns.get(col_idx)?.binary_search_gt(target))
                                 };
@@ -779,7 +776,7 @@ impl SegmentedTable {
                             }
                             crate::core::Operator::Lte => {
                                 let idx = if let Some(st) = store {
-                                    st.binary_search_gt(col_idx, target, &vol.meta.row_groups)
+                                    st.binary_search_gt(col_idx, target, &vol.meta.row_groups)?
                                 } else {
                                     Some(vol.columns.get(col_idx)?.binary_search_gt(target))
                                 };
@@ -791,7 +788,7 @@ impl SegmentedTable {
                             }
                             crate::core::Operator::Lt => {
                                 let idx = if let Some(st) = store {
-                                    st.binary_search_ge(col_idx, target, &vol.meta.row_groups)
+                                    st.binary_search_ge(col_idx, target, &vol.meta.row_groups)?
                                 } else {
                                     Some(vol.columns.get(col_idx)?.binary_search_ge(target))
                                 };

--- a/src/storage/volume/writer.rs
+++ b/src/storage/volume/writer.rs
@@ -732,15 +732,14 @@ impl CompressedBlockStore {
 
     /// Binary search on a sorted column using row-group zone maps.
     /// Decompresses only the group(s) containing the target value.
-    /// Returns global row index (same as ColumnData::binary_search_ge/gt),
-    /// or None when a block fails to decode: the caller must then keep the
-    /// range unnarrowed so the scan reaches the block and reports the error.
+    /// Returns a proven global row index, or None when optional group metadata
+    /// cannot support narrowing. Invalid geometry and decode failures propagate.
     pub fn binary_search_ge(
         &self,
         col_idx: usize,
         target: i64,
         row_groups: &[super::column::RowGroupMeta],
-    ) -> Option<usize> {
+    ) -> std::io::Result<Option<usize>> {
         self.binary_search_impl(col_idx, target, row_groups, false)
     }
 
@@ -749,7 +748,7 @@ impl CompressedBlockStore {
         col_idx: usize,
         target: i64,
         row_groups: &[super::column::RowGroupMeta],
-    ) -> Option<usize> {
+    ) -> std::io::Result<Option<usize>> {
         self.binary_search_impl(col_idx, target, row_groups, true)
     }
 
@@ -759,53 +758,93 @@ impl CompressedBlockStore {
         target: i64,
         row_groups: &[super::column::RowGroupMeta],
         strict: bool,
-    ) -> Option<usize> {
-        let num_groups = self.blocks[col_idx].len();
+    ) -> std::io::Result<Option<usize>> {
+        let num_groups = self
+            .blocks
+            .get(col_idx)
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "column index out of range",
+                )
+            })?
+            .len();
+        match self.col_type_tags.get(col_idx).copied() {
+            Some(super::format::COL_INT64 | super::format::COL_TIMESTAMP) => {}
+            Some(
+                super::format::COL_FLOAT64
+                | super::format::COL_BOOLEAN
+                | COL_DICTIONARY
+                | COL_BYTES,
+            ) => {
+                return Ok(None);
+            }
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "invalid column type tag",
+                ))
+            }
+        }
+        if self.group_size == 0 || num_groups != self.row_count.div_ceil(self.group_size) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid row group geometry",
+            ));
+        }
+        if num_groups == 0 {
+            return Ok(Some(0));
+        }
 
-        // Use zone maps to find the group containing the target.
-        // When duplicates span group boundaries, continue to the next group
-        // if the search result lands at the group end.
         if !row_groups.is_empty() {
+            if row_groups.len() != num_groups {
+                return Ok(None);
+            }
             for (gi, rg) in row_groups.iter().enumerate() {
-                if gi >= num_groups || col_idx >= rg.zone_maps.len() {
-                    continue;
+                let start = gi * self.group_size;
+                let group_rows = (self.row_count - start).min(self.group_size);
+                if rg.start_idx as usize != start || rg.end_idx as usize != start + group_rows {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "invalid row group bounds",
+                    ));
                 }
-                let zm = &rg.zone_maps[col_idx];
+                let Some(zm) = rg.zone_maps.get(col_idx) else {
+                    return Ok(None);
+                };
                 let max_i64 = match &zm.max {
                     crate::core::Value::Integer(v) => *v,
                     crate::core::Value::Timestamp(ts) => {
                         ts.timestamp_nanos_opt().unwrap_or(i64::MAX)
                     }
-                    _ => continue,
+                    _ => return Ok(None),
                 };
                 if target > max_i64 {
                     continue;
                 }
-                let col = self.group_column(col_idx, gi).ok()?;
-                let group_rows = (rg.end_idx - rg.start_idx) as usize;
+                let col = self.group_column(col_idx, gi)?;
                 let local = if strict {
                     col.binary_search_gt(target)
                 } else {
                     col.binary_search_ge(target)
                 };
                 if local < group_rows {
-                    return Some(rg.start_idx as usize + local);
+                    return Ok(Some(start + local));
                 }
             }
-            return Some(self.row_count);
+            return Ok(Some(self.row_count));
         }
 
         if num_groups == 1 {
-            let col = self.group_column(col_idx, 0).ok()?;
-            return Some(if strict {
+            let col = self.group_column(col_idx, 0)?;
+            return Ok(Some(if strict {
                 col.binary_search_gt(target)
             } else {
                 col.binary_search_ge(target)
-            });
+            }));
         }
 
-        // Fallback: full column (shouldn't happen for V4 with zone maps)
-        Some(self.row_count)
+        Ok(None)
     }
 
     /// Number of groups for a given column.

--- a/tests/fallible_group_access_test.rs
+++ b/tests/fallible_group_access_test.rs
@@ -89,6 +89,22 @@ impl<T> ColumnErrorKind for Option<T> {
     }
 }
 
+trait BoundaryResult {
+    fn into_boundary_result(self) -> std::io::Result<Option<usize>>;
+}
+
+impl BoundaryResult for Option<usize> {
+    fn into_boundary_result(self) -> std::io::Result<Option<usize>> {
+        Ok(self)
+    }
+}
+
+impl BoundaryResult for std::io::Result<Option<usize>> {
+    fn into_boundary_result(self) -> std::io::Result<Option<usize>> {
+        self
+    }
+}
+
 // Keep the guards executable when only production changes are reverted.
 #[allow(dead_code)]
 trait BaselineUnwrap: Sized {
@@ -155,6 +171,255 @@ fn two_group_store(
         2,
         4,
     )
+}
+
+fn boundary_block(values: [i64; 2]) -> Vec<u8> {
+    let mut raw = vec![0, 0];
+    for value in values {
+        raw.extend_from_slice(&value.to_le_bytes());
+    }
+    raw
+}
+
+fn boundary_groups() -> Vec<stoolap::storage::volume::column::RowGroupMeta> {
+    use stoolap::core::Value;
+    use stoolap::storage::volume::column::{RowGroupMeta, ZoneMap};
+    [(0, 1, 2), (2, 2, 3)]
+        .into_iter()
+        .map(|(start, min, max)| RowGroupMeta {
+            start_idx: start,
+            end_idx: start + 2,
+            zone_maps: vec![ZoneMap {
+                min: Value::Integer(min),
+                max: Value::Integer(max),
+                null_count: 0,
+                row_count: 2,
+            }],
+        })
+        .collect()
+}
+
+#[test]
+fn boundary_reads_propagate_single_group_errors() {
+    let store = store(vec![0xff], 18, DataType::Integer);
+    assert_io_failure(|| store.binary_search_ge(0, 1, &[]), ErrorKind::InvalidData);
+    assert_io_failure(|| store.binary_search_gt(0, 1, &[]), ErrorKind::InvalidData);
+}
+
+#[test]
+fn boundary_reads_propagate_selected_group_errors() {
+    let store = two_group_store(
+        boundary_block([1, 2]),
+        vec![0xff],
+        vec![18, 18],
+        DataType::Integer,
+    );
+    let groups = boundary_groups();
+    assert_io_failure(
+        || store.binary_search_ge(0, 3, &groups),
+        ErrorKind::InvalidData,
+    );
+    assert_io_failure(
+        || store.binary_search_gt(0, 3, &groups),
+        ErrorKind::InvalidData,
+    );
+}
+
+#[test]
+fn boundary_reads_reject_invalid_column_indices() {
+    let store = store(boundary_block([1, 2]), 18, DataType::Integer);
+    assert_io_failure(
+        || store.binary_search_ge(1, 1, &[]),
+        ErrorKind::InvalidInput,
+    );
+    assert_io_failure(
+        || store.binary_search_gt(1, 1, &[]),
+        ErrorKind::InvalidInput,
+    );
+}
+
+#[test]
+fn boundary_reads_leave_unusable_metadata_unnarrowed() {
+    let store = two_group_store(
+        boundary_block([1, 2]),
+        boundary_block([2, 3]),
+        vec![18, 18],
+        DataType::Integer,
+    );
+    for variant in 0..4 {
+        let mut groups = boundary_groups();
+        match variant {
+            0 => groups.clear(),
+            1 => {
+                groups.pop();
+            }
+            2 => groups[0].zone_maps.clear(),
+            _ => groups[0].zone_maps[0].max = stoolap::core::Value::Float(2.0),
+        }
+        assert_eq!(
+            store
+                .binary_search_ge(0, 3, &groups)
+                .into_boundary_result()
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            store
+                .binary_search_gt(0, 3, &groups)
+                .into_boundary_result()
+                .unwrap(),
+            None
+        );
+    }
+}
+
+#[test]
+fn boundary_reads_reject_contradictory_group_bounds() {
+    let store = two_group_store(
+        boundary_block([1, 2]),
+        boundary_block([2, 3]),
+        vec![18, 18],
+        DataType::Integer,
+    );
+    for (start, end) in [(1, 2), (0, 1), (2, 1), (0, 3)] {
+        let mut groups = boundary_groups();
+        groups[0].start_idx = start;
+        groups[0].end_idx = end;
+        assert_io_failure(
+            || store.binary_search_ge(0, 2, &groups),
+            ErrorKind::InvalidData,
+        );
+        assert_io_failure(
+            || store.binary_search_gt(0, 2, &groups),
+            ErrorKind::InvalidData,
+        );
+    }
+}
+
+#[test]
+fn boundary_reads_leave_unsupported_types_unnarrowed() {
+    let columns = LazyColumns::eager(
+        vec![ColumnData::Float64 {
+            values: vec![1.0, 2.0],
+            nulls: vec![false; 2],
+        }],
+        vec![DataType::Float],
+    );
+    let store = CompressedBlockStore::compress_columns(&columns, &[DataType::Float], 2).unwrap();
+    assert_eq!(
+        store
+            .binary_search_ge(0, 1, &[])
+            .into_boundary_result()
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        store
+            .binary_search_gt(0, 1, &[])
+            .into_boundary_result()
+            .unwrap(),
+        None
+    );
+}
+
+#[test]
+fn boundary_reads_preserve_exact_duplicate_boundaries() {
+    let store = two_group_store(
+        boundary_block([1, 2]),
+        boundary_block([2, 3]),
+        vec![18, 18],
+        DataType::Integer,
+    );
+    let groups = boundary_groups();
+    for (target, ge, gt) in [(0, 0, 0), (1, 0, 1), (2, 1, 3), (3, 3, 4), (4, 4, 4)] {
+        assert_eq!(
+            store
+                .binary_search_ge(0, target, &groups)
+                .into_boundary_result()
+                .unwrap(),
+            Some(ge)
+        );
+        assert_eq!(
+            store
+                .binary_search_gt(0, target, &groups)
+                .into_boundary_result()
+                .unwrap(),
+            Some(gt)
+        );
+    }
+}
+
+#[test]
+fn boundary_reads_do_not_decode_pruned_groups() {
+    let store = two_group_store(
+        vec![0xff],
+        boundary_block([2, 3]),
+        vec![18, 18],
+        DataType::Integer,
+    );
+    let groups = boundary_groups();
+    assert_eq!(
+        store
+            .binary_search_ge(0, 3, &groups)
+            .into_boundary_result()
+            .unwrap(),
+        Some(3)
+    );
+    assert_eq!(
+        store
+            .binary_search_gt(0, 3, &groups)
+            .into_boundary_result()
+            .unwrap(),
+        Some(4)
+    );
+}
+
+#[test]
+fn range_scan_setup_propagates_boundary_failure() {
+    use stoolap::core::{Error, Value};
+    use stoolap::storage::expression::ComparisonExpr;
+    use stoolap::storage::traits::Table;
+    let table = malformed_warm_table();
+    let filter = ComparisonExpr::gte("b", Value::Integer(1));
+    match table.scan(&[0], Some(&filter)) {
+        Err(Error::Io { message }) => assert_eq!(message, "invalid column block length"),
+        Err(error) => panic!("unexpected error: {error:?}"),
+        Ok(_) => panic!("boundary failure became a successful scan"),
+    }
+}
+
+#[test]
+fn range_scan_without_group_metadata_preserves_matching_rows() {
+    use std::sync::Arc;
+    use stoolap::core::{Row, SchemaBuilder, Value};
+    use stoolap::storage::expression::ComparisonExpr;
+    use stoolap::storage::traits::Table;
+    use stoolap::storage::volume::writer::VolumeBuilder;
+    let schema = SchemaBuilder::new("group_access")
+        .column("a", DataType::Integer, false, true)
+        .column("b", DataType::Integer, false, false)
+        .build();
+    let mut builder = VolumeBuilder::new(&schema);
+    let rows = ROW_GROUP_SIZE + 2;
+    for id in 1..=rows as i64 {
+        builder.add_row(id, &Row::from_values(vec![Value::Integer(id); 2]));
+    }
+    let mut volume = builder.finish();
+    let store =
+        CompressedBlockStore::compress_columns(&volume.columns, &[DataType::Integer; 2], rows)
+            .unwrap();
+    volume.columns = LazyColumns::deferred(store, vec![DataType::Integer; 2]);
+    Arc::get_mut(&mut volume.meta).unwrap().row_groups.clear();
+    let table = warm_table(volume);
+    let filter = ComparisonExpr::gte("b", Value::Integer(ROW_GROUP_SIZE as i64 + 1));
+    let mut scanner = table.scan(&[0], Some(&filter)).unwrap();
+    let mut ids = Vec::new();
+    while scanner.next() {
+        ids.push(scanner.current_row_id());
+        assert_eq!(scanner.row()[0], Value::Integer(scanner.current_row_id()));
+    }
+    assert!(scanner.err().is_none());
+    assert_eq!(ids, vec![ROW_GROUP_SIZE as i64 + 1, rows as i64]);
 }
 
 #[test]
@@ -848,6 +1113,14 @@ fn scanner_whole_column_failures_are_sticky_in_both_directions() {
 }
 
 fn malformed_warm_table() -> stoolap::storage::volume::table::SegmentedTable {
+    let mut volume = two_column_volume();
+    volume.columns = malformed_columns();
+    warm_table(volume)
+}
+
+fn warm_table(
+    volume: stoolap::storage::volume::writer::FrozenVolume,
+) -> stoolap::storage::volume::table::SegmentedTable {
     use std::sync::Arc;
     use stoolap::core::SchemaBuilder;
     use stoolap::storage::mvcc::{MVCCTable, TransactionVersionStore, VersionStore};
@@ -858,8 +1131,7 @@ fn malformed_warm_table() -> stoolap::storage::volume::table::SegmentedTable {
         .column("a", DataType::Integer, false, true)
         .column("b", DataType::Integer, false, false)
         .build();
-    let mut volume = two_column_volume();
-    volume.columns = malformed_columns();
+    let rows = volume.meta.row_count;
     let manager = Arc::new(SegmentManager::new("group_access", None));
     manager.register_segment(
         1,
@@ -867,9 +1139,9 @@ fn malformed_warm_table() -> stoolap::storage::volume::table::SegmentedTable {
         SegmentMeta {
             segment_id: 1,
             file_path: Default::default(),
-            row_count: 2,
+            row_count: rows,
             min_row_id: 1,
-            max_row_id: 2,
+            max_row_id: rows as i64,
             creation_lsn: 0,
             seal_seq: 0,
             schema_version: 0,


### PR DESCRIPTION
I make sorted-column range narrowing distinguish a storage failure from unavailable optional metadata. A multi-group volume without group metadata previously returned the end of the volume as a proven boundary, so a matching range scan could return no rows. I keep that range open and propagate failures from boundary blocks that are actually read.

I change `CompressedBlockStore::binary_search_ge/gt` to `io::Result<Option<usize>>` and propagate errors through all four compressed-boundary calls in `SegmentedTable::prune_volume`. Missing or unusable optional metadata returns `Ok(None)`. Invalid column indices, contradictory group geometry and decode failures return errors. Exact duplicate boundaries and pruning of untouched corrupt groups retain their behavior. I leave the eager `ColumnData` searches unchanged.

This is a Stage 1 prerequisite of #122. I add no retained structure: 0 bytes per row and per volume, no new successful-path allocation or lock, and no per-row work. The added validation runs once per boundary and visited metadata group. Failed reads may construct an I/O error.

Row-latency acceptance is inconclusive. Source review and correctness checks are complete; I do not treat overlapping timing ranges as a performance pass.

Validation:

- 72 focused local tests passed across `fallible_group_access_test` and `ordered_limited_scan_test`; the same 72 passed with `--features test-filedb`.
- Reverting only production changes left 57 tests passing and made all 8 new bug guards fail. The public missing-metadata guard returned `[]` instead of `[65537, 65538]`. Exact source restoration made the guards pass. Two new valid-input cases are controls.
- `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings` passed.
- Independent source/test review, fixes and re-review closed with no blockers.
- All 14 CI checks passed, including the three platform full suites and coverage. I did not duplicate the full suite locally.

I measured parent `36cee1a3` against this patch using external release probes: opt-level 3, thin LTO, one codegen unit, panic abort. Each timing condition has seven identical-parent controls, seven parent runs and seven candidate runs in contiguous blocks. I retained every completed result. Power stayed fixed within each study, low-power mode was off, no Cargo/Rust jobs were observed at process boundaries, and the completed sleep/display audits were clean.

For cached integer boundary searches, each sample contains 64 GE/GT calls with exact index checks. The 16-group store keeps four selected groups resident under a 16 MiB cache setting. These measurements ran on battery power.

| Store | Parent p50 range, us/64 calls | Candidate p50 range | Median change |
|---|---:|---:|---:|
| 1 group | 2.292..2.542 | 2.334..2.417 | 0.00% |
| 16 groups | 2.750..3.042 | 2.916..3.042 | +5.95% |

The 16-group median rose from 2.792 to 2.958 us and median elapsed time rose 4.06%. I report this as an observed helper slowdown with uncertain attribution. Every timing run had exactly 6.4 million cache hits and zero misses. In separate allocation windows, 27 of 28 runs recorded zero allocations; the first single-group candidate run recorded 20 allocations and 1,120 bytes retained. One separate heap-profile capture did not reproduce that outlier. I retain it as unattributed.

I then ran a separate SQL regression screen on AC power at 16 and 64 MiB: 2,000 transactions per process at 1,000 scheduled transactions/s, each performing INSERT, UPDATE, PK point lookup and COMMIT. Mixed runs add 2,000 sorted cold-range reads and 10 ingest/checkpoint jobs through cloned handles. All 84 processes completed exact foreground/background counts with zero errors. The first battery-required SQL preflight ran no children; I fixed the SQL profile to AC before collecting samples.

The following changes compare medians of seven per-process quantiles, in p50 / p95 / p99 order:

| Cache/load | INSERT | UPDATE | PK point |
|---|---:|---:|---:|
| 16 MiB idle | +2.44% / +7.06% / +11.34% | +0.15% / +0.70% / +2.40% | +0.00% / +4.66% / +3.25% |
| 16 MiB mixed | -1.00% / -1.77% / -3.22% | +0.00% / -1.25% / -5.24% | -0.19% / -1.08% / -1.33% |
| 64 MiB idle | +2.46% / +5.97% / +4.07% | -1.61% / -2.71% / -0.68% | -2.59% / +1.90% / +8.96% |
| 64 MiB mixed | +3.13% / +6.23% / +14.54% | -0.28% / -0.96% / -3.31% | +0.39% / +0.43% / +4.72% |

INSERT centers and some tails rose, while UPDATE and point results vary by condition. The unchanged baseline varies substantially too. Each foreground or analytics p99 has only about 20 observations beyond it. In the 16 MiB idle case, median arrival lag shifted from about 196..197 us in controls to roughly 320 us later. The 1,000 transactions/s is scheduled offered load, not measured capacity. I cannot establish row-latency acceptance from this screen.

<details>
<summary>Foreground latency ranges, microseconds</summary>

Each cell is the minimum..maximum of seven process quantiles. I show the same-binary control range separately.

| Cache/load | Operation/quantile | Control | Parent | Candidate |
|---|---|---:|---:|---:|
| 16 MiB idle | insert p50 | 4.875..5.500 | 3.333..5.459 | 4.917..5.292 |
| 16 MiB idle | insert p95 | 10.292..12.375 | 10.000..11.666 | 10.584..14.042 |
| 16 MiB idle | insert p99 | 14.625..19.375 | 14.417..18.709 | 15.916..24.084 |
| 16 MiB idle | update p50 | 27.709..29.375 | 17.291..29.417 | 26.417..28.833 |
| 16 MiB idle | update p95 | 52.125..58.875 | 49.375..59.834 | 53.208..65.875 |
| 16 MiB idle | update p99 | 67.375..78.667 | 70.083..79.833 | 71.209..96.500 |
| 16 MiB idle | point p50 | 5.958..7.792 | 4.166..7.208 | 5.709..7.250 |
| 16 MiB idle | point p95 | 12.917..15.583 | 11.917..14.958 | 13.250..16.167 |
| 16 MiB idle | point p99 | 18.542..24.542 | 18.375..22.292 | 19.250..27.708 |
| 16 MiB idle | commit p50 | 22.833..27.417 | 17.208..26.500 | 20.625..26.208 |
| 16 MiB idle | commit p95 | 49.042..59.042 | 45.708..55.417 | 48.000..53.708 |
| 16 MiB idle | commit p99 | 70.500..90.875 | 71.250..84.042 | 72.458..91.333 |
| 16 MiB mixed | insert p50 | 2.042..4.334 | 3.250..4.792 | 3.292..4.292 |
| 16 MiB mixed | insert p95 | 6.417..14.917 | 12.417..15.125 | 13.125..15.208 |
| 16 MiB mixed | insert p99 | 17.417..36.542 | 29.916..35.792 | 30.834..38.916 |
| 16 MiB mixed | update p50 | 33.750..61.375 | 55.084..62.583 | 53.500..62.084 |
| 16 MiB mixed | update p95 | 67.125..156.208 | 146.875..160.875 | 146.333..160.375 |
| 16 MiB mixed | update p99 | 102.708..206.625 | 181.000..199.084 | 175.208..209.000 |
| 16 MiB mixed | point p50 | 10.708..22.166 | 19.417..23.166 | 18.959..22.208 |
| 16 MiB mixed | point p95 | 21.667..60.625 | 56.125..61.667 | 54.750..61.583 |
| 16 MiB mixed | point p99 | 38.750..72.041 | 66.958..71.584 | 64.708..74.667 |
| 16 MiB mixed | commit p50 | 9.542..24.542 | 18.541..25.333 | 18.250..22.459 |
| 16 MiB mixed | commit p95 | 2605.459..2803.458 | 2380.875..2738.167 | 2495.500..2783.583 |
| 16 MiB mixed | commit p99 | 3857.125..6098.083 | 4130.083..4760.416 | 4186.959..6471.708 |
| 64 MiB idle | insert p50 | 4.750..5.250 | 3.917..5.375 | 4.708..5.292 |
| 64 MiB idle | insert p95 | 10.167..11.125 | 9.875..10.916 | 10.750..11.708 |
| 64 MiB idle | insert p99 | 15.500..19.666 | 15.333..19.333 | 16.625..19.125 |
| 64 MiB idle | update p50 | 26.875..28.542 | 19.583..29.291 | 25.375..28.959 |
| 64 MiB idle | update p95 | 52.750..56.542 | 51.125..56.625 | 52.125..56.292 |
| 64 MiB idle | update p99 | 68.625..77.250 | 71.500..74.708 | 68.709..76.042 |
| 64 MiB idle | point p50 | 5.625..7.167 | 5.000..7.292 | 5.375..6.833 |
| 64 MiB idle | point p95 | 13.000..14.208 | 12.708..14.083 | 12.958..13.584 |
| 64 MiB idle | point p99 | 18.417..21.375 | 17.750..23.750 | 18.458..23.208 |
| 64 MiB idle | commit p50 | 21.417..26.250 | 18.792..26.917 | 19.708..25.416 |
| 64 MiB idle | commit p95 | 49.167..54.667 | 47.625..54.333 | 48.792..51.792 |
| 64 MiB idle | commit p99 | 72.250..85.083 | 72.917..84.833 | 72.333..85.125 |
| 64 MiB mixed | insert p50 | 3.416..4.084 | 3.000..4.208 | 3.417..4.709 |
| 64 MiB mixed | insert p95 | 11.750..14.625 | 12.500..14.125 | 13.667..15.209 |
| 64 MiB mixed | insert p99 | 27.041..38.834 | 28.250..35.250 | 29.750..36.209 |
| 64 MiB mixed | update p50 | 54.000..59.916 | 54.791..62.875 | 55.667..62.625 |
| 64 MiB mixed | update p95 | 145.125..152.375 | 148.750..160.875 | 150.500..156.000 |
| 64 MiB mixed | update p99 | 168.416..190.000 | 179.250..205.084 | 182.708..195.875 |
| 64 MiB mixed | point p50 | 19.166..21.833 | 18.666..22.833 | 20.125..23.208 |
| 64 MiB mixed | point p95 | 53.417..58.625 | 57.708..61.500 | 56.458..61.000 |
| 64 MiB mixed | point p99 | 61.250..69.792 | 66.459..74.166 | 66.834..73.834 |
| 64 MiB mixed | commit p50 | 18.917..23.833 | 15.709..23.000 | 18.334..23.583 |
| 64 MiB mixed | commit p95 | 2411.750..2867.167 | 2545.833..2835.000 | 2431.625..2817.500 |
| 64 MiB mixed | commit p99 | 3812.667..6782.334 | 3791.167..6828.041 | 4043.000..6863.959 |

</details>

Warm reads and the post-loop PK scan also have higher candidate centers than the parent. PK-scan control medians were higher than parent medians in all four conditions; warm-read controls were higher in three of four. That variation limits attribution. I retain these sparse auxiliary observations:

| Cache/load | Warm-query median change | PK-scan median change |
|---|---:|---:|
| 16 MiB idle | +39.70% | +23.88% |
| 16 MiB mixed | +31.65% | +29.06% |
| 64 MiB idle | +29.93% | +50.04% |
| 64 MiB mixed | +4.70% | +15.36% |

<details>
<summary>Throughput, first query after reopening and PK-ordered scan</summary>

Each cell is range / median across seven processes. First-query figures retain the OS file cache. Warm figures summarize each process's 10 following reads. The ordered scan returns exactly 1,024 rows.

| Cache/load | Cohort | Transactions/s | First query, ms | Warm median, us | PK-ordered scan, us |
|---|---|---:|---:|---:|---:|
| 16 MiB idle | control | 1000.345..1000.386 / 1000.360 | 0.678..0.876 / 0.693 | 3.479..5.958 / 4.604 | 206.084..335.750 / 261.542 |
| 16 MiB idle | base | 1000.271..1000.381 / 1000.302 | 0.490..0.810 / 0.758 | 2.854..5.771 / 4.042 | 95.541..270.459 / 163.125 |
| 16 MiB idle | candidate | 1000.285..1000.319 / 1000.302 | 0.593..0.938 / 0.775 | 4.250..6.292 / 5.646 | 128.291..244.458 / 202.083 |
| 16 MiB mixed | control | 1000.210..1000.306 / 1000.241 | 0.596..0.803 / 0.787 | 4.333..6.062 / 5.021 | 156.667..361.500 / 317.583 |
| 16 MiB mixed | base | 1000.177..1000.300 / 1000.257 | 0.773..0.813 / 0.780 | 4.292..5.583 / 4.542 | 233.500..346.334 / 253.375 |
| 16 MiB mixed | candidate | 1000.220..1000.342 / 1000.287 | 0.744..0.810 / 0.789 | 5.438..6.229 / 5.979 | 122.875..392.250 / 327.000 |
| 64 MiB idle | control | 1000.279..1000.317 / 1000.298 | 0.755..0.866 / 0.785 | 4.188..15.792 / 5.083 | 147.917..284.500 / 264.583 |
| 64 MiB idle | base | 1000.076..1000.325 / 1000.302 | 0.668..0.836 / 0.755 | 3.583..5.291 / 4.313 | 131.875..271.833 / 147.125 |
| 64 MiB idle | candidate | 1000.280..1000.435 / 1000.312 | 0.774..0.809 / 0.779 | 4.250..6.229 / 5.604 | 136.667..379.667 / 220.750 |
| 64 MiB mixed | control | 1000.223..1000.328 / 1000.260 | 0.684..0.875 / 0.767 | 3.958..5.312 / 4.771 | 94.416..356.667 / 315.750 |
| 64 MiB mixed | base | 1000.224..1000.311 / 1000.282 | 0.737..0.931 / 0.777 | 4.125..6.062 / 5.333 | 88.416..368.541 / 167.417 |
| 64 MiB mixed | candidate | 1000.172..1000.305 / 1000.297 | 0.772..0.857 / 0.790 | 4.917..6.187 / 5.583 | 165.834..349.833 / 193.125 |

</details>

All 28 SQL allocation runs matched exactly at both budgets and on both builds: 22,610 allocations and 30,686,976 allocated bytes per 200 idle transactions. Retained bytes grew from 4,961,241 to 5,025,929 on both builds. The process-lifetime peak was 68,470,270 bytes before and after the measured window; setup dominates that peak. Measurement buffers and reporting are outside the allocation window. I did not measure mixed-maintenance allocations or per-operation allocation counts.

The debugger pilot confirms the sorted SQL query reaches the changed helper during startup. Maintenance changes volume residency during mixed runs: their ending group cache is empty, with only about 3,347..3,497 total hits, so this is not continuous cached-helper exposure. Idle runs end with 3 entries and 1,769,472 decoded-cache bytes. Both budgets are above the observed working set. `MEMORY_STATS` supplies ending estimates, not per-ledger peaks or RSS; this is not a pressure/enforcement test.

I do not change the format, identity accessors, row-count closures, statement rollback, memory accounting or admission. Checkpoint timings cover only 10 jobs per mixed process, so their p95 and p99 select the same ninth sample. Seal/remover fence distributions, OS RSS and future-format cases are not measured here. I have not reproduced or reclassified historical #136 timings. The remaining Stage 1 work and the storage plan stay open.
