### PR TITLE
Validate V4 metadata before constructing volume state

### DIFF
--- a/src/storage/volume/format.rs
+++ b/src/storage/volume/format.rs
@@ -427,7 +427,7 @@ fn read_value(data: &[u8], pos: &mut usize) -> io::Result<Value> {
         2 => Ok(Value::Float(read_f64(data, pos)?)),
         3 => {
             let slen = read_u32(data, pos)? as usize;
-            if *pos + slen > data.len() {
+            if slen > data.len() - *pos {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "truncated volume: text value data",
@@ -460,7 +460,7 @@ fn read_value(data: &[u8], pos: &mut usize) -> io::Result<Value> {
         }
         6 => {
             let len = read_u32(data, pos)? as usize;
-            if *pos + len > data.len() {
+            if len > data.len() - *pos {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "truncated extension data",
@@ -1160,14 +1160,30 @@ pub(crate) fn serialize_volume_metadata(vol: &FrozenVolume) -> io::Result<Vec<u8
     Ok(buf)
 }
 
+fn check_metadata_count(data: &[u8], pos: usize, count: usize, width: usize) -> io::Result<()> {
+    if count > (data.len() - pos) / width {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "V4 metadata count exceeds remaining bytes",
+        ));
+    }
+    Ok(())
+}
+
 /// Deserialize volume metadata from V4 format bytes.
 pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetadata> {
     let mut pos = 0;
 
-    let row_count = read_u64(data, &mut pos)? as usize;
+    let row_count = usize::try_from(read_u64(data, &mut pos)?).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "V4 row count exceeds address space",
+        )
+    })?;
     let col_count = read_u32(data, &mut pos)? as usize;
 
     // Column directory
+    check_metadata_count(data, pos, col_count, 6)?;
     let mut col_type_tags = Vec::with_capacity(col_count);
     let mut col_ext_types = Vec::with_capacity(col_count);
     let mut col_sorted = Vec::with_capacity(col_count);
@@ -1196,10 +1212,22 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
 
     // Shared dictionary
     let dict_len = read_u32(data, &mut pos)? as usize;
+    let declared_dict_len = col_dict_counts.iter().try_fold(0usize, |sum, &count| {
+        sum.checked_add(count as usize).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "V4 dictionary count overflow")
+        })
+    })?;
+    if declared_dict_len != dict_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "V4 dictionary counts do not match shared dictionary length",
+        ));
+    }
+    check_metadata_count(data, pos, dict_len, 4)?;
     let mut shared_dict = Vec::with_capacity(dict_len);
     for _ in 0..dict_len {
         let slen = read_u32(data, &mut pos)? as usize;
-        if pos + slen > data.len() {
+        if slen > data.len() - pos {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "truncated V4 metadata: dictionary string",
@@ -1212,9 +1240,11 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
     }
 
     // Row IDs (bulk read — single memcpy on LE platforms)
+    check_metadata_count(data, pos, row_count, 8)?;
     let row_ids = read_i64_bulk(data, &mut pos, row_count)?;
 
     // Zone maps
+    check_metadata_count(data, pos, col_count, 12)?;
     let mut zone_maps = Vec::with_capacity(col_count);
     for _ in 0..col_count {
         let min = read_value(data, &mut pos)?;
@@ -1231,11 +1261,17 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
 
     // Bloom filters
     let num_blooms = read_u32(data, &mut pos)? as usize;
+    check_metadata_count(data, pos, num_blooms, 20)?;
     let mut bloom_filters = Vec::with_capacity(num_blooms);
     for _ in 0..num_blooms {
-        let num_bits = read_u64(data, &mut pos)? as usize;
+        let num_bits = usize::try_from(read_u64(data, &mut pos)?).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "V4 bloom size exceeds address space",
+            )
+        })?;
         let data_len = read_u32(data, &mut pos)? as usize;
-        if pos + data_len > data.len() {
+        if data_len > data.len() - pos {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "truncated V4 metadata: bloom filter",
@@ -1243,6 +1279,12 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
         }
         let bits_bytes = &data[pos..pos + data_len];
         pos += data_len;
+        if num_bits == 0 || !data_len.is_multiple_of(8) || num_bits.div_ceil(64) != data_len / 8 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid V4 bloom backing geometry",
+            ));
+        }
         bloom_filters.push(super::column::ColumnBloomFilter::from_parts(
             num_bits, bits_bytes,
         ));
