### PR TITLE
Keep captured scan payloads stable across concurrent updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,8 @@ jobs:
     - name: Differential oracle tests (Stoolap vs SQLite)
       run: cargo test --test differential_oracle_test --features sqlite
 
-    - name: Failpoint I/O tests
-      run: cargo test --test failpoint_io_test --features test-failpoints -- --test-threads=1
+    - name: Failpoint tests
+      run: cargo test --test failpoint_io_test --test captured_version_payload_test --features test-failpoints -- --test-threads=1
 
   coverage:
     name: Code Coverage

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -15,6 +15,14 @@ description: Release history and version notes for Stoolap
 
 <section class="changelog-list">
   <div class="container">
+    <article class="changelog-release">
+      <header class="changelog-release-header">
+        <span class="changelog-tag">Unreleased</span>
+      </header>
+      <div class="changelog-body">
+        <p>Fixed captured-version scans reading a newer row payload after a concurrent UPDATE reused its arena slot. These scans now read the payload retained by the visible version, preserving snapshot values, filter results, ordering, and aggregates.</p>
+      </div>
+    </article>
     <div id="changelogContent">
       <div class="changelog-loading" id="changelogLoading">
         <div class="changelog-spinner"></div>

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -2466,6 +2466,14 @@ impl VersionStore {
         let schema = self.schema.read();
         let compiled_filter = CompiledFilter::compile(filter, &schema);
         drop(schema); // Release lock early
+        let fully_compiled = compiled_filter.is_fully_compiled();
+        let matches_row = |row: &Row| {
+            if fully_compiled {
+                compiled_filter.matches_arc_slice(row.as_slice())
+            } else {
+                compiled_filter.matches(row)
+            }
+        };
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
         let versions = self.snapshot_versions();
@@ -2481,7 +2489,7 @@ impl VersionStore {
             if checker.is_visible(head_txn_id, txn_id) {
                 // HEAD is visible - check if deleted
                 if (head_deleted_at == 0 || !checker.is_visible(head_deleted_at, txn_id))
-                    && compiled_filter.matches(&chain.version.data)
+                    && matches_row(&chain.version.data)
                 {
                     let mut version_copy = chain.version.clone();
                     version_copy.create_time = current_seq;
@@ -2498,7 +2506,7 @@ impl VersionStore {
 
                 if checker.is_visible(version_txn_id, txn_id) {
                     if (deleted_at_txn_id == 0 || !checker.is_visible(deleted_at_txn_id, txn_id))
-                        && compiled_filter.matches(&e.version.data)
+                        && matches_row(&e.version.data)
                     {
                         let mut version_copy = e.version.clone();
                         version_copy.create_time = current_seq;
@@ -3093,6 +3101,14 @@ impl VersionStore {
         let schema = self.schema.read();
         let compiled_filter = CompiledFilter::compile(filter, &schema);
         drop(schema); // Release lock early
+        let fully_compiled = compiled_filter.is_fully_compiled();
+        let matches_row = |row: &Row| {
+            if fully_compiled {
+                compiled_filter.matches_arc_slice(row.as_slice())
+            } else {
+                compiled_filter.matches(row)
+            }
+        };
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
         let versions = self.snapshot_versions();
@@ -3112,7 +3128,7 @@ impl VersionStore {
                         break; // Row is deleted
                     }
 
-                    if compiled_filter.matches(&e.version.data) {
+                    if matches_row(&e.version.data) {
                         result.push((row_id, e.version.data.clone()));
                     }
                     break;
@@ -3149,6 +3165,14 @@ impl VersionStore {
         let schema = self.schema.read();
         let compiled_filter = CompiledFilter::compile(filter, &schema);
         drop(schema);
+        let fully_compiled = compiled_filter.is_fully_compiled();
+        let matches_row = |row: &Row| {
+            if fully_compiled {
+                compiled_filter.matches_arc_slice(row.as_slice())
+            } else {
+                compiled_filter.matches(row)
+            }
+        };
 
         let versions = self.snapshot_versions();
 
@@ -3164,9 +3188,7 @@ impl VersionStore {
                         break;
                     }
 
-                    if compiled_filter.matches(&e.version.data)
-                        && !callback(row_id, e.version.data.clone())
-                    {
+                    if matches_row(&e.version.data) && !callback(row_id, e.version.data.clone()) {
                         return;
                     }
                     break;
@@ -3207,6 +3229,14 @@ impl VersionStore {
         let schema = self.schema.read();
         let compiled_filter = CompiledFilter::compile(filter, &schema);
         drop(schema);
+        let fully_compiled = compiled_filter.is_fully_compiled();
+        let matches_row = |row: &Row| {
+            if fully_compiled {
+                compiled_filter.matches_arc_slice(row.as_slice())
+            } else {
+                compiled_filter.matches(row)
+            }
+        };
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
         let versions = self.snapshot_versions();
@@ -3229,7 +3259,7 @@ impl VersionStore {
                         break; // Row is deleted
                     }
 
-                    if compiled_filter.matches(&e.version.data) {
+                    if matches_row(&e.version.data) {
                         if skipped < offset {
                             skipped += 1;
                         } else {

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -705,6 +705,14 @@ impl VersionStore {
         &self.table_name
     }
 
+    #[inline]
+    fn snapshot_versions(&self) -> crate::common::CowBTree<VersionChainEntry> {
+        let versions = self.versions.read().clone();
+        #[cfg(any(test, feature = "test-failpoints"))]
+        crate::test_failpoints::version_root_captured();
+        versions
+    }
+
     /// Returns the schema (cheap CompactArc clone)
     pub fn schema(&self) -> CompactArc<Schema> {
         self.schema.read().clone()
@@ -1725,21 +1733,8 @@ impl VersionStore {
         let mut results = Vec::with_capacity(row_ids.len());
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
+        let versions = self.snapshot_versions();
 
-        // Pre-acquire arena lock for O(1) Arc clones
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
-
-        // Helper: get row from arena (O(1)) or version (O(n) clone)
-        let get_row = |entry: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(entry.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            entry.version.data.clone()
-        };
         for &row_id in row_ids {
             if let Some(chain) = versions.get(row_id) {
                 // FAST PATH: Check HEAD version first - O(1) for common case
@@ -1751,7 +1746,7 @@ impl VersionStore {
                     if head_deleted_at == 0 || !checker.is_visible(head_deleted_at, txn_id) {
                         let mut version_copy = chain.version.clone();
                         version_copy.create_time = current_seq;
-                        results.push((row_id, get_row(chain), version_copy));
+                        results.push((row_id, chain.version.data.clone(), version_copy));
                     }
                     continue;
                 }
@@ -1771,7 +1766,7 @@ impl VersionStore {
                             // Store the current sequence in create_time for later retrieval
                             // (This is a bit of a hack, but avoids changing the struct)
                             version_copy.create_time = current_seq;
-                            results.push((row_id, get_row(e), version_copy));
+                            results.push((row_id, e.version.data.clone(), version_copy));
                         }
                         break;
                     }
@@ -2236,21 +2231,8 @@ impl VersionStore {
         };
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
+        let versions = self.snapshot_versions();
 
-        // Pre-acquire arena lock for O(1) Arc clones
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
-
-        // Helper: get row from arena (O(1)) or version (O(n) clone)
-        let get_row = |entry: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(entry.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            entry.version.data.clone()
-        };
         let mut results = RowVec::with_capacity(versions.len());
 
         for (&row_id, chain) in versions.iter() {
@@ -2261,7 +2243,7 @@ impl VersionStore {
             if checker.is_visible(head_txn_id, txn_id) {
                 // HEAD is visible - check if deleted
                 if head_deleted_at == 0 || !checker.is_visible(head_deleted_at, txn_id) {
-                    results.push((row_id, get_row(chain)));
+                    results.push((row_id, chain.version.data.clone()));
                 }
                 continue;
             }
@@ -2274,7 +2256,7 @@ impl VersionStore {
 
                 if checker.is_visible(version_txn_id, txn_id) {
                     if deleted_at_txn_id == 0 || !checker.is_visible(deleted_at_txn_id, txn_id) {
-                        results.push((row_id, get_row(e)));
+                        results.push((row_id, e.version.data.clone()));
                     }
                     break;
                 }
@@ -2285,12 +2267,7 @@ impl VersionStore {
         results
     }
 
-    /// Returns all visible rows using arena for zero-copy scanning
-    ///
-    /// This method provides 50x+ faster full table scans by:
-    /// 1. Pre-acquiring arena locks once
-    /// 2. Reading directly during visibility iteration (single pass)
-    /// 3. Using contiguous arena memory for cache locality
+    /// Returns all visible rows from a captured version root.
     #[inline]
     pub fn get_all_visible_rows_arena(&self, txn_id: i64) -> RowVec {
         if self.closed.load(Ordering::Acquire) {
@@ -2303,23 +2280,8 @@ impl VersionStore {
         };
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
+        let versions = self.snapshot_versions();
 
-        // Pre-acquire arena lock ONCE for the entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
-
-        // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
-
-        // Single-pass: read directly from arena during visibility check
         let mut result = RowVec::with_capacity(versions.len());
 
         for (&row_id, chain) in versions.iter() {
@@ -2330,7 +2292,7 @@ impl VersionStore {
             if checker.is_visible(head_txn_id, txn_id) {
                 // HEAD is visible - check if deleted
                 if head_deleted_at == 0 || !checker.is_visible(head_deleted_at, txn_id) {
-                    result.push((row_id, get_row_data(chain)));
+                    result.push((row_id, chain.version.data.clone()));
                 }
                 continue;
             }
@@ -2343,7 +2305,7 @@ impl VersionStore {
 
                 if checker.is_visible(version_txn_id, txn_id) {
                     if deleted_at_txn_id == 0 || !checker.is_visible(deleted_at_txn_id, txn_id) {
-                        result.push((row_id, get_row_data(e)));
+                        result.push((row_id, e.version.data.clone()));
                     }
                     break;
                 }
@@ -2372,23 +2334,7 @@ impl VersionStore {
         };
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
-
-        // Pre-acquire arena lock ONCE for the entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
-
-        // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
-
-        // Single-pass: read directly from arena during visibility check
+        let versions = self.snapshot_versions();
 
         // Ensure capacity
         let current_capacity = result.capacity();
@@ -2405,7 +2351,7 @@ impl VersionStore {
             if checker.is_visible(head_txn_id, txn_id) {
                 // HEAD is visible - check if deleted
                 if head_deleted_at == 0 || !checker.is_visible(head_deleted_at, txn_id) {
-                    result.push((row_id, get_row_data(chain)));
+                    result.push((row_id, chain.version.data.clone()));
                 }
                 continue;
             }
@@ -2418,7 +2364,7 @@ impl VersionStore {
 
                 if checker.is_visible(version_txn_id, txn_id) {
                     if deleted_at_txn_id == 0 || !checker.is_visible(deleted_at_txn_id, txn_id) {
-                        result.push((row_id, get_row_data(e)));
+                        result.push((row_id, e.version.data.clone()));
                     }
                     break;
                 }
@@ -2452,23 +2398,8 @@ impl VersionStore {
         let current_seq = checker.get_current_sequence();
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
+        let versions = self.snapshot_versions();
 
-        // Pre-acquire arena lock ONCE for the entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
-
-        // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
-
-        // Single-pass: read directly from arena during visibility check
         let mut result: Vec<(i64, Row, RowVersion)> = Vec::with_capacity(versions.len());
 
         for (&row_id, chain) in versions.iter() {
@@ -2481,7 +2412,7 @@ impl VersionStore {
                 if head_deleted_at == 0 || !checker.is_visible(head_deleted_at, txn_id) {
                     let mut version_copy = chain.version.clone();
                     version_copy.create_time = current_seq;
-                    result.push((row_id, get_row_data(chain), version_copy));
+                    result.push((row_id, chain.version.data.clone(), version_copy));
                 }
                 continue;
             }
@@ -2496,7 +2427,7 @@ impl VersionStore {
                     if deleted_at_txn_id == 0 || !checker.is_visible(deleted_at_txn_id, txn_id) {
                         let mut version_copy = e.version.clone();
                         version_copy.create_time = current_seq;
-                        result.push((row_id, get_row_data(e), version_copy));
+                        result.push((row_id, e.version.data.clone(), version_copy));
                     }
                     break;
                 }
@@ -2537,11 +2468,7 @@ impl VersionStore {
         drop(schema); // Release lock early
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
-
-        // Pre-acquire arena lock ONCE for the entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
+        let versions = self.snapshot_versions();
 
         // Single-pass: read, filter, and collect in one loop
         let mut result: Vec<(i64, Row, RowVersion)> = Vec::with_capacity(versions.len() / 4);
@@ -2553,29 +2480,12 @@ impl VersionStore {
 
             if checker.is_visible(head_txn_id, txn_id) {
                 // HEAD is visible - check if deleted
-                if head_deleted_at == 0 || !checker.is_visible(head_deleted_at, txn_id) {
-                    // Try arena path first (zero-copy filter check using matches_arc_slice)
-                    if let Some(idx) = unpack_arena_idx(chain.arena_idx) {
-                        if let Some(arc_row) = arena_data.get(idx) {
-                            // Filter directly on Arc slice - no Row allocation for non-matching rows
-                            if compiled_filter.matches_arc_slice(arc_row.as_ref()) {
-                                let mut version_copy = chain.version.clone();
-                                version_copy.create_time = current_seq;
-                                result.push((
-                                    row_id,
-                                    Row::from_arc(CompactArc::clone(arc_row)),
-                                    version_copy,
-                                ));
-                            }
-                            continue;
-                        }
-                    }
-                    // Fallback: filter on version data
-                    if compiled_filter.matches(&chain.version.data) {
-                        let mut version_copy = chain.version.clone();
-                        version_copy.create_time = current_seq;
-                        result.push((row_id, chain.version.data.clone(), version_copy));
-                    }
+                if (head_deleted_at == 0 || !checker.is_visible(head_deleted_at, txn_id))
+                    && compiled_filter.matches(&chain.version.data)
+                {
+                    let mut version_copy = chain.version.clone();
+                    version_copy.create_time = current_seq;
+                    result.push((row_id, chain.version.data.clone(), version_copy));
                 }
                 continue;
             }
@@ -2587,29 +2497,12 @@ impl VersionStore {
                 let deleted_at_txn_id = e.version.deleted_at_txn_id;
 
                 if checker.is_visible(version_txn_id, txn_id) {
-                    if deleted_at_txn_id == 0 || !checker.is_visible(deleted_at_txn_id, txn_id) {
-                        // Try arena path first (zero-copy filter check using matches_arc_slice)
-                        if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                            if let Some(arc_row) = arena_data.get(idx) {
-                                // Filter directly on Arc slice - no Row allocation for non-matching rows
-                                if compiled_filter.matches_arc_slice(arc_row.as_ref()) {
-                                    let mut version_copy = e.version.clone();
-                                    version_copy.create_time = current_seq;
-                                    result.push((
-                                        row_id,
-                                        Row::from_arc(CompactArc::clone(arc_row)),
-                                        version_copy,
-                                    ));
-                                }
-                                break;
-                            }
-                        }
-                        // Fallback: filter on version data
-                        if compiled_filter.matches(&e.version.data) {
-                            let mut version_copy = e.version.clone();
-                            version_copy.create_time = current_seq;
-                            result.push((row_id, e.version.data.clone(), version_copy));
-                        }
+                    if (deleted_at_txn_id == 0 || !checker.is_visible(deleted_at_txn_id, txn_id))
+                        && compiled_filter.matches(&e.version.data)
+                    {
+                        let mut version_copy = e.version.clone();
+                        version_copy.create_time = current_seq;
+                        result.push((row_id, e.version.data.clone(), version_copy));
                     }
                     break;
                 }
@@ -2635,23 +2528,8 @@ impl VersionStore {
         };
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
+        let versions = self.snapshot_versions();
 
-        // Pre-acquire arena lock ONCE for the entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
-
-        // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
-
-        // Single-pass: read directly from arena during visibility check
         let mut result = RowVec::with_capacity(versions.len());
 
         for (&row_id, chain) in versions.iter() {
@@ -2662,7 +2540,7 @@ impl VersionStore {
             if checker.is_visible(head_txn_id, txn_id) {
                 // HEAD is visible - check if deleted
                 if head_deleted_at == 0 || !checker.is_visible(head_deleted_at, txn_id) {
-                    result.push((row_id, get_row_data(chain)));
+                    result.push((row_id, chain.version.data.clone()));
                 }
                 continue;
             }
@@ -2675,7 +2553,7 @@ impl VersionStore {
 
                 if checker.is_visible(version_txn_id, txn_id) {
                     if deleted_at_txn_id == 0 || !checker.is_visible(deleted_at_txn_id, txn_id) {
-                        result.push((row_id, get_row_data(e)));
+                        result.push((row_id, e.version.data.clone()));
                     }
                     break;
                 }
@@ -2708,21 +2586,7 @@ impl VersionStore {
         };
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
-
-        // Pre-acquire arena lock ONCE for the entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
-
-        // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
+        let versions = self.snapshot_versions();
 
         // Collect with early termination
         // A user-supplied limit can be i64::MAX; only pre-allocate what
@@ -2770,7 +2634,7 @@ impl VersionStore {
                 if skipped < offset {
                     skipped += 1;
                 } else {
-                    result.push((row_id, get_row_data(entry)));
+                    result.push((row_id, entry.version.data.clone()));
                     if result.len() >= limit {
                         break; // Early termination!
                     }
@@ -2868,21 +2732,7 @@ impl VersionStore {
         };
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
-
-        // Pre-acquire arena lock ONCE for this batch
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
-
-        // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
+        let versions = self.snapshot_versions();
 
         // Use range for efficient cursor-based iteration
         let mut result = RowVec::with_capacity(batch_size);
@@ -2933,7 +2783,7 @@ impl VersionStore {
                     has_more = true;
                     break; // Early termination - found one more than needed
                 }
-                result.push((row_id, get_row_data(entry)));
+                result.push((row_id, entry.version.data.clone()));
             }
         }
 
@@ -2972,21 +2822,7 @@ impl VersionStore {
         };
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
-
-        // Pre-acquire arena lock ONCE for this batch
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
-
-        // Helper closure to get row data from arena or version
-        let get_row_data = |e: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            e.version.data.clone()
-        };
+        let versions = self.snapshot_versions();
 
         // Use range for efficient cursor-based iteration
         buffer.reserve(batch_size);
@@ -3037,7 +2873,7 @@ impl VersionStore {
                     has_more = true;
                     break; // Early termination - found one more than needed
                 }
-                buffer.push((row_id, get_row_data(entry)));
+                buffer.push((row_id, entry.version.data.clone()));
             }
         }
 
@@ -3075,21 +2911,7 @@ impl VersionStore {
         };
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
-
-        // Pre-acquire arena lock ONCE for this entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
-
-        // Helper to get row data from an entry
-        let get_row_from_entry = |entry: &VersionChainEntry| -> Row {
-            if let Some(idx) = unpack_arena_idx(entry.arena_idx) {
-                if let Some(arc_row) = arena_data.get(idx) {
-                    return Row::from_arc(CompactArc::clone(arc_row));
-                }
-            }
-            entry.version.data.clone()
-        };
+        let versions = self.snapshot_versions();
 
         // Collect with offset/limit
         // Cap capacity to avoid overflow when limit is usize::MAX
@@ -3111,7 +2933,7 @@ impl VersionStore {
                             if skipped < offset {
                                 skipped += 1;
                             } else {
-                                result.push((*row_id, get_row_from_entry(entry)));
+                                result.push((*row_id, entry.version.data.clone()));
                                 if result.len() >= limit {
                                     return Some(result);
                                 }
@@ -3134,7 +2956,7 @@ impl VersionStore {
                             if skipped < offset {
                                 skipped += 1;
                             } else {
-                                result.push((row_id, get_row_from_entry(entry)));
+                                result.push((row_id, entry.version.data.clone()));
                                 if result.len() >= limit {
                                     return Some(result);
                                 }
@@ -3182,11 +3004,7 @@ impl VersionStore {
         };
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
-
-        // Pre-acquire arena lock ONCE for this entire operation
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
+        let versions = self.snapshot_versions();
 
         // Helper to find visible version and get row data
         let find_visible_row = |chain: &VersionChainEntry| -> Option<Row> {
@@ -3200,17 +3018,7 @@ impl VersionStore {
                         break; // Row is deleted
                     }
 
-                    // Read row data from arena or version
-                    let row_data = if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                        if let Some(arc_row) = arena_data.get(idx) {
-                            Row::from_arc(CompactArc::clone(arc_row))
-                        } else {
-                            e.version.data.clone()
-                        }
-                    } else {
-                        e.version.data.clone()
-                    };
-                    return Some(row_data);
+                    return Some(e.version.data.clone());
                 }
                 current = e.prev.as_ref().map(|b| b.as_ref());
             }
@@ -3287,11 +3095,7 @@ impl VersionStore {
         drop(schema); // Release lock early
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
-
-        // Pre-acquire arena lock ONCE
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
+        let versions = self.snapshot_versions();
 
         // Single-pass: read, filter, and collect in one loop
         let mut result = RowVec::with_capacity(versions.len() / 4);
@@ -3308,18 +3112,6 @@ impl VersionStore {
                         break; // Row is deleted
                     }
 
-                    // OPTIMIZATION: Filter BEFORE cloning to avoid allocation for non-matching rows
-                    // Try arena path first (zero-copy filter check using matches_arc_slice)
-                    if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                        if let Some(arc_row) = arena_data.get(idx) {
-                            // Filter directly on Arc slice - no Row allocation for non-matching rows
-                            if compiled_filter.matches_arc_slice(arc_row.as_ref()) {
-                                result.push((row_id, Row::from_arc(CompactArc::clone(arc_row))));
-                            }
-                            break;
-                        }
-                    }
-                    // Fallback: filter on version data (already allocated)
                     if compiled_filter.matches(&e.version.data) {
                         result.push((row_id, e.version.data.clone()));
                     }
@@ -3358,9 +3150,7 @@ impl VersionStore {
         let compiled_filter = CompiledFilter::compile(filter, &schema);
         drop(schema);
 
-        let versions = self.versions.read().clone();
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
+        let versions = self.snapshot_versions();
 
         for (&row_id, chain) in versions.iter() {
             let mut current: Option<&VersionChainEntry> = Some(chain);
@@ -3374,17 +3164,6 @@ impl VersionStore {
                         break;
                     }
 
-                    if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                        if let Some(arc_row) = arena_data.get(idx) {
-                            if compiled_filter.matches_arc_slice(arc_row.as_ref()) {
-                                let row = Row::from_arc(CompactArc::clone(arc_row));
-                                if !callback(row_id, row) {
-                                    return;
-                                }
-                            }
-                            break;
-                        }
-                    }
                     if compiled_filter.matches(&e.version.data)
                         && !callback(row_id, e.version.data.clone())
                     {
@@ -3430,11 +3209,7 @@ impl VersionStore {
         drop(schema);
 
         // Clone CowBTree to release read lock early, allowing concurrent commits
-        let versions = self.versions.read().clone();
-
-        // Pre-acquire arena lock ONCE
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
+        let versions = self.snapshot_versions();
 
         // Collect with offset/limit and early termination
         // A user-supplied limit can be i64::MAX; only pre-allocate what
@@ -3454,26 +3229,6 @@ impl VersionStore {
                         break; // Row is deleted
                     }
 
-                    // OPTIMIZATION: Filter BEFORE cloning to avoid allocation for non-matching rows
-                    // Try arena path first (zero-copy filter check using matches_arc_slice)
-                    if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                        if let Some(arc_row) = arena_data.get(idx) {
-                            // Filter directly on Arc slice - no Row allocation for non-matching rows
-                            if compiled_filter.matches_arc_slice(arc_row.as_ref()) {
-                                if skipped < offset {
-                                    skipped += 1;
-                                } else {
-                                    result
-                                        .push((row_id, Row::from_arc(CompactArc::clone(arc_row))));
-                                    if result.len() >= limit {
-                                        return result; // Early termination!
-                                    }
-                                }
-                            }
-                            break;
-                        }
-                    }
-                    // Fallback: filter on version data (already allocated)
                     if compiled_filter.matches(&e.version.data) {
                         if skipped < offset {
                             skipped += 1;
@@ -3884,9 +3639,7 @@ impl VersionStore {
         // SLOW PATH: CowBTree iteration — materialize during collection because
         // the visible version may be a chain entry (not HEAD), and RowIndex-based
         // deferred materialization would lose track of which version was visible.
-        let versions = self.versions.read().clone();
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
+        let versions = self.snapshot_versions();
 
         let mut materialized: Vec<(i64, Row, Option<Value>)> = Vec::with_capacity(versions.len());
 
@@ -3897,15 +3650,7 @@ impl VersionStore {
                     if e.version.deleted_at_txn_id == 0
                         || !checker.is_visible(e.version.deleted_at_txn_id, txn_id)
                     {
-                        let row = if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                            if let Some(arc_row) = arena_data.get(idx) {
-                                Row::from_arc(CompactArc::clone(arc_row))
-                            } else {
-                                e.version.data.clone()
-                            }
-                        } else {
-                            e.version.data.clone()
-                        };
+                        let row = e.version.data.clone();
                         let sort_val = row.get(sort_col_idx).cloned();
                         materialized.push((row_id, row, sort_val));
                     }
@@ -3915,8 +3660,6 @@ impl VersionStore {
             }
         }
 
-        // Drop locks before sort
-        drop(arena_guard);
         drop(versions);
 
         if materialized.is_empty() {
@@ -4450,10 +4193,8 @@ impl VersionStore {
             }
         }
 
-        // SLOW PATH: CowBTree iteration with arena data retrieval
-        let versions = self.versions.read().clone();
-        let arena_guard = self.arena.read_guard();
-        let arena_data = arena_guard.data();
+        // SLOW PATH: Read the payload owned by each captured version.
+        let versions = self.snapshot_versions();
 
         for chain in versions.values() {
             let mut current: Option<&VersionChainEntry> = Some(chain);
@@ -4462,15 +4203,7 @@ impl VersionStore {
                     if e.version.deleted_at_txn_id == 0
                         || !checker.is_visible(e.version.deleted_at_txn_id, txn_id)
                     {
-                        if let Some(idx) = unpack_arena_idx(e.arena_idx) {
-                            if let Some(arc_row) = arena_data.get(idx) {
-                                accumulate_from!(arc_row, results, aggregates);
-                            } else {
-                                accumulate_from!(e.version.data, results, aggregates);
-                            }
-                        } else {
-                            accumulate_from!(e.version.data, results, aggregates);
-                        }
+                        accumulate_from!(e.version.data, results, aggregates);
                     }
                     break;
                 }

--- a/src/test_failpoints.rs
+++ b/src/test_failpoints.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Test-only failpoint flags for injecting I/O errors.
-//!
-//! Each flag is an `AtomicBool` that can be armed from integration tests.
-//! Source code checks these flags inside `#[cfg(test)]` guards, so they
-//! have zero cost in release builds.
+//! Test failpoints for I/O errors and deterministic reader/writer rendezvous.
+//! Flags and hooks are enabled by unit tests or the `test-failpoints` feature.
+//! Normal builds without that feature compile out the failpoints and their calls.
 
+use std::cell::RefCell;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Mutex, MutexGuard};
 
@@ -44,6 +43,22 @@ pub static CHECKPOINT_WRITE_FAIL: AtomicBool = AtomicBool::new(false);
 /// interfere with each other without this lock.
 static FAILPOINT_LOCK: Mutex<()> = Mutex::new(());
 
+thread_local! {
+    static VERSION_ROOT_HOOK: RefCell<Option<Box<dyn FnOnce()>>> = RefCell::new(None);
+}
+
+/// Run once on this thread immediately after its next version root is copied.
+pub fn after_version_root(hook: impl FnOnce() + 'static) {
+    VERSION_ROOT_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+pub(crate) fn version_root_captured() {
+    let hook = VERSION_ROOT_HOOK.with(|slot| slot.borrow_mut().take());
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
 /// Reset all failpoints to disabled state
 pub fn reset_all() {
     use std::sync::atomic::Ordering::Release;
@@ -53,6 +68,7 @@ pub fn reset_all() {
     SNAPSHOT_SYNC_FAIL.store(false, Release);
     SNAPSHOT_RENAME_FAIL.store(false, Release);
     CHECKPOINT_WRITE_FAIL.store(false, Release);
+    VERSION_ROOT_HOOK.with(|slot| *slot.borrow_mut() = None);
 }
 
 /// RAII guard that serializes failpoint tests and resets all failpoints on drop.

--- a/tests/captured_version_payload_test.rs
+++ b/tests/captured_version_payload_test.rs
@@ -1,0 +1,170 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "test-failpoints")]
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use stoolap::core::{Row, RowVec, Value};
+use stoolap::storage::expression::ComparisonExpr;
+use stoolap::storage::mvcc::version_store::{
+    AggregateOp, AggregateResult, RowVersion, VersionStore,
+};
+use stoolap::storage::Engine;
+use stoolap::{test_failpoints, Database, IsolationLevel};
+
+fn read_across_update<T>(name: &str, read: impl FnOnce(&VersionStore, i64) -> T) -> T {
+    let _guard = test_failpoints::FailpointGuard::new();
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute(
+        "CREATE TABLE accounts (id INTEGER PRIMARY KEY, balance INTEGER, note TEXT)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO accounts VALUES (1, 100, 'original shared payload')",
+        (),
+    )
+    .unwrap();
+    let store = db.engine().get_version_store("accounts").unwrap();
+    let reader = db
+        .engine()
+        .begin_transaction_with_level(IsolationLevel::SnapshotIsolation)
+        .unwrap();
+    let writer = db.clone();
+    let updated = Arc::new(AtomicBool::new(false));
+    let updated_in_hook = Arc::clone(&updated);
+    test_failpoints::after_version_root(move || {
+        let count = std::thread::spawn(move || {
+            writer.execute(
+                "UPDATE accounts SET balance = 900, note = 'updated shared payload' WHERE id = 1",
+                (),
+            )
+        })
+        .join()
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            count, 1,
+            "rendezvous writer must commit one ordinary UPDATE"
+        );
+        updated_in_hook.store(true, Ordering::Release);
+    });
+    let result = read(&store, reader.id());
+    assert!(
+        updated.load(Ordering::Acquire),
+        "reader must hit rendezvous"
+    );
+    let current: i64 = db
+        .query_one("SELECT balance FROM accounts WHERE id = 1", ())
+        .unwrap();
+    assert_eq!(current, 900, "UPDATE must be visible outside the snapshot");
+    result
+}
+
+fn update_rows(rows: Vec<(i64, Row, RowVersion)>) -> RowVec {
+    rows.into_iter()
+        .map(|(id, row, version)| {
+            assert_eq!(row, version.data, "payload must match its captured version");
+            (id, row)
+        })
+        .collect()
+}
+
+fn balance_filter() -> ComparisonExpr {
+    ComparisonExpr::eq("balance", Value::Integer(100))
+}
+
+macro_rules! captured_rows_test {
+    ($name:ident, $read:expr) => {
+        #[test]
+        fn $name() {
+            let rows = read_across_update(stringify!($name), $read);
+            assert_eq!(rows.len(), 1, "snapshot must retain the matching row");
+            assert_eq!(rows[0].0, 1);
+            assert_eq!(
+                rows[0].1.as_slice(),
+                &[
+                    Value::Integer(1),
+                    Value::Integer(100),
+                    Value::text("original shared payload"),
+                ],
+                "snapshot must not substitute the updated arena payload"
+            );
+        }
+    };
+}
+
+captured_rows_test!(captured_all_rows, |store, id| store
+    .get_all_visible_rows(id));
+captured_rows_test!(captured_arena_rows, |store, id| store
+    .get_all_visible_rows_arena(id));
+captured_rows_test!(captured_cached_rows, |store, id| store
+    .get_all_visible_rows_cached(id));
+captured_rows_test!(captured_unsorted_rows, |store, id| store
+    .get_all_visible_rows_unsorted(id));
+captured_rows_test!(captured_update_versions, |store, id| update_rows(
+    store.get_visible_versions_for_update(&[1], id)
+));
+captured_rows_test!(captured_update_rows, |store, id| update_rows(
+    store.get_all_visible_rows_for_update(id)
+));
+captured_rows_test!(captured_filtered_update, |store, id| update_rows(
+    store.get_all_visible_rows_for_update_filtered(id, &balance_filter())
+));
+captured_rows_test!(captured_limited_rows, |store, id| store
+    .get_visible_rows_with_limit(id, 1, 0));
+captured_rows_test!(captured_batch, |store, id| store
+    .get_visible_rows_batch(id, 0, 1)
+    .0);
+captured_rows_test!(captured_batch_into, |store, id| {
+    let mut rows = RowVec::new();
+    assert!(!store.get_visible_rows_batch_into(id, 0, 1, &mut rows));
+    rows
+});
+captured_rows_test!(captured_pk_ordered, |store, id| store
+    .collect_rows_pk_ordered(id, true, 1, 0)
+    .unwrap());
+captured_rows_test!(captured_keyset, |store, id| store.collect_rows_keyset(
+    id,
+    Some(0),
+    None,
+    true,
+    1
+));
+captured_rows_test!(captured_filtered_rows, |store, id| store
+    .get_all_visible_rows_filtered(id, &balance_filter()));
+captured_rows_test!(captured_filtered_callback, |store, id| {
+    let mut rows = RowVec::new();
+    store.for_each_visible_filtered(id, &balance_filter(), |row_id, row| {
+        rows.push((row_id, row));
+        true
+    });
+    rows
+});
+captured_rows_test!(captured_filtered_limit, |store, id| store
+    .get_visible_rows_filtered_with_limit(id, &balance_filter(), 1, 0));
+captured_rows_test!(captured_sorted_rows, |store, id| store
+    .get_visible_rows_sorted_limit(id, 1, true, 1, 0));
+
+#[test]
+fn captured_aggregate() {
+    let values = read_across_update("captured_aggregate", |store, id| {
+        store.compute_aggregates(id, &[(AggregateOp::Sum, 1)])
+    });
+    assert!(
+        matches!(values.as_slice(), [AggregateResult::Sum(100.0, 1)]),
+        "snapshot must aggregate the captured value, got {values:?}"
+    );
+}


### PR DESCRIPTION
An ordinary UPDATE overwrites its existing arena slot. A scan could copy the version tree before that UPDATE, then fetch its payload from the arena after the UPDATE committed. It returned the newer value under the older version's identity, violating snapshot visibility. I fix this existing correctness bug independently of the chunked-arena work.

I read the payload already owned by each selected version in 17 scan, update-read, ordered-read and aggregate branches. I remove their redundant arena guards and lookup fallbacks. Committed nondeleted versions and the arena already share the same CompactArc, so their owned results retain the existing reference-count increment. At the five filter call sites, I classify the filter once per scan with is_fully_compiled(): fully compiled predicates use matches_arc_slice on the captured payload, and predicates containing Dynamic nodes use matches on the borrowed Row. This preserves the compiled slice path without reaching Dynamic's temporary values vector. Classification walks the filter tree once per scan; evaluation selects the route using the cached boolean. I add no per-row or per-volume structure, allocation, counter or lock.

The test-failpoints feature now provides a one-shot thread-local rendezvous after the version-tree clone and before arena access. Each guard begins a real snapshot transaction, captures its root, completes an ordinary SQL UPDATE on a separate database handle, and resumes the reader. The hook and its calls are compiled out of normal builds without test-failpoints. CI explicitly runs the new target.

Validation so far:

- With only the payload fix reverted and identical rendezvous instrumentation retained, all 17 guards fail on wrong payload, lost predicate membership, Row/RowVersion disagreement, or SUM(900) instead of SUM(100). Every writer completed and joined; no guard uses a writer-progress timeout as its failure oracle.
- With the fix restored and its checksum verified, all 17 guards pass.
- Default compatibility: 60/60 passed across seven focused targets.
- With test-filedb and test-failpoints: 91/91 passed across those seven targets, the new 17-guard target and the existing failpoint I/O target.
- Formatting and all-target/all-feature clippy with warnings denied passed. After the equivalent conditional cleanup, all 17 guards passed again in both default and filedb configurations.
- The filter-dispatch correction passed formatting, all-target/all-feature clippy with warnings denied, and 55/55 tests in both default and filedb configurations across the 17 snapshot guards plus scan, cast and expression-pushdown targets.
- Full-suite CI passed on the original head 122cfc19. CI for the filter-dispatch correction is pending; earlier CI is not validation of the updated head.

Independent source, negative-proof, final-diff and validation evidence reviews are complete, with no open findings.

Release note: Fixed captured-version scans reading newer row payloads during concurrent UPDATE, preserving snapshot values, filter membership, ordering and aggregates. The user-facing changelog includes this as an Unreleased fix.

I leave live locked-root point readers, fast arena scans, StreamingResult and deferred RowIndex materialization unchanged. This does not establish complete statement visibility tokens or fix the separate deferred-materialization lifetime gap. No file format or chunk representation changes. I have not rerun full local suites; full-suite coverage belongs to CI. The reported 2,000-row range-scan regression from 254.5 to 277.6 microseconds motivated preserving the compiled slice route. Those six-run comparisons in both build orderings were not rerun during this correction, and the final mixed dispatch has not been timed. Row latency, writer CoW allocations and retained-memory acceptance remain open.
