### PR TITLE
Propagate cold-read failures through executor scan and subquery paths

### DIFF
--- a/src/executor/dml.rs
+++ b/src/executor/dml.rs
@@ -2034,17 +2034,13 @@ impl Executor {
                 let outer_tables = vec![table_name.to_string()];
 
                 // Try EXISTS semi-join optimization
-                let exists_optimized = self
-                    .try_optimize_exists_to_semi_join(where_clause, ctx, &outer_tables, None)
-                    .ok()
-                    .flatten();
+                let exists_optimized =
+                    self.try_optimize_exists_to_semi_join(where_clause, ctx, &outer_tables, None)?;
 
                 // Try IN semi-join optimization (on EXISTS result or original)
                 let expr_for_in = exists_optimized.as_ref().unwrap_or(where_clause.as_ref());
-                let in_optimized = self
-                    .try_optimize_in_to_semi_join(expr_for_in, ctx, &outer_tables)
-                    .ok()
-                    .flatten();
+                let in_optimized =
+                    self.try_optimize_in_to_semi_join(expr_for_in, ctx, &outer_tables)?;
 
                 // Determine final expression without unnecessary clones
                 let current_expr = in_optimized
@@ -2177,8 +2173,9 @@ impl Executor {
                                     outer_row_map,
                                     CompactArc::clone(&column_names),
                                 );
-                                self.process_correlated_where(mem_where, &correlated_ctx)
-                                    .and_then(|processed| evaluator.evaluate_bool(&processed))
+                                let processed =
+                                    self.process_correlated_where(mem_where, &correlated_ctx)?;
+                                evaluator.evaluate_bool(&processed)
                             } else {
                                 evaluator.evaluate_bool(mem_where)
                             };
