### PR TITLE
docs: sync homepage release version

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,7 +11,7 @@ github:
   repository_url: https://github.com/stoolap/stoolap
 
 # Latest release shown in the homepage hero badge
-stoolap_version: v0.4.0
+stoolap_version: v0.4.1
 
 # Google Analytics
 google_analytics: 

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,7 +25,7 @@ title: High-performance embedded SQL database in Rust
       </span>
       <a class="hero-badge" href="{{ '/changelog/' | relative_url }}" aria-label="Latest release">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
-        <span id="heroVersion">{{ site.stoolap_version | default: "v0.4.0" }}</span>
+        <span id="heroVersion">{{ site.stoolap_version | default: "v0.4.1" }}</span>
       </a>
     </div>
     <div class="hero-terminal" id="heroTerminal" aria-hidden="true">


### PR DESCRIPTION
Fixes #145\n\nThe repository and latest GitHub release are v0.4.1, but the deployed homepage and its source fallback still display v0.4.0. Update both source values so the homepage badge reflects the current release.\n\nValidation:\n- cargo test --tests (5450 passed)\n- git diff --check\n- Live homepage checked before the change; source values now match the v0.4.1 release.\n\nThis is documentation/site metadata only; no runtime or dependency changes.