### PR TITLE
Evaluate a non-literal LIKE ESCAPE instead of dropping it

### DIFF
--- a/src/executor/expression/compiler.rs
+++ b/src/executor/expression/compiler.rs
@@ -1286,16 +1286,35 @@ impl<'a> ExprCompiler<'a> {
         let is_glob = op_upper.contains("GLOB");
         let is_regexp = op_upper.contains("REGEXP") || op_upper.contains("RLIKE");
 
-        // Extract escape character if present
-        let escape_char: Option<char> = if let Some(ref escape_expr) = like.escape {
-            if let Expression::StringLiteral(lit) = &**escape_expr {
-                lit.value.chars().next()
-            } else {
-                None
+        // ESCAPE is baked in when it is a literal or folds to one. Anything else
+        // is evaluated per row, never dropped.
+        let mut runtime_escape: Option<&Expression> = None;
+        let escape_char: Option<char> = match like.escape.as_deref() {
+            None => None,
+            Some(Expression::StringLiteral(lit)) => lit.value.chars().next(),
+            Some(escape_expr) => {
+                match is_column_free(escape_expr)
+                    .then(|| self.try_fold_constant(escape_expr))
+                    .flatten()
+                {
+                    Some(Value::Text(text)) => text.chars().next(),
+                    _ => {
+                        runtime_escape = Some(escape_expr);
+                        None
+                    }
+                }
             }
-        } else {
-            None
         };
+
+        if let Some(escape_expr) = runtime_escape.filter(|_| !is_glob && !is_regexp) {
+            self.compile_expr(&like.pattern, builder)?;
+            self.compile_expr(escape_expr, builder)?;
+            builder.emit(Op::LikeDynamicEscapeExpr(case_insensitive));
+            if negated {
+                builder.emit(Op::Not);
+            }
+            return Ok(());
+        }
 
         // Try to compile pattern at compile time
         let pattern_str = Self::extract_pattern_string(&like.pattern);

--- a/src/executor/expression/ops.rs
+++ b/src/executor/expression/ops.rs
@@ -547,6 +547,10 @@ pub enum Op {
     /// Stack: [text, pattern_text] -> [bool]
     LikeDynamicEscape(bool, char), // case_insensitive, escape_char
 
+    /// Dynamic LIKE with ESCAPE: both pattern and escape are on the stack
+    /// Stack: [text, pattern_text, escape_text] -> [bool]
+    LikeDynamicEscapeExpr(bool), // case_insensitive
+
     /// Dynamic GLOB: pattern is on the stack
     /// Stack: [text, pattern_text] -> [bool]
     GlobDynamic,
@@ -928,6 +932,9 @@ impl std::fmt::Debug for Op {
                     "LikeDynamicEscape(case_insensitive={}, escape='{}')",
                     ci, esc
                 )
+            }
+            Op::LikeDynamicEscapeExpr(ci) => {
+                write!(f, "LikeDynamicEscapeExpr(case_insensitive={})", ci)
             }
             Op::GlobDynamic => write!(f, "GlobDynamic"),
             Op::RegexpDynamic => write!(f, "RegexpDynamic"),

--- a/src/executor/expression/program.rs
+++ b/src/executor/expression/program.rs
@@ -268,7 +268,7 @@ impl Program {
                 | Op::CaseCompare => -1,
 
                 // Pop 3, push 1 (-2)
-                Op::Between | Op::NotBetween => -2,
+                Op::Between | Op::NotBetween | Op::LikeDynamicEscapeExpr(_) => -2,
                 // Pop the value and its items, push 1
                 Op::InList(count) => -i32::try_from(*count).unwrap_or(i32::MAX),
 

--- a/src/executor/expression/vm.rs
+++ b/src/executor/expression/vm.rs
@@ -265,6 +265,41 @@ impl ExprVM {
 
     /// Execute a program and return the result
     #[inline]
+    /// Match a runtime pattern, caching the compiled form per (pattern, case, escape).
+    fn like_dynamic_escape(
+        &mut self,
+        text_val: &Value,
+        pattern_val: &Value,
+        ci: bool,
+        esc: Option<char>,
+    ) -> Value {
+        match (text_val, pattern_val) {
+            (Value::Text(text), Value::Text(pat)) => {
+                let need_compile = match &self.cached_like {
+                    Some((cached_pat, cached_ci, cached_esc, _)) => {
+                        cached_pat.as_str() != pat.as_str()
+                            || *cached_ci != ci
+                            || *cached_esc != esc
+                    }
+                    None => true,
+                };
+                if need_compile {
+                    // !% becomes \% so CompiledPattern treats the wildcard as literal
+                    let processed = match esc {
+                        Some(esc) => process_like_escape_runtime(pat, esc),
+                        None => pat.to_string(),
+                    };
+                    let compiled = CompiledPattern::compile(&processed, ci);
+                    self.cached_like = Some((pat.clone(), ci, esc, compiled));
+                }
+                let (_, _, _, ref compiled) = self.cached_like.as_ref().unwrap();
+                Value::Boolean(compiled.matches(text, ci))
+            }
+            (Value::Null(_), _) | (_, Value::Null(_)) => Value::Null(DataType::Boolean),
+            _ => Value::Boolean(false),
+        }
+    }
+
     pub fn execute(&mut self, program: &Program, ctx: &ExecuteContext) -> Result<Value> {
         // Ensure stack has enough capacity
         if self.stack.capacity() < program.max_stack_depth() {
@@ -1164,30 +1199,34 @@ impl ExprVM {
                 Op::LikeDynamicEscape(case_insensitive, escape_char) => {
                     let pattern_val = self.stack.pop().unwrap_or_else(Value::null_unknown);
                     let text_val = self.stack.pop().unwrap_or_else(Value::null_unknown);
-                    let result = match (&text_val, &pattern_val) {
-                        (Value::Text(text), Value::Text(pat)) => {
-                            let ci = *case_insensitive;
-                            let esc = *escape_char;
-                            let need_compile = match &self.cached_like {
-                                Some((cached_pat, cached_ci, cached_esc, _)) => {
-                                    cached_pat.as_str() != pat.as_str()
-                                        || *cached_ci != ci
-                                        || *cached_esc != Some(esc)
-                                }
-                                None => true,
-                            };
-                            if need_compile {
-                                // Pre-process the escape character in the pattern at runtime,
-                                // converting e.g. !% -> \% so CompiledPattern treats it as literal
-                                let processed = process_like_escape_runtime(pat, esc);
-                                let compiled = CompiledPattern::compile(&processed, ci);
-                                self.cached_like = Some((pat.clone(), ci, Some(esc), compiled));
-                            }
-                            let (_, _, _, ref compiled) = self.cached_like.as_ref().unwrap();
-                            Value::Boolean(compiled.matches(text, ci))
+                    let escape = Some(*escape_char);
+                    let result = self.like_dynamic_escape(
+                        &text_val,
+                        &pattern_val,
+                        *case_insensitive,
+                        escape,
+                    );
+                    self.stack.push(result);
+                    pc += 1;
+                }
+
+                Op::LikeDynamicEscapeExpr(case_insensitive) => {
+                    let escape_val = self.stack.pop().unwrap_or_else(Value::null_unknown);
+                    let pattern_val = self.stack.pop().unwrap_or_else(Value::null_unknown);
+                    let text_val = self.stack.pop().unwrap_or_else(Value::null_unknown);
+                    let result = match &escape_val {
+                        Value::Text(escape) => self.like_dynamic_escape(
+                            &text_val,
+                            &pattern_val,
+                            *case_insensitive,
+                            escape.chars().next(),
+                        ),
+                        Value::Null(_) => Value::Null(DataType::Boolean),
+                        _ => {
+                            return Err(crate::core::Error::invalid_argument(
+                                "ESCAPE must be a single-character string",
+                            ))
                         }
-                        (Value::Null(_), _) | (_, Value::Null(_)) => Value::Null(DataType::Boolean),
-                        _ => Value::Boolean(false),
                     };
                     self.stack.push(result);
                     pc += 1;

--- a/tests/bug_like_escape_test.rs
+++ b/tests/bug_like_escape_test.rs
@@ -109,3 +109,57 @@ fn test_like_escape_underscore_with_escape_clause() {
     let ids = query_ids(&db, "SELECT id FROM t WHERE val LIKE '%!_%' ESCAPE '!'");
     assert_eq!(ids, vec![5], "ESCAPE '!' should treat !_ as literal '_'");
 }
+
+#[test]
+fn test_like_escape_from_folded_expression() {
+    let db = setup_db("like_escape_folded");
+    let ids = query_ids(
+        &db,
+        "SELECT id FROM t WHERE val LIKE '%!_%' ESCAPE SUBSTR('!x', 1, 1)",
+    );
+    assert_eq!(ids, vec![5], "a folded ESCAPE must act like the literal");
+}
+
+#[test]
+fn test_like_escape_negated_from_folded_expression() {
+    let db = setup_db("like_escape_folded_not");
+    let ids = query_ids(
+        &db,
+        "SELECT id FROM t WHERE val NOT LIKE '%!_%' ESCAPE UPPER('!')",
+    );
+    assert_eq!(
+        ids,
+        vec![1, 2, 3, 4, 6, 7, 8],
+        "NOT LIKE must honour a folded ESCAPE"
+    );
+}
+
+#[test]
+fn test_like_escape_from_parameter() {
+    let db = setup_db("like_escape_param");
+    let mut rows = db
+        .query("SELECT id FROM t WHERE val LIKE ? ESCAPE ?", ("%!_%", "!"))
+        .unwrap();
+    let mut ids = Vec::new();
+    while let Some(Ok(row)) = rows.next() {
+        ids.push(row.get::<i64>(0).unwrap());
+    }
+    assert_eq!(ids, vec![5], "a parameter ESCAPE must be honoured");
+}
+
+#[test]
+fn test_like_escape_from_column() {
+    let db = Database::open("memory://like_escape_column").unwrap();
+    db.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT, esc TEXT)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO t VALUES (1, 'under_score', '!'), (2, 'underXscore', '!')",
+        (),
+    )
+    .unwrap();
+    let ids = query_ids(&db, "SELECT id FROM t WHERE val LIKE '%!_%' ESCAPE esc");
+    assert_eq!(ids, vec![1], "a column ESCAPE must be evaluated per row");
+}


### PR DESCRIPTION
A LIKE whose ESCAPE clause is not a string literal silently lost the escape character and returned the wrong rows, with no error:

```sql
SELECT name FROM t WHERE name LIKE 'a!_b' ESCAPE SUBSTR('!x', 1, 1);
-- expected the row 'a_b', returned nothing
```

The compiler read the escape only from `Expression::StringLiteral` and used `None` for every other shape (`src/executor/expression/compiler.rs`). The pattern was then compiled with `_` still a wildcard and `!` an ordinary character, so nothing matched. The same applied to a parameter (`LIKE ? ESCAPE ?`) and to a column reference.

A column-free escape expression is now folded with the compiler's existing `try_fold_constant` and baked into the current opcode. One that cannot be folded is compiled onto the stack and read per row by a new `LikeDynamicEscapeExpr` op, which reuses the runtime escape processing and the compiled-pattern cache that the dynamic-pattern op already keeps. An escape that evaluates to NULL yields NULL, an empty string means no escape (matching the existing `ESCAPE ''` behaviour), and a non-text value is rejected.

Literal escapes keep their compile-time path untouched, so no existing query gains per-row work. The runtime op runs only for shapes that returned wrong answers before.

Validation:

- Four guards added to `tests/bug_like_escape_test.rs` cover a folded expression, a negated folded expression, a parameter, and a column. All four fail on the same checkout with only `src/` reverted to main; the seven original escape tests pass in both states.
- 145 tests pass across the LIKE, expression and pushdown targets.
- The full in-memory suite passes: 5439 tests, 0 failures.
- `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.

I did not change GLOB or REGEXP, which do not take ESCAPE. I did not change the multi-character literal behaviour, which still takes the first character, or the pushdown converter in `expr_converter.rs`, which drops LIKE expressions it cannot represent rather than mishandling them. I did not measure timings, since no existing query path gains work.