### PR TITLE
Order NULL keys consistently in storage sorted-limit scans

### DIFF
--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -21,6 +21,7 @@ description: Release history and version notes for Stoolap
       </header>
       <div class="changelog-body">
         <p>Fixed captured-version scans reading a newer row payload after a concurrent UPDATE reused its arena slot. These scans now read the payload retained by the visible version, preserving snapshot values, filter results, ordering, and aggregates.</p>
+        <p>Fixed sorted LIMIT scans through the storage API treating NULL keys as equal to non-NULL keys. These scans now place NULLs last in ascending order and first in descending order, matching SQL's default NULL ordering.</p>
       </div>
     </article>
     <div id="changelogContent">

--- a/src/core/value.rs
+++ b/src/core/value.rs
@@ -452,6 +452,30 @@ impl Value {
         Ok(s1.cmp(&s2))
     }
 
+    /// Compare storage sort keys with NULLs last in ascending order.
+    #[inline]
+    pub(crate) fn compare_nulls_last(&self, other: &Value) -> Ordering {
+        match self.compare(other) {
+            Ok(order) => order,
+            Err(error) => self.nulls_last_on_error(error),
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn nulls_last_on_error(&self, error: Error) -> Ordering {
+        match error {
+            Error::NullComparison => {
+                if self.is_null() {
+                    Ordering::Greater
+                } else {
+                    Ordering::Less
+                }
+            }
+            _ => Ordering::Equal,
+        }
+    }
+
     /// Compare values of the same type
     fn compare_same_type(&self, other: &Value) -> Result<Ordering> {
         match (self, other) {

--- a/src/storage/mvcc/table.rs
+++ b/src/storage/mvcc/table.rs
@@ -3149,7 +3149,7 @@ impl Table for MVCCTable {
                     (None, None) => std::cmp::Ordering::Equal,
                     (None, Some(_)) => std::cmp::Ordering::Less,
                     (Some(_), None) => std::cmp::Ordering::Greater,
-                    (Some(va), Some(vb)) => va.compare(vb).unwrap_or(std::cmp::Ordering::Equal),
+                    (Some(va), Some(vb)) => va.compare_nulls_last(vb),
                 };
                 if ascending {
                     cmp

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -3646,7 +3646,7 @@ impl VersionStore {
                         (None, None) => std::cmp::Ordering::Equal,
                         (None, Some(_)) => std::cmp::Ordering::Less,
                         (Some(_), None) => std::cmp::Ordering::Greater,
-                        (Some(va), Some(vb)) => va.compare(vb).unwrap_or(std::cmp::Ordering::Equal),
+                        (Some(va), Some(vb)) => va.compare_nulls_last(vb),
                     };
                     if ascending {
                         cmp
@@ -3702,7 +3702,7 @@ impl VersionStore {
                 (None, None) => std::cmp::Ordering::Equal,
                 (None, Some(_)) => std::cmp::Ordering::Less,
                 (Some(_), None) => std::cmp::Ordering::Greater,
-                (Some(va), Some(vb)) => va.compare(vb).unwrap_or(std::cmp::Ordering::Equal),
+                (Some(va), Some(vb)) => va.compare_nulls_last(vb),
             };
             if ascending {
                 cmp

--- a/src/storage/traits/table.rs
+++ b/src/storage/traits/table.rs
@@ -554,7 +554,7 @@ pub trait Table: Send + Sync {
                 (None, None) => std::cmp::Ordering::Equal,
                 (None, Some(_)) => std::cmp::Ordering::Less,
                 (Some(_), None) => std::cmp::Ordering::Greater,
-                (Some(va), Some(vb)) => va.compare(vb).unwrap_or(std::cmp::Ordering::Equal),
+                (Some(va), Some(vb)) => va.compare_nulls_last(vb),
             };
             if ascending {
                 cmp

--- a/src/storage/volume/table.rs
+++ b/src/storage/volume/table.rs
@@ -2407,7 +2407,7 @@ impl Table for SegmentedTable {
                 (None, None) => std::cmp::Ordering::Equal,
                 (None, Some(_)) => std::cmp::Ordering::Less,
                 (Some(_), None) => std::cmp::Ordering::Greater,
-                (Some(va), Some(vb)) => va.compare(vb).unwrap_or(std::cmp::Ordering::Equal),
+                (Some(va), Some(vb)) => va.compare_nulls_last(vb),
             };
             if ascending {
                 cmp

--- a/tests/storage_sorted_null_test.rs
+++ b/tests/storage_sorted_null_test.rs
@@ -1,0 +1,158 @@
+// Copyright 2026 Stoolap Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use stoolap::core::{DataType, Row, Value};
+use stoolap::storage::volume::io::write_volume_to_disk;
+use stoolap::storage::volume::manifest::{SegmentManager, SegmentMeta};
+use stoolap::storage::volume::table::SegmentedTable;
+use stoolap::storage::volume::writer::VolumeBuilder;
+use stoolap::storage::{Engine, Table};
+use stoolap::{Database, IsolationLevel};
+
+fn setup(name: &str, hot_values: &str) -> Database {
+    let db = Database::open(&format!("memory://{name}")).unwrap();
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, k INTEGER)", ())
+        .unwrap();
+    db.execute(&format!("INSERT INTO t VALUES {hot_values}"), ())
+        .unwrap();
+    db.execute(
+        "CREATE TABLE reference (id INTEGER PRIMARY KEY, k INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO reference VALUES (1, NULL), (2, 20), (3, 10), (4, NULL), (5, 30)",
+        (),
+    )
+    .unwrap();
+    db
+}
+
+fn check_storage_order(db: &Database, table: &dyn Table) {
+    for (ascending, direction) in [(true, "ASC"), (false, "DESC")] {
+        let expected: Vec<i64> = db
+            .query(
+                &format!("SELECT id FROM reference ORDER BY k {direction}, id ASC"),
+                (),
+            )
+            .unwrap()
+            .map(|row| row.unwrap().get::<i64>(0).unwrap())
+            .collect();
+        for limit in [0, 1, 3, 10] {
+            for offset in [0, 2, 4, 8] {
+                let rows = table
+                    .collect_rows_sorted_with_limit(1, ascending, limit, offset)
+                    .unwrap();
+                let actual: Vec<i64> = rows
+                    .iter()
+                    .map(|row| row.get(0).unwrap().as_int64().unwrap())
+                    .collect();
+                let wanted: Vec<i64> = expected.iter().skip(offset).take(limit).copied().collect();
+                assert_eq!(actual, wanted, "{direction} LIMIT {limit} OFFSET {offset}");
+            }
+        }
+    }
+}
+
+#[test]
+fn storage_sorted_nulls_read_committed() {
+    let db = setup(
+        "storage_sorted_nulls_read_committed",
+        "(1, NULL), (2, 20), (3, 10), (4, NULL), (5, 30)",
+    );
+    let tx = db
+        .engine()
+        .begin_transaction_with_level(IsolationLevel::ReadCommitted)
+        .unwrap();
+    let table = tx.get_table("t").unwrap();
+    check_storage_order(&db, table.as_ref());
+}
+
+#[test]
+fn storage_sorted_nulls_snapshot_history() {
+    let db = setup(
+        "storage_sorted_nulls_snapshot_history",
+        "(1, NULL), (2, 20), (3, 10), (4, NULL), (5, 30)",
+    );
+    let tx = db
+        .engine()
+        .begin_transaction_with_level(IsolationLevel::SnapshotIsolation)
+        .unwrap();
+    db.execute("UPDATE t SET k = 99 WHERE id = 3", ()).unwrap();
+    let table = tx.get_table("t").unwrap();
+    check_storage_order(&db, table.as_ref());
+}
+
+#[test]
+fn storage_sorted_nulls_local_rows() {
+    let db = setup(
+        "storage_sorted_nulls_local_rows",
+        "(1, NULL), (2, 20), (3, 10), (4, NULL), (5, 30)",
+    );
+    let mut tx = db.engine().begin_transaction().unwrap();
+    let mut table = tx.get_table("t").unwrap();
+    table
+        .insert(Row::from_values(vec![Value::Integer(6), Value::Integer(5)]))
+        .unwrap();
+    db.execute("INSERT INTO reference VALUES (6, 5)", ())
+        .unwrap();
+    check_storage_order(&db, table.as_ref());
+    tx.rollback().unwrap();
+}
+
+#[test]
+fn storage_sorted_nulls_merged_volume() {
+    let db = setup(
+        "storage_sorted_nulls_merged_volume",
+        "(3, 10), (4, NULL), (5, 30)",
+    );
+    let tx = db
+        .engine()
+        .begin_transaction_with_level(IsolationLevel::ReadCommitted)
+        .unwrap();
+    let hot = tx.get_table("t").unwrap();
+    let schema = hot.schema().clone();
+    let mut builder = VolumeBuilder::new(&schema);
+    builder.add_row(
+        1,
+        &Row::from_values(vec![Value::Integer(1), Value::null(DataType::Integer)]),
+    );
+    builder.add_row(
+        2,
+        &Row::from_values(vec![Value::Integer(2), Value::Integer(20)]),
+    );
+    let volume = builder.finish();
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_volume_to_disk(dir.path(), "t", 1, &volume).unwrap();
+    let manager = Arc::new(SegmentManager::new("t", Some(dir.path().to_path_buf())));
+    manager.register_segment(
+        1,
+        Arc::new(volume),
+        SegmentMeta {
+            segment_id: 1,
+            file_path: path,
+            row_count: 2,
+            min_row_id: 1,
+            max_row_id: 2,
+            schema_version: 0,
+            creation_lsn: 0,
+            seal_seq: 0,
+        },
+        Some(&schema),
+    );
+    let table = SegmentedTable::new(hot, manager);
+    check_storage_order(&db, &table);
+}


### PR DESCRIPTION
I replaced this NULL-ordering correction with #150, which removes the unused APIs. I am closing this PR without merging it.

The changed sorted-limit storage API serves no SQL executor path. Repository callers are limited to its own implementation chain and tests; SQL ORDER BY/LIMIT already uses collect_rows_ordered_by_index and scan_top_k. The deferred RowIndex readers and StreamingResult module have no production callers either. #150 removes those public Rust symbols and discloses that API change.

The capture-gap guard and forced-root writer experiment exercised this unused API, not a SQL execution path. The timing campaigns were disproportionate to this scope. Their results do not establish a live SQL regression or an acceptance result for the deletion. No comparator, captured-root reader or bounded-heap replacement from this work will be shipped.