@@ -2273,8 +2270,9 @@ impl Executor {
                 if needs_memory_filter {
                     if let Some(ref where_clause) = memory_where_clause {
                         let held = if where_is_correlated {
-                            self.process_correlated_where(where_clause, &correlated_ctx)
-                                .and_then(|processed| evaluator.evaluate_bool(&processed))
+                            let processed =
+                                self.process_correlated_where(where_clause, &correlated_ctx)?;
+                            evaluator.evaluate_bool(&processed)
                         } else {
                             evaluator.evaluate_bool(where_clause)
                         };
@@ -2290,17 +2288,14 @@ impl Executor {
                 for (idx, col_type, vec_dims, expr, is_correlated) in update_indices.iter() {
                     let evaluated = if *is_correlated {
                         // Process correlated expression - this executes the subquery
-                        match self.process_correlated_expression(expr, &correlated_ctx) {
-                            Ok(processed_expr) => {
-                                // Now evaluate the processed expression (subquery replaced with value)
-                                let mut eval = CompiledEvaluator::new(function_registry)
-                                    .with_context(&correlated_ctx);
-                                eval.init_columns_arc(CompactArc::clone(&column_names));
-                                eval.set_row_array(row);
-                                eval.evaluate(&processed_expr).ok()
-                            }
-                            Err(_) => None,
-                        }
+                        let processed_expr =
+                            self.process_correlated_expression(expr, &correlated_ctx)?;
+                        // Now evaluate the processed expression (subquery replaced with value)
+                        let mut eval =
+                            CompiledEvaluator::new(function_registry).with_context(&correlated_ctx);
+                        eval.init_columns_arc(CompactArc::clone(&column_names));
+                        eval.set_row_array(row);
+                        eval.evaluate(&processed_expr).ok()
                     } else {
                         evaluator.evaluate(expr).ok()
                     };
@@ -2324,6 +2319,9 @@ impl Executor {
                 if !new_values.is_empty() {
                     precomputed.insert(pk_value, new_values);
                 }
+            }
+            if let Some(error) = scanner.err() {
+                return Err(error.clone());
             }
             drop(scanner);
 
@@ -2526,11 +2524,10 @@ impl Executor {
                                     std::mem::take(&mut outer_row_map),
                                     CompactArc::clone(&column_names),
                                 );
-                                let held = self
-                                    .process_correlated_where(where_expr, &correlated_ctx)
-                                    .and_then(|processed| evaluator.evaluate_bool(&processed));
+                                let processed =
+                                    self.process_correlated_where(where_expr, &correlated_ctx);
                                 outer_row_map = correlated_ctx.outer_row.take().unwrap_or_default();
-                                held
+                                evaluator.evaluate_bool(&processed?)
                             } else {
                                 evaluator.evaluate_bool(where_expr)
                             };
@@ -2840,17 +2837,13 @@ impl Executor {
                 let outer_tables = vec![table_name.to_string()];
 
                 // Try EXISTS semi-join optimization
-                let exists_optimized = self
-                    .try_optimize_exists_to_semi_join(where_clause, ctx, &outer_tables, None)
-                    .ok()
-                    .flatten();
+                let exists_optimized =
+                    self.try_optimize_exists_to_semi_join(where_clause, ctx, &outer_tables, None)?;
 
                 // Try IN semi-join optimization (on EXISTS result or original)
                 let expr_for_in = exists_optimized.as_ref().unwrap_or(where_clause.as_ref());
-                let in_optimized = self
-                    .try_optimize_in_to_semi_join(expr_for_in, ctx, &outer_tables)
-                    .ok()
-                    .flatten();
+                let in_optimized =
+                    self.try_optimize_in_to_semi_join(expr_for_in, ctx, &outer_tables)?;
 
                 // Determine final expression without unnecessary clones
                 let (current_expr, any_optimized) = match (&exists_optimized, &in_optimized) {
@@ -3034,25 +3027,16 @@ impl Executor {
                             );
 
                             // Process correlated subquery with outer context
-                            match self.process_correlated_where(where_expr, &correlated_ctx) {
-                                Ok(processed) => {
-                                    // OPTIMIZATION: Take ownership instead of cloning
-                                    evaluator.set_outer_row_owned(
-                                        correlated_ctx.outer_row.take().unwrap_or_default(),
-                                    );
-                                    let result =
-                                        evaluator.evaluate_bool(&processed).unwrap_or(false);
-                                    // Take back map for reuse instead of clearing
-                                    outer_row_map = evaluator.take_outer_row();
-                                    result
-                                }
-                                Err(_) => {
-                                    // Take back map from context even on error
-                                    outer_row_map =
-                                        correlated_ctx.outer_row.take().unwrap_or_default();
-                                    false
-                                }
-                            }
+                            let processed =
+                                self.process_correlated_where(where_expr, &correlated_ctx)?;
+                            // OPTIMIZATION: Take ownership instead of cloning
+                            evaluator.set_outer_row_owned(
+                                correlated_ctx.outer_row.take().unwrap_or_default(),
+                            );
+                            let result = evaluator.evaluate_bool(&processed).unwrap_or(false);
+                            // Take back map for reuse instead of clearing
+                            outer_row_map = evaluator.take_outer_row();
+                            result
                         } else if let Some(ref program) = memory_where_program {
                             let mut exec_ctx =
                                 ExecuteContext::new(row).with_transaction_id(transaction_id);
@@ -3093,6 +3077,9 @@ impl Executor {
                         None => rows_to_delete_by_row_id.push((scanner.current_row_id(), row_data)),
                     }
                 }
+            }
+            if let Some(error) = scanner.err() {
+                return Err(error.clone());
             }
             // Drop scanner to release borrow
             drop(scanner);
@@ -3732,7 +3719,11 @@ impl Executor {
             None
         };
 
+        let scan_error = scanner.err().cloned();
         scanner.close()?;
+        if let Some(error) = scan_error {
+            return Err(error);
+        }
         Ok(result)
     }
 

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3201,22 +3201,17 @@ impl Executor {
                     // Avoid cloning upfront - only clone if no optimization succeeds
 
                     // 1. Try EXISTS semi-join optimization
-                    let exists_optimized = self
-                        .try_optimize_exists_to_semi_join(
-                            where_expr,
-                            ctx,
-                            &outer_tables,
-                            outer_limit,
-                        )
-                        .ok()
-                        .flatten();
+                    let exists_optimized = self.try_optimize_exists_to_semi_join(
+                        where_expr,
+                        ctx,
+                        &outer_tables,
+                        outer_limit,
+                    )?;
 
                     // 2. Try IN semi-join optimization (on EXISTS result or original)
                     let expr_for_in = exists_optimized.as_ref().unwrap_or(where_expr);
-                    let in_optimized = self
-                        .try_optimize_in_to_semi_join(expr_for_in, ctx, &outer_tables)
-                        .ok()
-                        .flatten();
+                    let in_optimized =
+                        self.try_optimize_in_to_semi_join(expr_for_in, ctx, &outer_tables)?;
 
                     // Determine final expression without unnecessary clones
                     let (current_expr, any_optimized) = match (exists_optimized, in_optimized) {
@@ -3433,6 +3428,9 @@ impl Executor {
                         RowVec::with_capacity(scanner.estimated_count().unwrap_or(64));
                     while scanner.next() {
                         all_rows.push(scanner.take_row_with_id());
+                    }
+                    if let Some(error) = scanner.err() {
+                        return Err(error.clone());
                     }
                     all_rows
                 };
@@ -3678,6 +3676,9 @@ impl Executor {
                             break;
                         }
                     }
+                }
+                if let Some(error) = scanner.err() {
+                    return Err(error.clone());
                 }
                 (rows, None, None)
             }

--- a/src/executor/subquery.rs
+++ b/src/executor/subquery.rs
@@ -3600,7 +3600,9 @@ impl Executor {
     /// of them defines
     fn nested_reads_outer_columns(nested: &SelectStatement, subquery_tables: &[String]) -> bool {
         let mut tables = subquery_tables.to_vec();
-        tables.extend(Self::collect_subquery_table_columns(nested));
+        if let Some(from) = &nested.table_expr {
+            Self::collect_table_names_from_source(from, &mut tables);
+        }
         nested
             .where_clause
             .as_deref()
@@ -3883,7 +3885,7 @@ impl Executor {
         // Example: WHERE o.customer_id = c.id AND c.country = 'USA'
         // The "c.country = 'USA'" references outer table and can't be pushed to inner query.
         if let Some(ref rem) = remaining {
-            if Self::expression_references_outer_tables(rem.as_ref(), outer_tables, &inner_tables) {
+            if Self::references_outer_columns(rem.as_ref(), &inner_tables) {
                 return None;
             }
         }
@@ -4023,131 +4025,6 @@ impl Executor {
                 Some(id.value.to_string())
             }
             _ => None,
-        }
-    }
-
-    /// Check if an expression references any outer tables.
-    /// Used to determine if a predicate can be pushed to the inner query in semi-join optimization.
-    fn expression_references_outer_tables(
-        expr: &Expression,
-        outer_tables: &[String],
-        inner_tables: &[String],
-    ) -> bool {
-        match expr {
-            Expression::QualifiedIdentifier(qid) => {
-                // Use pre-computed value_lower to avoid allocation
-                let table = &qid.qualifier.value_lower;
-                // One pass over the inner table answers every outer row, so
-                // any name the inner table does not own has to be read per
-                // row, whether it belongs to the query above or one further
-                let _ = outer_tables;
-                !inner_tables.iter().any(|t| t.eq_ignore_ascii_case(table))
-            }
-            Expression::Infix(infix) => {
-                Self::expression_references_outer_tables(&infix.left, outer_tables, inner_tables)
-                    || Self::expression_references_outer_tables(
-                        &infix.right,
-                        outer_tables,
-                        inner_tables,
-                    )
-            }
-            Expression::Prefix(prefix) => {
-                Self::expression_references_outer_tables(&prefix.right, outer_tables, inner_tables)
-            }
-            Expression::FunctionCall(func) => func.arguments.iter().any(|arg| {
-                Self::expression_references_outer_tables(arg, outer_tables, inner_tables)
-            }),
-            Expression::In(in_expr) => {
-                Self::expression_references_outer_tables(&in_expr.left, outer_tables, inner_tables)
-                    || Self::expression_references_outer_tables(
-                        &in_expr.right,
-                        outer_tables,
-                        inner_tables,
-                    )
-            }
-            Expression::Between(between) => {
-                Self::expression_references_outer_tables(&between.expr, outer_tables, inner_tables)
-                    || Self::expression_references_outer_tables(
-                        &between.lower,
-                        outer_tables,
-                        inner_tables,
-                    )
-                    || Self::expression_references_outer_tables(
-                        &between.upper,
-                        outer_tables,
-                        inner_tables,
-                    )
-            }
-            Expression::Case(case) => {
-                case.value.as_ref().is_some_and(|op| {
-                    Self::expression_references_outer_tables(
-                        op.as_ref(),
-                        outer_tables,
-                        inner_tables,
-                    )
-                }) || case.when_clauses.iter().any(|wc| {
-                    Self::expression_references_outer_tables(
-                        &wc.condition,
-                        outer_tables,
-                        inner_tables,
-                    ) || Self::expression_references_outer_tables(
-                        &wc.then_result,
-                        outer_tables,
-                        inner_tables,
-                    )
-                }) || case.else_value.as_ref().is_some_and(|el| {
-                    Self::expression_references_outer_tables(
-                        el.as_ref(),
-                        outer_tables,
-                        inner_tables,
-                    )
-                })
-            }
-            // For subqueries, check if their WHERE clause references outer tables.
-            // A nested EXISTS that only references its own scope and the immediate
-            // parent (inner_tables) is safe for semi-join. But if it references
-            // grandparent scope (outer_tables), semi-join cannot handle it.
-            Expression::Exists(exists) => {
-                Self::subquery_references_outer_tables(&exists.subquery, outer_tables, inner_tables)
-            }
-            Expression::ScalarSubquery(sq) => {
-                Self::subquery_references_outer_tables(&sq.subquery, outer_tables, inner_tables)
-            }
-            Expression::AllAny(aa) => {
-                Self::subquery_references_outer_tables(&aa.subquery, outer_tables, inner_tables)
-            }
-            // Literals and other expressions don't reference tables
-            _ => false,
-        }
-    }
-
-    /// Check if a subquery's WHERE clause references any of the outer tables.
-    /// This is used to determine if a nested EXISTS/ScalarSubquery can be safely
-    /// handled by the semi-join optimization (which only provides inner table context).
-    fn subquery_references_outer_tables(
-        subquery: &SelectStatement,
-        outer_tables: &[String],
-        inner_tables: &[String],
-    ) -> bool {
-        if let Some(ref where_clause) = subquery.where_clause {
-            // Collect the subquery's own tables to extend inner_tables
-            let mut sub_tables: Vec<String> = inner_tables.to_vec();
-            Self::collect_table_names_from_source_if_present(&subquery.table_expr, &mut sub_tables);
-            // Check if the WHERE references outer tables (grandparent scope)
-            if Self::expression_references_outer_tables(where_clause, outer_tables, &sub_tables) {
-                return true;
-            }
-        }
-        false
-    }
-
-    /// Collect table names from an optional table expression.
-    fn collect_table_names_from_source_if_present(
-        table_expr: &Option<Box<Expression>>,
-        tables: &mut Vec<String>,
-    ) {
-        if let Some(ref expr) = table_expr {
-            Self::collect_table_names_from_source(expr.as_ref(), tables);
         }
     }
 
@@ -4781,17 +4658,15 @@ impl Executor {
         &self,
         expr: &Expression,
         ctx: &ExecutionContext,
-        outer_tables: &[String],
+        _outer_tables: &[String],
     ) -> Result<Option<Expression>> {
         match expr {
             Expression::In(in_expr) => {
                 // Check if right side is a scalar subquery
                 if let Expression::ScalarSubquery(subquery) = in_expr.right.as_ref() {
-                    if let Some(info) = Self::try_extract_in_semi_join_info(
-                        in_expr,
-                        &subquery.subquery,
-                        outer_tables,
-                    ) {
+                    if let Some(info) =
+                        Self::try_extract_in_semi_join_info(in_expr, &subquery.subquery)
+                    {
                         // Execute subquery once and build hash set
                         let hash_set = self.execute_semi_join_optimization(&info, ctx)?;
                         return Ok(Some(Self::transform_exists_to_in_list(&info, hash_set)));
@@ -4802,9 +4677,10 @@ impl Executor {
 
             Expression::Infix(infix) if infix.operator.eq_ignore_ascii_case("AND") => {
                 // Try to optimize IN in either branch of AND
-                let left_opt = self.try_optimize_in_to_semi_join(&infix.left, ctx, outer_tables)?;
+                let left_opt =
+                    self.try_optimize_in_to_semi_join(&infix.left, ctx, _outer_tables)?;
                 let right_opt =
-                    self.try_optimize_in_to_semi_join(&infix.right, ctx, outer_tables)?;
+                    self.try_optimize_in_to_semi_join(&infix.right, ctx, _outer_tables)?;
 
                 match (left_opt, right_opt) {
                     (Some(new_left), Some(new_right)) => {
@@ -4836,9 +4712,10 @@ impl Executor {
 
             Expression::Infix(infix) if infix.operator.eq_ignore_ascii_case("OR") => {
                 // Try to optimize IN in either branch of OR
-                let left_opt = self.try_optimize_in_to_semi_join(&infix.left, ctx, outer_tables)?;
+                let left_opt =
+                    self.try_optimize_in_to_semi_join(&infix.left, ctx, _outer_tables)?;
                 let right_opt =
-                    self.try_optimize_in_to_semi_join(&infix.right, ctx, outer_tables)?;
+                    self.try_optimize_in_to_semi_join(&infix.right, ctx, _outer_tables)?;
 
                 match (left_opt, right_opt) {
                     (Some(new_left), Some(new_right)) => {
@@ -4883,7 +4760,6 @@ impl Executor {
     fn try_extract_in_semi_join_info(
         in_expr: &InExpression,
         subquery: &SelectStatement,
-        outer_tables: &[String],
     ) -> Option<SemiJoinInfo> {
         // 1. Extract outer column from left side of IN
         let (outer_column, outer_table): (String, Option<String>) = match in_expr.left.as_ref() {
@@ -4930,7 +4806,7 @@ impl Executor {
 
         // 5. Check if WHERE clause references outer tables
         if let Some(ref where_clause) = subquery.where_clause {
-            if Self::expression_references_outer_tables(where_clause, outer_tables, &inner_tables) {
+            if Self::references_outer_columns(where_clause, &inner_tables) {
                 return None; // Correlated WHERE, can't optimize
             }
         }

--- a/tests/executor_cold_error_test.rs
+++ b/tests/executor_cold_error_test.rs
@@ -1,0 +1,327 @@
+// Copyright 2025 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use stoolap::core::{DataType, Error, Row, SchemaBuilder, Value};
+use stoolap::storage::volume::io::{read_volume_from_disk, write_volume_to_disk};
+use stoolap::storage::volume::manifest::{SegmentManager, SegmentMeta};
+use stoolap::storage::volume::writer::VolumeBuilder;
+use stoolap::Database;
+
+struct Fixture {
+    _dir: tempfile::TempDir,
+    dsn: String,
+    damaged_path: PathBuf,
+    original: Vec<u8>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let dsn = format!(
+            "file://{}?checkpoint_on_close=off&checkpoint_interval=3600&cleanup_interval=3600",
+            dir.path().display()
+        );
+        let db = Database::open(&dsn).unwrap();
+        db.execute(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER NOT NULL)",
+            (),
+        )
+        .unwrap();
+        db.close().unwrap();
+        drop(db);
+        let schema = SchemaBuilder::new("t")
+            .column("id", DataType::Integer, false, true)
+            .column("v", DataType::Integer, false, false)
+            .build();
+        let volume_dir = dir.path().join("volumes");
+        let manager = SegmentManager::new("t", Some(volume_dir.clone()));
+        let mut damaged_path = PathBuf::new();
+        let mut original = Vec::new();
+        for id in 1..=2 {
+            let mut builder = VolumeBuilder::new(&schema);
+            builder.add_row(
+                id,
+                &Row::from_values(vec![Value::Integer(id), Value::Integer(id * 10)]),
+            );
+            let volume = builder.finish();
+            let path = write_volume_to_disk(&volume_dir, "t", id as u64, &volume).unwrap();
+            if id == 2 {
+                original = std::fs::read(&path).unwrap();
+                let meta_len = u32::from_le_bytes(original[16..20].try_into().unwrap()) as usize;
+                let mut bytes = original[..20 + meta_len].to_vec();
+                for size in [9u64, 10] {
+                    bytes.extend_from_slice(&size.to_le_bytes());
+                    bytes.extend_from_slice(&size.to_le_bytes());
+                }
+                bytes.push(0);
+                bytes.extend_from_slice(&id.to_le_bytes());
+                bytes.extend_from_slice(&[0; 10]);
+                bytes.extend_from_slice(&crc32fast::hash(&bytes).to_le_bytes());
+                std::fs::write(&path, bytes).unwrap();
+                damaged_path = path.clone();
+            }
+            manager.register_segment(
+                id as u64,
+                Arc::new(read_volume_from_disk(&path).unwrap()),
+                SegmentMeta {
+                    segment_id: id as u64,
+                    file_path: path.file_name().unwrap().into(),
+                    row_count: 1,
+                    min_row_id: id,
+                    max_row_id: id,
+                    creation_lsn: 0,
+                    seal_seq: 0,
+                    schema_version: 0,
+                },
+                Some(&schema),
+            );
+        }
+        manager.persist().unwrap();
+        Self {
+            _dir: dir,
+            dsn,
+            damaged_path,
+            original,
+        }
+    }
+
+    fn open(&self) -> Database {
+        Database::open(&self.dsn).unwrap()
+    }
+
+    fn assert_cold_unchanged(&self, db: Database) {
+        db.close().unwrap();
+        drop(db);
+        std::fs::write(&self.damaged_path, &self.original).unwrap();
+        let db = self.open();
+        assert_eq!(
+            pairs(&db, "SELECT * FROM t ORDER BY id"),
+            [(1, 10), (2, 20)]
+        );
+        db.close().unwrap();
+    }
+}
+
+fn assert_read_error(db: &Database, sql: &str) {
+    let result = db
+        .query(sql, ())
+        .and_then(|rows| rows.collect::<Result<Vec<_>, _>>());
+    assert!(
+        matches!(result, Err(Error::Internal { ref message })
+            if message == "corrupt V4 block: invalid column block length"
+                || message == "scan error: corrupt V4 block: invalid column block length"),
+        "{sql}: {result:?}"
+    );
+}
+
+fn add_target(db: &Database) {
+    db.execute(
+        "CREATE TABLE target (id INTEGER PRIMARY KEY, v INTEGER UNIQUE)",
+        (),
+    )
+    .unwrap();
+    begin_target_update(db);
+}
+
+fn begin_target_update(db: &Database) {
+    db.execute("INSERT INTO target VALUES (1, 100), (2, 200)", ())
+        .unwrap();
+    db.execute("BEGIN", ()).unwrap();
+    db.execute("UPDATE target SET v = 101 WHERE id = 1", ())
+        .unwrap();
+}
+
+fn assert_target_unchanged(db: &Database) {
+    assert_eq!(
+        pairs(db, "SELECT * FROM target ORDER BY id"),
+        [(1, 101), (2, 200)]
+    );
+}
+
+fn pairs(db: &Database, sql: &str) -> Vec<(i64, i64)> {
+    db.query(sql, ())
+        .unwrap()
+        .map(|row| {
+            let row = row.unwrap();
+            (row.get(0).unwrap(), row.get(1).unwrap())
+        })
+        .collect()
+}
+
+#[test]
+fn unread_corrupt_volume_does_not_fail_pruned_query() {
+    let fixture = Fixture::new();
+    let db = fixture.open();
+    assert_eq!(pairs(&db, "SELECT * FROM t WHERE id = 1"), [(1, 10)]);
+    fixture.assert_cold_unchanged(db);
+}
+
+#[test]
+fn parallel_filter_propagates_late_scan_error() {
+    let fixture = Fixture::new();
+    let db = fixture.open();
+    assert_read_error(
+        &db,
+        "SELECT v FROM t WHERE id > 0 AND RANDOM() >= 0 ORDER BY id",
+    );
+    fixture.assert_cold_unchanged(db);
+}
+
+#[test]
+fn correlated_filter_propagates_late_scan_error() {
+    let fixture = Fixture::new();
+    let db = fixture.open();
+    add_target(&db);
+    assert_read_error(&db, "SELECT v FROM t WHERE (SELECT target.v FROM target WHERE target.id = t.id) > 0 ORDER BY id");
+    db.execute("COMMIT", ()).unwrap();
+    fixture.assert_cold_unchanged(db);
+}
+
+#[test]
+fn delete_returning_does_not_delete_readable_prefix() {
+    let fixture = Fixture::new();
+    let db = fixture.open();
+    assert_read_error(&db, "DELETE FROM t RETURNING id");
+    fixture.assert_cold_unchanged(db);
+}
+
+#[test]
+fn correlated_update_precompute_propagates_late_scan_error() {
+    let fixture = Fixture::new();
+    let db = fixture.open();
+    add_target(&db);
+    assert_read_error(
+        &db,
+        "UPDATE t SET v = (SELECT target.v FROM target WHERE target.id = t.id) WHERE id = 1",
+    );
+    assert_target_unchanged(&db);
+    db.execute("COMMIT", ()).unwrap();
+    fixture.assert_cold_unchanged(db);
+}
+
+#[test]
+fn correlated_set_error_preserves_prior_statement() {
+    let fixture = Fixture::new();
+    let db = fixture.open();
+    add_target(&db);
+    assert_read_error(
+        &db,
+        "UPDATE target SET v = (SELECT t.v FROM t WHERE t.id = target.id)",
+    );
+    assert_target_unchanged(&db);
+    db.execute("COMMIT", ()).unwrap();
+    assert_target_unchanged(&db);
+    fixture.assert_cold_unchanged(db);
+}
+
+#[test]
+fn correlated_update_filter_error_preserves_prior_statement() {
+    let fixture = Fixture::new();
+    let db = fixture.open();
+    db.execute("CREATE TABLE target (id INTEGER, v INTEGER UNIQUE)", ())
+        .unwrap();
+    begin_target_update(&db);
+    assert_read_error(
+        &db,
+        "UPDATE target SET v = v + 1 WHERE (SELECT t.v FROM t WHERE t.id = target.id) > 0",
+    );
+    assert_target_unchanged(&db);
+    db.execute("COMMIT", ()).unwrap();
+    assert_target_unchanged(&db);
+    fixture.assert_cold_unchanged(db);
+}
+
+#[test]
+fn correlated_delete_filter_error_preserves_prior_statement() {
+    let fixture = Fixture::new();
+    let db = fixture.open();
+    add_target(&db);
+    assert_read_error(
+        &db,
+        "DELETE FROM target WHERE (SELECT t.v FROM t WHERE t.id = target.id) > 0",
+    );
+    assert_target_unchanged(&db);
+    db.execute("COMMIT", ()).unwrap();
+    assert_target_unchanged(&db);
+    fixture.assert_cold_unchanged(db);
+}
+
+#[test]
+fn correlated_precompute_filter_error_preserves_prior_statement() {
+    let fixture = Fixture::new();
+    let db = fixture.open();
+    add_target(&db);
+    assert_read_error(&db, "UPDATE target SET v = (SELECT t.id FROM t WHERE t.id = target.id) WHERE (SELECT t.v FROM t WHERE t.id = target.id) > 0");
+    assert_target_unchanged(&db);
+    db.execute("COMMIT", ()).unwrap();
+    fixture.assert_cold_unchanged(db);
+}
+
+#[test]
+fn correlated_fk_precheck_reports_read_error_before_set_error() {
+    let fixture = Fixture::new();
+    let db = fixture.open();
+    db.execute("CREATE TABLE target (id INTEGER, v INTEGER UNIQUE)", ())
+        .unwrap();
+    db.execute("CREATE TABLE child (id INTEGER PRIMARY KEY, parent_v INTEGER REFERENCES target(v) ON UPDATE RESTRICT)", ()).unwrap();
+    begin_target_update(&db);
+    assert_read_error(
+        &db,
+        "UPDATE target SET v = 'bad' WHERE (SELECT t.v FROM t WHERE t.id = target.id + 0) > 0",
+    );
+    assert_target_unchanged(&db);
+    db.execute("COMMIT", ()).unwrap();
+    fixture.assert_cold_unchanged(db);
+}
+
+fn assert_exists_optimizer_error(sql: &str) {
+    let fixture = Fixture::new();
+    let db = fixture.open();
+    db.execute(
+        "CREATE TABLE target (id INTEGER PRIMARY KEY, v INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO target VALUES (1, 10), (2, 10)", ())
+        .unwrap();
+    assert_read_error(&db, sql);
+    assert_eq!(
+        pairs(&db, "SELECT * FROM target ORDER BY id"),
+        [(1, 10), (2, 10)]
+    );
+    fixture.assert_cold_unchanged(db);
+}
+
+#[test]
+fn select_preserves_exists_optimizer_error() {
+    assert_exists_optimizer_error(
+        "SELECT id FROM target WHERE EXISTS (SELECT 1 FROM t WHERE t.v = target.v)",
+    );
+}
+
+#[test]
+fn update_preserves_exists_optimizer_error() {
+    assert_exists_optimizer_error(
+        "UPDATE target SET v = v + 1 WHERE EXISTS (SELECT 1 FROM t WHERE t.v = target.v)",
+    );
+}
+
+#[test]
+fn delete_preserves_exists_optimizer_error() {
+    assert_exists_optimizer_error(
+        "DELETE FROM target WHERE EXISTS (SELECT 1 FROM t WHERE t.v = target.v)",
+    );
+}

--- a/tests/subquery_coverage_test.rs
+++ b/tests/subquery_coverage_test.rs
@@ -1553,3 +1553,89 @@ fn test_predicate_between_with_outer_ref() {
         "BETWEEN predicate with outer ref should return results"
     );
 }
+
+fn assert_semi_join_outer_reference(name: &str, predicate: &str, expected: &[i64]) {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE outer_t (id INTEGER PRIMARY KEY, val INTEGER, pattern TEXT)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE inner_t (id INTEGER PRIMARY KEY, outer_id INTEGER, v INTEGER, label TEXT)",
+        (),
+    )
+    .unwrap();
+    db.execute("CREATE TABLE third_t (n INTEGER)", ()).unwrap();
+    db.execute("INSERT INTO outer_t VALUES (1, 5, 'a%'), (2, 30, 'b%')", ())
+        .unwrap();
+    db.execute(
+        "INSERT INTO inner_t VALUES (1, 1, 5, 'a_b'), (2, 2, 7, 'baa')",
+        (),
+    )
+    .unwrap();
+    db.execute("INSERT INTO third_t VALUES (10), (20)", ())
+        .unwrap();
+    let ids: Vec<i64> = db
+        .query(
+            &format!("SELECT o.id FROM outer_t o WHERE {predicate} ORDER BY o.id"),
+            (),
+        )
+        .unwrap()
+        .map(|row| row.unwrap().get(0).unwrap())
+        .collect();
+    assert_eq!(ids, expected);
+}
+
+#[test]
+fn test_semi_join_outer_reference_in_like_pattern() {
+    assert_semi_join_outer_reference(
+        "test_semi_join_outer_reference_in_like_pattern",
+        "EXISTS (SELECT 1 FROM inner_t i WHERE i.outer_id = o.id AND i.label LIKE o.pattern)",
+        &[1, 2],
+    );
+}
+
+#[test]
+fn test_semi_join_rejects_outer_reference_in_like_escape() {
+    use stoolap::executor::Executor;
+    use stoolap::parser::ast::{Expression, Statement};
+
+    let statements = stoolap::parser::parse_sql(
+        "SELECT o.id FROM outer_t o WHERE EXISTS (SELECT 1 FROM inner_t i WHERE i.outer_id = o.id AND i.label LIKE 'a!_b' ESCAPE o.escape_char)",
+    ).unwrap();
+    let Statement::Select(select) = &statements[0] else {
+        panic!("expected SELECT");
+    };
+    let Some(Expression::Exists(exists)) = select.where_clause.as_deref() else {
+        panic!("expected EXISTS predicate");
+    };
+    assert!(Executor::try_extract_semi_join_info(exists, false, &["o".into()]).is_none());
+}
+
+#[test]
+fn test_semi_join_outer_reference_in_list_value() {
+    assert_semi_join_outer_reference(
+        "test_semi_join_outer_reference_in_list_value",
+        "EXISTS (SELECT 1 FROM inner_t i WHERE i.outer_id = o.id AND i.v IN (o.val, -1))",
+        &[1],
+    );
+}
+
+#[test]
+fn test_semi_join_outer_reference_in_any_left_operand() {
+    assert_semi_join_outer_reference(
+        "test_semi_join_outer_reference_in_any_left_operand",
+        "EXISTS (SELECT 1 FROM inner_t i WHERE i.outer_id = o.id AND o.val > ANY (SELECT n FROM third_t))",
+        &[2],
+    );
+}
+
+#[test]
+fn test_semi_join_outer_reference_in_nested_projection() {
+    assert_semi_join_outer_reference(
+        "test_semi_join_outer_reference_in_nested_projection",
+        "EXISTS (SELECT 1 FROM inner_t i WHERE i.outer_id = o.id AND (SELECT o.val FROM third_t LIMIT 1) > 10)",
+        &[2],
+    );
+}


### PR DESCRIPTION
I propagate late cold-read failures through the executor before it returns partial query results or uses an incomplete set of rows for UPDATE or DELETE. A readable volume followed by a corrupt one previously let DELETE RETURNING report the readable row as success. Correlated DML could skip a row whose nested query failed, and a semi-join fallback could hide a failed read by pruning that volume on its retry.

I check scanner errors after the affected drains and preserve errors from correlated query processing and semi-join preparation. The existing statement guard handles the resulting failure. I use the executor's existing scope-aware reference walker to reject unsupported semi-join shapes before execution, including outer references inside CAST, LIKE, lists, and nested subqueries. This keeps valid correlated SQL working while genuine read errors propagate. I remove the incomplete duplicate walker. This is a Stage 1 prerequisite of #122 against main, following the merged #140 and #141.

Validation:

- All 12 original cold-error regression guards fail on the same checkout with only the two executor source files reverted; the healthy-volume pruning control passes. They use real V4 files with a valid checksum and malformed deferred column payload, without modifying resident row identity metadata.
- The four correlated-query failures reported by CI and all five added correlation guards fail when only the classifier correction is reverted. Four new guards check exact SQL results; the LIKE ESCAPE guard checks planner rejection through parsed SQL.
- All 160 focused tests pass with default features and all 160 pass with test-filedb across subquery_coverage_test, executor_cold_error_test, correlated_subquery_test, subquery_update_test, subquery_delete_test, where_subquery_containers_test, nested_subquery_binding_test, and subquery_advanced_test.
- The earlier executor-error revision passed 106 focused tests in each configuration, including transaction, RETURNING, FK, and cold-upsert coverage. The current run includes all 13 original corruption/pruning cases.
- Formatting, all-target/all-feature clippy with warnings denied, and independent source, fixture, and negative-proof re-reviews pass. Full CI is pending for this correction; the previous CI run exposed the four correlation failures above.

I add no persistent structure or retained per-row/per-volume bytes. Scanner checks run once at the end of a drain, and the correlated paths propagate errors they already receive. Cloning a terminal error happens only on failure. Correlation classification traverses the query's expressions during preparation, including the additional nested scopes needed for correctness. Nested table names append directly into the existing scope vector instead of allocating a second collector vector. No locks are added. Timing and allocation measurements remain pending, so I do not claim row-latency acceptance.

The no-declared-PK UPDATE tests establish error propagation and preservation of prior statements, not rollback of an already-published hot batch. I leave generic expression-evaluator error semantics unchanged. The IN optimizer and unique-conflict scanner fallback have compatibility coverage but no dedicated ordinary-SQL negative guard for their error boundaries. The LIKE ESCAPE guard establishes optimization eligibility only: a separate dynamic-escape execution probe returned no rows instead of the matching row, which this correction does not fix. I do not change file format, publication, WAL recovery, residency, backup, or restore. Later snapshot, budget, clustering, and crash-coverage scenarios remain outside this prerequisite.