@@ -1252,6 +1294,13 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
     let total_rows = read_u64(data, &mut pos)?;
     let live_rows = read_u64(data, &mut pos)?;
     let stats_col_count = read_u32(data, &mut pos)? as usize;
+    if stats_col_count != col_count {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "V4 statistics column count mismatch",
+        ));
+    }
+    check_metadata_count(data, pos, stats_col_count, 44)?;
     let mut stat_columns = Vec::with_capacity(stats_col_count);
     for _ in 0..stats_col_count {
         let sum_int = read_i128(data, &mut pos)?;
@@ -1271,10 +1320,11 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
     }
 
     // Column names
+    check_metadata_count(data, pos, col_count, 4)?;
     let mut column_names = Vec::with_capacity(col_count);
     for _ in 0..col_count {
         let slen = read_u32(data, &mut pos)? as usize;
-        if pos + slen > data.len() {
+        if slen > data.len() - pos {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "truncated V4 metadata: column name",
@@ -1301,6 +1351,11 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
 
     // Row groups
     let num_groups = read_u32(data, &mut pos)? as usize;
+    let group_width = col_count
+        .checked_mul(12)
+        .and_then(|width| width.checked_add(8))
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "V4 group width overflow"))?;
+    check_metadata_count(data, pos, num_groups, group_width)?;
     let mut row_groups = Vec::with_capacity(num_groups);
     for _ in 0..num_groups {
         let start_idx = read_u32(data, &mut pos)?;
@@ -1323,6 +1378,13 @@ pub(crate) fn deserialize_volume_metadata(data: &[u8]) -> io::Result<VolumeMetad
             end_idx,
             zone_maps: group_zone_maps,
         });
+    }
+
+    if pos != data.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "trailing bytes in V4 metadata",
+        ));
     }
 
     let column_name_map = column_names

