### PR TITLE
Return assigned WAL LSNs from DML recording

### DIFF
--- a/src/storage/mvcc/persistence.rs
+++ b/src/storage/mvcc/persistence.rs
@@ -471,7 +471,7 @@ impl PersistenceManager {
         Ok(())
     }
 
-    /// Record a DML operation (INSERT, UPDATE, DELETE)
+    /// Record DML and return its assigned WAL LSN, or None when persistence is disabled.
     pub fn record_dml_operation(
         &self,
         txn_id: i64,
@@ -479,9 +479,9 @@ impl PersistenceManager {
         row_id: i64,
         op: WALOperationType,
         version: &RowVersion,
-    ) -> Result<()> {
+    ) -> Result<Option<u64>> {
         if !self.is_enabled() {
-            return Ok(());
+            return Ok(None);
         }
 
         let wal = self.wal.as_ref().ok_or(Error::WalNotInitialized)?;
@@ -491,8 +491,7 @@ impl PersistenceManager {
 
         let entry = WALEntry::new(txn_id, table_name.to_string(), row_id, op, data);
 
-        wal.append_entry(entry)?;
-        Ok(())
+        wal.append_entry(entry).map(Some)
     }
 
     /// Record a transaction commit

--- a/tests/dml_lsn_receipt_test.rs
+++ b/tests/dml_lsn_receipt_test.rs
@@ -1,0 +1,103 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use stoolap::core::{Error, Row, Value};
+use stoolap::storage::mvcc::persistence::PersistenceManager;
+use stoolap::storage::mvcc::version_store::RowVersion;
+use stoolap::storage::mvcc::wal_manager::WALOperationType;
+use stoolap::{PersistenceConfig, SyncMode};
+
+#[test]
+fn dml_receipts_match_interleaved_replay_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = PersistenceConfig {
+        enabled: true,
+        sync_mode: SyncMode::Full,
+        ..Default::default()
+    };
+    let pm = PersistenceManager::new(Some(dir.path()), &config).unwrap();
+    pm.start().unwrap();
+    pm.record_ddl_operation("t", WALOperationType::CreateTable, b"schema")
+        .unwrap();
+    let mut receipts = Vec::new();
+    for (txn_id, row_id, op) in [
+        (10, 1, WALOperationType::Insert),
+        (20, 2, WALOperationType::Insert),
+        (10, 3, WALOperationType::Delete),
+    ] {
+        let version = RowVersion::new(txn_id, Row::from_values(vec![Value::Integer(row_id)]));
+        let receipt = pm
+            .record_dml_operation(txn_id, "t", row_id, op, &version)
+            .unwrap();
+        receipts.push((txn_id, row_id, format!("{receipt:?}")));
+    }
+    pm.record_commit(20).unwrap();
+    pm.record_commit(10).unwrap();
+    let end_lsn = pm.current_lsn();
+    pm.stop().unwrap();
+
+    let pm = PersistenceManager::new(Some(dir.path()), &config).unwrap();
+    let mut replayed = Vec::new();
+    let mut commit_lsn = 0;
+    pm.replay_two_phase(0, |entry| {
+        if entry.is_commit_marker() && entry.txn_id == 10 {
+            commit_lsn = entry.lsn;
+        } else if matches!(
+            entry.operation,
+            WALOperationType::Insert | WALOperationType::Delete
+        ) {
+            replayed.push((entry.txn_id, entry.row_id, entry.lsn));
+        }
+        Ok(())
+    })
+    .unwrap();
+    assert_eq!(replayed.len(), receipts.len());
+    for ((txn_id, row_id, receipt), &(replayed_txn, replayed_row, lsn)) in
+        receipts.iter().zip(&replayed)
+    {
+        assert_eq!((*txn_id, *row_id), (replayed_txn, replayed_row));
+        assert_eq!(
+            receipt,
+            &format!("Some({lsn})"),
+            "receipt must identify the DML frame"
+        );
+    }
+    let first_dml = replayed[0].2;
+    assert!(first_dml < commit_lsn);
+    assert!(first_dml < end_lsn);
+    pm.stop().unwrap();
+}
+
+#[test]
+fn disabled_persistence_has_no_dml_receipt() {
+    let pm = PersistenceManager::new(None, &PersistenceConfig::default()).unwrap();
+    let version = RowVersion::new(1, Row::from_values(vec![Value::Integer(1)]));
+    let receipt = pm
+        .record_dml_operation(1, "t", 1, WALOperationType::Insert, &version)
+        .unwrap();
+    assert_eq!(format!("{receipt:?}"), "None");
+}
+
+#[test]
+fn closed_wal_returns_error_instead_of_dml_receipt() {
+    let dir = tempfile::tempdir().unwrap();
+    let pm = PersistenceManager::new(Some(dir.path()), &PersistenceConfig::default()).unwrap();
+    pm.start().unwrap();
+    pm.stop().unwrap();
+    let version = RowVersion::new(1, Row::from_values(vec![Value::Integer(1)]));
+    assert!(matches!(
+        pm.record_dml_operation(1, "t", 1, WALOperationType::Insert, &version),
+        Err(Error::WalNotRunning)
+    ));
+}


### PR DESCRIPTION
I return the LSN assigned to each DML append from `PersistenceManager::record_dml_operation`. Enabled persistence returns `Some(lsn)`, disabled persistence returns `None`, and append errors propagate as before. Callers can now retain the DML frame identity instead of substituting a later commit marker or append position.

This is the independent LSN plumbing piece. Engine commit callers still discard the receipt until their consumer lands. I have not added transaction minima, chunk state, detached obligations, recovery cutoff changes or WAL truncation logic. The public return type changes from `Result<()>` to `Result<Option<u64>>`.

Cost: no new per-row or per-volume structure, heap allocation site, lock or counter. The existing append result is returned to the caller. This is source-level cost analysis, not a row-latency measurement.

Validation: the focused target passed 3/3 in both default and test-filedb configurations. Receipts match replay for interleaved transactions, disabled persistence returns None, and the stopped-WAL control preserves Error::WalNotRunning. Reversing only the production signature/body made the two receipt guards fail with () versus Some(3)/None, while the error control passed; restoring it made all three pass. Formatting and all-target/all-feature clippy with warnings denied passed. Full suites run in CI. Row-latency acceptance has not been measured for this change, so this PR remains draft.
