### PR TITLE
Borrow volume identities through fallible reader paths

### DIFF
--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -715,7 +715,7 @@ impl MVCCEngine {
 
                 // Sync auto-increment counters from segment data so the next
                 // generated row_id doesn't collide with cold rows.
-                self.sync_auto_increment_from_segments();
+                self.sync_auto_increment_from_segments()?;
 
                 // Migration: if we loaded from legacy snapshots, seal all data
                 // into volumes and remove the old snapshots/ directory.
@@ -1498,8 +1498,9 @@ impl MVCCEngine {
 
                 for (_, cs) in volumes.iter() {
                     let vol = &cs.volume;
+                    let row_ids = vol.row_ids()?;
                     let Some(start) = (0..vol.meta.row_count).find(|&i| {
-                        let row_id = vol.meta.row_ids[i];
+                        let row_id = row_ids[i];
                         !tombstones.contains_key(&row_id) && !seen.contains(&row_id)
                     }) else {
                         continue;
@@ -1514,8 +1515,7 @@ impl MVCCEngine {
                             }
                         }
                     }
-                    for i in start..vol.meta.row_count {
-                        let row_id = vol.meta.row_ids[i];
+                    for (i, &row_id) in row_ids.iter().enumerate().skip(start) {
                         if tombstones.contains_key(&row_id) || !seen.insert(row_id) {
                             continue;
                         }
@@ -3430,46 +3430,34 @@ impl MVCCEngine {
     /// the max row_id in segments (which may be higher than hot buffer).
     /// Normal secondary indexes are NOT populated from cold data.
     /// HNSW is the one cold index that needs explicit graph rebuild.
-    fn sync_auto_increment_from_segments(&self) {
-        // Collect segment data under segment_managers lock, then drop it
-        // before acquiring version_stores lock to avoid multi-lock deadlock.
-        let segment_data: Vec<(String, i64)> = {
+    fn sync_auto_increment_from_segments(&self) -> Result<()> {
+        let mut segment_data: Vec<_> = {
             let mgrs = self.segment_managers.read().unwrap();
             if mgrs.is_empty() {
-                return;
+                return Ok(());
             }
             mgrs.iter()
-                .filter_map(|(table_name, mgr)| {
-                    let segments = mgr.get_segments_ordered_meta();
-                    let mut max_vol_row_id: i64 = 0;
-                    for vol in &segments {
-                        // Row IDs are sorted (from B-tree iteration during seal).
-                        // Use last() for O(1) instead of iterating all row_ids.
-                        if let Some(&last_id) = vol.meta.row_ids.last() {
-                            if last_id > max_vol_row_id {
-                                max_vol_row_id = last_id;
-                            }
-                        }
-                    }
-                    if max_vol_row_id > 0 {
-                        Some((table_name.clone(), max_vol_row_id))
-                    } else {
-                        None
-                    }
-                })
+                .map(|(table_name, mgr)| (table_name.clone(), Arc::clone(mgr), 0i64))
                 .collect()
         };
 
-        if segment_data.is_empty() {
-            return;
+        for (_, mgr, max_vol_row_id) in &mut segment_data {
+            for vol in mgr.get_segments_ordered_meta() {
+                if let Some(&last_id) = vol.row_ids()?.last() {
+                    *max_vol_row_id = (*max_vol_row_id).max(last_id);
+                }
+            }
         }
 
         let stores = self.version_stores.read().unwrap();
-        for (table_name, max_vol_row_id) in &segment_data {
-            if let Some(store) = stores.get(table_name) {
-                store.set_auto_increment_counter(*max_vol_row_id);
+        for (table_name, _, max_vol_row_id) in &segment_data {
+            if *max_vol_row_id > 0 {
+                if let Some(store) = stores.get(table_name) {
+                    store.set_auto_increment_counter(*max_vol_row_id);
+                }
             }
         }
+        Ok(())
     }
 
     /// Drops a column from a table
@@ -4209,9 +4197,14 @@ impl MVCCEngine {
                     let vol = &cs.volume;
                     let mapping = mgr.get_volume_mapping(*seg_id, schema);
 
-                    for i in 0..vol.meta.row_count {
-                        let row_id = vol.meta.row_ids[i];
-
+                    let row_ids = match vol.row_ids() {
+                        Ok(ids) => ids,
+                        Err(_) => {
+                            write_error = true;
+                            break;
+                        }
+                    };
+                    for (i, &row_id) in row_ids.iter().enumerate() {
                         // Skip tombstoned rows not already in hot snapshot.
                         // For int-PK tables, pre-cutoff deletes are in `seen`.
                         // For non-int-PK tables, tombstones are the only signal.
@@ -5047,7 +5040,10 @@ impl MVCCEngine {
         // Sync auto-increment counters from segment managers.
         // Without this, tables loaded as volumes would have stale counters
         // and new INSERTs could collide with existing row IDs.
-        self.sync_auto_increment_from_segments();
+        if let Err(error) = self.sync_auto_increment_from_segments() {
+            self.registry.start_accepting_transactions();
+            return Err(error);
+        }
 
         // Increment schema epoch to invalidate all caches
         self.schema_epoch
@@ -5613,8 +5609,7 @@ impl MVCCEngine {
                 };
 
             for (vol_idx, (_seg_id, vol)) in volumes.iter().enumerate() {
-                for i in 0..vol.meta.row_count {
-                    let row_id = vol.meta.row_ids[i];
+                for (i, &row_id) in vol.row_ids()?.iter().enumerate() {
                     // Apply tombstone only if it was committed before the earliest
                     // snapshot (safe to physically remove). Tombstones created after
                     // are preserved — the row stays in the merged volume so snapshots
@@ -5640,14 +5635,15 @@ impl MVCCEngine {
             if live_refs.is_empty() {
                 // All rows in merged volumes are tombstoned. Remove those
                 // volumes and their tombstones, but keep unmerged volumes intact.
-                let merged_row_ids: FxHashSet<i64> = volumes
-                    .iter()
-                    .flat_map(|(_, vol)| vol.meta.row_ids.iter().copied())
-                    .collect();
+                for (_, vol) in volumes.iter() {
+                    for &row_id in vol.row_ids()? {
+                        seen.insert(row_id);
+                    }
+                }
                 mgr.replace_segments_atomic_remove_only(&old_ids);
                 // Only clear tombstones that were actually applied during compaction.
                 // Post-snapshot tombstones are preserved for snapshot visibility.
-                mgr.remove_tombstones_matching_snapshot(&applied_tombstones, &merged_row_ids);
+                mgr.remove_tombstones_matching_snapshot(&applied_tombstones, &seen);
 
                 // Persist manifest BEFORE deleting files (same safety as non-empty path).
                 if let Err(e) = mgr.persist_manifest_only() {
@@ -5778,6 +5774,22 @@ impl MVCCEngine {
                 }
             }
 
+            if prepare_error.is_none() && !new_volumes.is_empty() {
+                for (_, vol) in volumes.iter() {
+                    match vol.row_ids() {
+                        Ok(ids) => {
+                            for &row_id in ids {
+                                seen.insert(row_id);
+                            }
+                        }
+                        Err(error) => {
+                            prepare_error = Some(error.into());
+                            break;
+                        }
+                    }
+                }
+            }
+
             if prepare_error.is_some() || new_volumes.is_empty() {
                 // Clean up any volumes we did write before failure
                 let vol_table_dir = vol_dir.join(table_name);
@@ -5796,13 +5808,7 @@ impl MVCCEngine {
 
             // Clear only tombstones that existed at snapshot time for
             // row_ids in the merged volumes.
-            {
-                let merged_row_ids: FxHashSet<i64> = volumes
-                    .iter()
-                    .flat_map(|(_, vol)| vol.meta.row_ids.iter().copied())
-                    .collect();
-                mgr.remove_tombstones_matching_snapshot(&applied_tombstones, &merged_row_ids);
-            }
+            mgr.remove_tombstones_matching_snapshot(&applied_tombstones, &seen);
 
             // CRITICAL: Persist manifest BEFORE deleting old files.
             if let Err(e) = mgr.persist_manifest_only() {

--- a/src/storage/volume/format.rs
+++ b/src/storage/volume/format.rs
@@ -1040,7 +1040,8 @@ pub(crate) struct VolumeMetadata {
 /// The caller LZ4-compresses the result before writing to disk.
 pub(crate) fn serialize_volume_metadata(vol: &FrozenVolume) -> io::Result<Vec<u8>> {
     let col_count = vol.columns.len();
-    let estimated = 12 + col_count * 6 + vol.meta.row_ids.len() * 8 + col_count * 40;
+    let row_ids = vol.row_ids()?;
+    let estimated = 12 + col_count * 6 + row_ids.len() * 8 + col_count * 40;
     let mut buf = Vec::with_capacity(estimated);
 
     // Row count + col count
@@ -1099,7 +1100,7 @@ pub(crate) fn serialize_volume_metadata(vol: &FrozenVolume) -> io::Result<Vec<u8
     }
 
     // Row IDs (bulk — single memcpy on LE)
-    write_i64_bulk(&mut buf, &vol.meta.row_ids);
+    write_i64_bulk(&mut buf, row_ids);
 
     // Zone maps
     for zm in &vol.meta.zone_maps {

--- a/src/storage/volume/manifest.rs
+++ b/src/storage/volume/manifest.rs
@@ -1055,12 +1055,13 @@ impl SegmentManager {
                 _ => None,
             };
             if let Some(target) = target {
+                let row_ids = vol.row_ids()?;
                 let col = vol.columns.get(pi)?;
                 if vol.is_sorted(pi) {
                     let start = col.binary_search_ge(target);
                     let mut i = start;
                     while i < vol.meta.row_count && col.get_i64(i) == target {
-                        let rid = vol.meta.row_ids[i];
+                        let rid = row_ids[i];
                         if seen.insert(rid) && !ts.contains_key(&rid) {
                             if seg_ids.len() > 1 {
                                 if let Some(current_val) =
@@ -1077,8 +1078,7 @@ impl SegmentManager {
                         i += 1;
                     }
                 } else {
-                    for i in 0..vol.meta.row_count {
-                        let rid = vol.meta.row_ids[i];
+                    for (i, &rid) in row_ids.iter().enumerate() {
                         if !seen.insert(rid) {
                             continue;
                         }
@@ -1253,11 +1253,12 @@ impl SegmentManager {
                 vol
             };
             // Tier 3: Per-volume hash index
+            let row_ids = vol.row_ids()?;
             let mut vol_result: Option<i64> = None;
             if !has_missing {
                 // Common path: no schema evolution, pass values directly (zero alloc)
                 vol.unique_lookup_all(&vol_col_indices, values, |row_idx| {
-                    let rid = vol.meta.row_ids[row_idx as usize];
+                    let rid = row_ids[row_idx as usize];
                     if ts.contains_key(&rid) {
                         false
                     } else if seen.insert(rid) {
@@ -1276,8 +1277,7 @@ impl SegmentManager {
                     .filter(|(_, &vi)| vi != usize::MAX)
                     .map(|(i, &vi)| vol.columns.get(vi).map(|col| (i, col)))
                     .collect::<std::io::Result<_>>()?;
-                for i in 0..vol.meta.row_count {
-                    let rid = vol.meta.row_ids[i];
+                for (i, &rid) in row_ids.iter().enumerate() {
                     if ts.contains_key(&rid) || !seen.insert(rid) {
                         continue;
                     }

--- a/src/storage/volume/scanner.rs
+++ b/src/storage/volume/scanner.rs
@@ -325,7 +325,8 @@ impl VolumeScanner {
         volume: Arc<FrozenVolume>,
         project_cols: Vec<usize>,
         _delete_vector: Option<()>,
-    ) -> Self {
+    ) -> Result<Self> {
+        let end_idx = volume.row_ids()?.len();
         let project = if project_cols.is_empty() {
             (0..volume.columns.len()).collect()
         } else {
@@ -335,7 +336,7 @@ impl VolumeScanner {
         // Stamp with current global eviction epoch so the volume ages correctly.
         volume.mark_accessed();
         let mut s = Self {
-            end_idx: volume.meta.row_count,
+            end_idx,
             volume,
             project_cols: project,
             is_full_projection,
@@ -373,7 +374,7 @@ impl VolumeScanner {
             }
             s.needed_cols = Some(mask);
         }
-        s
+        Ok(s)
     }
 
     /// Create a scanner with a start/end range (for binary-search narrowing).
@@ -383,7 +384,8 @@ impl VolumeScanner {
         start_idx: usize,
         end_idx: usize,
         _delete_vector: Option<()>,
-    ) -> Self {
+    ) -> Result<Self> {
+        volume.row_ids()?;
         let project = if project_cols.is_empty() {
             (0..volume.columns.len()).collect()
         } else {
@@ -430,7 +432,7 @@ impl VolumeScanner {
             }
             s.needed_cols = Some(mask);
         }
-        s
+        Ok(s)
     }
 
     /// Set per-transaction pending cold deletes. The owning transaction
@@ -1488,7 +1490,7 @@ mod tests {
     #[test]
     fn test_full_scan() {
         let vol = make_test_volume();
-        let mut scanner = VolumeScanner::new(vol, vec![], None);
+        let mut scanner = VolumeScanner::new(vol, vec![], None).unwrap();
 
         let mut count = 0;
         while scanner.next() {
@@ -1504,7 +1506,7 @@ mod tests {
     fn test_projected_scan() {
         let vol = make_test_volume();
         // Only scan name and price (columns 1, 2)
-        let mut scanner = VolumeScanner::new(vol, vec![1, 2], None);
+        let mut scanner = VolumeScanner::new(vol, vec![1, 2], None).unwrap();
 
         assert!(scanner.next());
         let row = scanner.row();
@@ -1517,7 +1519,7 @@ mod tests {
     fn test_range_scan() {
         let vol = make_test_volume();
         // Scan rows 2..4 (indices 2, 3)
-        let mut scanner = VolumeScanner::with_range(Arc::clone(&vol), vec![], 2, 4, None);
+        let mut scanner = VolumeScanner::with_range(Arc::clone(&vol), vec![], 2, 4, None).unwrap();
 
         let mut count = 0;
         let mut ids = Vec::new();
@@ -1541,7 +1543,7 @@ mod tests {
     #[test]
     fn test_take_row() {
         let vol = make_test_volume();
-        let mut scanner = VolumeScanner::new(vol, vec![0], None);
+        let mut scanner = VolumeScanner::new(vol, vec![0], None).unwrap();
 
         assert!(scanner.next());
         let row = scanner.take_row();
@@ -1553,20 +1555,10 @@ mod tests {
         let vol = make_test_volume();
 
         // Create two scanners: first 2 rows, then last 2 rows
-        let scanner1 = Box::new(VolumeScanner::with_range(
-            Arc::clone(&vol),
-            vec![0],
-            0,
-            2,
-            None,
-        ));
-        let scanner2 = Box::new(VolumeScanner::with_range(
-            Arc::clone(&vol),
-            vec![0],
-            3,
-            5,
-            None,
-        ));
+        let scanner1 =
+            Box::new(VolumeScanner::with_range(Arc::clone(&vol), vec![0], 0, 2, None).unwrap());
+        let scanner2 =
+            Box::new(VolumeScanner::with_range(Arc::clone(&vol), vec![0], 3, 5, None).unwrap());
 
         let mut merger = MergingScanner::new(vec![scanner1, scanner2]);
 
@@ -1583,10 +1575,10 @@ mod tests {
     #[test]
     fn test_estimated_count() {
         let vol = make_test_volume();
-        let scanner = VolumeScanner::new(Arc::clone(&vol), vec![], None);
+        let scanner = VolumeScanner::new(Arc::clone(&vol), vec![], None).unwrap();
         assert_eq!(scanner.estimated_count(), Some(5));
 
-        let scanner = VolumeScanner::with_range(vol, vec![], 2, 4, None);
+        let scanner = VolumeScanner::with_range(vol, vec![], 2, 4, None).unwrap();
         assert_eq!(scanner.estimated_count(), Some(2));
     }
 }

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -308,10 +308,11 @@ impl SegmentedTable {
             // Use column mapping to translate schema indices to physical volume indices.
             // After DROP COLUMN + ADD COLUMN, schema positions may not match volume layout.
             let mapping = self.segment_mgr.get_volume_mapping(*seg_id, schema);
+            let row_ids = vol.row_ids()?;
             let Some(start) = (0..vol.meta.row_count).find(|&i| {
                 cs.is_visible(i)
-                    && !self.is_row_tombstoned(&ts, vol.meta.row_ids[i])
-                    && !hot_skip.contains(&vol.meta.row_ids[i])
+                    && !self.is_row_tombstoned(&ts, row_ids[i])
+                    && !hot_skip.contains(&row_ids[i])
             }) else {
                 continue;
             };
@@ -319,11 +320,10 @@ impl SegmentedTable {
                 Some(super::writer::ColSource::Volume(phys)) => vol.columns.get(*phys).map(Some),
                 _ => Ok(None),
             }).collect::<std::io::Result<smallvec::SmallVec<[Option<&super::column::ColumnData>; 4]>>>()?;
-            for i in start..vol.meta.row_count {
+            for (i, &rid) in row_ids.iter().enumerate().skip(start) {
                 if !cs.is_visible(i) {
                     continue;
                 }
-                let rid = vol.meta.row_ids[i];
                 if self.is_row_tombstoned(&ts, rid) {
                     continue;
                 }
@@ -393,8 +393,9 @@ impl SegmentedTable {
             let vol = &cs.volume;
             // Use column mapping to translate schema indices to physical volume indices.
             let mapping = self.segment_mgr.get_volume_mapping(*seg_id, schema);
+            let row_ids = vol.row_ids()?;
             let Some(start) = (0..vol.meta.row_count)
-                .find(|&i| cs.is_visible(i) && !self.is_row_tombstoned(&ts, vol.meta.row_ids[i]))
+                .find(|&i| cs.is_visible(i) && !self.is_row_tombstoned(&ts, row_ids[i]))
             else {
                 continue;
             };
@@ -402,11 +403,10 @@ impl SegmentedTable {
                 Some(super::writer::ColSource::Volume(phys)) => vol.columns.get(*phys).map(Some),
                 _ => Ok(None),
             }).collect::<std::io::Result<smallvec::SmallVec<[Option<&super::column::ColumnData>; 4]>>>()?;
-            for i in start..vol.meta.row_count {
+            for (i, &rid) in row_ids.iter().enumerate().skip(start) {
                 if !cs.is_visible(i) {
                     continue;
                 }
-                let rid = vol.meta.row_ids[i];
                 if self.is_row_tombstoned(&ts, rid) {
                     continue;
                 }
@@ -877,7 +877,7 @@ impl SegmentedTable {
                 )
             } else {
                 VolumeScanner::new(Arc::clone(vol), column_indices.to_vec(), None)
-            };
+            }?;
             // Each scanner gets the same small hot_skip Arc (no clone of hot IDs).
             // Inter-volume dedup is handled by the per-volume visibility bitmap.
             scanner.set_skip_sets(Arc::clone(&tombstones_arc), Arc::clone(&hot_skip_arc));
@@ -1030,12 +1030,13 @@ impl SegmentedTable {
                     }
                 };
 
+                let row_ids = vol.row_ids()?;
                 let mut vol_rows = RowVec::new();
                 while let Some(i) = next_row() {
                     if !cs.is_visible(i) {
                         continue;
                     }
-                    let row_id = vol.meta.row_ids[i];
+                    let row_id = row_ids[i];
                     if self.is_row_tombstoned(tombstones_ref, row_id)
                         || hot_skip_ref.contains(&row_id)
                     {
@@ -1249,7 +1250,7 @@ impl SegmentedTable {
     #[allow(clippy::too_many_arguments)]
     fn min_column_scan_generic(
         &self,
-        vol: &FrozenVolume,
+        row_ids: &[i64],
         cs: &super::manifest::ColdSegment,
         col: &super::column::ColumnData,
         overall_min: &mut Option<Value>,
@@ -1257,11 +1258,10 @@ impl SegmentedTable {
         hot_skip: &FxHashSet<i64>,
         no_tombstones: bool,
     ) {
-        for i in 0..vol.meta.row_count {
+        for (i, &rid) in row_ids.iter().enumerate() {
             if col.is_null(i) || !cs.is_visible(i) {
                 continue;
             }
-            let rid = vol.meta.row_ids[i];
             if hot_skip.contains(&rid) {
                 continue;
             }
@@ -1284,7 +1284,7 @@ impl SegmentedTable {
     #[allow(clippy::too_many_arguments)]
     fn max_column_scan_generic(
         &self,
-        vol: &FrozenVolume,
+        row_ids: &[i64],
         cs: &super::manifest::ColdSegment,
         col: &super::column::ColumnData,
         overall_max: &mut Option<Value>,
@@ -1292,11 +1292,10 @@ impl SegmentedTable {
         hot_skip: &FxHashSet<i64>,
         no_tombstones: bool,
     ) {
-        for i in 0..vol.meta.row_count {
+        for (i, &rid) in row_ids.iter().enumerate() {
             if col.is_null(i) || !cs.is_visible(i) {
                 continue;
             }
-            let rid = vol.meta.row_ids[i];
             if hot_skip.contains(&rid) {
                 continue;
             }
@@ -1498,11 +1497,10 @@ impl Table for SegmentedTable {
 
             let mapping = cs.mapping.clone();
 
-            for i in 0..vol.meta.row_count {
+            for (i, &row_id) in vol.row_ids()?.iter().enumerate() {
                 if !cs.is_visible(i) {
                     continue;
                 }
-                let row_id = vol.meta.row_ids[i];
                 if self.is_row_tombstoned(&tombstones_arc, row_id) || hot_skip.contains(&row_id) {
                     continue;
                 }
@@ -1745,11 +1743,10 @@ impl Table for SegmentedTable {
         let mut ids = Vec::new();
         for (_, cs) in volumes.iter() {
             let vol = &cs.volume;
-            for i in 0..vol.meta.row_count {
+            for (i, &id) in vol.row_ids()?.iter().enumerate() {
                 if !cs.is_visible(i) {
                     continue;
                 }
-                let id = vol.meta.row_ids[i];
                 if !self.is_row_tombstoned(&tombstones_arc, id) && !hot_skip.contains(&id) {
                     ids.push(id);
                 }
@@ -1855,11 +1852,10 @@ impl Table for SegmentedTable {
 
             let mapping = cs.mapping.clone();
 
-            for i in 0..vol.meta.row_count {
+            for (i, &row_id) in vol.row_ids()?.iter().enumerate() {
                 if !cs.is_visible(i) {
                     continue;
                 }
-                let row_id = vol.meta.row_ids[i];
                 if self.is_row_tombstoned(&tombstones_arc, row_id) || hot_skip.contains(&row_id) {
                     continue;
                 }
@@ -2183,7 +2179,7 @@ impl Table for SegmentedTable {
             Default::default(),
         );
         for (nf_idx, (_seg_id, cs)) in volumes.iter().enumerate() {
-            for &rid in &cs.volume.meta.row_ids {
+            for &rid in cs.volume.row_ids()? {
                 if hot_skip.contains(&rid) || self.is_row_tombstoned(&tombstones_arc, rid) {
                     continue;
                 }
@@ -2225,8 +2221,7 @@ impl Table for SegmentedTable {
 
             let mapping = self.segment_mgr.get_volume_mapping(*seg_id, current_schema);
 
-            for i in 0..vol.meta.row_count {
-                let rid = vol.meta.row_ids[i];
+            for (i, &rid) in vol.row_ids()?.iter().enumerate() {
                 if authority.get(&rid) != Some(&nf_idx) {
                     continue;
                 }
@@ -2342,11 +2337,10 @@ impl Table for SegmentedTable {
 
             let mapping = self.segment_mgr.get_volume_mapping(*seg_id, current_schema);
 
-            for i in 0..vol.meta.row_count {
+            for (i, &row_id) in vol.row_ids()?.iter().enumerate() {
                 if !cs.is_visible(i) {
                     continue;
                 }
-                let row_id = vol.meta.row_ids[i];
                 if self.is_row_tombstoned(&tombstones_arc, row_id) || hot_skip.contains(&row_id) {
                     continue;
                 }
@@ -2610,10 +2604,11 @@ impl Table for SegmentedTable {
 
         for (seg_id, cs) in volumes.iter() {
             let vol = &cs.volume;
+            let row_ids = vol.row_ids()?;
             let Some(start) = (0..vol.meta.row_count).find(|&i| {
                 cs.is_visible(i)
-                    && !self.is_row_tombstoned(&tombstones_arc, vol.meta.row_ids[i])
-                    && !hot_skip.contains(&vol.meta.row_ids[i])
+                    && !self.is_row_tombstoned(&tombstones_arc, row_ids[i])
+                    && !hot_skip.contains(&row_ids[i])
             }) else {
                 continue;
             };
@@ -2631,7 +2626,7 @@ impl Table for SegmentedTable {
                 if !cs.is_visible(i) {
                     continue;
                 }
-                let rid = vol.meta.row_ids[i];
+                let rid = row_ids[i];
                 if self.is_row_tombstoned(&tombstones_arc, rid) || hot_skip.contains(&rid) {
                     continue;
                 }
@@ -2795,6 +2790,7 @@ impl Table for SegmentedTable {
                 }
             }
 
+            let row_ids = vol.row_ids()?;
             // Typed direct scan: compare on primitive types to avoid Value alloc
             if let Some(pi) = phys {
                 let col = vol.columns.get(pi)?;
@@ -2806,7 +2802,7 @@ impl Table for SegmentedTable {
                             _ => {
                                 // Type mismatch: fall through to generic path
                                 self.min_column_scan_generic(
-                                    vol,
+                                    row_ids,
                                     cs,
                                     col,
                                     &mut overall_min,
@@ -2821,7 +2817,7 @@ impl Table for SegmentedTable {
                             if nulls[i] || !cs.is_visible(i) {
                                 continue;
                             }
-                            let rid = vol.meta.row_ids[i];
+                            let rid = row_ids[i];
                             if hot_skip.contains(&rid) {
                                 continue;
                             }
@@ -2843,7 +2839,7 @@ impl Table for SegmentedTable {
                             None => None,
                             _ => {
                                 self.min_column_scan_generic(
-                                    vol,
+                                    row_ids,
                                     cs,
                                     col,
                                     &mut overall_min,
@@ -2858,7 +2854,7 @@ impl Table for SegmentedTable {
                             if nulls[i] || !cs.is_visible(i) {
                                 continue;
                             }
-                            let rid = vol.meta.row_ids[i];
+                            let rid = row_ids[i];
                             if hot_skip.contains(&rid) {
                                 continue;
                             }
@@ -2889,7 +2885,7 @@ impl Table for SegmentedTable {
                             None => None,
                             _ => {
                                 self.min_column_scan_generic(
-                                    vol,
+                                    row_ids,
                                     cs,
                                     col,
                                     &mut overall_min,
@@ -2904,7 +2900,7 @@ impl Table for SegmentedTable {
                             if nulls[i] || !cs.is_visible(i) {
                                 continue;
                             }
-                            let rid = vol.meta.row_ids[i];
+                            let rid = row_ids[i];
                             if hot_skip.contains(&rid) {
                                 continue;
                             }
@@ -2929,7 +2925,7 @@ impl Table for SegmentedTable {
                     _ => {
                         // Dictionary, Boolean, Bytes: use generic get_value path
                         self.min_column_scan_generic(
-                            vol,
+                            row_ids,
                             cs,
                             col,
                             &mut overall_min,
@@ -2946,7 +2942,7 @@ impl Table for SegmentedTable {
                     if !cs.is_visible(i) {
                         return false;
                     }
-                    let rid = vol.meta.row_ids[i];
+                    let rid = row_ids[i];
                     if hot_skip.contains(&rid) {
                         return false;
                     }
@@ -3095,6 +3091,7 @@ impl Table for SegmentedTable {
                 }
             }
 
+            let row_ids = vol.row_ids()?;
             // Typed direct scan: compare on primitive types to avoid Value alloc
             if let Some(pi) = phys {
                 let col = vol.columns.get(pi)?;
@@ -3105,7 +3102,7 @@ impl Table for SegmentedTable {
                             None => None,
                             _ => {
                                 self.max_column_scan_generic(
-                                    vol,
+                                    row_ids,
                                     cs,
                                     col,
                                     &mut overall_max,
@@ -3120,7 +3117,7 @@ impl Table for SegmentedTable {
                             if nulls[i] || !cs.is_visible(i) {
                                 continue;
                             }
-                            let rid = vol.meta.row_ids[i];
+                            let rid = row_ids[i];
                             if hot_skip.contains(&rid) {
                                 continue;
                             }
@@ -3142,7 +3139,7 @@ impl Table for SegmentedTable {
                             None => None,
                             _ => {
                                 self.max_column_scan_generic(
-                                    vol,
+                                    row_ids,
                                     cs,
                                     col,
                                     &mut overall_max,
@@ -3157,7 +3154,7 @@ impl Table for SegmentedTable {
                             if nulls[i] || !cs.is_visible(i) {
                                 continue;
                             }
-                            let rid = vol.meta.row_ids[i];
+                            let rid = row_ids[i];
                             if hot_skip.contains(&rid) {
                                 continue;
                             }
@@ -3188,7 +3185,7 @@ impl Table for SegmentedTable {
                             None => None,
                             _ => {
                                 self.max_column_scan_generic(
-                                    vol,
+                                    row_ids,
                                     cs,
                                     col,
                                     &mut overall_max,
@@ -3203,7 +3200,7 @@ impl Table for SegmentedTable {
                             if nulls[i] || !cs.is_visible(i) {
                                 continue;
                             }
-                            let rid = vol.meta.row_ids[i];
+                            let rid = row_ids[i];
                             if hot_skip.contains(&rid) {
                                 continue;
                             }
@@ -3228,7 +3225,7 @@ impl Table for SegmentedTable {
                     _ => {
                         // Dictionary, Boolean, Bytes: use generic get_value path
                         self.max_column_scan_generic(
-                            vol,
+                            row_ids,
                             cs,
                             col,
                             &mut overall_max,
@@ -3243,7 +3240,7 @@ impl Table for SegmentedTable {
                     if !cs.is_visible(i) {
                         return false;
                     }
-                    let rid = vol.meta.row_ids[i];
+                    let rid = row_ids[i];
                     if hot_skip.contains(&rid) {
                         return false;
                     }
@@ -3315,10 +3312,11 @@ impl Table for SegmentedTable {
         let has_non_null_default = !default_val.is_null();
         for (seg_id, cs) in volumes.iter() {
             let vol = &cs.volume;
+            let row_ids = vol.row_ids()?;
             let Some(start) = (0..vol.meta.row_count).find(|&i| {
                 cs.is_visible(i)
-                    && !self.is_row_tombstoned(&tombstones_arc, vol.meta.row_ids[i])
-                    && !hot_skip.contains(&vol.meta.row_ids[i])
+                    && !self.is_row_tombstoned(&tombstones_arc, row_ids[i])
+                    && !hot_skip.contains(&row_ids[i])
             }) else {
                 continue;
             };
@@ -3332,11 +3330,10 @@ impl Table for SegmentedTable {
                 None
             };
             let column = phys.map(|pi| vol.columns.get(pi)).transpose()?;
-            for i in start..vol.meta.row_count {
+            for (i, &rid) in row_ids.iter().enumerate().skip(start) {
                 if !cs.is_visible(i) {
                     continue;
                 }
-                let rid = vol.meta.row_ids[i];
                 if self.is_row_tombstoned(&tombstones_arc, rid) || hot_skip.contains(&rid) {
                     continue;
                 }
@@ -3393,10 +3390,11 @@ impl Table for SegmentedTable {
         let has_non_null_default = !default_val.is_null();
         for (seg_id, cs) in volumes.iter() {
             let vol = &cs.volume;
+            let row_ids = vol.row_ids()?;
             let Some(start) = (0..vol.meta.row_count).find(|&i| {
                 cs.is_visible(i)
-                    && !self.is_row_tombstoned(&tombstones_arc, vol.meta.row_ids[i])
-                    && !hot_skip.contains(&vol.meta.row_ids[i])
+                    && !self.is_row_tombstoned(&tombstones_arc, row_ids[i])
+                    && !hot_skip.contains(&row_ids[i])
             }) else {
                 continue;
             };
@@ -3410,11 +3408,10 @@ impl Table for SegmentedTable {
                 None
             };
             let column = phys.map(|pi| vol.columns.get(pi)).transpose()?;
-            for i in start..vol.meta.row_count {
+            for (i, &rid) in row_ids.iter().enumerate().skip(start) {
                 if !cs.is_visible(i) {
                     continue;
                 }
-                let rid = vol.meta.row_ids[i];
                 if self.is_row_tombstoned(&tombstones_arc, rid) || hot_skip.contains(&rid) {
                     continue;
                 }
@@ -3513,20 +3510,19 @@ impl Table for SegmentedTable {
                 }
 
                 // Fallback: row-by-row scan on this volume's column
+                let row_ids = vol.row_ids()?;
                 let Some(start) = (0..vol.meta.row_count).find(|&i| {
                     cs.is_visible(i)
-                        && !hot_skip.contains(&vol.meta.row_ids[i])
-                        && (no_tombstones
-                            || !self.is_row_tombstoned(&tombstones_arc, vol.meta.row_ids[i]))
+                        && !hot_skip.contains(&row_ids[i])
+                        && (no_tombstones || !self.is_row_tombstoned(&tombstones_arc, row_ids[i]))
                 }) else {
                     continue;
                 };
                 let col = vol.columns.get(pi)?;
-                for i in start..vol.meta.row_count {
+                for (i, &rid) in row_ids.iter().enumerate().skip(start) {
                     if !cs.is_visible(i) {
                         continue;
                     }
-                    let rid = vol.meta.row_ids[i];
                     if hot_skip.contains(&rid) {
                         continue;
                     }
@@ -3539,11 +3535,12 @@ impl Table for SegmentedTable {
                 }
             } else if has_non_null_default {
                 // Column was added after this volume was sealed — use default
+                let row_ids = vol.row_ids()?;
                 let has_visible = (0..vol.meta.row_count).any(|i| {
                     if !cs.is_visible(i) {
                         return false;
                     }
-                    let rid = vol.meta.row_ids[i];
+                    let rid = row_ids[i];
                     if hot_skip.contains(&rid) {
                         return false;
                     }
@@ -3604,10 +3601,11 @@ impl Table for SegmentedTable {
         for (_seg_id, cs) in volumes.iter() {
             let vol = &cs.volume;
             let mapping = &cs.mapping;
+            let row_ids = vol.row_ids()?;
             let Some(start) = (0..vol.meta.row_count).find(|&i| {
                 cs.is_visible(i)
-                    && !self.is_row_tombstoned(&tombstones_arc, vol.meta.row_ids[i])
-                    && !hot_skip.contains(&vol.meta.row_ids[i])
+                    && !self.is_row_tombstoned(&tombstones_arc, row_ids[i])
+                    && !hot_skip.contains(&row_ids[i])
             }) else {
                 continue;
             };
@@ -3622,11 +3620,10 @@ impl Table for SegmentedTable {
             };
 
             let column = phys_col.map(|pc| vol.columns.get(pc)).transpose()?;
-            for i in start..vol.meta.row_count {
+            for (i, &rid) in row_ids.iter().enumerate().skip(start) {
                 if !cs.is_visible(i) {
                     continue;
                 }
-                let rid = vol.meta.row_ids[i];
                 if self.is_row_tombstoned(&tombstones_arc, rid) || hot_skip.contains(&rid) {
                     continue;
                 }
@@ -3719,10 +3716,11 @@ impl Table for SegmentedTable {
                     continue;
                 }
             }
+            let row_ids = vol.row_ids()?;
             let Some(start) = (0..vol.meta.row_count).find(|&i| {
                 cs.is_visible(i)
-                    && !self.is_row_tombstoned(&tombstones_arc, vol.meta.row_ids[i])
-                    && !hot_skip.contains(&vol.meta.row_ids[i])
+                    && !self.is_row_tombstoned(&tombstones_arc, row_ids[i])
+                    && !hot_skip.contains(&row_ids[i])
             }) else {
                 continue;
             };
@@ -3740,11 +3738,10 @@ impl Table for SegmentedTable {
             };
 
             let column = phys_col.map(|pc| vol.columns.get(pc)).transpose()?;
-            for i in start..vol.meta.row_count {
+            for (i, &rid) in row_ids.iter().enumerate().skip(start) {
                 if !cs.is_visible(i) {
                     continue;
                 }
-                let rid = vol.meta.row_ids[i];
                 if self.is_row_tombstoned(&tombstones_arc, rid) || hot_skip.contains(&rid) {
                     continue;
                 }
@@ -3847,8 +3844,8 @@ impl Table for SegmentedTable {
         //    For DESC, we iterate each source from the end.
 
         // Pre-compute column mappings for each volume.
-        struct VolSource {
-            row_ids: Vec<i64>,
+        struct VolSource<'a> {
+            row_ids: &'a [i64],
             cursor: usize,
             mapping: super::writer::ColumnMapping,
             volume: Arc<FrozenVolume>,
@@ -3864,7 +3861,7 @@ impl Table for SegmentedTable {
             }
             let mapping = self.segment_mgr.get_volume_mapping(*seg_id, &schema);
             vol_sources.push(VolSource {
-                row_ids: vol.meta.row_ids.clone(),
+                row_ids: vol.row_ids()?,
                 cursor: if ascending { 0 } else { vol.meta.row_count },
                 mapping,
                 volume: Arc::clone(&cs.volume),
@@ -4234,7 +4231,7 @@ impl Table for SegmentedTable {
                     }
                 }
                 let mut scanner =
-                    VolumeScanner::with_range(Arc::clone(vol), all_cols.clone(), start, end, None);
+                    VolumeScanner::with_range(Arc::clone(vol), all_cols.clone(), start, end, None)?;
                 scanner.set_skip_sets(Arc::clone(&tombstones_arc), Arc::clone(&hot_skip_arc));
                 scanner.set_visibility_bitmap(cs.visible.clone());
                 scanner.snapshot_seq = self.snapshot_seq;
@@ -4640,11 +4637,10 @@ impl Table for SegmentedTable {
             for (seg_id, cs) in volumes.iter() {
                 let vol = &cs.volume;
                 let mapping = self.segment_mgr.get_volume_mapping(*seg_id, &schema);
-                for i in 0..vol.meta.row_count {
+                for (i, &row_id) in vol.row_ids()?.iter().enumerate() {
                     if !cs.is_visible(i) {
                         continue;
                     }
-                    let row_id = vol.meta.row_ids[i];
                     if self.is_row_tombstoned(&tombstones_arc, row_id) || hot_skip.contains(&row_id)
                     {
                         continue;
@@ -5378,6 +5374,7 @@ impl Table for SegmentedTable {
                 let mut agg_columns =
                     smallvec::SmallVec::<[Option<&super::column::ColumnData>; 4]>::new();
                 let mut group_candidates: Vec<usize> = Vec::new();
+                let row_ids = vol.row_ids()?;
                 let row_count = vol.meta.row_count;
                 let rg_size = super::column::ROW_GROUP_SIZE;
                 let num_groups = row_count.div_ceil(rg_size);
@@ -5431,7 +5428,7 @@ impl Table for SegmentedTable {
                         if !cs.is_visible(i) {
                             continue;
                         }
-                        let row_id = vol.meta.row_ids[i];
+                        let row_id = row_ids[i];
                         if self.is_row_tombstoned(tombstones_ref, row_id)
                             || hot_skip_ref.contains(&row_id)
                         {
@@ -6128,10 +6125,11 @@ impl Table for SegmentedTable {
                     return Ok(None);
                 }
 
+                let row_ids = vol.row_ids()?;
                 let Some(start) = (0..vol.meta.row_count).find(|&i| {
                     cs.is_visible(i)
-                        && !self.is_row_tombstoned(tombstones_ref, vol.meta.row_ids[i])
-                        && !hot_skip_ref.contains(&vol.meta.row_ids[i])
+                        && !self.is_row_tombstoned(tombstones_ref, row_ids[i])
+                        && !hot_skip_ref.contains(&row_ids[i])
                 }) else {
                     return Ok(None);
                 };
@@ -6193,7 +6191,7 @@ impl Table for SegmentedTable {
                                     if !cs.is_visible(i) {
                                         continue;
                                     }
-                                    let rid = vol.meta.row_ids[i];
+                                    let rid = row_ids[i];
                                     if self.is_row_tombstoned(tombstones_ref, rid)
                                         || hot_skip_ref.contains(&rid)
                                     {
@@ -6235,11 +6233,10 @@ impl Table for SegmentedTable {
                             let mut null_acc: Vec<Accum> = vec![Accum::default(); agg_count];
                             let mut null_cnt: u32 = 0;
 
-                            for i in start..vol.meta.row_count {
+                            for (i, &rid) in row_ids.iter().enumerate().skip(start) {
                                 if !cs.is_visible(i) {
                                     continue;
                                 }
-                                let rid = vol.meta.row_ids[i];
                                 if self.is_row_tombstoned(tombstones_ref, rid)
                                     || hot_skip_ref.contains(&rid)
                                 {
@@ -6291,11 +6288,10 @@ impl Table for SegmentedTable {
                     super::writer::ColSource::Default(default_val) => {
                         let mut la = vec![Accum::default(); agg_count];
                         let mut visible = 0usize;
-                        for i in start..vol.meta.row_count {
+                        for (i, &rid) in row_ids.iter().enumerate().skip(start) {
                             if !cs.is_visible(i) {
                                 continue;
                             }
-                            let rid = vol.meta.row_ids[i];
                             if self.is_row_tombstoned(tombstones_ref, rid)
                                 || hot_skip_ref.contains(&rid)
                             {

--- a/tests/fallible_group_access_test.rs
+++ b/tests/fallible_group_access_test.rs
@@ -1089,7 +1089,7 @@ fn scanner_whole_column_failures_are_sticky_in_both_directions() {
         for mode in 0..3 {
             let mut volume = two_column_volume();
             volume.columns = LazyColumns::metadata_only(vec![DataType::Integer; 2]);
-            let mut scanner = VolumeScanner::new(Arc::new(volume), vec![1], None);
+            let mut scanner = VolumeScanner::new(Arc::new(volume), vec![1], None).unwrap();
             scanner.set_ordered_walk(ascending);
             if mode == 1 {
                 scanner.set_stop_key(1, &Value::Integer(1), ascending);
@@ -1497,7 +1497,7 @@ fn scanner_reports_a_missing_group_for_full_and_partial_projections() {
             2,
         );
         volume.columns = LazyColumns::deferred(store, vec![DataType::Integer; 2]);
-        let mut scanner = VolumeScanner::new(Arc::new(volume), projection, None);
+        let mut scanner = VolumeScanner::new(Arc::new(volume), projection, None).unwrap();
         let outcome = catch_unwind(AssertUnwindSafe(|| scanner.next()));
         assert!(outcome.is_ok(), "scanner panicked on missing group");
         assert!(!outcome.unwrap());
@@ -1528,7 +1528,7 @@ fn scanner_reports_structural_payload_corruption_after_reopen() {
     bytes.extend_from_slice(&crc32fast::hash(&bytes).to_le_bytes());
     std::fs::write(&path, bytes).unwrap();
     let volume = Arc::new(read_volume_from_disk(&path).unwrap());
-    let mut scanner = VolumeScanner::new(volume, vec![1], None);
+    let mut scanner = VolumeScanner::new(volume, vec![1], None).unwrap();
     assert!(!scanner.next(), "malformed block yielded a row");
     assert!(
         scanner.err().is_some(),


### PR DESCRIPTION
I route volume identity reads in scans, constraints, aggregates, scanner construction, serialization and maintenance through the fallible accessor introduced in #138. I acquire the borrowed IDs before row loops and callbacks, propagate failures through existing cleanup paths, and preserve the current accessor's inline `Ok` borrow. The current builder and loader already establish the length invariant, so I add no runtime metadata validation or fabricated corruption tests.

I remove the ordered PK merge's copy of every participating volume's ID array by borrowing from its existing pinned volume list. For compaction, I reuse the completed deduplication set when preparing tombstone cleanup before publication. Startup computes all segment maxima outside the manager-map guard before updating any auto-increment counter, using table names captured from the manager-map keys. Existing snapshot and restore callers only receive the necessary signature/cleanup adaptation.

| Cost | Change |
| --- | --- |
| Ordered PK merge | Removes one Vec allocation per participating volume, plus 8 copied bytes per physical row; the source descriptor is 8 bytes smaller on this target. |
| Compaction | Reuses the existing ID set instead of allocating a second one. Individual inserts avoid reservation growth for duplicate IDs. |
| Startup | One temporary manager Arc and 8 additional tuple bytes per staged table; table names are now cloned for empty/zero-maximum managers too. No persistent structure added. |
| Per-row identity access | Borrowed once outside loops; no new allocation, lock or length-validation branch. |

I passed formatting, all-target/all-feature clippy with warnings denied, and 124 focused tests in each of the default and file-backed configurations. The targets are `fallible_group_access_test`, `fallible_row_count_test`, `ordered_limited_scan_test`, `volume_checkpoint_test` and `volume_schema_test`. I use the existing compatibility and failure tests; the only integration-test edits adapt scanner construction. Independent source review found a potential duplicate-driven HashSet reservation; I fixed both loops and the re-review closed with no remaining source findings.

Performance measurements and full CI are pending. The source comparison is prepared, but latency sampling is waiting for AC power under the reviewed measurement protocol. I have not run a full local suite, per the agreed workflow. This remains a Stage 1 prerequisite for #122, not completion of the storage plan. Resident publication/planning metadata, visibility construction, observational statistics and the scanner's private row indexes retain their current access. Strict current-format loading and startup error handling remain follow-ups. This change does not introduce paged identity storage, memory-budget enforcement or backup/restore features; publication-fence distributions, per-ledger peaks and full pressure-workload acceptance are not measured here.