--- a/src/storage/volume/io.rs
+++ b/src/storage/volume/io.rs
@@ -203,10 +203,12 @@ fn read_volume_v4(path: &Path) -> Result<FrozenVolume> {
 
     let file = std::fs::File::open(path)
         .map_err(|e| crate::core::Error::internal(format!("V4 open {:?}: {}", path, e)))?;
-    let file_len = file
-        .metadata()
-        .map_err(|e| crate::core::Error::internal(format!("V4 stat {:?}: {}", path, e)))?
-        .len() as usize;
+    let file_len = usize::try_from(
+        file.metadata()
+            .map_err(|e| crate::core::Error::internal(format!("V4 stat {:?}: {}", path, e)))?
+            .len(),
+    )
+    .map_err(|_| inv("file length exceeds address space"))?;
     if file_len < 24 {
         return Err(inv("file too small"));
     }
@@ -238,6 +240,11 @@ fn read_volume_v4(path: &Path) -> Result<FrozenVolume> {
     let col_count = u32::from_le_bytes(header[8..12].try_into().unwrap()) as usize;
     let num_groups = u32::from_le_bytes(header[12..16].try_into().unwrap()) as usize;
     let meta_len = u32::from_le_bytes(header[16..20].try_into().unwrap()) as usize;
+    let mut remaining = file_len - 24;
+    if meta_len > remaining {
+        return Err(inv("metadata length exceeds file payload"));
+    }
+    remaining -= meta_len;
 
     // 2. Compressed metadata (read into temp buffer, decompress, drop)
     let mut meta_compressed = vec![0u8; meta_len];
@@ -247,9 +254,18 @@ fn read_volume_v4(path: &Path) -> Result<FrozenVolume> {
     // to avoid lz4_flex::decompress_size_prepended allocating a fresh Vec.
     let meta_raw = if meta_compressed.len() >= 4 {
         let uncomp_size = u32::from_le_bytes(meta_compressed[..4].try_into().unwrap()) as usize;
+        // Each LZ4 length-extension byte adds at most 255 output bytes.
+        if uncomp_size > (meta_compressed.len() - 4).saturating_mul(255)
+            || uncomp_size > isize::MAX as usize
+        {
+            return Err(inv("metadata LZ4 size exceeds possible expansion"));
+        }
         let mut buf = vec![0u8; uncomp_size];
-        lz4_flex::decompress_into(&meta_compressed[4..], &mut buf)
+        let decoded = lz4_flex::decompress_into(&meta_compressed[4..], &mut buf)
             .map_err(|e| inv(&format!("metadata LZ4: {}", e)))?;
+        if decoded != uncomp_size {
+            return Err(inv("metadata LZ4 decoded length mismatch"));
+        }
         drop(meta_compressed);
         buf
     } else {
@@ -267,20 +283,43 @@ fn read_volume_v4(path: &Path) -> Result<FrozenVolume> {
             meta.col_type_tags.len()
         )));
     }
+    if num_groups != meta.row_count.div_ceil(ROW_GROUP_SIZE) {
+        return Err(inv("block group count does not match row count"));
+    }
 
     // 3. Block index: (compressed_len: u64, decompressed_len: u64) pairs
-    let total_blocks = col_count * num_groups;
-    let mut index_buf = vec![0u8; total_blocks * 16];
+    let total_blocks = col_count
+        .checked_mul(num_groups)
+        .ok_or_else(|| inv("block count overflow"))?;
+    let index_len = total_blocks
+        .checked_mul(16)
+        .filter(|&len| len <= remaining)
+        .ok_or_else(|| inv("block index exceeds file payload"))?;
+    remaining -= index_len;
+    let mut index_buf = vec![0u8; index_len];
     crc_read!(&mut index_buf);
 
     let mut compressed_lens = Vec::with_capacity(total_blocks);
     let mut decompressed_lens_flat = Vec::with_capacity(total_blocks);
     for i in 0..total_blocks {
         let off = i * 16;
-        compressed_lens
-            .push(u64::from_le_bytes(index_buf[off..off + 8].try_into().unwrap()) as usize);
-        decompressed_lens_flat
-            .push(u64::from_le_bytes(index_buf[off + 8..off + 16].try_into().unwrap()) as usize);
+        let compressed_len = usize::try_from(u64::from_le_bytes(
+            index_buf[off..off + 8].try_into().unwrap(),
+        ))
+        .map_err(|_| inv("compressed block length exceeds address space"))?;
+        let decompressed_len = usize::try_from(u64::from_le_bytes(
+            index_buf[off + 8..off + 16].try_into().unwrap(),
+        ))
+        .map_err(|_| inv("decoded block length exceeds address space"))?;
+        if compressed_len > remaining {
+            return Err(inv("compressed block exceeds file payload"));
+        }
+        remaining -= compressed_len;
+        compressed_lens.push(compressed_len);
+        decompressed_lens_flat.push(decompressed_len);
+    }
+    if remaining != 0 {
+        return Err(inv("trailing bytes after volume payload"));
     }
     drop(index_buf);
 

--- a/tests/volume_metadata_test.rs
+++ b/tests/volume_metadata_test.rs
@@ -1,0 +1,178 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::path::Path;
+use stoolap::core::{DataType, Row, SchemaBuilder, Value};
+use stoolap::storage::volume::io::{read_volume_from_disk, write_volume_to_disk};
+use stoolap::storage::volume::writer::VolumeBuilder;
+
+fn fixture() -> (tempfile::TempDir, std::path::PathBuf, Vec<u8>) {
+    let dir = tempfile::tempdir().unwrap();
+    let schema = SchemaBuilder::new("metadata")
+        .column("v", DataType::Text, true, false)
+        .build();
+    let mut builder = VolumeBuilder::new(&schema);
+    builder.add_row(1, &Row::from_values(vec![Value::Null(DataType::Text)]));
+    let path = write_volume_to_disk(dir.path(), "metadata", 1, &builder.finish()).unwrap();
+    let bytes = std::fs::read(&path).unwrap();
+    (dir, path, bytes)
+}
+
+fn replace_metadata(bytes: &mut Vec<u8>, edit: impl FnOnce(&mut Vec<u8>)) {
+    let len = u32::from_le_bytes(bytes[16..20].try_into().unwrap()) as usize;
+    let mut metadata = lz4_flex::decompress_size_prepended(&bytes[20..20 + len]).unwrap();
+    edit(&mut metadata);
+    let compressed = lz4_flex::compress_prepend_size(&metadata);
+    bytes[16..20].copy_from_slice(&(compressed.len() as u32).to_le_bytes());
+    bytes.splice(20..20 + len, compressed);
+}
+
+fn assert_rejected(path: &Path, mut bytes: Vec<u8>) {
+    bytes.truncate(bytes.len() - 4);
+    bytes.extend_from_slice(&crc32fast::hash(&bytes).to_le_bytes());
+    std::fs::write(path, bytes).unwrap();
+    let result = catch_unwind(AssertUnwindSafe(|| read_volume_from_disk(path)));
+    assert!(result.is_ok(), "malformed file panicked while loading");
+    assert!(result.unwrap().is_err(), "malformed file was accepted");
+}
+
+#[test]
+fn metadata_rejects_short_lz4_output() {
+    let (_dir, path, mut bytes) = fixture();
+    let size = u32::from_le_bytes(bytes[20..24].try_into().unwrap());
+    bytes[20..24].copy_from_slice(&(size + 1).to_le_bytes());
+    assert_rejected(&path, bytes);
+}
+
+#[test]
+fn metadata_rejects_impossible_lz4_expansion() {
+    let (_dir, path, mut bytes) = fixture();
+    let compressed_len = u32::from_le_bytes(bytes[16..20].try_into().unwrap()) - 4;
+    bytes[20..24].copy_from_slice(&(compressed_len * 255 + 1).to_le_bytes());
+    assert_rejected(&path, bytes);
+}
+
+#[test]
+fn metadata_rejects_trailing_decoded_bytes() {
+    let (_dir, path, mut bytes) = fixture();
+    replace_metadata(&mut bytes, |metadata| metadata.push(0));
+    assert_rejected(&path, bytes);
+}
+
+#[test]
+fn metadata_rejects_overflowing_row_count() {
+    let (_dir, path, mut bytes) = fixture();
+    replace_metadata(&mut bytes, |metadata| {
+        metadata[..8].copy_from_slice(&u64::MAX.to_le_bytes());
+    });
+    assert_rejected(&path, bytes);
+}
+
+#[test]
+fn metadata_rejects_dictionary_count_past_shared_dictionary() {
+    let (_dir, path, mut bytes) = fixture();
+    replace_metadata(&mut bytes, |metadata| {
+        metadata[14..18].copy_from_slice(&1u32.to_le_bytes());
+    });
+    assert_rejected(&path, bytes);
+}
+
+#[test]
+fn metadata_rejects_unassigned_shared_dictionary_entries() {
+    let (_dir, path, mut bytes) = fixture();
+    replace_metadata(&mut bytes, |metadata| {
+        metadata[18..22].copy_from_slice(&1u32.to_le_bytes());
+        metadata.splice(22..22, 0u32.to_le_bytes());
+    });
+    assert_rejected(&path, bytes);
+}
+
+#[test]
+fn metadata_rejects_empty_bloom_backing() {
+    let (_dir, path, mut bytes) = fixture();
+    replace_metadata(&mut bytes, |metadata| {
+        // One null TEXT row puts the first bloom after its 12-byte zone map.
+        metadata[54..58].copy_from_slice(&0u32.to_le_bytes());
+        metadata.drain(58..66);
+    });
+    assert_rejected(&path, bytes);
+}
+
+#[test]
+fn metadata_rejects_incomplete_bloom_word() {
+    let (_dir, path, mut bytes) = fixture();
+    replace_metadata(&mut bytes, |metadata| {
+        metadata[54..58].copy_from_slice(&7u32.to_le_bytes());
+        metadata.remove(65);
+    });
+    assert_rejected(&path, bytes);
+}
+
+#[test]
+fn metadata_rejects_bloom_bit_count_outside_backing() {
+    for bits in [0u64, 65] {
+        let (_dir, path, mut bytes) = fixture();
+        replace_metadata(&mut bytes, |metadata| {
+            metadata[46..54].copy_from_slice(&bits.to_le_bytes());
+        });
+        assert_rejected(&path, bytes);
+    }
+}
+
+#[test]
+fn metadata_rejects_missing_column_statistics() {
+    let (_dir, path, mut bytes) = fixture();
+    replace_metadata(&mut bytes, |metadata| {
+        metadata[82..86].copy_from_slice(&0u32.to_le_bytes());
+        metadata.drain(86..130);
+    });
+    assert_rejected(&path, bytes);
+}
+
+#[test]
+fn volume_rejects_oversized_compressed_block() {
+    let (_dir, path, mut bytes) = fixture();
+    let meta_len = u32::from_le_bytes(bytes[16..20].try_into().unwrap()) as usize;
+    bytes[20 + meta_len..28 + meta_len].copy_from_slice(&u64::MAX.to_le_bytes());
+    assert_rejected(&path, bytes);
+}
+
+#[test]
+fn volume_rejects_trailing_file_bytes() {
+    let (_dir, path, mut bytes) = fixture();
+    bytes.extend_from_slice(&[0; 4]);
+    assert_rejected(&path, bytes);
+}
+
+#[test]
+fn volume_rejects_missing_block_group() {
+    let (_dir, path, mut bytes) = fixture();
+    bytes[12..16].copy_from_slice(&0u32.to_le_bytes());
+    let meta_len = u32::from_le_bytes(bytes[16..20].try_into().unwrap()) as usize;
+    bytes.truncate(24 + meta_len);
+    assert_rejected(&path, bytes);
+}
+
+#[test]
+fn metadata_preserves_null_dictionary_and_implicit_group() {
+    let (_dir, path, _bytes) = fixture();
+    let volume = read_volume_from_disk(&path).unwrap();
+    assert_eq!(volume.row_ids().unwrap(), &[1]);
+    assert!(volume.meta.row_groups.is_empty());
+    assert_eq!(
+        volume.get_row(0).unwrap().get(0),
+        Some(&Value::Null(DataType::Text))
+    );
+}


### PR DESCRIPTION
I reject malformed V4 metadata and file lengths at the file-reading boundary. Previously, a declared dictionary range, row count, or compressed-block length could panic; short LZ4 output, incomplete bloom backing, missing statistics, missing block groups, and trailing bytes could be accepted.

I check declared collection sizes against the remaining encoded bytes before allocation, require exact LZ4 output and metadata consumption, verify dictionary counts and bloom/statistics geometry, and check the block index against the file payload. The parsed dictionary total proves the existing constructor's ranges fit, and the remaining-byte row bound proves the existing bulk ID read fits. I keep those accessors and the public constructor unchanged.

This is a Stage 1 prerequisite of #122 stacked on #140. Validation:

- All 13 new failure guards failed on the original production source on the same checkout: three exposed parser panics and ten exposed accepted malformed inputs. The NULL-dictionary and implicit-group control passed.
- All 119 focused tests passed with default features across volume_metadata_test, fallible_group_access_test, volume_integration_test, volume_schema_test, and volume_checkpoint_test.
- The same 119 focused tests passed with test-filedb.
- Formatting and all-target/all-feature clippy with warnings denied passed after fixing one divisibility-style lint. The change from modulo to is_multiple_of is equivalent; the focused runs above preceded this final lint-only correction. All 14 parser tests passed again after the correction. All 14 CI checks passed, including the full Linux, macOS, and Windows suites.
- Independent source, fixture, and evidence reviews found no correctness blockers. The lint-only correction received a final source re-review.

I add no persistent structure or retained per-row/per-volume bytes. The new checks run during file ingestion: constant-sized count/length checks, one pass over column dictionary counts, one check per bloom, and bounds checks in the existing block-index loop. No per-row checks, locks, or success-path allocation sites are added. Row latency, file-load timing, and allocation totals remain unmeasured for this revision; I do not claim performance acceptance.

This is structural parser validation, not complete validation of metadata semantics or a memory-budget guarantee. Valid large metadata can still require a large decoded allocation; bounded legacy parsing and memory admission remain Stage 6. Column-block payload decoding remains deferred. The legacy startup loaders still skip failed volume reads; strict database-open enforcement needs K7's durable table ownership, as described in #140. There is no file-format change or WAL, publication, residency, backup, or restore redesign. I use focused local targets and the full suite in CI; later identity and budget acceptance scenarios are not exercised here.
