### PR TITLE
Propagate volume discovery failures during startup

### DIFF
--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -645,24 +645,13 @@ impl MVCCEngine {
                 // 2. If volumes/ exists with manifests -> new checkpoint-to-volume recovery
                 // 3. Otherwise -> pure WAL replay from beginning
                 let snapshot_dir = pm.path().join("snapshots");
-                let vol_dir = pm.path().join("volumes");
 
-                // Check for volumes/ with manifests (new architecture).
-                // This takes priority over snapshots/ because PRAGMA SNAPSHOT
-                // now creates backup .bin files in snapshots/ alongside volumes/.
-                let has_volumes = vol_dir.exists()
-                    && std::fs::read_dir(&vol_dir)
-                        .ok()
-                        .map(|entries| {
-                            entries
-                                .flatten()
-                                .any(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
-                        })
-                        .unwrap_or(false);
+                // Volume recovery takes priority over snapshot backup files.
+                let volume_lsn = self.load_manifests_from_volumes()?;
 
                 // Legacy snapshots: only used when volumes/ does NOT exist.
                 // This handles migration from pre-volume databases.
-                let has_legacy_snapshots = !has_volumes
+                let has_legacy_snapshots = volume_lsn.is_none()
                     && snapshot_dir.exists()
                     && std::fs::read_dir(&snapshot_dir)
                         .ok()
@@ -673,11 +662,10 @@ impl MVCCEngine {
                         })
                         .unwrap_or(false);
 
-                let replay_from_lsn = if has_volumes {
+                let replay_from_lsn = if let Some(lsn) = volume_lsn {
                     // New path: load manifests + volumes BEFORE WAL replay.
                     // Volumes must be loaded so is_row_id_in_volume() can check
                     // row_ids for idempotent INSERT during replay.
-                    let lsn = self.load_manifests_from_volumes()?;
                     self.load_standalone_volumes_no_schema_check();
                     lsn
                 } else if has_legacy_snapshots {
@@ -3143,42 +3131,38 @@ impl MVCCEngine {
         );
     }
 
-    /// Load manifests from the volumes/ directory for checkpoint-to-volume recovery.
-    ///
-    /// This is called during startup when no snapshot files exist but volumes/ has
-    /// manifest.bin files from a previous checkpoint cycle. Loads manifest metadata
-    /// (segment list, tombstones, checkpoint_lsn) into segment managers so that:
-    /// - WAL replay can check `is_row_id_in_volume_range()` for tombstone creation
-    /// - The minimum checkpoint_lsn determines where WAL replay starts
-    ///
-    /// Returns the minimum checkpoint_lsn across all loaded manifests (0 if none found).
-    /// Fails closed on an unreadable or unsupported manifest: opening with a
-    /// partially visible catalog lets the orphan reaper destroy live volumes.
-    /// Actual .vol files are loaded later by `load_standalone_volumes()` after WAL replay
-    /// creates the required schemas and version stores.
-    fn load_manifests_from_volumes(&self) -> Result<u64> {
+    /// Discover volume table directories and load their manifests before WAL replay.
+    /// None selects legacy recovery when there are no volume table directories.
+    /// Some selects volume recovery with its manifest-derived replay LSN.
+    fn load_manifests_from_volumes(&self) -> Result<Option<u64>> {
         let pm = match self.persistence.as_ref() {
             Some(pm) if pm.is_enabled() => pm,
-            _ => return Ok(0),
+            _ => return Ok(None),
         };
 
         let vol_dir = pm.path().join("volumes");
-        if !vol_dir.exists() {
-            return Ok(0);
-        }
-
         let entries = match std::fs::read_dir(&vol_dir) {
             Ok(e) => e,
-            Err(_) => return Ok(0),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(Error::internal(format!(
+                    "failed to read volume directory '{}': {}",
+                    vol_dir.display(),
+                    e
+                )));
+            }
         };
 
         let mut min_checkpoint_lsn: u64 = u64::MAX;
+        let mut has_table_dirs = false;
         let mut any_loaded = false;
 
-        for entry in entries.flatten() {
-            if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+        for entry in entries {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
                 continue;
             }
+            has_table_dirs = true;
 
             let table_name = entry.file_name().to_string_lossy().to_lowercase();
 
@@ -3215,19 +3199,22 @@ impl MVCCEngine {
             }
         }
 
+        if !has_table_dirs {
+            return Ok(None);
+        }
         if !any_loaded {
             // No manifests found, remove checkpoint.meta if present
             // to ensure full WAL replay
             let checkpoint_path = pm.path().join("wal").join("checkpoint.meta");
             let _ = std::fs::remove_file(checkpoint_path);
-            return Ok(0);
+            return Ok(Some(0));
         }
 
-        Ok(if min_checkpoint_lsn == u64::MAX {
+        Ok(Some(if min_checkpoint_lsn == u64::MAX {
             0
         } else {
             min_checkpoint_lsn
-        })
+        }))
     }
 
     /// Load standalone volumes from the volumes/ directory.

--- a/src/storage/volume/manifest.rs
+++ b/src/storage/volume/manifest.rs
@@ -2362,7 +2362,7 @@ impl SegmentManager {
         let table_dir = volume_dir.join(table_name);
         let manifest_path = table_dir.join("manifest.bin");
 
-        if !manifest_path.exists() {
+        if !manifest_path.try_exists()? {
             return Ok(None);
         }
 

--- a/tests/durability_test.rs
+++ b/tests/durability_test.rs
@@ -2782,6 +2782,57 @@ fn test_manifest_deleted() {
 }
 
 #[test]
+fn test_volume_directory_error_fails_before_wal_replay() {
+    let (fixture, _) = setup_db_with_volumes();
+    let volumes = fixture.db_path.join("volumes");
+    let saved = fixture.db_path.join("saved_volumes");
+    fs::rename(&volumes, &saved).unwrap();
+    fs::write(&volumes, b"directory unavailable").unwrap();
+
+    let error = match Database::open(&fixture.dsn) {
+        Err(error) => error,
+        Ok(_) => panic!("volume directory errors must fail opening"),
+    };
+    assert!(error.to_string().contains("volume directory"), "{error}");
+    fs::remove_file(&volumes).unwrap();
+    fs::rename(&saved, &volumes).unwrap();
+    let db = Database::open(&fixture.dsn).unwrap();
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM vol_test", ())
+            .unwrap(),
+        40
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_manifest_metadata_error_fails_before_wal_replay() {
+    let (fixture, _) = setup_db_with_volumes();
+    let manifest = find_manifest_file(&fixture.db_path, "vol_test").unwrap();
+    let saved = manifest.with_extension("saved");
+    fs::rename(&manifest, &saved).unwrap();
+    std::os::unix::fs::symlink("manifest.bin", &manifest).unwrap();
+
+    let error = match Database::open(&fixture.dsn) {
+        Err(error) => error,
+        Ok(_) => panic!("manifest metadata errors must fail opening"),
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains("manifest") && message.contains("vol_test"),
+        "{message}"
+    );
+    fs::remove_file(&manifest).unwrap();
+    fs::rename(&saved, &manifest).unwrap();
+    let db = Database::open(&fixture.dsn).unwrap();
+    assert_eq!(
+        db.query_one::<i64, _>("SELECT COUNT(*) FROM vol_test", ())
+            .unwrap(),
+        40
+    );
+}
+
+#[test]
 fn test_volume_truncated() {
     // Truncate a .vol file to partial state (simulates torn write during seal)
     let (fixture, _) = setup_db_with_volumes();


### PR DESCRIPTION
I make startup return an error when volume-directory discovery or manifest metadata access fails. Previously, those failures could select WAL-only recovery and open a partial database. One fallible discovery pass now chooses the recovery path; an absent or empty volume directory and an absent manifest keep their existing behavior.

This is a Stage 1 prerequisite of #122, based on merged #139. It changes only startup discovery. Both standalone volume loaders, their missing/corrupt-file behavior, and DROP/TRUNCATE recovery remain unchanged. Strict enforcement of manifest-listed files needs durable table ownership: DROP, recreation under the same name, and a later checkpoint can leave an old manifest after the retirement WAL has been truncated. K7 supplies the persisted identity needed to distinguish that state. I have not delivered that guarantee here.

Validation:

- Both new guards failed on the original production code, on the same checkout, at their expected open-success assertions. One places a regular file at the volume-directory path; the Unix-only guard creates a self-referential manifest symlink. Each restores the path and verifies the 40-row checkpoint-plus-WAL count with the fix applied.
- The default focused run passed 178 tests, with one nextest process-output leak classification in test_alter_table_with_checkpoint_recovery. This is not a measured heap leak.
- The same 178 tests passed with test-filedb, with one process-output leak classification in test_all_commit_markers_destroyed.
- A focused default-feature rerun of those two existing tests passed both with no leak classification.
- Formatting and all-target/all-feature clippy with warnings denied passed. All 14 CI checks passed on e3ea8d7f, including the full Linux, macOS and Windows suites, feature-gated tests, coverage and release builds.
- Independent source review and re-review closed after correcting the replay-LSN comment.

The source adds no per-row work, persistent structure, or retained per-row/per-volume bytes. Startup uses constant-sized local selection state and removes one redundant root-directory traversal. Failure messages allocate only on the error path. I have not measured row latency or allocations for this revision and do not claim a performance pass.

I am using focused local targets and the full suite in CI. There is no format, publication-fence, memory-budget, WAL replay, backup, or restore redesign. Legacy snapshot-directory discovery and the direct-engine failed-open retry/close lifecycle remain on their existing behavior. Later identity, paging, and memory-budget tests are not exercised by this startup-only change.
