### PR TITLE
Add a security policy and a cargo audit workflow

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,12 @@
+# Configuration for `cargo audit` and the Security Audit workflow.
+# Every ignored advisory needs a reason and a date, and is revisited when
+# the dependency that pulls it in moves.
+
+[advisories]
+ignore = [
+    # rkyv 0.7 is pulled in only by the optional `duckdb` feature (rust_decimal
+    # -> rkyv), used for the comparison benchmarks. It is not part of the
+    # library or CLI build. The fix is rkyv 0.8, which rust_decimal has not
+    # moved to yet. Reviewed 2026-09-11.
+    "RUSTSEC-2026-0235",
+]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,36 @@
+name: Security Audit
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.cargo/audit.toml'
+      - '.github/workflows/audit.yml'
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.cargo/audit.toml'
+      - '.github/workflows/audit.yml'
+  schedule:
+    - cron: '0 4 * * *' # 4 AM UTC daily, after the nightly suite
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  checks: write
+
+jobs:
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Audit Cargo.lock against the RustSec database
+      uses: rustsec/audit-check@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +812,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1104,7 +1124,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1244,7 +1264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1664,10 +1684,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1684,9 +1707,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2566,7 +2589,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2949,14 +2972,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -2979,7 +3003,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3041,6 +3065,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3079,6 +3114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3086,6 +3127,15 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.2",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3380,7 +3430,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3410,9 +3460,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3612,7 +3662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3623,7 +3673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3945,9 +3995,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -3964,7 +4014,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4672,7 +4722,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ cargo fmt --check
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## Security
+
+To report a vulnerability, see [SECURITY.md](SECURITY.md). Dependencies are audited against the RustSec advisory database in CI.
+
 ## License
 
 Apache License 2.0. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are released for the latest minor version on the `main` branch. Older releases do not receive backported fixes.
+
+| Version | Supported |
+|---------|-----------|
+| 0.4.x   | Yes       |
+| < 0.4   | No        |
+
+## Reporting a vulnerability
+
+Please do not open a public issue for a security problem.
+
+Report it privately through [GitHub Security Advisories](https://github.com/stoolap/stoolap/security/advisories/new) for this repository. Include a description of the issue, the affected version or commit, and steps or a minimal SQL script that reproduces it.
+
+You will receive an acknowledgement within 7 days. Once the report is confirmed, a fix is prepared on a private branch, released in a new version, and the advisory is published with credit to the reporter unless they prefer otherwise.
+
+## Scope
+
+Stoolap is an embedded database library. It runs inside the calling process with that process's privileges and has no network listener, authentication or access control of its own. The following are in scope:
+
+- Memory safety defects reachable through the public Rust, C or driver APIs, including through valid or malformed SQL.
+- Data corruption or silent data loss, including on crash, on WAL replay or on volume reload.
+- Panics reachable from SQL or the API that abort the host process (the release profile uses `panic = "abort"`).
+- Vulnerabilities in dependencies, which are checked continuously with `cargo audit` in CI.
+
+The following are out of scope: denial of service through queries that legitimately consume large amounts of memory or time on the caller's own data, and issues in applications that embed Stoolap.
+
+## Dependency auditing
+
+The `Cargo.lock` is checked against the [RustSec advisory database](https://rustsec.org/) on every push and pull request, and once a day on a schedule, by the `Security Audit` workflow. A new advisory affecting a locked dependency fails the workflow until the dependency is updated or the advisory is triaged and ignored in `.cargo/audit.toml` with a reason.


### PR DESCRIPTION
## Summary

Adds a security policy and a `cargo audit` workflow, and updates `Cargo.lock` so the audit passes.

- `SECURITY.md`: how to report a vulnerability (private advisories), what is in scope for an embedded engine with `panic = "abort"`, and how dependency advisories are handled. Linked from the README.
- `.github/workflows/audit.yml`: runs `rustsec/audit-check` on pushes and pull requests that touch `Cargo.toml`, `Cargo.lock` or the audit config, and once a day on a schedule so a new advisory against an unchanged lockfile still surfaces.
- `.cargo/audit.toml`: the ignore list, with a reason and review date per entry.

## Lockfile

`cargo audit` reported 11 advisories on `main`. Ten are fixed by moving the locked version within the same semver range (`cargo update -p ...`, no `Cargo.toml` change):

| Crate | From | To | Advisories | Reached through |
|---|---|---|---|---|
| crossbeam-epoch | 0.9.18 | 0.9.21 | RUSTSEC-2026-0204 | crossbeam (core dependency) |
| h2 | 0.4.13 | 0.4.19 | RUSTSEC-2026-0258 | hf-hub (`semantic` feature) |
| quinn-proto | 0.11.13 | 0.11.17 | RUSTSEC-2026-0185, -0037 | hf-hub (`semantic` feature) |
| rustls-webpki | 0.103.9 | 0.103.15 | RUSTSEC-2026-0104, -0098, -0099, -0049 | ureq (`semantic`, `ann-benchmark` features) |
| tar | 0.4.44 | 0.4.46 | RUSTSEC-2026-0068, -0067 | hf-hub (`semantic` feature) |

Only crossbeam-epoch is in the library or CLI build; the rest are behind optional features. The quinn-proto bump adds rand 0.10 (and rand_core, rand_pcg, chacha20, cpufeatures) as new transitive entries for the `semantic` feature; the crate's own rand 0.9 dependency is unchanged.

The remaining advisory, RUSTSEC-2026-0235 (rkyv 0.7), comes only from `duckdb` → `rust_decimal`, used by the optional comparison benchmarks. The fix is rkyv 0.8, which rust_decimal has not adopted, so it is ignored with that reason in `.cargo/audit.toml`.

The seven `unmaintained` / `unsound` warnings (anyhow, lru, memmap2, rand, paste, number_prefix) are informational and do not fail the job.

## Verification

- `cargo audit`: 0 vulnerabilities, 7 allowed warnings.
- `cargo check` on stable with default features.
- `cargo +1.88 check --all-targets --features "semantic ann-benchmark sqlite ffi test-failpoints stress-tests test-filedb mimalloc"` (MSRV; `duckdb` left out to avoid the bundled C++ build).
- `cargo test --lib` on stable.
